### PR TITLE
Add pre-commit formatting hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ CMakeUserPresets.json
 typos.toml
 __pycache__/
 vcpkg_installed/
+.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -23,6 +23,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -38,6 +54,49 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774104215,
+        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -61,6 +120,7 @@
       "inputs": {
         "claude-code": "claude-code",
         "flake-utils": "flake-utils",
+        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,8 @@
     claude-code.url = "github:sadjow/claude-code-nix";
     claude-code.inputs.nixpkgs.follows = "nixpkgs";
     claude-code.inputs.flake-utils.follows = "flake-utils";
+    git-hooks.url = "github:cachix/git-hooks.nix";
+    git-hooks.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -15,6 +17,7 @@
       nixpkgs,
       flake-utils,
       claude-code,
+      git-hooks,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
@@ -23,12 +26,37 @@
           inherit system;
           config.allowUnfree = true;
         };
+        pre-commit-check = git-hooks.lib.${system}.run {
+          src = ./.;
+          hooks = {
+            clang-format = {
+              enable = true;
+              types_or = pkgs.lib.mkForce [
+                "c"
+                "c++"
+                "cuda"
+              ];
+            };
+            gersemi = {
+              enable = true;
+              name = "gersemi";
+              entry = "${pkgs.gersemi}/bin/gersemi -i";
+              files = "(\\.cmake$|CMakeLists\\.txt$)";
+              pass_filenames = true;
+            };
+          };
+        };
       in
       {
+        checks = {
+          inherit pre-commit-check;
+        };
+
         formatter = pkgs.nixfmt-tree;
 
         devShells.default = pkgs.mkShell.override { stdenv = pkgs.clangStdenv; } {
           name = "chucky";
+          inherit (pre-commit-check) shellHook;
 
           nativeBuildInputs = with pkgs; [
             cmake

--- a/tests/experiments/CMakeLists.txt
+++ b/tests/experiments/CMakeLists.txt
@@ -25,5 +25,8 @@ add_gpu_experiment(index.ops.cuda index.ops.cuda.c LINKS CUDA::cuda_driver CUDA:
 
 add_gpu_experiment(test_morton morton.c LINKS lod_plan lod index_ops chucky_log)
 if(CHUCKY_ENABLE_GPU)
-    target_include_directories(test_morton PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+    target_include_directories(
+        test_morton
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..
+    )
 endif()

--- a/tests/test_cpu_zarr_fs.c
+++ b/tests/test_cpu_zarr_fs.c
@@ -59,8 +59,8 @@ verify_shard(const char* path,
     return -1;
   }
 
-  if (shard_index_parse(shard_data, shard_len, chunks_per_shard, offsets,
-                        nbytes)) {
+  if (shard_index_parse(
+        shard_data, shard_len, chunks_per_shard, offsets, nbytes)) {
     log_error("  shard_index_parse failed for %s", path);
     free(offsets);
     free(nbytes);
@@ -83,7 +83,9 @@ verify_shard(const char* path,
       errors++;
       continue;
     }
-    if (chunk_decompress(shard_data + offsets[i], (size_t)nbytes[i], decomp,
+    if (chunk_decompress(shard_data + offsets[i],
+                         (size_t)nbytes[i],
+                         decomp,
                          chunk_stride_bytes)) {
       log_error("  %s chunk %zu: decompress failed", path, i);
       errors++;
@@ -193,8 +195,8 @@ test_pipeline(const char* tmpdir)
         snprintf(path, sizeof(path), "%s/0/c/%d/%d/%d", tmpdir, sa, sy, sx);
         CHECK(Fail4, test_file_exists(path));
 
-        int valid = verify_shard(path, (size_t)chunks_per_shard_total,
-                                 chunk_stride_bytes);
+        int valid = verify_shard(
+          path, (size_t)chunks_per_shard_total, chunk_stride_bytes);
         CHECK(Fail4, valid >= 0);
         total_valid_chunks += valid;
       }
@@ -202,7 +204,8 @@ test_pipeline(const char* tmpdir)
 
     int expected_chunks = n_epochs * chunks_per_epoch;
     if (total_valid_chunks != expected_chunks) {
-      log_error("  expected %d valid chunks, got %d", expected_chunks,
+      log_error("  expected %d valid chunks, got %d",
+                expected_chunks,
                 total_valid_chunks);
       goto Fail4;
     }
@@ -319,8 +322,8 @@ test_streaming_append(const char* tmpdir)
         snprintf(path, sizeof(path), "%s/0/c/%d/%d/%d", tmpdir, sa, sy, sx);
         CHECK(Fail4, test_file_exists(path));
 
-        int valid = verify_shard(path, (size_t)chunks_per_shard_total,
-                                 chunk_stride_bytes);
+        int valid = verify_shard(
+          path, (size_t)chunks_per_shard_total, chunk_stride_bytes);
         CHECK(Fail4, valid >= 0);
         total_valid_chunks += valid;
       }
@@ -328,7 +331,8 @@ test_streaming_append(const char* tmpdir)
 
     int expected_chunks = n_epochs * chunks_per_epoch;
     if (total_valid_chunks != expected_chunks) {
-      log_error("  expected %d valid chunks, got %d", expected_chunks,
+      log_error("  expected %d valid chunks, got %d",
+                expected_chunks,
                 total_valid_chunks);
       goto Fail4;
     }


### PR DESCRIPTION
## Summary
- Add git-hooks.nix for pre-commit formatting enforcement
- clang-format for C/C++/CUDA sources
- gersemi for CMakeLists.txt and .cmake files
- Hooks auto-install on `nix develop`
- Initial formatting pass on existing source files

## Test plan
- [x] `nix flake check` evaluates cleanly
- [x] Pre-commit hooks pass on staged files
- [x] Verify hooks activate on `nix develop` in a fresh checkout