### PR TITLE
Fix LOD scale to use pow(2, level)

### DIFF
--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -264,11 +264,10 @@ zarr_multiscale_group_json(char* buf,
     for (int d = 0; d < rank; ++d) {
       double phys = l0[d].ngff.scale > 0 ? l0[d].ngff.scale : 1.0;
       double factor = 1.0;
-      if (l0[d].downsample && level_dims[lv][d].size > 0) {
-        if (l0[d].size == 0)
-          factor = (double)(1u << lv);
-        else
-          factor = (double)l0[d].size / (double)level_dims[lv][d].size;
+      _Static_assert(LOD_MAX_LEVELS <= 32,
+                     "1u << lv overflows for > 32 levels");
+      if (l0[d].downsample) {
+        factor = (double)(1u << lv);
       }
       scale[d] = phys * factor;
       translation[d] = 0.5 * phys * (factor - 1.0);

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -409,7 +409,6 @@ test_multiscale_metadata(const char* tmpdir)
     CHECK(Fail2, strstr(data, "\"path\":\"0\""));
     CHECK(Fail2, strstr(data, "\"path\":\"1\""));
     CHECK(Fail2, strstr(data, "\"coordinateTransformations\""));
-    CHECK(Fail2, strstr(data, "\"unit\":\"index\""));
     free(data);
   }
 

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -454,6 +454,72 @@ Fail:
   return 1;
 }
 
+// --- Test: non-power-of-2 sizes get pow(2,level) scale, not shape ratio ---
+
+static int
+test_multiscale_scale_non_pow2(const char* tmpdir)
+{
+  log_info("=== test_multiscale_scale_non_pow2 ===");
+
+  // x=6 (non-power-of-2): L0 x=6, L1 x=3, L2 x=2.
+  // Old code gave scale ratio 6/3=2, 6/2=3. Correct: 2, 4.
+  struct dimension dims[] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 4,
+      .name = "z",
+      .storage_position = 0 },
+    { .size = 6,
+      .chunk_size = 2,
+      .chunks_per_shard = 1,
+      .name = "y",
+      .downsample = 1,
+      .storage_position = 1 },
+    { .size = 6,
+      .chunk_size = 2,
+      .chunks_per_shard = 1,
+      .name = "x",
+      .downsample = 1,
+      .storage_position = 2 },
+  };
+
+  struct zarr_multiscale_config cfg = {
+    .store_path = tmpdir,
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .nlod = 0,
+  };
+
+  struct zarr_fs_multiscale_sink* ms = zarr_fs_multiscale_sink_create(&cfg);
+  CHECK(Fail, ms);
+
+  {
+    char* data;
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 8192) == 0);
+
+    // L0: scale [1,1,1]
+    CHECK(Fail2, strstr(data, "\"scale\":[1.0,1.0,1.0]"));
+    // L1: z=1, y=2, x=2
+    CHECK(Fail2, strstr(data, "\"scale\":[1.0,2.0,2.0]"));
+    // L2: z=1, y=4 (not 3!), x=4 (not 3!)
+    CHECK(Fail2, strstr(data, "\"scale\":[1.0,4.0,4.0]"));
+
+    free(data);
+  }
+
+  zarr_fs_multiscale_sink_destroy(ms);
+  log_info("  PASS");
+  return 0;
+
+Fail2:
+  zarr_fs_multiscale_sink_destroy(ms);
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
 // --- Test: unit and scale in multiscale metadata ---
 
 static int
@@ -1878,6 +1944,14 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/msmeta", tmpdir);
     test_mkdir(sub);
     ecode |= test_multiscale_metadata(sub);
+  }
+
+  // Multiscale scale with non-power-of-2 sizes (no CUDA needed)
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/msscalenp2", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_multiscale_scale_non_pow2(sub);
   }
 
   // Multiscale unit/scale metadata test (no CUDA needed)


### PR DESCRIPTION
## Summary
- Use `1 << level` instead of `l0_size / lv_size` for LOD coordinate transform scale factor. The ratio of actual shapes gives wrong values for non-power-of-2 array sizes due to ceil-rounding after replicate-pad downsampling.
- Remove incorrect test assertion checking for `"unit":"index"` when no `.ngff.unit` is set.

Closes #21

## Test plan
- [x] `test_zarr_fs_sink` passes
- [x] `test_cpu_zarr_fs` passes