### PR TITLE
Fix LOD level count termination

### DIFF
--- a/src/lod/lod_plan.c
+++ b/src/lod/lod_plan.c
@@ -141,18 +141,19 @@ lod_segment(const struct lod_plan* p, int level)
   return (struct lod_span){ .beg = next.beg - base, .end = next.end - base };
 }
 
-// Would halving produce a level where any LOD dim < its chunk size?
+// Are all LOD dims already at 1 chunk or fewer?
+// Stop generating levels when every dim fits in a single chunk.
 static int
-next_level_below_chunk(int lod_ndim,
-                       const uint64_t* lod_shape,
-                       const uint64_t* lod_chunk)
+all_chunks_le_one(int lod_ndim,
+                  const uint64_t* lod_shape,
+                  const uint64_t* lod_chunk)
 {
   for (int d = 0; d < lod_ndim; ++d) {
-    uint64_t next = (lod_shape[d] + 1) / 2;
-    if (next < lod_chunk[d])
-      return 1;
+    uint64_t nchunks = (lod_shape[d] + lod_chunk[d] - 1) / lod_chunk[d];
+    if (nchunks > 1)
+      return 0;
   }
-  return 0;
+  return 1;
 }
 
 int
@@ -249,9 +250,8 @@ lod_plan_init_shapes(struct lod_plan* p,
 
   p->nlod = 1;
   while (p->nlod < max_levels &&
-         !is_all_ones(p->lod_ndim, p->lod_shapes[p->nlod - 1]) &&
-         !next_level_below_chunk(
-           p->lod_ndim, p->lod_shapes[p->nlod - 1], lod_chunk)) {
+         !all_chunks_le_one(p->lod_ndim, p->lod_shapes[p->nlod - 1],
+                            lod_chunk)) {
     for (int k = 0; k < p->lod_ndim; ++k)
       p->lod_shapes[p->nlod][k] = (p->lod_shapes[p->nlod - 1][k] + 1) / 2;
     memcpy(p->shapes[p->nlod],

--- a/src/lod/lod_plan.c
+++ b/src/lod/lod_plan.c
@@ -17,15 +17,6 @@ clamped_extent(uint64_t shape_d, uint64_t lo, uint64_t scale)
   return (e < scale) ? e : scale;
 }
 
-static int
-is_all_ones(int n, const uint64_t* v)
-{
-  for (int d = 0; d < n; ++d)
-    if (v[d] > 1)
-      return 0;
-  return 1;
-}
-
 uint64_t
 morton_rank(int ndim, const uint64_t* shape, const uint64_t* coords, int depth)
 {
@@ -149,7 +140,7 @@ all_chunks_le_one(int lod_ndim,
                   const uint64_t* lod_chunk)
 {
   for (int d = 0; d < lod_ndim; ++d) {
-    uint64_t nchunks = (lod_shape[d] + lod_chunk[d] - 1) / lod_chunk[d];
+    uint64_t nchunks = ceildiv(lod_shape[d], lod_chunk[d]);
     if (nchunks > 1)
       return 0;
   }
@@ -249,9 +240,9 @@ lod_plan_init_shapes(struct lod_plan* p,
     lod_chunk[k] = chunk_shape ? chunk_shape[p->lod_map[k]] : 1;
 
   p->nlod = 1;
-  while (p->nlod < max_levels &&
-         !all_chunks_le_one(p->lod_ndim, p->lod_shapes[p->nlod - 1],
-                            lod_chunk)) {
+  while (
+    p->nlod < max_levels &&
+    !all_chunks_le_one(p->lod_ndim, p->lod_shapes[p->nlod - 1], lod_chunk)) {
     for (int k = 0; k < p->lod_ndim; ++k)
       p->lod_shapes[p->nlod][k] = (p->lod_shapes[p->nlod - 1][k] + 1) / 2;
     memcpy(p->shapes[p->nlod],

--- a/tests/test_lod_cpu.c
+++ b/tests/test_lod_cpu.c
@@ -197,6 +197,84 @@ Fail:
   return 1;
 }
 
+// Verify nlod for a given (shape, chunk, mask) matches expected.
+static int
+check_nlod(const char* label,
+           int ndim,
+           const uint64_t* shape,
+           const uint64_t* chunk_shape,
+           uint32_t lod_mask,
+           int expected_nlod)
+{
+  log_info("=== %s ===", label);
+  struct lod_plan plan;
+  CHECK(Fail,
+        lod_plan_init_shapes(&plan, ndim, shape, chunk_shape, lod_mask, 32) ==
+          0);
+  if (plan.nlod != expected_nlod) {
+    log_error("  expected nlod=%d, got nlod=%d", expected_nlod, plan.nlod);
+    goto Fail;
+  }
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+// Regression: shape > chunk > shape/2 must still generate an extra level.
+// Old code stopped early because it checked whether the *next* halved shape
+// would fall below chunk size, missing the valid level where shape <= chunk.
+static int
+test_level_count_regression(void)
+{
+  int rc = 0;
+  // 1D: shape=9, chunk=8 → 2 chunks at L0 → halve to 5 (1 chunk) → nlod=2
+  rc |=
+    check_nlod("nlod_1d_9c8", 1, (uint64_t[]){ 9 }, (uint64_t[]){ 8 }, 0x1, 2);
+  // 2D: one dim needs extra level, other already fits
+  // dim0: shape=9, chunk=8 → 2 chunks; dim1: shape=3, chunk=4 → 1 chunk
+  // L0: (9,3) → dim0 has 2 chunks → continue
+  // L1: (5,2) → dim0 has 1 chunk → stop → nlod=2
+  rc |= check_nlod(
+    "nlod_2d_asym", 2, (uint64_t[]){ 9, 3 }, (uint64_t[]){ 8, 4 }, 0x3, 2);
+  return rc;
+}
+
+// shape <= chunk should produce nlod=1 (no additional levels).
+static int
+test_level_count_shape_le_chunk(void)
+{
+  int rc = 0;
+  // shape == chunk → 1 chunk → nlod=1
+  rc |= check_nlod("nlod_eq", 1, (uint64_t[]){ 8 }, (uint64_t[]){ 8 }, 0x1, 1);
+  // shape < chunk → 1 chunk → nlod=1
+  rc |= check_nlod("nlod_lt", 1, (uint64_t[]){ 3 }, (uint64_t[]){ 8 }, 0x1, 1);
+  // 2D: both dims fit in 1 chunk
+  rc |= check_nlod(
+    "nlod_2d_le", 2, (uint64_t[]){ 4, 6 }, (uint64_t[]){ 8, 8 }, 0x3, 1);
+  return rc;
+}
+
+// max_levels should cap the level count.
+static int
+test_level_count_max_levels(void)
+{
+  log_info("=== nlod_max_levels ===");
+  // shape=256, chunk=1 → would need 9 levels to reach 1 chunk.
+  // Cap at max_levels=3.
+  struct lod_plan plan;
+  CHECK(Fail,
+        lod_plan_init_shapes(
+          &plan, 1, (uint64_t[]){ 256 }, (uint64_t[]){ 1 }, 0x1, 3) == 0);
+  CHECK(Fail, plan.nlod == 3);
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
 int
 main(int ac, char* av[])
 {
@@ -209,5 +287,8 @@ main(int ac, char* av[])
   rc |= test_scatter_reduce_f32(lod_reduce_max, "f32_max");
   rc |= test_scatter_reduce_u16();
   rc |= test_f16_rejected();
+  rc |= test_level_count_regression();
+  rc |= test_level_count_shape_le_chunk();
+  rc |= test_level_count_max_levels();
   return rc;
 }


### PR DESCRIPTION
The LOD halving loop stopped when any dim's next level would be smaller than
its chunk size. This prevented generating valid levels where the array fits
in a single (partial) chunk.

Replace `next_level_below_chunk` with `all_chunks_le_one`: stop when every
LOD dim already has chunk count <= 1, not when array size < chunk size.

Example: y=48, chunk=16. Old: 48→24→stop (12<16). New: 48→24→12→stop
(ceil(12/16)=1, single chunk).