### PR TITLE
Fix subdirectory include paths

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -4,7 +4,7 @@
 
 - [x] multiple-array streaming (HCS use case) cpu
 - [ ] multiple-array streaming (HCS use case) gpu
-- [ ] generalized append dimensions
+- [x] generalized append dimensions
 - [x] s3 writer
 - [x] make a report to characterize performance/memory by chunk size
 - [ ] interface for streaming from device, integrating with a cuda stream
@@ -42,6 +42,19 @@ Cleanup
 - [ ] make sure everything has extern c guards
 - [ ] comments at the top of each test
 - [ ] look into j8 failures
+
+## 2026-03-28
+
+Starting integration in earnest. This is going to be interesting...
+
+## 2026-03-27
+
+On multiarray, if I were streaming timestamps while streaming video, I kind
+of want to wait till I have a full epoch's worth of timepoints before pushing
+the bytes so that I can switch streams... Either that or allow managing both
+epochs/batches in memory at the same time.
+
+On acquire-zarr integration. I think I can just hit the public api.
 
 ## 2026-03-26
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,28 @@
 {
   "nodes": {
+    "claude-code": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774649084,
+        "narHash": "sha256-GNyQRoMJxxasuw2/cOYSU4KEwLVwFr81c2UpVM1vGko=",
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "rev": "f632b3d71e2dbebedeccb0a09a42f27a53af1a33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -20,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773389992,
-        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {
@@ -36,6 +59,7 @@
     },
     "root": {
       "inputs": {
+        "claude-code": "claude-code",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,9 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    claude-code.url = "github:sadjow/claude-code-nix";
+    claude-code.inputs.nixpkgs.follows = "nixpkgs";
+    claude-code.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs =
@@ -11,6 +14,7 @@
       self, # required even if the lsp complains
       nixpkgs,
       flake-utils,
+      claude-code,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
@@ -26,18 +30,12 @@
         devShells.default = pkgs.mkShell.override { stdenv = pkgs.clangStdenv; } {
           name = "chucky";
 
-          buildInputs = with pkgs; [
+          nativeBuildInputs = with pkgs; [
             cmake
-            cudaPackages.cudatoolkit
-            cudaPackages.nvcomp
-            cudaPackages.nvcomp.static
+            claude-code.packages.${system}.default
             docker
             gdb
             gh
-            llvmPackages.openmp
-            (lz4.overrideAttrs (old: {
-              cmakeFlags = (old.cmakeFlags or [ ]) ++ [ "-DBUILD_STATIC_LIBS=ON" ];
-            }))
             man-pages
             man-pages-posix
             neocmakelsp
@@ -46,6 +44,19 @@
             perf
             pkg-config
             tokei
+            awscli2
+            python3
+            uv
+          ];
+
+          buildInputs = with pkgs; [
+            cudaPackages.cudatoolkit
+            cudaPackages.nvcomp
+            cudaPackages.nvcomp.static
+            llvmPackages.openmp
+            (lz4.overrideAttrs (old: {
+              cmakeFlags = (old.cmakeFlags or [ ]) ++ [ "-DBUILD_STATIC_LIBS=ON" ];
+            }))
             (zstd.override { enableStatic = true; })
             # s3 writer
             aws-c-common
@@ -58,10 +69,6 @@
             aws-c-sdkutils
             aws-checksums
             s2n-tls
-            awscli2
-            # for viewing w neuroglancer
-            python3
-            uv
           ];
         };
       }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,10 +2,11 @@
 #   Creates a STATIC library, exposes its headers, and links warnings.
 #   LINKS are added as PUBLIC dependencies.
 #   All targets get src/ as their single public include root.
+set(_SRC_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 function(add_src_lib TARGET)
     cmake_parse_arguments(ARG "" "" "SOURCES;LINKS" ${ARGN})
     add_library(${TARGET} STATIC ${ARG_SOURCES})
-    target_include_directories(${TARGET} PUBLIC ${CMAKE_SOURCE_DIR}/src)
+    target_include_directories(${TARGET} PUBLIC ${_SRC_INCLUDE_DIR})
     target_link_libraries(${TARGET} PRIVATE warnings)
     if(ARG_LINKS)
         target_link_libraries(${TARGET} PUBLIC ${ARG_LINKS})


### PR DESCRIPTION
## Summary
- Replace `CMAKE_SOURCE_DIR` with a captured `CMAKE_CURRENT_SOURCE_DIR` in `add_src_lib` so include paths resolve correctly when chucky is consumed via `add_subdirectory()`.

Closes #1

## Test plan
- [x] Full build passes
- [x] All tests pass