### PR TITLE
Add unit and scale fields to struct dimension

### DIFF
--- a/src/dimension.c
+++ b/src/dimension.c
@@ -53,6 +53,8 @@ dims_create(struct dimension* dims, const char* names, const uint64_t* sizes)
       .chunk_size = sizes[i],
       .chunks_per_shard = 0,
       .name = name_table[ch],
+      .unit = NULL,
+      .scale = 1.0,
       .downsample = 0,
       .storage_position = i,
       .axis_type = dimension_axis_space,

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -53,11 +53,9 @@ dims_create(struct dimension* dims, const char* names, const uint64_t* sizes)
       .chunk_size = sizes[i],
       .chunks_per_shard = 0,
       .name = name_table[ch],
-      .unit = NULL,
-      .scale = 1.0,
       .downsample = 0,
       .storage_position = i,
-      .axis_type = dimension_axis_space,
+      .ngff = { .unit = NULL, .scale = 1.0, .type = dimension_axis_space },
     };
   }
   return rank;

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -20,10 +20,14 @@ struct dimension
   uint64_t chunks_per_shard; // 0 means all chunks along this dimension
                              // (must be > 0 when size == 0)
   const char* name;          // optional label (e.g. "x"), may be NULL
-  int downsample;            // include in LOD pyramid
-  uint8_t storage_position;  // position in storage layout (0=outermost).
-                             // dims[0].storage_position must be 0.
-                             // Must be a valid permutation of 0..rank-1.
+  const char* unit;          // OME-NGFF v0.5 axis unit (e.g. "micrometer"),
+                             // NULL defaults to "index" in metadata
+  double scale;   // physical pixel scale for coordinateTransformations
+                  // (must be non-negative; 0 treated as 1.0)
+  int downsample; // include in LOD pyramid
+  uint8_t storage_position; // position in storage layout (0=outermost).
+                            // dims[0].storage_position must be 0.
+                            // Must be a valid permutation of 0..rank-1.
   enum dimension_axis_type axis_type; // OME-NGFF axis type
 };
 

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -13,6 +13,17 @@ enum dimension_axis_type
   dimension_axis_other,
 };
 
+// OME-NGFF v0.5 axis metadata: unit, scale, and type.
+// Only consumed by zarr metadata writers.
+struct omengff_axis
+{
+  const char* unit; // axis unit (e.g. "micrometer"),
+                    // NULL defaults to "index" in metadata
+  double scale;     // physical pixel scale for coordinateTransformations
+                    // (must be non-negative; 0 treated as 1.0)
+  enum dimension_axis_type type; // space, time, channel, or other
+};
+
 struct dimension
 {
   uint64_t size; // 0 means unbounded (dim 0 only: stream indefinitely)
@@ -20,15 +31,11 @@ struct dimension
   uint64_t chunks_per_shard; // 0 means all chunks along this dimension
                              // (must be > 0 when size == 0)
   const char* name;          // optional label (e.g. "x"), may be NULL
-  const char* unit;          // OME-NGFF v0.5 axis unit (e.g. "micrometer"),
-                             // NULL defaults to "index" in metadata
-  double scale;   // physical pixel scale for coordinateTransformations
-                  // (must be non-negative; 0 treated as 1.0)
-  int downsample; // include in LOD pyramid
-  uint8_t storage_position; // position in storage layout (0=outermost).
-                            // dims[0].storage_position must be 0.
-                            // Must be a valid permutation of 0..rank-1.
-  enum dimension_axis_type axis_type; // OME-NGFF axis type
+  int downsample;            // include in LOD pyramid
+  uint8_t storage_position;  // position in storage layout (0=outermost).
+                             // dims[0].storage_position must be 0.
+                             // Must be a valid permutation of 0..rank-1.
+  struct omengff_axis ngff;  // OME-NGFF v0.5 axis metadata
 };
 
 // Initialize dims from a name string and sizes array.

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -242,6 +242,8 @@ zarr_multiscale_group_json(char* buf,
       }
       jw_string(&jw, type);
     }
+    jw_key(&jw, "unit");
+    jw_string(&jw, l0[d].unit ? l0[d].unit : "index");
     jw_object_end(&jw);
   }
   jw_array_end(&jw);
@@ -255,6 +257,21 @@ zarr_multiscale_group_json(char* buf,
     snprintf(lvstr, sizeof(lvstr), "%d", lv);
     jw_string(&jw, lvstr);
 
+    // Precompute per-axis physical scale and downsample factor
+    double scale[MAX_ZARR_RANK], translation[MAX_ZARR_RANK];
+    for (int d = 0; d < rank; ++d) {
+      double phys = l0[d].scale > 0 ? l0[d].scale : 1.0;
+      double factor = 1.0;
+      if (l0[d].downsample && level_dims[lv][d].size > 0) {
+        if (l0[d].size == 0)
+          factor = (double)(1u << lv);
+        else
+          factor = (double)l0[d].size / (double)level_dims[lv][d].size;
+      }
+      scale[d] = phys * factor;
+      translation[d] = 0.5 * phys * (factor - 1.0);
+    }
+
     jw_key(&jw, "coordinateTransformations");
     jw_array_begin(&jw);
     // scale
@@ -263,16 +280,8 @@ zarr_multiscale_group_json(char* buf,
     jw_string(&jw, "scale");
     jw_key(&jw, "scale");
     jw_array_begin(&jw);
-    for (int d = 0; d < rank; ++d) {
-      double scale = 1.0;
-      if (l0[d].downsample && level_dims[lv][d].size > 0) {
-        if (l0[d].size == 0)
-          scale = (double)(1u << lv);
-        else
-          scale = (double)l0[d].size / (double)level_dims[lv][d].size;
-      }
-      jw_float(&jw, scale);
-    }
+    for (int d = 0; d < rank; ++d)
+      jw_float(&jw, scale[d]);
     jw_array_end(&jw);
     jw_object_end(&jw);
     // translation
@@ -281,18 +290,8 @@ zarr_multiscale_group_json(char* buf,
     jw_string(&jw, "translation");
     jw_key(&jw, "translation");
     jw_array_begin(&jw);
-    for (int d = 0; d < rank; ++d) {
-      double t = 0.0;
-      if (l0[d].downsample && level_dims[lv][d].size > 0) {
-        double factor;
-        if (l0[d].size == 0)
-          factor = (double)(1u << lv);
-        else
-          factor = (double)l0[d].size / (double)level_dims[lv][d].size;
-        t = 0.5 * (factor - 1.0);
-      }
-      jw_float(&jw, t);
-    }
+    for (int d = 0; d < rank; ++d)
+      jw_float(&jw, translation[d]);
     jw_array_end(&jw);
     jw_object_end(&jw);
     jw_array_end(&jw);

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -226,7 +226,7 @@ zarr_multiscale_group_json(char* buf,
     jw_key(&jw, "type");
     {
       const char* type;
-      switch (l0[d].axis_type) {
+      switch (l0[d].ngff.type) {
         case dimension_axis_time:
           type = "time";
           break;
@@ -243,7 +243,7 @@ zarr_multiscale_group_json(char* buf,
       jw_string(&jw, type);
     }
     jw_key(&jw, "unit");
-    jw_string(&jw, l0[d].unit ? l0[d].unit : "index");
+    jw_string(&jw, l0[d].ngff.unit ? l0[d].ngff.unit : "index");
     jw_object_end(&jw);
   }
   jw_array_end(&jw);
@@ -260,7 +260,7 @@ zarr_multiscale_group_json(char* buf,
     // Precompute per-axis physical scale and downsample factor
     double scale[MAX_ZARR_RANK], translation[MAX_ZARR_RANK];
     for (int d = 0; d < rank; ++d) {
-      double phys = l0[d].scale > 0 ? l0[d].scale : 1.0;
+      double phys = l0[d].ngff.scale > 0 ? l0[d].ngff.scale : 1.0;
       double factor = 1.0;
       if (l0[d].downsample && level_dims[lv][d].size > 0) {
         if (l0[d].size == 0)

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -409,6 +409,7 @@ test_multiscale_metadata(const char* tmpdir)
     CHECK(Fail2, strstr(data, "\"path\":\"0\""));
     CHECK(Fail2, strstr(data, "\"path\":\"1\""));
     CHECK(Fail2, strstr(data, "\"coordinateTransformations\""));
+    CHECK(Fail2, strstr(data, "\"unit\":\"index\""));
     free(data);
   }
 
@@ -440,6 +441,77 @@ test_multiscale_metadata(const char* tmpdir)
     data[len < 4095 ? len : 4095] = '\0';
 
     CHECK(Fail2, strstr((char*)data, "\"shape\":[64,32,32]"));
+    free(data);
+  }
+
+  zarr_fs_multiscale_sink_destroy(ms);
+  log_info("  PASS");
+  return 0;
+
+Fail2:
+  zarr_fs_multiscale_sink_destroy(ms);
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+// --- Test: unit and scale in multiscale metadata ---
+
+static int
+test_multiscale_unit_scale(const char* tmpdir)
+{
+  log_info("=== test_multiscale_unit_scale ===");
+
+  struct dimension dims[] = {
+    { .size = 64,
+      .chunk_size = 8,
+      .chunks_per_shard = 4,
+      .name = "z",
+      .unit = "micrometer",
+      .scale = 0.5,
+      .downsample = 1,
+      .storage_position = 0 },
+    { .size = 32,
+      .chunk_size = 8,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .unit = "micrometer",
+      .scale = 0.3,
+      .storage_position = 1 },
+    { .size = 64,
+      .chunk_size = 8,
+      .chunks_per_shard = 4,
+      .name = "x",
+      .unit = NULL, // should default to "index"
+      .scale = 0.0, // should default to 1.0
+      .downsample = 1,
+      .storage_position = 2 },
+  };
+
+  struct zarr_multiscale_config cfg = {
+    .store_path = tmpdir,
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .nlod = 0,
+  };
+
+  struct zarr_fs_multiscale_sink* ms = zarr_fs_multiscale_sink_create(&cfg);
+  CHECK(Fail, ms);
+
+  {
+    char* data;
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 8192) == 0);
+
+    // Check explicit units
+    CHECK(Fail2, strstr(data, "\"unit\":\"micrometer\""));
+    // Check NULL unit defaults to "index"
+    CHECK(Fail2, strstr(data, "\"unit\":\"index\""));
+
+    // L0 scale: z=0.5*1=0.5, y=0.3*1=0.3, x=1.0*1=1.0
+    CHECK(Fail2, strstr(data, "\"scale\":[0.5,0.3,1.0]"));
+
     free(data);
   }
 
@@ -1815,6 +1887,14 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/msmeta", tmpdir);
     test_mkdir(sub);
     ecode |= test_multiscale_metadata(sub);
+  }
+
+  // Multiscale unit/scale metadata test (no CUDA needed)
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/msunitscale", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_multiscale_unit_scale(sub);
   }
 
   // Multiscale unbounded metadata test (no CUDA needed)

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -467,25 +467,22 @@ test_multiscale_unit_scale(const char* tmpdir)
       .chunk_size = 8,
       .chunks_per_shard = 4,
       .name = "z",
-      .unit = "micrometer",
-      .scale = 0.5,
       .downsample = 1,
-      .storage_position = 0 },
+      .storage_position = 0,
+      .ngff = { .unit = "micrometer", .scale = 0.5 } },
     { .size = 32,
       .chunk_size = 8,
       .chunks_per_shard = 2,
       .name = "y",
-      .unit = "micrometer",
-      .scale = 0.3,
-      .storage_position = 1 },
+      .storage_position = 1,
+      .ngff = { .unit = "micrometer", .scale = 0.3 } },
     { .size = 64,
       .chunk_size = 8,
       .chunks_per_shard = 4,
       .name = "x",
-      .unit = NULL, // should default to "index"
-      .scale = 0.0, // should default to 1.0
       .downsample = 1,
-      .storage_position = 2 },
+      .storage_position = 2,
+      .ngff = { .unit = NULL, .scale = 0.0 } }, // defaults: "index", 1.0
   };
 
   struct zarr_multiscale_config cfg = {


### PR DESCRIPTION
## Summary
- Add `struct omengff_axis` with `unit`, `scale`, and `type` fields for OME-NGFF v0.5 axis metadata
- Nest it as `ngff` inside `struct dimension`, separating metadata from chunking/sharding config
- `zarr_multiscale_group_json` now emits `"unit"` on axes (defaults to `"index"`) and uses `dimension.ngff.scale` in coordinateTransformations
- Precompute per-axis scale/translation in a single loop instead of duplicating factor logic

Closes #12

## Test plan
- [x] New `test_multiscale_unit_scale` verifies explicit unit/scale values in group JSON
- [x] Existing `test_multiscale_metadata` checks default `"unit":"index"` path