### PR TITLE
Allow NULL array_name in fs sink

### DIFF
--- a/src/lod/lod_plan.c
+++ b/src/lod/lod_plan.c
@@ -141,18 +141,19 @@ lod_segment(const struct lod_plan* p, int level)
   return (struct lod_span){ .beg = next.beg - base, .end = next.end - base };
 }
 
-// Would halving produce a level where any LOD dim < its chunk size?
+// Are all LOD dims already at 1 chunk or fewer?
+// Stop generating levels when every dim fits in a single chunk.
 static int
-next_level_below_chunk(int lod_ndim,
-                       const uint64_t* lod_shape,
-                       const uint64_t* lod_chunk)
+all_chunks_le_one(int lod_ndim,
+                  const uint64_t* lod_shape,
+                  const uint64_t* lod_chunk)
 {
   for (int d = 0; d < lod_ndim; ++d) {
-    uint64_t next = (lod_shape[d] + 1) / 2;
-    if (next < lod_chunk[d])
-      return 1;
+    uint64_t nchunks = (lod_shape[d] + lod_chunk[d] - 1) / lod_chunk[d];
+    if (nchunks > 1)
+      return 0;
   }
-  return 0;
+  return 1;
 }
 
 int
@@ -249,9 +250,8 @@ lod_plan_init_shapes(struct lod_plan* p,
 
   p->nlod = 1;
   while (p->nlod < max_levels &&
-         !is_all_ones(p->lod_ndim, p->lod_shapes[p->nlod - 1]) &&
-         !next_level_below_chunk(
-           p->lod_ndim, p->lod_shapes[p->nlod - 1], lod_chunk)) {
+         !all_chunks_le_one(p->lod_ndim, p->lod_shapes[p->nlod - 1],
+                            lod_chunk)) {
     for (int k = 0; k < p->lod_ndim; ++k)
       p->lod_shapes[p->nlod][k] = (p->lod_shapes[p->nlod - 1][k] + 1) / 2;
     memcpy(p->shapes[p->nlod],

--- a/src/zarr/zarr_fs_sink.c
+++ b/src/zarr/zarr_fs_sink.c
@@ -386,7 +386,6 @@ zarr_fs_sink_create(const struct zarr_config* cfg)
 {
   CHECK(Fail, cfg);
   CHECK(Fail, cfg->store_path);
-  CHECK(Fail, cfg->array_name);
   CHECK(Fail, cfg->rank > 0 && cfg->rank <= MAX_ZARR_RANK);
   CHECK(Fail, cfg->dimensions);
 
@@ -428,11 +427,15 @@ zarr_fs_sink_create(const struct zarr_config* cfg)
   }
 
   // Build array directory path
-  snprintf(zs->array_dir,
-           sizeof(zs->array_dir),
-           "%s/%s",
-           cfg->store_path,
-           cfg->array_name);
+  if (cfg->array_name)
+    snprintf(zs->array_dir,
+             sizeof(zs->array_dir),
+             "%s/%s",
+             cfg->store_path,
+             cfg->array_name);
+  else
+    snprintf(
+      zs->array_dir, sizeof(zs->array_dir), "%s", cfg->store_path);
 
   // Create directory tree: ensure shard directories exist.
   // shard_inner_count = prod(shard_count[d] for d >= n_append).
@@ -469,7 +472,8 @@ zarr_fs_sink_create(const struct zarr_config* cfg)
   }
 
   // Write metadata
-  CHECK(Fail_alloc, write_root_metadata_file(cfg->store_path) == 0);
+  if (cfg->array_name)
+    CHECK(Fail_alloc, write_root_metadata_file(cfg->store_path) == 0);
   CHECK(Fail_alloc,
         write_array_metadata_file(zs->array_dir,
                                   zs->rank,


### PR DESCRIPTION
When array_name is NULL, write the array directly at store_path (no
subdirectory). Supports the flat-at-root layout for single non-multiscale
arrays.

Skip writing root group metadata when there is no parent group.

see also discussion in acquire-project/acquire-zarr#211