### PR TITLE
Add CI and codecov badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage-report/lcov.info
           fail_ci_if_error: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Chucky
 
+[![CI](https://github.com/acquire-project/chucky/actions/workflows/ci.yml/badge.svg)](https://github.com/acquire-project/chucky/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/acquire-project/chucky/graph/badge.svg)](https://codecov.io/gh/acquire-project/chucky)
+
 A high-performance streaming library for tiled transformation and compression of
 large multidimensional arrays (tensors) using CUDA.
 


### PR DESCRIPTION
## Summary
- Fix codecov "missing base commit" by using full git history (`fetch-depth: 0`) in the coverage job
- Add CI status and codecov badges to the README