### PR TITLE
Add CI with optional GPU build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cpu-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build CPU-only image
+        run: docker build -f Dockerfile.cpu -t chucky-cpu .
+
+      - name: Run CPU tests
+        run: >
+          docker run --rm chucky-cpu
+          ctest --test-dir build --output-on-failure
+          --exclude-regex test-test_zarr_s3_sink
+
+  gpu-tests:
+    runs-on: [self-hosted, gpu]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test (GPU)
+        run: docker compose run --rm test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,10 @@
 cmake_minimum_required(VERSION 3.18)
-project(chucky LANGUAGES C CXX CUDA)
+project(chucky LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 17)
-set(CMAKE_CUDA_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-set(CMAKE_CUDA_ARCHITECTURES 100)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -16,8 +13,24 @@ include(Warnings)
 include(Nix)
 include(OpenMP)
 
-find_package(CUDAToolkit 12.8 REQUIRED)
-find_package(Nvcomp REQUIRED)
+# GPU auto-detection: ON if a CUDA compiler is found, OFF otherwise.
+# Override with -DCHUCKY_ENABLE_GPU=OFF to force a CPU-only build.
+include(CheckLanguage)
+check_language(CUDA)
+if(CMAKE_CUDA_COMPILER)
+    set(_GPU_DEFAULT ON)
+else()
+    set(_GPU_DEFAULT OFF)
+endif()
+option(CHUCKY_ENABLE_GPU "Build GPU (CUDA) backends and tests" ${_GPU_DEFAULT})
+
+if(CHUCKY_ENABLE_GPU)
+    enable_language(CUDA)
+    set(CMAKE_CUDA_STANDARD 17)
+    set(CMAKE_CUDA_ARCHITECTURES 100)
+    find_package(CUDAToolkit 12.8 REQUIRED)
+    find_package(Nvcomp REQUIRED)
+endif()
 find_package(Threads REQUIRED)
 find_package(lz4 CONFIG QUIET)
 if(lz4_FOUND)
@@ -48,4 +61,7 @@ add_subdirectory(src)
 
 enable_testing()
 add_subdirectory(tests)
-add_subdirectory(bench)
+
+if(CHUCKY_ENABLE_GPU)
+    add_subdirectory(bench)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,6 +16,13 @@
         "CMAKE_C_FLAGS": "-I/usr/local/cuda/include",
         "CMAKE_CXX_FLAGS": "-I/usr/local/cuda/include"
       }
+    },
+    {
+      "name": "cpu-only",
+      "inherits": "default",
+      "cacheVariables": {
+        "CHUCKY_ENABLE_GPU": "OFF"
+      }
     }
   ]
 }

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -6,6 +6,7 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
         cmake \
         ninja-build \
         libzstd-dev \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+# CPU-only build for CI — no CUDA, no nvcomp.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake \
+        ninja-build \
+        libzstd-dev \
+        liblz4-dev \
+        libomp-dev \
+        libssl-dev \
+        git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build AWS C libraries from source (not packaged in Ubuntu 24.04).
+RUN git clone --depth 1 --branch v0.12.6 https://github.com/awslabs/aws-c-common.git      /tmp/b && cmake -S /tmp/b -B /tmp/b/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/aws -DCMAKE_PREFIX_PATH=/opt/aws -DBUILD_TESTING=OFF && cmake --build /tmp/b/build --target install && rm -rf /tmp/b \
+ && git clone --depth 1 --branch v0.9.13  https://github.com/awslabs/aws-c-cal.git          /tmp/b && cmake -S /tmp/b -B /tmp/b/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/aws -DCMAKE_PREFIX_PATH=/opt/aws -DBUILD_TESTING=OFF && cmake --build /tmp/b/build --target install && rm -rf /tmp/b \
+ && git clone --depth 1 --branch v0.2.10  https://github.com/awslabs/aws-checksums.git      /tmp/b && cmake -S /tmp/b -B /tmp/b/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/aws -DCMAKE_PREFIX_PATH=/opt/aws -DBUILD_TESTING=OFF && cmake --build /tmp/b/build --target install && rm -rf /tmp/b \
+ && git clone --depth 1 --branch v1.7.0   https://github.com/aws/s2n-tls.git               /tmp/b && cmake -S /tmp/b -B /tmp/b/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/aws -DCMAKE_PREFIX_PATH=/opt/aws -DBUILD_TESTING=OFF && cmake --build /tmp/b/build --target install && rm -rf /tmp/b \
+ && git clone --depth 1 --branch v0.26.3  https://github.com/awslabs/aws-c-io.git           /tmp/b && cmake -S /tmp/b -B /tmp/b/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/aws -DCMAKE_PREFIX_PATH=/opt/aws -DBUILD_TESTING=OFF && cmake --build /tmp/b/build --target install && rm -rf /tmp/b \
+ && git clone --depth 1 --branch v0.3.2   https://github.com/awslabs/aws-c-compression.git  /tmp/b && cmake -S /tmp/b -B /tmp/b/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/aws -DCMAKE_PREFIX_PATH=/opt/aws -DBUILD_TESTING=OFF && cmake --build /tmp/b/build --target install && rm -rf /tmp/b \
+ && git clone --depth 1 --branch v0.10.12 https://github.com/awslabs/aws-c-http.git         /tmp/b && cmake -S /tmp/b -B /tmp/b/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/aws -DCMAKE_PREFIX_PATH=/opt/aws -DBUILD_TESTING=OFF && cmake --build /tmp/b/build --target install && rm -rf /tmp/b \
+ && git clone --depth 1 --branch v0.2.4   https://github.com/awslabs/aws-c-sdkutils.git     /tmp/b && cmake -S /tmp/b -B /tmp/b/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/aws -DCMAKE_PREFIX_PATH=/opt/aws -DBUILD_TESTING=OFF && cmake --build /tmp/b/build --target install && rm -rf /tmp/b \
+ && git clone --depth 1 --branch v0.10.1  https://github.com/awslabs/aws-c-auth.git         /tmp/b && cmake -S /tmp/b -B /tmp/b/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/aws -DCMAKE_PREFIX_PATH=/opt/aws -DBUILD_TESTING=OFF && cmake --build /tmp/b/build --target install && rm -rf /tmp/b \
+ && git clone --depth 1 --branch v0.11.5  https://github.com/awslabs/aws-c-s3.git           /tmp/b && cmake -S /tmp/b -B /tmp/b/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/aws -DCMAKE_PREFIX_PATH=/opt/aws -DBUILD_TESTING=OFF && cmake --build /tmp/b/build --target install && rm -rf /tmp/b
+
+ENV CMAKE_PREFIX_PATH="/opt/aws"
+
+WORKDIR /src
+COPY . .
+
+RUN cmake --preset cpu-only \
+        -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build build

--- a/README.md
+++ b/README.md
@@ -36,18 +36,39 @@ up to 32 LOD levels. Internal layout supports up to 64 dimensions.
 
 ### Prerequisites
 
+**Full (GPU) build:**
+
 - **CUDA Toolkit** (12.8+) — CUDA runtime and nvcc compiler
 - [**nvcomp**][nvcomp] (5.x) — NVIDIA compression library for GPU-accelerated
   codecs
-- **aws-c-s3** — Amazon S3 client library for S3 storage backend
-- **zstd** — Zstandard compression (CPU-side, used by tests)
-- **CMake** (3.18+) + **Ninja** — build system
 - NVIDIA GPU with 8+ GB VRAM (16+ GB recommended for multiscale workloads)
+
+**CPU-only build** — no CUDA or GPU required.
+
+**Both:**
+
+- **aws-c-s3** — Amazon S3 client library for S3 storage backend
+- **lz4**, **zstd** — compression libraries
+- **CMake** (3.18+) + **Ninja** — build system
 
 The default build targets SM 100 (Blackwell). For other GPUs, set
 `CMAKE_CUDA_ARCHITECTURES` at configure time.
 
 ### Build
+
+The build auto-detects CUDA. If a CUDA compiler is found, GPU backends are
+enabled automatically. To force a CPU-only build, use the `cpu-only` preset or
+pass `-DCHUCKY_ENABLE_GPU=OFF`.
+
+```
+# Full build (auto-detects CUDA)
+cmake --preset default
+cmake --build build
+
+# CPU-only build (no CUDA required)
+cmake --preset cpu-only
+cmake --build build
+```
 
 The easiest way to get the non-CUDA dependencies (lz4, zstd, aws-c-s3) is via
 [vcpkg][vcpkg]. A `vcpkg.json` manifest is included in the repo:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,9 @@ add_src_lib(stream_config SOURCES stream/config.c stream/config.h stream/layouts
 
 # --- Backend subdirectories ---
 
-add_subdirectory(gpu)
+if(CHUCKY_ENABLE_GPU)
+    add_subdirectory(gpu)
+endif()
 add_subdirectory(cpu)
 
 add_subdirectory(multiarray)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,25 +15,44 @@ function(add_test_lib TARGET)
     target_link_libraries(${TARGET} PRIVATE warnings)
 endfunction()
 
+# GPU-only wrappers: no-op when CHUCKY_ENABLE_GPU is OFF.
+function(add_gpu_test_exe TGT)
+    if(CHUCKY_ENABLE_GPU)
+        add_test_exe(${TGT} ${ARGN})
+    endif()
+endfunction()
+
+function(add_gpu_test_lib TARGET)
+    if(CHUCKY_ENABLE_GPU)
+        add_test_lib(${TARGET} ${ARGN})
+    endif()
+endfunction()
+
 # Index operations utility library (shared between tests)
 add_test_lib(index_ops_util index.ops.util.c)
 target_link_libraries(index_ops_util PUBLIC index_ops)
 
 # Morton/LOD CPU reference library (shared between tests)
-add_test_lib(morton_util morton.util.c morton.util.h)
-target_link_libraries(morton_util PUBLIC lod_plan index_ops CUDA::cuda_driver)
+add_gpu_test_lib(morton_util morton.util.c morton.util.h)
+if(CHUCKY_ENABLE_GPU)
+    target_link_libraries(morton_util PUBLIC lod_plan index_ops CUDA::cuda_driver)
+endif()
 
 # Shared test shard sink (multi-shard-safe)
 add_test_lib(test_shard_sink test_shard_sink.c test_shard_sink.h)
 target_link_libraries(test_shard_sink PUBLIC writer)
 
 # Shared GPU test helpers (fill, config builder)
-add_test_lib(test_gpu_helpers test_gpu_helpers.c test_gpu_helpers.h)
-target_link_libraries(test_gpu_helpers PUBLIC stream CUDA::cuda_driver)
+add_gpu_test_lib(test_gpu_helpers test_gpu_helpers.c test_gpu_helpers.h)
+if(CHUCKY_ENABLE_GPU)
+    target_link_libraries(test_gpu_helpers PUBLIC stream CUDA::cuda_driver)
+endif()
 
 # Shared shard verification helpers (index parse, decompress+verify)
-add_test_lib(test_shard_verify test_shard_verify.c test_shard_verify.h)
-target_link_libraries(test_shard_verify PUBLIC stream Zstd::Zstd)
+add_gpu_test_lib(test_shard_verify test_shard_verify.c test_shard_verify.h)
+if(CHUCKY_ENABLE_GPU)
+    target_link_libraries(test_shard_verify PUBLIC stream Zstd::Zstd)
+endif()
 
 # Shared voxel coordinate encoding helpers
 add_test_lib(test_voxel_encode test_voxel_encode.c test_voxel_encode.h)
@@ -42,7 +61,7 @@ add_test_lib(test_voxel_encode test_voxel_encode.c test_voxel_encode.h)
 add_test_exe(test_index_ops test_index_ops.c index_ops chucky_log)
 
 # Standalone transpose kernel test
-add_test_exe(test_transpose test_transpose.c CUDA::cuda_driver CUDA::cudart_static stream index_ops_util)
+add_gpu_test_exe(test_transpose test_transpose.c CUDA::cuda_driver CUDA::cudart_static stream index_ops_util)
 
 # CPU transpose test (no CUDA)
 add_test_exe(test_transpose_cpu test_transpose_cpu.c transpose_cpu index_ops_util chucky_log)
@@ -66,35 +85,39 @@ add_test_exe(test_multiarray_cpu test_multiarray_cpu.c multiarray_cpu stream_cpu
 add_test_exe(test_multi_append test_multi_append.c stream_cpu writer test_shard_sink chucky_log)
 
 # Cross-validate GPU vs CPU (byte-exact shard comparison with CODEC_NONE)
-add_test_exe(test_cross_validate test_cross_validate.c CUDA::cuda_driver CUDA::cudart_static stream stream_cpu writer)
+add_gpu_test_exe(test_cross_validate test_cross_validate.c CUDA::cuda_driver CUDA::cudart_static stream stream_cpu writer)
 
 # Test platform utilities
-add_test_lib(test_platform test_platform.h)
-add_platform_sources(test_platform)
+add_gpu_test_lib(test_platform test_platform.h)
+if(CHUCKY_ENABLE_GPU)
+    add_platform_sources(test_platform)
+endif()
 
 # Shared test data generation library
-add_test_lib(test_data test_data.c test_data.h)
-target_link_libraries(test_data PUBLIC stream)
+add_gpu_test_lib(test_data test_data.c test_data.h)
+if(CHUCKY_ENABLE_GPU)
+    target_link_libraries(test_data PUBLIC stream)
+endif()
 
 # Tests with zstd
-add_test_exe(test_stream          test_stream.c          CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd index_ops_util test_shard_sink test_gpu_helpers test_shard_verify test_voxel_encode)
-add_test_exe(test_compress        test_compress.c        CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd)
-add_test_exe(test_aggregate       test_aggregate.c       CUDA::cuda_driver CUDA::cudart_static aggregate index_ops_util)
+add_gpu_test_exe(test_stream          test_stream.c          CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd index_ops_util test_shard_sink test_gpu_helpers test_shard_verify test_voxel_encode)
+add_gpu_test_exe(test_compress        test_compress.c        CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd)
+add_gpu_test_exe(test_aggregate       test_aggregate.c       CUDA::cuda_driver CUDA::cudart_static aggregate index_ops_util)
 
 add_test_exe(test_json_writer test_json_writer.c json_writer chucky_log)
 add_test_exe(test_io_queue    test_io_queue.c    io_queue chucky_log)
 
-add_test_exe(test_zarr_fs_sink   test_zarr_fs_sink.c   CUDA::cuda_driver CUDA::cudart_static zarr_fs_sink stream Zstd::Zstd test_platform test_shard_verify test_voxel_encode)
+add_gpu_test_exe(test_zarr_fs_sink   test_zarr_fs_sink.c   CUDA::cuda_driver CUDA::cudart_static zarr_fs_sink stream Zstd::Zstd test_platform test_shard_verify test_voxel_encode)
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   zarr_s3_sink platform_cmd chucky_log)
 
-add_test_exe(test_ingest       test_ingest.c       CUDA::cuda_driver CUDA::cudart_static stream index_ops_util)
-add_test_exe(test_compress_agg test_compress_agg.c CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd test_gpu_helpers index_ops_util test_shard_verify)
-add_test_exe(test_batch        test_batch.c        CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink test_gpu_helpers)
-add_test_exe(test_d2h_deliver  test_d2h_deliver.c  CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd test_shard_sink test_gpu_helpers index_ops_util)
-add_test_exe(test_flush_orch  test_flush_orchestration.c CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink test_gpu_helpers)
-add_test_exe(test_dimension   test_dimension.c   stream chucky_log)
-add_test_exe(test_lod         test_lod.c         CUDA::cuda_driver CUDA::cudart_static lod lod_plan index_ops morton_util)
-add_test_exe(test_lod_dtypes  test_lod_dtypes.cu CUDA::cuda_driver CUDA::cudart_static lod lod_plan)
-add_test_exe(test_multiscale  test_multiscale.c  CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd test_data test_shard_sink)
+add_gpu_test_exe(test_ingest       test_ingest.c       CUDA::cuda_driver CUDA::cudart_static stream index_ops_util)
+add_gpu_test_exe(test_compress_agg test_compress_agg.c CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd test_gpu_helpers index_ops_util test_shard_verify)
+add_gpu_test_exe(test_batch        test_batch.c        CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink test_gpu_helpers)
+add_gpu_test_exe(test_d2h_deliver  test_d2h_deliver.c  CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd test_shard_sink test_gpu_helpers index_ops_util)
+add_gpu_test_exe(test_flush_orch  test_flush_orchestration.c CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink test_gpu_helpers)
+add_test_exe(test_dimension   test_dimension.c   stream_config dimension chucky_log)
+add_gpu_test_exe(test_lod         test_lod.c         CUDA::cuda_driver CUDA::cudart_static lod lod_plan index_ops morton_util)
+add_gpu_test_exe(test_lod_dtypes  test_lod_dtypes.cu CUDA::cuda_driver CUDA::cudart_static lod lod_plan)
+add_gpu_test_exe(test_multiscale  test_multiscale.c  CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd test_data test_shard_sink)
 
 add_subdirectory(experiments)

--- a/tests/experiments/CMakeLists.txt
+++ b/tests/experiments/CMakeLists.txt
@@ -7,10 +7,21 @@ function(add_experiment TGT SOURCE_FILE)
     set_nix_rpath(${TGT})
 endfunction()
 
-add_experiment(index.ops index.ops.c CUDA::cuda_driver index_ops_util stream)
-enable_openmp(index.ops)
+# GPU-only wrapper: no-op when CHUCKY_ENABLE_GPU is OFF.
+function(add_gpu_experiment TGT)
+    if(CHUCKY_ENABLE_GPU)
+        add_experiment(${TGT} ${ARGN})
+    endif()
+endfunction()
 
-add_experiment(index.ops.cuda index.ops.cuda.c CUDA::cuda_driver CUDA::cudart_static transpose index_ops_util chucky_log)
+add_gpu_experiment(index.ops index.ops.c CUDA::cuda_driver index_ops_util stream)
+if(CHUCKY_ENABLE_GPU)
+    enable_openmp(index.ops)
+endif()
 
-add_experiment(test_morton morton.c lod_plan lod index_ops chucky_log)
-target_include_directories(test_morton PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+add_gpu_experiment(index.ops.cuda index.ops.cuda.c CUDA::cuda_driver CUDA::cudart_static transpose index_ops_util chucky_log)
+
+add_gpu_experiment(test_morton morton.c lod_plan lod index_ops chucky_log)
+if(CHUCKY_ENABLE_GPU)
+    target_include_directories(test_morton PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+endif()


### PR DESCRIPTION
## Summary
- Make CUDA optional via `CHUCKY_ENABLE_GPU` CMake option (auto-detects CUDA, override with `-DCHUCKY_ENABLE_GPU=OFF`)
- Add `cpu-only` CMake preset for CPU-only builds
- Add `add_gpu_test_exe`/`add_gpu_test_lib`/`add_gpu_experiment` helpers that no-op when GPU is disabled
- Add GitHub Actions CI: CPU tests on `ubuntu-latest`, GPU tests on `[self-hosted, gpu]`
- Add `Dockerfile.cpu` for CPU-only CI builds
- Fix `test_dimension` to link `stream_config dimension` instead of GPU `stream`

## Test plan
- [x] `cmake --preset cpu-only` configures and builds successfully (80 targets)
- [x] All 11 CPU tests pass
- [x] `cmake --preset default` auto-detects GPU, builds all 160 targets
- [x] All 26 tests pass (except pre-existing S3/MinIO test)