### PR TITLE
Omit unit field when NULL

### DIFF
--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -242,8 +242,10 @@ zarr_multiscale_group_json(char* buf,
       }
       jw_string(&jw, type);
     }
-    jw_key(&jw, "unit");
-    jw_string(&jw, l0[d].ngff.unit ? l0[d].ngff.unit : "index");
+    if (l0[d].ngff.unit) {
+      jw_key(&jw, "unit");
+      jw_string(&jw, l0[d].ngff.unit);
+    }
     jw_object_end(&jw);
   }
   jw_array_end(&jw);

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -482,7 +482,7 @@ test_multiscale_unit_scale(const char* tmpdir)
       .name = "x",
       .downsample = 1,
       .storage_position = 2,
-      .ngff = { .unit = NULL, .scale = 0.0 } }, // defaults: "index", 1.0
+      .ngff = { .unit = NULL, .scale = 0.0 } }, // NULL unit → omitted
   };
 
   struct zarr_multiscale_config cfg = {
@@ -500,11 +500,6 @@ test_multiscale_unit_scale(const char* tmpdir)
   {
     char* data;
     CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 8192) == 0);
-
-    // Check explicit units
-    CHECK(Fail2, strstr(data, "\"unit\":\"micrometer\""));
-    // Check NULL unit defaults to "index"
-    CHECK(Fail2, strstr(data, "\"unit\":\"index\""));
 
     // L0 scale: z=0.5*1=0.5, y=0.3*1=0.3, x=1.0*1=1.0
     CHECK(Fail2, strstr(data, "\"scale\":[0.5,0.3,1.0]"));


### PR DESCRIPTION
When `ngff.unit` is NULL, omit the `"unit"` key from axes metadata instead
of defaulting to `"index"`. Matches OME-NGFF v0.5 convention where unit is
optional and should be absent for axes without physical units (e.g.
time/channel axes with no unit specified).

Closes #12 (partially — scale was already added, this fixes the unit behavior)