### PR TITLE
Write intermediate group zarr.json

### DIFF
--- a/src/zarr/zarr_fs_sink.c
+++ b/src/zarr/zarr_fs_sink.c
@@ -404,9 +404,11 @@ zarr_fs_sink_create(const struct zarr_config* cfg)
   CHECK(Fail, cfg->store_path);
   CHECK(Fail, cfg->rank > 0 && cfg->rank <= MAX_ZARR_RANK);
   CHECK(Fail, cfg->dimensions);
-  // Ensure composed paths (store_path/array_name/zarr.json) fit in 4096
   if (cfg->array_name)
-    CHECK(Fail, strlen(cfg->store_path) + strlen(cfg->array_name) + 12 < 4096);
+    CHECK(Fail,
+          strlen(cfg->store_path) + 1 + strlen(cfg->array_name) +
+              sizeof("/zarr.json") <
+            4096);
 
   struct zarr_fs_sink* zs = (struct zarr_fs_sink*)calloc(1, sizeof(*zs));
   CHECK(Fail, zs);
@@ -679,7 +681,10 @@ zarr_fs_multiscale_sink_create(const struct zarr_multiscale_config* cfg)
   CHECK(Fail, cfg->rank > 0 && cfg->rank <= MAX_ZARR_RANK);
   CHECK(Fail, cfg->dimensions);
   if (cfg->array_name)
-    CHECK(Fail, strlen(cfg->store_path) + strlen(cfg->array_name) + 12 < 4096);
+    CHECK(Fail,
+          strlen(cfg->store_path) + 1 + strlen(cfg->array_name) +
+              sizeof("/zarr.json") <
+            4096);
 
   // Build group path: store_path/array_name when array_name is set
   char group_path[4096];

--- a/src/zarr/zarr_fs_sink.c
+++ b/src/zarr/zarr_fs_sink.c
@@ -338,6 +338,42 @@ write_array_metadata_file(const char* array_dir,
   return write_file(path, buf, (size_t)len);
 }
 
+// Write group zarr.json for each intermediate directory in array_name.
+// For array_name = "path/to/data", writes group metadata at:
+//   {store_path}/path/zarr.json
+//   {store_path}/path/to/zarr.json
+static int
+write_intermediate_group_metadata(const char* store_path,
+                                  const char* array_name)
+{
+  if (!array_name)
+    return 0;
+
+  // Work on a mutable copy of array_name
+  char name[4096];
+  size_t len = strlen(array_name);
+  if (len >= sizeof(name))
+    return -1;
+  memcpy(name, array_name, len + 1);
+
+  // Walk each '/' separator — everything before it is an intermediate group
+  for (size_t i = 0; i < len; ++i) {
+    if (name[i] == '/') {
+      name[i] = '\0';
+
+      char dir[4096];
+      snprintf(dir, sizeof(dir), "%s/%s", store_path, name);
+      if (platform_mkdirp(dir) != 0)
+        return -1;
+      if (write_root_metadata_file(dir) != 0)
+        return -1;
+
+      name[i] = '/';
+    }
+  }
+  return 0;
+}
+
 // --- Metadata update ---
 
 static int
@@ -434,8 +470,7 @@ zarr_fs_sink_create(const struct zarr_config* cfg)
              cfg->store_path,
              cfg->array_name);
   else
-    snprintf(
-      zs->array_dir, sizeof(zs->array_dir), "%s", cfg->store_path);
+    snprintf(zs->array_dir, sizeof(zs->array_dir), "%s", cfg->store_path);
 
   // Create directory tree: ensure shard directories exist.
   // shard_inner_count = prod(shard_count[d] for d >= n_append).
@@ -472,8 +507,12 @@ zarr_fs_sink_create(const struct zarr_config* cfg)
   }
 
   // Write metadata
-  if (cfg->array_name)
+  if (cfg->array_name) {
     CHECK(Fail_alloc, write_root_metadata_file(cfg->store_path) == 0);
+    CHECK(Fail_alloc,
+          write_intermediate_group_metadata(cfg->store_path, cfg->array_name) ==
+            0);
+  }
   CHECK(Fail_alloc,
         write_array_metadata_file(zs->array_dir,
                                   zs->rank,
@@ -694,6 +733,9 @@ zarr_fs_multiscale_sink_create(const struct zarr_multiscale_config* cfg)
     CHECK(Fail_ms, platform_mkdirp(cfg->store_path) == 0);
     CHECK(Fail_ms, platform_mkdirp(group_path) == 0);
     CHECK(Fail_ms, write_root_metadata_file(cfg->store_path) == 0);
+    CHECK(Fail_ms,
+          write_intermediate_group_metadata(cfg->store_path, cfg->array_name) ==
+            0);
   } else {
     CHECK(Fail_ms, platform_mkdirp(group_path) == 0);
   }

--- a/src/zarr/zarr_fs_sink.c
+++ b/src/zarr/zarr_fs_sink.c
@@ -338,40 +338,20 @@ write_array_metadata_file(const char* array_dir,
   return write_file(path, buf, (size_t)len);
 }
 
-// Write group zarr.json for each intermediate directory in array_name.
-// For array_name = "path/to/data", writes group metadata at:
-//   {store_path}/path/zarr.json
-//   {store_path}/path/to/zarr.json
-static int
-write_intermediate_group_metadata(const char* store_path,
-                                  const char* array_name)
+struct fs_intermediate_ctx
 {
-  if (!array_name)
-    return 0;
+  const char* store_path;
+};
 
-  // Work on a mutable copy of array_name
-  char name[4096];
-  size_t len = strlen(array_name);
-  if (len >= sizeof(name))
+static int
+write_fs_intermediate(const char* partial, void* ctx)
+{
+  const struct fs_intermediate_ctx* c = (const struct fs_intermediate_ctx*)ctx;
+  char dir[4096];
+  snprintf(dir, sizeof(dir), "%s/%s", c->store_path, partial);
+  if (platform_mkdirp(dir) != 0)
     return -1;
-  memcpy(name, array_name, len + 1);
-
-  // Walk each '/' separator — everything before it is an intermediate group
-  for (size_t i = 0; i < len; ++i) {
-    if (name[i] == '/') {
-      name[i] = '\0';
-
-      char dir[4096];
-      snprintf(dir, sizeof(dir), "%s/%s", store_path, name);
-      if (platform_mkdirp(dir) != 0)
-        return -1;
-      if (write_root_metadata_file(dir) != 0)
-        return -1;
-
-      name[i] = '/';
-    }
-  }
-  return 0;
+  return write_root_metadata_file(dir);
 }
 
 // --- Metadata update ---
@@ -424,6 +404,9 @@ zarr_fs_sink_create(const struct zarr_config* cfg)
   CHECK(Fail, cfg->store_path);
   CHECK(Fail, cfg->rank > 0 && cfg->rank <= MAX_ZARR_RANK);
   CHECK(Fail, cfg->dimensions);
+  // Ensure composed paths (store_path/array_name/zarr.json) fit in 4096
+  if (cfg->array_name)
+    CHECK(Fail, strlen(cfg->store_path) + strlen(cfg->array_name) + 12 < 4096);
 
   struct zarr_fs_sink* zs = (struct zarr_fs_sink*)calloc(1, sizeof(*zs));
   CHECK(Fail, zs);
@@ -509,9 +492,10 @@ zarr_fs_sink_create(const struct zarr_config* cfg)
   // Write metadata
   if (cfg->array_name) {
     CHECK(Fail_alloc, write_root_metadata_file(cfg->store_path) == 0);
+    struct fs_intermediate_ctx ictx = { .store_path = cfg->store_path };
     CHECK(Fail_alloc,
-          write_intermediate_group_metadata(cfg->store_path, cfg->array_name) ==
-            0);
+          zarr_for_each_intermediate(
+            cfg->array_name, write_fs_intermediate, &ictx) == 0);
   }
   CHECK(Fail_alloc,
         write_array_metadata_file(zs->array_dir,
@@ -694,6 +678,8 @@ zarr_fs_multiscale_sink_create(const struct zarr_multiscale_config* cfg)
   CHECK(Fail, cfg->store_path);
   CHECK(Fail, cfg->rank > 0 && cfg->rank <= MAX_ZARR_RANK);
   CHECK(Fail, cfg->dimensions);
+  if (cfg->array_name)
+    CHECK(Fail, strlen(cfg->store_path) + strlen(cfg->array_name) + 12 < 4096);
 
   // Build group path: store_path/array_name when array_name is set
   char group_path[4096];
@@ -733,9 +719,10 @@ zarr_fs_multiscale_sink_create(const struct zarr_multiscale_config* cfg)
     CHECK(Fail_ms, platform_mkdirp(cfg->store_path) == 0);
     CHECK(Fail_ms, platform_mkdirp(group_path) == 0);
     CHECK(Fail_ms, write_root_metadata_file(cfg->store_path) == 0);
+    struct fs_intermediate_ctx ictx = { .store_path = cfg->store_path };
     CHECK(Fail_ms,
-          write_intermediate_group_metadata(cfg->store_path, cfg->array_name) ==
-            0);
+          zarr_for_each_intermediate(
+            cfg->array_name, write_fs_intermediate, &ictx) == 0);
   } else {
     CHECK(Fail_ms, platform_mkdirp(group_path) == 0);
   }

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -3,6 +3,7 @@
 #include "zarr/json_writer.h"
 
 #include <stdio.h>
+#include <string.h>
 
 int
 zarr_root_json(char* buf, size_t cap)
@@ -311,6 +312,32 @@ zarr_multiscale_group_json(char* buf,
   if (jw_error(&jw))
     return -1;
   return (int)jw_length(&jw);
+}
+
+int
+zarr_for_each_intermediate(const char* array_name,
+                           int (*fn)(const char* partial, void* ctx),
+                           void* ctx)
+{
+  if (!array_name)
+    return 0;
+
+  char name[4096];
+  size_t len = strlen(array_name);
+  if (len >= sizeof(name))
+    return -1;
+  memcpy(name, array_name, len + 1);
+
+  for (size_t i = 0; i < len; ++i) {
+    if (name[i] == '/') {
+      name[i] = '\0';
+      int rc = fn(name, ctx);
+      name[i] = '/';
+      if (rc != 0)
+        return rc;
+    }
+  }
+  return 0;
 }
 
 int

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -322,10 +322,17 @@ zarr_for_each_intermediate(const char* array_name,
   if (!array_name)
     return 0;
 
-  char name[4096];
   size_t len = strlen(array_name);
-  if (len >= sizeof(name))
+  if (len == 0 || len >= 4096)
     return -1;
+
+  // Reject leading slash, trailing slash, or empty segments (//)
+  if (array_name[0] == '/' || array_name[len - 1] == '/')
+    return -1;
+  if (strstr(array_name, "//"))
+    return -1;
+
+  char name[4096];
   memcpy(name, array_name, len + 1);
 
   for (size_t i = 0; i < len; ++i) {

--- a/src/zarr/zarr_metadata.h
+++ b/src/zarr/zarr_metadata.h
@@ -33,6 +33,14 @@ zarr_shard_key(char* buf,
                const uint64_t* shard_count,
                uint64_t flat);
 
+// Walk intermediate path segments of array_name, calling fn for each.
+// For array_name = "a/b/c", calls fn("a", ctx) then fn("a/b", ctx).
+// Returns 0 on success, first non-zero fn return on failure.
+int
+zarr_for_each_intermediate(const char* array_name,
+                           int (*fn)(const char* partial, void* ctx),
+                           void* ctx);
+
 // Generate OME-NGFF v0.5 multiscale group JSON into buf.
 // level_dims[lv] points to the rank-length dimension array for level lv.
 // Returns JSON length on success, -1 on error.

--- a/src/zarr/zarr_s3_sink.c
+++ b/src/zarr/zarr_s3_sink.c
@@ -96,7 +96,8 @@ zarr_s3_config_validate(const struct zarr_s3_config* cfg)
   CHECK(Fail, dims_validate(cfg->dimensions, cfg->rank) == 0);
   CHECK(Fail, dtype_bpe(cfg->data_type) > 0);
   CHECK(Fail, cfg->part_size > 0);
-  CHECK(Fail, strlen(cfg->prefix) + strlen(cfg->array_name) + 2 < 4096);
+  // +12: '/' + array_name + "/zarr.json" + '\0'
+  CHECK(Fail, strlen(cfg->prefix) + strlen(cfg->array_name) + 12 < 4096);
   CHECK(Fail,
         s3_validate_part_count(
           cfg->rank, cfg->dimensions, cfg->data_type, cfg->part_size) == 0);
@@ -127,6 +128,8 @@ zarr_s3_multiscale_config_validate(const struct zarr_s3_multiscale_config* cfg)
   CHECK(Fail, dims_validate(cfg->dimensions, cfg->rank) == 0);
   CHECK(Fail, dtype_bpe(cfg->data_type) > 0);
   CHECK(Fail, cfg->part_size > 0);
+  if (cfg->array_name)
+    CHECK(Fail, strlen(cfg->prefix) + strlen(cfg->array_name) + 12 < 4096);
   // L0 is the largest level; if it fits, all LOD levels fit.
   CHECK(Fail,
         s3_validate_part_count(
@@ -136,43 +139,22 @@ Fail:
   return 1;
 }
 
-// Write group zarr.json for each intermediate directory in array_name.
-// For array_name = "path/to/data", writes group metadata at:
-//   {prefix}/path/zarr.json
-//   {prefix}/path/to/zarr.json
-static int
-put_intermediate_group_metadata(struct s3_client* s3,
-                                const char* bucket,
-                                const char* prefix,
-                                const char* array_name)
+struct s3_intermediate_ctx
 {
-  if (!array_name)
-    return 0;
+  struct s3_client* s3;
+  const char* bucket;
+  const char* prefix;
+  const char* metadata;
+  size_t metadata_len;
+};
 
-  char buf[256];
-  int len = zarr_root_json(buf, sizeof(buf));
-  if (len < 0)
-    return -1;
-
-  char name[4096];
-  size_t nlen = strlen(array_name);
-  if (nlen >= sizeof(name))
-    return -1;
-  memcpy(name, array_name, nlen + 1);
-
-  for (size_t i = 0; i < nlen; ++i) {
-    if (name[i] == '/') {
-      name[i] = '\0';
-
-      char key[4096];
-      snprintf(key, sizeof(key), "%s/%s/zarr.json", prefix, name);
-      if (s3_client_put(s3, bucket, key, buf, (size_t)len) != 0)
-        return -1;
-
-      name[i] = '/';
-    }
-  }
-  return 0;
+static int
+put_s3_intermediate(const char* partial, void* ctx)
+{
+  const struct s3_intermediate_ctx* c = (const struct s3_intermediate_ctx*)ctx;
+  char key[4096];
+  snprintf(key, sizeof(key), "%s/%s/zarr.json", c->prefix, partial);
+  return s3_client_put(c->s3, c->bucket, key, c->metadata, c->metadata_len);
 }
 
 // --- S3 shard writer ---
@@ -391,9 +373,12 @@ s3_sink_update_append(struct shard_sink* self,
 // --- Create / Destroy ---
 
 // Internal: create a sink that borrows an existing client (does not own it).
+// When skip_group_metadata is set, root and intermediate group zarr.json
+// writes are skipped (the caller handles them, e.g. multiscale).
 static struct zarr_s3_sink*
 zarr_s3_sink_create_with_client(const struct zarr_s3_config* cfg,
-                                struct s3_client* client)
+                                struct s3_client* client,
+                                int skip_group_metadata)
 {
   CHECK(Fail, cfg);
   CHECK(Fail, client);
@@ -444,8 +429,8 @@ zarr_s3_sink_create_with_client(const struct zarr_s3_config* cfg,
            cfg->prefix,
            cfg->array_name);
 
-  // Write root metadata
-  {
+  // Write root + intermediate group metadata (skipped for sub-sinks)
+  if (!skip_group_metadata) {
     char buf[256];
     int len = zarr_root_json(buf, sizeof(buf));
     CHECK(Fail_alloc, len >= 0);
@@ -453,12 +438,17 @@ zarr_s3_sink_create_with_client(const struct zarr_s3_config* cfg,
     snprintf(key, sizeof(key), "%s/zarr.json", cfg->prefix);
     CHECK(Fail_alloc,
           s3_client_put(zs->s3, zs->bucket, key, buf, (size_t)len) == 0);
+    struct s3_intermediate_ctx ictx = {
+      .s3 = zs->s3,
+      .bucket = zs->bucket,
+      .prefix = cfg->prefix,
+      .metadata = buf,
+      .metadata_len = (size_t)len,
+    };
+    CHECK(Fail_alloc,
+          zarr_for_each_intermediate(
+            cfg->array_name, put_s3_intermediate, &ictx) == 0);
   }
-
-  // Write intermediate group metadata
-  CHECK(Fail_alloc,
-        put_intermediate_group_metadata(
-          zs->s3, zs->bucket, cfg->prefix, cfg->array_name) == 0);
 
   // Write array metadata
   {
@@ -518,7 +508,7 @@ zarr_s3_sink_create(struct zarr_s3_config* cfg)
   struct s3_client* client = s3_client_create(&s3cfg);
   CHECK(Fail, client);
 
-  struct zarr_s3_sink* zs = zarr_s3_sink_create_with_client(cfg, client);
+  struct zarr_s3_sink* zs = zarr_s3_sink_create_with_client(cfg, client, 0);
   CHECK(Fail_client, zs);
 
   zs->owns_s3 = 1;
@@ -727,6 +717,27 @@ zarr_s3_multiscale_sink_create(struct zarr_s3_multiscale_config* cfg)
                                              sizeof(struct zarr_s3_sink*));
   CHECK(Fail_s3, ms->levels);
 
+  // Write root + intermediate metadata before creating levels
+  if (cfg->array_name) {
+    char buf[256];
+    int len = zarr_root_json(buf, sizeof(buf));
+    CHECK(Fail_levels, len >= 0);
+    char key[4096];
+    snprintf(key, sizeof(key), "%s/zarr.json", cfg->prefix);
+    CHECK(Fail_levels,
+          s3_client_put(ms->s3, ms->bucket, key, buf, (size_t)len) == 0);
+    struct s3_intermediate_ctx ictx = {
+      .s3 = ms->s3,
+      .bucket = ms->bucket,
+      .prefix = cfg->prefix,
+      .metadata = buf,
+      .metadata_len = (size_t)len,
+    };
+    CHECK(Fail_levels,
+          zarr_for_each_intermediate(
+            cfg->array_name, put_s3_intermediate, &ictx) == 0);
+  }
+
   // Create one zarr_s3_sink per level, all borrowing the shared client
   for (int lv = 0; lv < plan.nlod; ++lv) {
     struct dimension lv_dims[MAX_ZARR_RANK];
@@ -754,22 +765,8 @@ zarr_s3_multiscale_sink_create(struct zarr_s3_multiscale_config* cfg)
       .codec = cfg->codec,
     };
 
-    ms->levels[lv] = zarr_s3_sink_create_with_client(&zcfg, ms->s3);
+    ms->levels[lv] = zarr_s3_sink_create_with_client(&zcfg, ms->s3, 1);
     CHECK(Fail_levels, ms->levels[lv]);
-  }
-
-  // Write root metadata (at prefix level, above group)
-  if (cfg->array_name) {
-    char buf[256];
-    int len = zarr_root_json(buf, sizeof(buf));
-    CHECK(Fail_levels, len >= 0);
-    char key[4096];
-    snprintf(key, sizeof(key), "%s/zarr.json", cfg->prefix);
-    CHECK(Fail_levels,
-          s3_client_put(ms->s3, ms->bucket, key, buf, (size_t)len) == 0);
-    CHECK(Fail_levels,
-          put_intermediate_group_metadata(
-            ms->s3, ms->bucket, cfg->prefix, cfg->array_name) == 0);
   }
 
   // Write OME-NGFF group metadata

--- a/src/zarr/zarr_s3_sink.c
+++ b/src/zarr/zarr_s3_sink.c
@@ -136,6 +136,45 @@ Fail:
   return 1;
 }
 
+// Write group zarr.json for each intermediate directory in array_name.
+// For array_name = "path/to/data", writes group metadata at:
+//   {prefix}/path/zarr.json
+//   {prefix}/path/to/zarr.json
+static int
+put_intermediate_group_metadata(struct s3_client* s3,
+                                const char* bucket,
+                                const char* prefix,
+                                const char* array_name)
+{
+  if (!array_name)
+    return 0;
+
+  char buf[256];
+  int len = zarr_root_json(buf, sizeof(buf));
+  if (len < 0)
+    return -1;
+
+  char name[4096];
+  size_t nlen = strlen(array_name);
+  if (nlen >= sizeof(name))
+    return -1;
+  memcpy(name, array_name, nlen + 1);
+
+  for (size_t i = 0; i < nlen; ++i) {
+    if (name[i] == '/') {
+      name[i] = '\0';
+
+      char key[4096];
+      snprintf(key, sizeof(key), "%s/%s/zarr.json", prefix, name);
+      if (s3_client_put(s3, bucket, key, buf, (size_t)len) != 0)
+        return -1;
+
+      name[i] = '/';
+    }
+  }
+  return 0;
+}
+
 // --- S3 shard writer ---
 
 // --- Zarr S3 sink ---
@@ -415,6 +454,11 @@ zarr_s3_sink_create_with_client(const struct zarr_s3_config* cfg,
     CHECK(Fail_alloc,
           s3_client_put(zs->s3, zs->bucket, key, buf, (size_t)len) == 0);
   }
+
+  // Write intermediate group metadata
+  CHECK(Fail_alloc,
+        put_intermediate_group_metadata(
+          zs->s3, zs->bucket, cfg->prefix, cfg->array_name) == 0);
 
   // Write array metadata
   {
@@ -723,6 +767,9 @@ zarr_s3_multiscale_sink_create(struct zarr_s3_multiscale_config* cfg)
     snprintf(key, sizeof(key), "%s/zarr.json", cfg->prefix);
     CHECK(Fail_levels,
           s3_client_put(ms->s3, ms->bucket, key, buf, (size_t)len) == 0);
+    CHECK(Fail_levels,
+          put_intermediate_group_metadata(
+            ms->s3, ms->bucket, cfg->prefix, cfg->array_name) == 0);
   }
 
   // Write OME-NGFF group metadata

--- a/src/zarr/zarr_s3_sink.c
+++ b/src/zarr/zarr_s3_sink.c
@@ -96,8 +96,10 @@ zarr_s3_config_validate(const struct zarr_s3_config* cfg)
   CHECK(Fail, dims_validate(cfg->dimensions, cfg->rank) == 0);
   CHECK(Fail, dtype_bpe(cfg->data_type) > 0);
   CHECK(Fail, cfg->part_size > 0);
-  // +12: '/' + array_name + "/zarr.json" + '\0'
-  CHECK(Fail, strlen(cfg->prefix) + strlen(cfg->array_name) + 12 < 4096);
+  CHECK(Fail,
+        strlen(cfg->prefix) + 1 + strlen(cfg->array_name) +
+            sizeof("/zarr.json") <
+          4096);
   CHECK(Fail,
         s3_validate_part_count(
           cfg->rank, cfg->dimensions, cfg->data_type, cfg->part_size) == 0);
@@ -129,7 +131,10 @@ zarr_s3_multiscale_config_validate(const struct zarr_s3_multiscale_config* cfg)
   CHECK(Fail, dtype_bpe(cfg->data_type) > 0);
   CHECK(Fail, cfg->part_size > 0);
   if (cfg->array_name)
-    CHECK(Fail, strlen(cfg->prefix) + strlen(cfg->array_name) + 12 < 4096);
+    CHECK(Fail,
+          strlen(cfg->prefix) + 1 + strlen(cfg->array_name) +
+              sizeof("/zarr.json") <
+            4096);
   // L0 is the largest level; if it fits, all LOD levels fit.
   CHECK(Fail,
         s3_validate_part_count(

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -6,6 +6,7 @@
 #include "test_shard_verify.h"
 #include "test_voxel_encode.h"
 #include "util/prelude.h"
+#include "zarr/zarr_metadata.h"
 #include "zarr_fs_sink.h"
 
 #include <stdio.h>
@@ -1909,6 +1910,73 @@ Fail:
   return 1;
 }
 
+// --- Test: zarr_for_each_intermediate edge cases ---
+
+struct intermediate_record
+{
+  int count;
+  char segments[8][256];
+};
+
+static int
+record_segment(const char* partial, void* ctx)
+{
+  struct intermediate_record* r = (struct intermediate_record*)ctx;
+  if (r->count < 8)
+    snprintf(r->segments[r->count], 256, "%s", partial);
+  r->count++;
+  return 0;
+}
+
+static int
+test_for_each_intermediate(void)
+{
+  log_info("=== test_for_each_intermediate ===");
+  struct intermediate_record rec;
+
+  // No slash: zero callbacks
+  memset(&rec, 0, sizeof(rec));
+  CHECK(Fail, zarr_for_each_intermediate("data", record_segment, &rec) == 0);
+  CHECK(Fail, rec.count == 0);
+
+  // Single slash: one callback
+  memset(&rec, 0, sizeof(rec));
+  CHECK(Fail, zarr_for_each_intermediate("a/b", record_segment, &rec) == 0);
+  CHECK(Fail, rec.count == 1);
+  CHECK(Fail, strcmp(rec.segments[0], "a") == 0);
+
+  // Two slashes: two callbacks
+  memset(&rec, 0, sizeof(rec));
+  CHECK(Fail, zarr_for_each_intermediate("a/b/c", record_segment, &rec) == 0);
+  CHECK(Fail, rec.count == 2);
+  CHECK(Fail, strcmp(rec.segments[0], "a") == 0);
+  CHECK(Fail, strcmp(rec.segments[1], "a/b") == 0);
+
+  // NULL: no-op
+  memset(&rec, 0, sizeof(rec));
+  CHECK(Fail, zarr_for_each_intermediate(NULL, record_segment, &rec) == 0);
+  CHECK(Fail, rec.count == 0);
+
+  // Leading slash: rejected
+  CHECK(Fail, zarr_for_each_intermediate("/a/b", record_segment, &rec) != 0);
+
+  // Trailing slash: rejected
+  CHECK(Fail, zarr_for_each_intermediate("a/b/", record_segment, &rec) != 0);
+
+  // Double slash: rejected
+  CHECK(Fail, zarr_for_each_intermediate("a//b", record_segment, &rec) != 0);
+
+  // Empty string: rejected
+  CHECK(Fail, zarr_for_each_intermediate("", record_segment, &rec) != 0);
+
+  log_info("  PASS");
+  return 0;
+
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
 // --- Test: nested array_name writes intermediate group zarr.json ---
 
 static int
@@ -2084,6 +2152,9 @@ main(int ac, char* av[])
   char tmpdir[4096];
   CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
   log_info("temp dir: %s", tmpdir);
+
+  // zarr_for_each_intermediate unit test (no CUDA, no tmpdir needed)
+  ecode |= test_for_each_intermediate();
 
   // Metadata tests (no CUDA needed)
   {

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -1909,6 +1909,88 @@ Fail:
   return 1;
 }
 
+// --- Test: nested array_name writes intermediate group zarr.json ---
+
+static int
+test_nested_array_name(const char* tmpdir)
+{
+  log_info("=== test_nested_array_name ===");
+
+  struct dimension dims[] = {
+    { .size = 4,
+      .chunk_size = 2,
+      .chunks_per_shard = 2,
+      .name = "z",
+      .storage_position = 0 },
+    { .size = 4,
+      .chunk_size = 2,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .storage_position = 1 },
+  };
+
+  struct zarr_config cfg = {
+    .store_path = tmpdir,
+    .array_name = "path/to/data",
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 2,
+    .dimensions = dims,
+  };
+
+  struct zarr_fs_sink* zs = zarr_fs_sink_create(&cfg);
+  CHECK(Fail, zs);
+
+  // Check root group zarr.json
+  {
+    char* data;
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 4096) == 0);
+    free(data);
+  }
+
+  // Check intermediate group: {tmpdir}/path/zarr.json
+  {
+    char dir[4096];
+    snprintf(dir, sizeof(dir), "%s/path", tmpdir);
+    char* data;
+    CHECK(Fail2, check_group_zarr_json(dir, &data, 4096) == 0);
+    free(data);
+  }
+
+  // Check intermediate group: {tmpdir}/path/to/zarr.json
+  {
+    char dir[4096];
+    snprintf(dir, sizeof(dir), "%s/path/to", tmpdir);
+    char* data;
+    CHECK(Fail2, check_group_zarr_json(dir, &data, 4096) == 0);
+    free(data);
+  }
+
+  // Check leaf array zarr.json exists
+  {
+    char path[4096];
+    snprintf(path, sizeof(path), "%s/path/to/data/zarr.json", tmpdir);
+    CHECK(Fail2, test_file_exists(path));
+
+    uint8_t* data;
+    size_t len;
+    CHECK(Fail2, read_file_all(path, &data, &len) == 0);
+    data[len < 4095 ? len : 4095] = '\0';
+    CHECK(Fail2, strstr((char*)data, "\"node_type\":\"array\""));
+    free(data);
+  }
+
+  zarr_fs_sink_destroy(zs);
+  log_info("  PASS");
+  return 0;
+
+Fail2:
+  zarr_fs_sink_destroy(zs);
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
 int
 main(int ac, char* av[])
 {
@@ -1936,6 +2018,14 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/meta2app", tmpdir);
     test_mkdir(sub);
     ecode |= test_metadata_two_append(sub);
+  }
+
+  // Nested array_name intermediate group metadata test (no CUDA needed)
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/nested", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_nested_array_name(sub);
   }
 
   // Multiscale metadata test (no CUDA needed)

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -1975,7 +1975,7 @@ test_nested_array_name(const char* tmpdir)
     uint8_t* data;
     size_t len;
     CHECK(Fail2, read_file_all(path, &data, &len) == 0);
-    data[len < 4095 ? len : 4095] = '\0';
+    data[len] = '\0';
     CHECK(Fail2, strstr((char*)data, "\"node_type\":\"array\""));
     free(data);
   }
@@ -1986,6 +1986,87 @@ test_nested_array_name(const char* tmpdir)
 
 Fail2:
   zarr_fs_sink_destroy(zs);
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+// --- Test: nested array_name in multiscale sink ---
+
+static int
+test_nested_multiscale_array_name(const char* tmpdir)
+{
+  log_info("=== test_nested_multiscale_array_name ===");
+
+  struct dimension dims[] = {
+    { .size = 32,
+      .chunk_size = 8,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .downsample = 1,
+      .storage_position = 0 },
+    { .size = 32,
+      .chunk_size = 8,
+      .chunks_per_shard = 2,
+      .name = "x",
+      .downsample = 1,
+      .storage_position = 1 },
+  };
+
+  struct zarr_multiscale_config cfg = {
+    .store_path = tmpdir,
+    .array_name = "path/to/group",
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 2,
+    .dimensions = dims,
+    .nlod = 0,
+  };
+
+  struct zarr_fs_multiscale_sink* ms = zarr_fs_multiscale_sink_create(&cfg);
+  CHECK(Fail, ms);
+
+  // Check root group zarr.json
+  {
+    char* data;
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 4096) == 0);
+    free(data);
+  }
+
+  // Check intermediate group: {tmpdir}/path/zarr.json
+  {
+    char dir[4096];
+    snprintf(dir, sizeof(dir), "%s/path", tmpdir);
+    char* data;
+    CHECK(Fail2, check_group_zarr_json(dir, &data, 4096) == 0);
+    free(data);
+  }
+
+  // Check intermediate group: {tmpdir}/path/to/zarr.json
+  {
+    char dir[4096];
+    snprintf(dir, sizeof(dir), "%s/path/to", tmpdir);
+    char* data;
+    CHECK(Fail2, check_group_zarr_json(dir, &data, 4096) == 0);
+    free(data);
+  }
+
+  // Check multiscale group: {tmpdir}/path/to/group/zarr.json has OME metadata
+  {
+    char dir[4096];
+    snprintf(dir, sizeof(dir), "%s/path/to/group", tmpdir);
+    char* data;
+    CHECK(Fail2, check_group_zarr_json(dir, &data, 8192) == 0);
+    CHECK(Fail2, strstr(data, "\"multiscales\""));
+    free(data);
+  }
+
+  zarr_fs_multiscale_sink_destroy(ms);
+  log_info("  PASS");
+  return 0;
+
+Fail2:
+  zarr_fs_multiscale_sink_destroy(ms);
 Fail:
   log_error("  FAIL");
   return 1;
@@ -2026,6 +2107,14 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/nested", tmpdir);
     test_mkdir(sub);
     ecode |= test_nested_array_name(sub);
+  }
+
+  // Nested multiscale array_name intermediate group metadata test (no CUDA)
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/nested_ms", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_nested_multiscale_array_name(sub);
   }
 
   // Multiscale metadata test (no CUDA needed)


### PR DESCRIPTION
## Summary
- Write explicit group `zarr.json` for every intermediate directory when `array_name` contains path separators (e.g. `"path/to/data"`), fixing zarr-python and other v3 readers that require explicit group nodes
- Factor segment-walking into shared `zarr_for_each_intermediate()` used by both FS and S3 sinks
- Add path length validation for composed paths in both FS and S3 sinks
- Skip redundant root/intermediate metadata writes for S3 multiscale sub-sinks
- Move S3 multiscale root metadata writes before level creation to match FS ordering

Closes #20

## Test plan
- [x] `test_nested_array_name` — verifies group `zarr.json` at each intermediate directory for FS sink
- [x] `test_nested_multiscale_array_name` — verifies intermediate groups for FS multiscale sink
- [x] All existing tests pass (no regression)