### PR TITLE
Fix final shape for append dims

### DIFF
--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -700,13 +700,6 @@ cpu_flush(struct writer* self)
   }
 
   // Emit partial shards.
-  uint64_t append_chunks[LOD_MAX_LEVELS];
-  for (int lv = 0; lv < s->levels.nlod; ++lv) {
-    struct shard_state* ss = &s->shard[lv];
-    append_chunks[lv] =
-      ss->shard_epoch * ss->chunks_per_shard_append + ss->epoch_in_shard;
-  }
-
   {
     struct platform_clock emit_clk = { 0 };
     platform_toc(&emit_clk);
@@ -731,11 +724,8 @@ cpu_flush(struct writer* self)
     const uint8_t na = dim_info_n_append(&s->cl.dims);
     for (int lv = 0; lv < s->levels.nlod; ++lv) {
       uint64_t append_sizes[HALF_MAX_RANK];
-      dim_info_decompose_append_sizes(
-        &s->cl.dims, append_chunks[lv], append_sizes);
-      if (lv == 0)
-        append_sizes[0] =
-          dim_info_exact_dim0(&s->cl.dims, s->cursor_elements);
+      dim_info_final_append_sizes(
+        &s->cl.dims, s->cursor_elements, lv, append_sizes);
       if (s->shard_sink->update_append(
             s->shard_sink, (uint8_t)lv, na, append_sizes))
         return writer_error();

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -733,6 +733,9 @@ cpu_flush(struct writer* self)
       uint64_t append_sizes[HALF_MAX_RANK];
       dim_info_decompose_append_sizes(
         &s->cl.dims, append_chunks[lv], append_sizes);
+      if (lv == 0)
+        append_sizes[0] =
+          dim_info_exact_dim0(&s->cl.dims, s->cursor_elements);
       if (s->shard_sink->update_append(
             s->shard_sink, (uint8_t)lv, na, append_sizes))
         return writer_error();

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -222,6 +222,8 @@ tile_stream_gpu_flush(struct writer* self)
       uint64_t append_sizes[HALF_MAX_RANK];
       dim_info_decompose_append_sizes(
         &s->dims, append_chunks[lv], append_sizes);
+      if (lv == 0)
+        append_sizes[0] = dim_info_exact_dim0(&s->dims, s->cursor);
       if (s->shard_sink->update_append(
             s->shard_sink, (uint8_t)lv, na, append_sizes))
         return writer_error();

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -37,7 +37,7 @@ dispatch_ingest(struct tile_stream_gpu* s)
     return ingest_dispatch_multiscale(&s->stage,
                                       s->lod.d_linear,
                                       s->layout.epoch_elements,
-                                      &s->cursor,
+                                      &s->cursor_elements,
                                       dtype_bpe(s->config.dtype),
                                       s->streams.h2d,
                                       s->streams.compute);
@@ -47,7 +47,7 @@ dispatch_ingest(struct tile_stream_gpu* s)
                                    &s->lod.layout_gpu[0],
                                    current_pool_epoch(s, s->batch.accumulated),
                                    s->pools.ready[s->pools.current],
-                                   &s->cursor,
+                                   &s->cursor_elements,
                                    dtype_bpe(s->config.dtype),
                                    s->streams.h2d,
                                    s->streams.compute);
@@ -70,11 +70,11 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
   const uint8_t* src = (const uint8_t*)input.beg;
   const uint8_t* end = (const uint8_t*)input.end;
 
-  const uint64_t max_cursor = s->max_cursor;
+  const uint64_t max_cursor_elements = s->max_cursor_elements;
 
   while (src < end) {
     // Bounded append dims: check capacity
-    if (max_cursor > 0 && s->cursor >= max_cursor) {
+    if (max_cursor_elements > 0 && s->cursor_elements >= max_cursor_elements) {
       struct writer_result fr = tile_stream_gpu_flush(&s->writer);
       if (fr.error)
         return writer_error_at(src, end);
@@ -82,14 +82,16 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
     }
 
     const uint64_t epoch_remaining =
-      s->layout.epoch_elements - (s->cursor % s->layout.epoch_elements);
+      s->layout.epoch_elements -
+      (s->cursor_elements % s->layout.epoch_elements);
     const uint64_t input_remaining = (uint64_t)(end - src) / bytes_per_element;
     uint64_t elements_this_pass =
       epoch_remaining < input_remaining ? epoch_remaining : input_remaining;
 
     // Bounded append dims: clamp to remaining capacity
-    if (max_cursor > 0) {
-      const uint64_t remaining_capacity = max_cursor - s->cursor;
+    if (max_cursor_elements > 0) {
+      const uint64_t remaining_capacity =
+        max_cursor_elements - s->cursor_elements;
       if (elements_this_pass > remaining_capacity)
         elements_this_pass = remaining_capacity;
     }
@@ -108,7 +110,7 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
           struct staging_slot* ss = &s->stage.slot[si];
           CU(Error, cuEventSynchronize(ss->t_h2d_end));
 
-          if (s->cursor > 0) {
+          if (s->cursor_elements > 0) {
             accumulate_metric_cu(&s->metrics.h2d,
                                  ss->t_h2d_start,
                                  ss->t_h2d_end,
@@ -146,7 +148,8 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
     }
     src += bytes_this_pass;
 
-    if (s->cursor % s->layout.epoch_elements == 0 && s->cursor > 0) {
+    if (s->cursor_elements % s->layout.epoch_elements == 0 &&
+        s->cursor_elements > 0) {
       struct writer_result fr = flush_accumulate_epoch(s);
       if (fr.error)
         return writer_error_at(src, end);
@@ -177,7 +180,7 @@ tile_stream_gpu_flush(struct writer* self)
     return r;
 
   // Flush any partial epoch first (sub-epoch data)
-  if (s->cursor % s->layout.epoch_elements != 0) {
+  if (s->cursor_elements % s->layout.epoch_elements != 0) {
     // run_lod + record pool event + increment epochs_accumulated
     if (flush_run_epoch_lod(s))
       return writer_error();
@@ -197,15 +200,6 @@ tile_stream_gpu_flush(struct writer* self)
   if (r.error)
     return r;
 
-  // Capture actual append chunk counts before partial shard emission,
-  // since finalize_shards resets epoch_in_shard and increments shard_epoch.
-  uint64_t append_chunks[LOD_MAX_LEVELS];
-  for (int lv = 0; lv < s->levels.nlod; ++lv) {
-    struct shard_state* ss = &s->compress_agg.levels[lv].shard;
-    append_chunks[lv] =
-      ss->shard_epoch * ss->chunks_per_shard_append + ss->epoch_in_shard;
-  }
-
   // Emit partial shards for all levels
   for (int lv = 0; lv < s->levels.nlod; ++lv) {
     if (s->compress_agg.levels[lv].shard.epoch_in_shard > 0) {
@@ -220,10 +214,8 @@ tile_stream_gpu_flush(struct writer* self)
     const uint8_t na = dim_info_n_append(&s->dims);
     for (int lv = 0; lv < s->levels.nlod; ++lv) {
       uint64_t append_sizes[HALF_MAX_RANK];
-      dim_info_decompose_append_sizes(
-        &s->dims, append_chunks[lv], append_sizes);
-      if (lv == 0)
-        append_sizes[0] = dim_info_exact_dim0(&s->dims, s->cursor);
+      dim_info_final_append_sizes(
+        &s->dims, s->cursor_elements, lv, append_sizes);
       if (s->shard_sink->update_append(
             s->shard_sink, (uint8_t)lv, na, append_sizes))
         return writer_error();

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -244,14 +244,14 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
 
   CU(FailPhase2, cuStreamSynchronize(out->streams.compute));
 
-  // Precompute max_cursor so append doesn't recompute each call.
+  // Precompute max_cursor_elements so append doesn't recompute each call.
   {
     const struct dimension* dims = config->dimensions;
     const uint8_t na = dim_info_n_append(&out->dims);
     if (dims[0].size > 0) {
-      out->max_cursor = out->layout.epoch_elements;
+      out->max_cursor_elements = out->layout.epoch_elements;
       for (int d = 0; d < na; ++d)
-        out->max_cursor *= ceildiv(dims[d].size, dims[d].chunk_size);
+        out->max_cursor_elements *= ceildiv(dims[d].size, dims[d].chunk_size);
     }
   }
 
@@ -289,7 +289,7 @@ tile_stream_gpu_writer(struct tile_stream_gpu* s)
 uint64_t
 tile_stream_gpu_cursor(const struct tile_stream_gpu* s)
 {
-  return s->cursor;
+  return s->cursor_elements;
 }
 
 struct tile_stream_status

--- a/src/gpu/stream.internal.h
+++ b/src/gpu/stream.internal.h
@@ -169,8 +169,8 @@ struct tile_stream_gpu
 
   struct pool_state pools;
   struct staging_state stage;
-  uint64_t cursor;
-  uint64_t max_cursor; // 0 = unbounded
+  uint64_t cursor_elements;
+  uint64_t max_cursor_elements; // 0 = unbounded
   struct stream_metrics metrics;
   struct platform_clock metadata_update_clock;
 };

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -842,14 +842,9 @@ finalize_all_shards(struct multiarray_tile_stream_cpu* ms)
     if (desc->sink->update_append) {
       const uint8_t na = dim_info_n_append(&desc->cl.dims);
       for (int lv = 0; lv < desc->levels.nlod; ++lv) {
-        struct shard_state* ss = &desc->shard[lv];
-        uint64_t total_ac =
-          ss->shard_epoch * ss->chunks_per_shard_append + ss->epoch_in_shard;
         uint64_t append_sizes[HALF_MAX_RANK];
-        dim_info_decompose_append_sizes(&desc->cl.dims, total_ac, append_sizes);
-        if (lv == 0)
-          append_sizes[0] =
-            dim_info_exact_dim0(&desc->cl.dims, desc->cursor_elements);
+        dim_info_final_append_sizes(
+          &desc->cl.dims, desc->cursor_elements, lv, append_sizes);
         if (desc->sink->update_append(
               desc->sink, (uint8_t)lv, na, append_sizes))
           return 1;

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -847,6 +847,9 @@ finalize_all_shards(struct multiarray_tile_stream_cpu* ms)
           ss->shard_epoch * ss->chunks_per_shard_append + ss->epoch_in_shard;
         uint64_t append_sizes[HALF_MAX_RANK];
         dim_info_decompose_append_sizes(&desc->cl.dims, total_ac, append_sizes);
+        if (lv == 0)
+          append_sizes[0] =
+            dim_info_exact_dim0(&desc->cl.dims, desc->cursor_elements);
         if (desc->sink->update_append(
               desc->sink, (uint8_t)lv, na, append_sizes))
           return 1;

--- a/src/stream/dim_info.h
+++ b/src/stream/dim_info.h
@@ -66,20 +66,36 @@ dim_info_decompose_append_sizes(const struct dim_info* info,
                                 uint64_t total_append_chunks,
                                 uint64_t* append_sizes);
 
-// Compute the exact dim 0 extent from a flat element cursor.
-// Returns cursor_elements / product(dim[d].size for d=1..rank-1).
-// Use this to fix up append_sizes[0] after decompose_append_sizes when
-// the exact cursor is known (e.g. at final flush).
-static inline uint64_t
-dim_info_exact_dim0(const struct dim_info* info, uint64_t cursor_elements)
+// Compute exact append dim sizes for final metadata.
+//
+// Bounded append dims (1..n_append-1) report their declared size.
+// Dim 0: derived from cursor_elements / product(all other dim sizes).
+// For LOD level > 0 with append_downsample: ceildiv(dim0, 2^level).
+//
+// Precondition: cursor_elements is a multiple of the inner-dim product
+// (no partial frames).
+static inline void
+dim_info_final_append_sizes(const struct dim_info* info,
+                            uint64_t cursor_elements,
+                            int level,
+                            uint64_t* append_sizes)
 {
+  for (const struct dimension* d = info->append.beg + 1; d < info->append.end;
+       ++d)
+    append_sizes[dim_index(info, d)] = d->size;
+
   uint64_t inner = 1;
   for (const struct dimension* d = info->append.beg + 1; d < info->append.end;
        ++d)
     inner *= d->size;
   for (const struct dimension* d = info->inner.beg; d < info->inner.end; ++d)
     inner *= d->size;
-  return inner > 0 ? cursor_elements / inner : 0;
+  uint64_t dim0 = inner > 0 ? cursor_elements / inner : 0;
+
+  if (level > 0 && info->append_downsample)
+    dim0 = (dim0 + ((1ull << level) - 1)) >> level;
+
+  append_sizes[0] = dim0;
 }
 
 // Partition dims into append/inner, validate constraints, precompute

--- a/src/stream/dim_info.h
+++ b/src/stream/dim_info.h
@@ -66,6 +66,22 @@ dim_info_decompose_append_sizes(const struct dim_info* info,
                                 uint64_t total_append_chunks,
                                 uint64_t* append_sizes);
 
+// Compute the exact dim 0 extent from a flat element cursor.
+// Returns cursor_elements / product(dim[d].size for d=1..rank-1).
+// Use this to fix up append_sizes[0] after decompose_append_sizes when
+// the exact cursor is known (e.g. at final flush).
+static inline uint64_t
+dim_info_exact_dim0(const struct dim_info* info, uint64_t cursor_elements)
+{
+  uint64_t inner = 1;
+  for (const struct dimension* d = info->append.beg + 1; d < info->append.end;
+       ++d)
+    inner *= d->size;
+  for (const struct dimension* d = info->inner.beg; d < info->inner.end; ++d)
+    inner *= d->size;
+  return inner > 0 ? cursor_elements / inner : 0;
+}
+
 // Partition dims into append/inner, validate constraints, precompute
 // derived values. Returns 0 on success.
 //

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -460,6 +460,86 @@ Error:
   return !ok;
 }
 
+static int
+test_dim_info_final_append_sizes(void)
+{
+  // Bug scenario: 12 frames with chunk_size=5 should report 12, not 15.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 0, 64, 64 };
+  dims_create(dims, "tyx", sizes);
+  uint64_t cs[] = { 5, 32, 32 };
+  dims_set_chunk_sizes(dims, 3, cs);
+  dims[0].chunks_per_shard = 4;
+
+  struct dim_info info;
+  CHECK(Error, dim_info_init(&info, dims, 3) == 0);
+
+  // 12 frames of 64x64
+  uint64_t cursor = 12 * 64 * 64;
+  uint64_t append_sizes[1];
+
+  // Level 0: exact dim0 = 12 (not ceildiv(12,5)*5 = 15)
+  dim_info_final_append_sizes(&info, cursor, 0, append_sizes);
+  CHECK(Error, append_sizes[0] == 12);
+
+  // Without append_downsample, all levels report the same dim0
+  dim_info_final_append_sizes(&info, cursor, 1, append_sizes);
+  CHECK(Error, append_sizes[0] == 12);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_dim_info_final_append_sizes_lod(void)
+{
+  // With append_downsample, LOD levels halve dim 0.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 0, 64, 64 };
+  dims_create(dims, "tyx", sizes);
+  uint64_t cs[] = { 1, 32, 32 };
+  dims_set_chunk_sizes(dims, 3, cs);
+  dims[0].chunks_per_shard = 4;
+  dims_set_downsample_by_name(dims, 3, "tyx");
+
+  struct dim_info info;
+  CHECK(Error, dim_info_init(&info, dims, 3) == 0);
+  CHECK(Error, info.append_downsample == 1);
+
+  uint64_t cursor = 12 * 64 * 64;
+  uint64_t append_sizes[1];
+
+  // Level 0: exact
+  dim_info_final_append_sizes(&info, cursor, 0, append_sizes);
+  CHECK(Error, append_sizes[0] == 12);
+
+  // Level 1: ceildiv(12, 2) = 6
+  dim_info_final_append_sizes(&info, cursor, 1, append_sizes);
+  CHECK(Error, append_sizes[0] == 6);
+
+  // Level 2: ceildiv(12, 4) = 3
+  dim_info_final_append_sizes(&info, cursor, 2, append_sizes);
+  CHECK(Error, append_sizes[0] == 3);
+
+  // Level 3: ceildiv(12, 8) = 2
+  dim_info_final_append_sizes(&info, cursor, 3, append_sizes);
+  CHECK(Error, append_sizes[0] == 2);
+
+  // Odd count: 11 frames
+  cursor = 11 * 64 * 64;
+  dim_info_final_append_sizes(&info, cursor, 1, append_sizes);
+  CHECK(Error, append_sizes[0] == 6); // ceildiv(11, 2)
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
 int
 main(void)
 {
@@ -487,6 +567,8 @@ main(void)
     { "dim_info_three_append", test_dim_info_three_append },
     { "dim_info_rejects_unbounded_non_dim0",
       test_dim_info_rejects_unbounded_non_dim0 },
+    { "dim_info_final_append_sizes", test_dim_info_final_append_sizes },
+    { "dim_info_final_append_sizes_lod", test_dim_info_final_append_sizes_lod },
   };
   for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
     int r = tests[i].fn();

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -487,6 +487,29 @@ test_dim_info_final_append_sizes(void)
   dim_info_final_append_sizes(&info, cursor, 1, append_sizes);
   CHECK(Error, append_sizes[0] == 12);
 
+  // n_append=2: "tzyx", chunk (1,1,64,64), z bounded at size=10
+  {
+    struct dimension dims2[4];
+    uint64_t sizes2[] = { 0, 10, 128, 128 };
+    dims_create(dims2, "tzyx", sizes2);
+    uint64_t cs2[] = { 1, 1, 64, 64 };
+    dims_set_chunk_sizes(dims2, 4, cs2);
+    dims2[0].chunks_per_shard = 4;
+    dims2[1].chunks_per_shard = 10;
+    dims_set_downsample_by_name(dims2, 4, "yx");
+
+    struct dim_info info2;
+    CHECK(Error, dim_info_init(&info2, dims2, 4) == 0);
+    CHECK(Error, dim_info_n_append(&info2) == 2);
+
+    // 7 frames of 10×128×128
+    uint64_t cursor2 = 7 * 10 * 128 * 128;
+    uint64_t as2[2];
+    dim_info_final_append_sizes(&info2, cursor2, 0, as2);
+    CHECK(Error, as2[0] == 7);  // dim 0: exact from cursor
+    CHECK(Error, as2[1] == 10); // dim 1: bounded, declared size
+  }
+
   ok = 1;
 Error:
   REPORT_TEST(ok);


### PR DESCRIPTION
The final metadata update for unbounded append dimensions reported the
chunk-padded extent instead of the actual element count. For example,
12 frames with chunk_size=5 reported shape[0]=15 instead of 12.

Fix: at flush time, override append_sizes[0] with the exact count
derived from the element cursor, rather than the chunk-rounded value
from decompose_append_sizes.

Affects CPU stream, GPU stream, and multiarray flush paths.