### PR TITLE
Fix batch aggregate perm ordering

### DIFF
--- a/src/cpu/pipeline.c
+++ b/src/cpu/pipeline.c
@@ -3,20 +3,40 @@
 #include "cpu/aggregate.h"
 #include "cpu/compress.h"
 #include "cpu/lod.h"
+#include "defs.limits.h"
 #include "platform/platform.h"
-#include "util/index.ops.h"
 #include "util/metric.h"
 #include "util/prelude.h"
+
+// ---- batch LUT computation ----
+
+// Convenience: compute pool_epochs from the standard formula
+// pool_epoch = (a + 1) * period - 1, then delegate to aggregate_batch_luts.
+static void
+compute_batch_luts(const struct computed_stream_layouts* cl,
+                   const struct level_geometry* levels,
+                   const struct aggregate_layout* agg,
+                   int lv,
+                   uint32_t active_count,
+                   uint32_t* out_gather,
+                   uint32_t* out_perm)
+{
+  uint32_t pool_epochs[MAX_BATCH_EPOCHS];
+  for (uint32_t a = 0; a < active_count; ++a) {
+    uint32_t period = (cl->dims.append_downsample && lv > 0) ? (1u << lv) : 1;
+    pool_epochs[a] = (a + 1) * period - 1;
+  }
+  aggregate_batch_luts(
+    agg, levels, lv, active_count, pool_epochs, out_gather, out_perm);
+}
 
 // ---- flush_batch helpers ----
 
 static struct aggregate_cpu_workspace
-make_agg_workspace(const struct flush_level_view* lvl,
-                   uint32_t* perm,
-                   size_t* permuted_sizes)
+make_agg_workspace(const struct flush_level_view* lvl, size_t* permuted_sizes)
 {
   return (struct aggregate_cpu_workspace){
-    .perm = perm,
+    .perm = lvl->batch_chunk_to_shard_map,
     .permuted_sizes = permuted_sizes,
     .data = lvl->agg_slot->data,
     .data_capacity = lvl->agg_slot->data_capacity_bytes,
@@ -54,7 +74,7 @@ deliver_aggregate(int lv,
   return 0;
 }
 
-// Aggregate + deliver using the batch path (K_l > 1 with full batch).
+// Aggregate + deliver a batch of active_count epochs.
 static int
 aggregate_and_deliver_batch(int lv,
                             const struct flush_batch_params* p,
@@ -65,8 +85,8 @@ aggregate_and_deliver_batch(int lv,
   if (p->metrics)
     platform_toc(&clk);
 
-  struct aggregate_cpu_workspace ws = make_agg_workspace(
-    lvl, lvl->batch_chunk_to_shard_map, p->shard_order_sizes_bytes);
+  struct aggregate_cpu_workspace ws =
+    make_agg_workspace(lvl, p->shard_order_sizes_bytes);
   struct aggregate_result ar;
   if (aggregate_cpu_batch_into(p->compressed,
                                p->comp_sizes,
@@ -84,36 +104,6 @@ aggregate_and_deliver_batch(int lv,
   }
 
   return deliver_aggregate(lv, p, lvl, &ar, active_count);
-}
-
-// Aggregate + deliver one epoch using the per-epoch fallback path.
-static int
-aggregate_and_deliver_epoch(int lv,
-                            const struct flush_batch_params* p,
-                            const struct flush_level_view* lvl,
-                            uint64_t comp_base)
-{
-  struct platform_clock clk = { 0 };
-  if (p->metrics)
-    platform_toc(&clk);
-
-  const void* comp_lv =
-    (const char*)p->compressed + comp_base * p->max_output_size_bytes;
-  const size_t* sizes_lv = p->comp_sizes + comp_base;
-
-  struct aggregate_cpu_workspace ws = make_agg_workspace(
-    lvl, lvl->chunk_to_shard_map, p->shard_order_sizes_bytes);
-  struct aggregate_result ar;
-  if (aggregate_cpu_into(comp_lv, sizes_lv, lvl->agg_layout, &ws, &ar))
-    return 1;
-
-  if (p->metrics) {
-    float ms = (float)(platform_toc(&clk) * 1000.0);
-    size_t agg_bytes = ar.offsets[lvl->agg_layout->covering_count];
-    accumulate_metric_ms(&p->metrics->aggregate, ms, agg_bytes, 0);
-  }
-
-  return deliver_aggregate(lv, p, lvl, &ar, 1);
 }
 
 // ---- flush_batch ----
@@ -163,19 +153,30 @@ cpu_pipeline_flush_batch(const struct flush_batch_params* p,
     if (p->sink->wait_fence)
       p->sink->wait_fence(p->sink, (uint8_t)lv, *lvl->io_done);
 
-    if (active_count == lvl->batch_active_count &&
-        lvl->batch_active_count > 1) {
-      if (aggregate_and_deliver_batch(lv, p, lvl, active_count))
+    // Recompute batch LUTs if active_count differs from pre-computed.
+    if (active_count != lvl->batch_active_count) {
+      // LUT buffers are sized for max(batch_active_count, 1) * M entries.
+      uint32_t lut_cap =
+        lvl->batch_active_count > 0 ? lvl->batch_active_count : 1;
+      if (active_count > lut_cap)
         return 1;
-    } else {
-      for (uint32_t e = 0; e < n_epochs; ++e) {
-        if (!(active_masks[e] & (1u << lv)))
-          continue;
-        uint64_t comp_base = (uint64_t)e * total_chunks + lvl->chunk_offset;
-        if (aggregate_and_deliver_epoch(lv, p, lvl, comp_base))
-          return 1;
-      }
+
+      uint32_t pool_epochs[MAX_BATCH_EPOCHS];
+      uint32_t ai = 0;
+      for (uint32_t e = 0; e < n_epochs; ++e)
+        if (active_masks[e] & (1u << lv))
+          pool_epochs[ai++] = e;
+      aggregate_batch_luts(lvl->agg_layout,
+                           p->levels_geo,
+                           lv,
+                           active_count,
+                           pool_epochs,
+                           lvl->batch_gather,
+                           lvl->batch_chunk_to_shard_map);
     }
+
+    if (aggregate_and_deliver_batch(lv, p, lvl, active_count))
+      return 1;
 
     // Record fence so next batch waits for this delivery's IO.
     if (p->sink->record_fence)
@@ -333,35 +334,20 @@ cpu_pipeline_compute_luts(
   const struct aggregate_layout agg_layout[LOD_MAX_LEVELS],
   struct lut_targets* out)
 {
-  // Per-level chunk-to-shard map + batch LUTs.
+  // Per-level batch LUTs.
   for (int lv = 0; lv < levels->nlod; ++lv) {
     const struct aggregate_layout* agg = &agg_layout[lv];
-    uint64_t M_lv = agg->chunks_per_epoch;
-
-    // Single-epoch permutation.
-    for (uint64_t i = 0; i < M_lv; ++i)
-      out->chunk_to_shard_map[lv][i] = (uint32_t)ravel(
-        agg->lifted_rank, agg->lifted_shape, agg->lifted_strides, i);
-
-    // Batch LUTs (K_l > 1 only).
     uint32_t K_l = batch_active_count[lv];
-    if (K_l > 1) {
-      uint64_t total_chunks = levels->total_chunks;
-      for (uint32_t a = 0; a < K_l; ++a) {
-        uint32_t period =
-          (cl->dims.append_downsample && lv > 0) ? (1u << lv) : 1;
-        uint32_t pool_epoch = (a + 1) * period - 1;
+    uint32_t slot_count = K_l > 0 ? K_l : 1;
 
-        for (uint64_t j = 0; j < M_lv; ++j) {
-          uint64_t idx = (uint64_t)a * M_lv + j;
-          out->batch_gather[lv][idx] = (uint32_t)(pool_epoch * total_chunks +
-                                                  levels->chunk_offset[lv] + j);
-          uint32_t perm_pos = (uint32_t)ravel(
-            agg->lifted_rank, agg->lifted_shape, agg->lifted_strides, j);
-          out->batch_chunk_to_shard_map[lv][idx] = perm_pos * K_l + a;
-        }
-      }
-    }
+    if (out->batch_gather[lv] && out->batch_chunk_to_shard_map[lv])
+      compute_batch_luts(cl,
+                         levels,
+                         agg,
+                         lv,
+                         slot_count,
+                         out->batch_gather[lv],
+                         out->batch_chunk_to_shard_map[lv]);
   }
 
   // LOD LUTs (multiscale only).

--- a/src/cpu/pipeline.h
+++ b/src/cpu/pipeline.h
@@ -21,9 +21,8 @@ struct flush_level_view
   struct aggregate_layout* agg_layout;
   uint32_t batch_active_count;
   uint64_t chunk_offset;
-  uint32_t* chunk_to_shard_map;
-  uint32_t* batch_chunk_to_shard_map;
-  uint32_t* batch_gather;
+  uint32_t* batch_chunk_to_shard_map; // [K_l * M_lv] perm LUT (mutable)
+  uint32_t* batch_gather;             // [K_l * M_lv] gather LUT (mutable)
   struct cpu_agg_slot* agg_slot;
   struct shard_state* shard;
   struct io_event*
@@ -41,6 +40,8 @@ struct flush_batch_params
   size_t* comp_sizes;
   uint64_t total_chunks;
   int nlod;
+  const struct computed_stream_layouts* cl;
+  const struct level_geometry* levels_geo;
   struct flush_level_view levels[LOD_MAX_LEVELS];
   size_t* shard_order_sizes_bytes;
   struct shard_sink* sink;
@@ -82,7 +83,6 @@ cpu_pipeline_scatter_epoch(const struct scatter_epoch_params* p,
 
 struct lut_targets
 {
-  uint32_t* chunk_to_shard_map[LOD_MAX_LEVELS];
   uint32_t* batch_gather[LOD_MAX_LEVELS];
   uint32_t* batch_chunk_to_shard_map[LOD_MAX_LEVELS];
   uint32_t* scatter_lut;

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -741,7 +741,6 @@ cpu_flush_final(struct writer* self)
   struct tile_stream_cpu* s =
     container_of(self, struct tile_stream_cpu, writer);
   struct writer_result r = cpu_flush(self);
-  if (!r.error)
-    s->flushed = 1;
+  s->flushed = 1;
   return r;
 }

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -16,6 +16,8 @@ static struct writer_result
 cpu_append(struct writer* self, struct slice input);
 static struct writer_result
 cpu_flush(struct writer* self);
+static struct writer_result
+cpu_flush_final(struct writer* self);
 
 // ---- Create / Destroy ----
 
@@ -79,10 +81,6 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
       if (batch_C > max_batch_C)
         max_batch_C = batch_C;
 
-      // Per-level perm (single-epoch, for fallback).
-      s->chunk_to_shard_map[lv] = (uint32_t*)malloc(M_lv * sizeof(uint32_t));
-      CHECK(Fail, s->chunk_to_shard_map[lv]);
-
       // Per-level aggregate output buffers (batch-scaled).
       size_t data_lv = agg_pool_bytes((uint64_t)slot_count * M_lv,
                                       agg->max_comp_chunk_bytes,
@@ -103,9 +101,9 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
         }
       }
 
-      // Batch aggregate LUTs (K_l > 1 only).
-      if (K_l > 1) {
-        uint64_t lut_len = (uint64_t)K_l * M_lv;
+      // Batch aggregate LUTs (gather + perm).
+      if (M_lv > 0) {
+        uint64_t lut_len = (uint64_t)slot_count * M_lv;
 
         s->batch_gather[lv] = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
         s->batch_chunk_to_shard_map[lv] =
@@ -180,7 +178,6 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
       .scatter_batch_offsets = s->scatter_batch_offsets,
     };
     for (int lv = 0; lv < s->levels.nlod; ++lv) {
-      luts.chunk_to_shard_map[lv] = s->chunk_to_shard_map[lv];
       luts.batch_gather[lv] = s->batch_gather[lv];
       luts.batch_chunk_to_shard_map[lv] = s->batch_chunk_to_shard_map[lv];
       luts.morton_lut[lv] = s->morton_lut[lv];
@@ -217,7 +214,7 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
   }
 
   s->writer.append = cpu_append;
-  s->writer.flush = cpu_flush;
+  s->writer.flush = cpu_flush_final;
 
   platform_toc(&s->metadata_update_clock);
 
@@ -241,7 +238,6 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
         free(ss->shards[si].index);
       free(ss->shards);
     }
-    free(s->chunk_to_shard_map[lv]);
     free(s->batch_gather[lv]);
     free(s->batch_chunk_to_shard_map[lv]);
     free(s->morton_lut[lv]);
@@ -333,14 +329,13 @@ compute_memory_info(const struct computed_stream_layouts* cl,
                                       al->cps_inner,
                                       al->page_size);
 
-      agg += M_lv * sizeof(uint32_t); // per-epoch perm
       agg += data_lv +
              (batch_C + 1) * sizeof(size_t) + // offsets (batch-scaled)
              batch_C * sizeof(size_t);        // chunk_sizes (batch-scaled)
 
       // Batch LUTs (gather + perm).
-      if (K_l > 1) {
-        uint64_t lut_len = (uint64_t)K_l * M_lv;
+      {
+        uint64_t lut_len = (uint64_t)slot_count * M_lv;
         agg += 2 * lut_len * sizeof(uint32_t);
       }
     }
@@ -457,6 +452,8 @@ make_flush_params(struct tile_stream_cpu* s)
     .comp_sizes = s->comp_sizes,
     .total_chunks = s->levels.total_chunks,
     .nlod = s->levels.nlod,
+    .cl = &s->cl,
+    .levels_geo = &s->levels,
     .shard_order_sizes_bytes = s->shard_order_sizes,
     .sink = s->shard_sink,
     .shard_alignment_bytes = s->config.shard_alignment,
@@ -467,7 +464,6 @@ make_flush_params(struct tile_stream_cpu* s)
       .agg_layout = &s->agg_layout[lv],
       .batch_active_count = s->batch_active_count[lv],
       .chunk_offset = s->levels.chunk_offset[lv],
-      .chunk_to_shard_map = s->chunk_to_shard_map[lv],
       .batch_chunk_to_shard_map = s->batch_chunk_to_shard_map[lv],
       .batch_gather = s->batch_gather[lv],
       .agg_slot = &s->agg_slots[lv],
@@ -510,6 +506,10 @@ cpu_append(struct writer* self, struct slice input)
 {
   struct tile_stream_cpu* s =
     container_of(self, struct tile_stream_cpu, writer);
+
+  if (s->flushed)
+    return writer_finished_at(input.beg, input.end);
+
   const size_t bytes_per_element = dtype_bpe(s->config.dtype);
   const uint8_t* src = (const uint8_t*)input.beg;
   const uint8_t* end = (const uint8_t*)input.end;
@@ -733,4 +733,15 @@ cpu_flush(struct writer* self)
   }
 
   return writer_ok();
+}
+
+static struct writer_result
+cpu_flush_final(struct writer* self)
+{
+  struct tile_stream_cpu* s =
+    container_of(self, struct tile_stream_cpu, writer);
+  struct writer_result r = cpu_flush(self);
+  if (!r.error)
+    s->flushed = 1;
+  return r;
 }

--- a/src/cpu/stream.internal.h
+++ b/src/cpu/stream.internal.h
@@ -28,16 +28,14 @@ struct tile_stream_cpu
   struct shard_state shard[LOD_MAX_LEVELS];
   struct aggregate_layout agg_layout[LOD_MAX_LEVELS];
 
-  // Per-level aggregate output (batch-scaled when K > 1).
-  uint32_t* chunk_to_shard_map[LOD_MAX_LEVELS];  // [M] chunk → shard position
+  // Per-level aggregate output (batch-scaled).
   struct cpu_agg_slot agg_slots[LOD_MAX_LEVELS]; // [level] sized for batch
   size_t* shard_order_sizes;                     // [max_batch_C] shared scratch
 
-  // Batch aggregate LUTs (K > 1 only, per level).
-  uint32_t* batch_gather[LOD_MAX_LEVELS]; // [K_l * M_l]
-  uint32_t*
-    batch_chunk_to_shard_map[LOD_MAX_LEVELS];  // [K_l * M_l] interleaved map
-  uint32_t batch_active_count[LOD_MAX_LEVELS]; // K_l per level
+  // Batch aggregate LUTs (per level).
+  uint32_t* batch_gather[LOD_MAX_LEVELS];             // [K_l * M_l]
+  uint32_t* batch_chunk_to_shard_map[LOD_MAX_LEVELS]; // [K_l * M_l]
+  uint32_t batch_active_count[LOD_MAX_LEVELS];        // K_l per level
 
   // LOD (multiscale only)
   void* linear; // linear epoch buffer (input accumulated here before scatter)
@@ -57,6 +55,7 @@ struct tile_stream_cpu
   uint64_t
     max_cursor_elements; // precomputed: total elements across all append chunks
   int pool_fully_covered; // 1 if scatter overwrites every pool position
+  int flushed;            // 1 after flush; append after flush is an error
 
   // Batch accumulation state (K = cl.epochs_per_batch).
   uint32_t batch_accumulated;                    // 0..K-1

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -286,6 +286,11 @@ compress_agg_kick(struct compress_agg_stage* stage,
 
     // Recompute LUTs if active_count doesn't match pre-computed.
     if (active_count != lvl->batch_active_count) {
+      // LUT buffers are sized for max(batch_active_count, 1) * chunks_lv.
+      uint32_t lut_cap =
+        lvl->batch_active_count > 0 ? lvl->batch_active_count : 1;
+      CHECK(Error, active_count <= lut_cap);
+
       // Scan masks for actual pool positions (unless already done above).
       {
         uint32_t ai = 0;

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -1,9 +1,11 @@
 #include "gpu/flush.compress_agg.h"
 #include "gpu/flush.helpers.h"
 
+#include "defs.limits.h"
 #include "gpu/aggregate.h"
 #include "gpu/compress.h"
 #include "gpu/prelude.cuda.h"
+#include "stream/layouts.h"
 #include "util/prelude.h"
 #include "zarr/crc32c.h"
 #include "zarr/shard_delivery.h"
@@ -140,62 +142,53 @@ compress_agg_init(struct compress_agg_stage* stage,
     ss->shard_epoch = 0;
   }
 
-  // Batch LUTs (K > 1 only)
-  if (K > 1) {
-    for (int lv = 0; lv < cl->levels.nlod; ++lv) {
-      struct level_flush_state* lvl = &stage->levels[lv];
-      uint32_t batch_count = lvl->batch_active_count;
-      uint64_t chunks_lv = cl->levels.chunk_count[lv];
-      uint64_t lut_len = (uint64_t)batch_count * chunks_lv;
+  // Batch LUTs (gather + perm, epoch-major shard order).
+  for (int lv = 0; lv < cl->levels.nlod; ++lv) {
+    struct level_flush_state* lvl = &stage->levels[lv];
+    uint32_t batch_count = lvl->batch_active_count;
+    uint32_t slot_count = batch_count > 0 ? batch_count : 1;
+    uint64_t chunks_lv = cl->levels.chunk_count[lv];
+    uint64_t lut_len = (uint64_t)slot_count * chunks_lv;
 
-      if (lut_len == 0)
-        continue;
+    if (lut_len == 0)
+      continue;
 
-      uint32_t* h_gather = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
-      uint32_t* h_perm = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
-      CHECK(Fail, h_gather && h_perm);
+    uint32_t* h_gather = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
+    uint32_t* h_perm = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
+    CHECK(Fail, h_gather && h_perm);
 
-      const struct aggregate_layout* al = &lvl->agg_layout;
-
-      for (uint32_t a = 0; a < batch_count; ++a) {
+    {
+      uint32_t pool_epochs[MAX_BATCH_EPOCHS];
+      for (uint32_t a = 0; a < slot_count; ++a) {
         uint32_t period = 1;
         if (cl->dims.append_downsample && lv > 0)
           period = 1u << lv;
-        uint32_t pool_epoch = (a + 1) * period - 1;
-
-        for (uint64_t j = 0; j < chunks_lv; ++j) {
-          uint64_t idx = (uint64_t)a * chunks_lv + j;
-          h_gather[idx] = (uint32_t)(pool_epoch * total_chunks +
-                                     cl->levels.chunk_offset[lv] + j);
-
-          uint64_t perm_pos = 0;
-          uint64_t rest = j;
-          for (int d = al->lifted_rank - 1; d >= 0; --d) {
-            uint64_t coord = rest % al->lifted_shape[d];
-            rest /= al->lifted_shape[d];
-            perm_pos += coord * (uint64_t)al->lifted_strides[d];
-          }
-          h_perm[idx] = (uint32_t)(perm_pos * batch_count + a);
-        }
+        pool_epochs[a] = (a + 1) * period - 1;
       }
-
-      CU(LutFail, cuMemAlloc(&lvl->d_batch_gather, lut_len * sizeof(uint32_t)));
-      CU(LutFail,
-         cuMemcpyHtoD(
-           lvl->d_batch_gather, h_gather, lut_len * sizeof(uint32_t)));
-      CU(LutFail, cuMemAlloc(&lvl->d_batch_perm, lut_len * sizeof(uint32_t)));
-      CU(LutFail,
-         cuMemcpyHtoD(lvl->d_batch_perm, h_perm, lut_len * sizeof(uint32_t)));
-
-      free(h_gather);
-      free(h_perm);
-      continue;
-
-    LutFail:
-      free(h_gather);
-      free(h_perm);
-      goto Fail;
+      aggregate_batch_luts(&lvl->agg_layout,
+                           &cl->levels,
+                           lv,
+                           slot_count,
+                           pool_epochs,
+                           h_gather,
+                           h_perm);
     }
+
+    CU(LutFail, cuMemAlloc(&lvl->d_batch_gather, lut_len * sizeof(uint32_t)));
+    CU(LutFail,
+       cuMemcpyHtoD(lvl->d_batch_gather, h_gather, lut_len * sizeof(uint32_t)));
+    CU(LutFail, cuMemAlloc(&lvl->d_batch_perm, lut_len * sizeof(uint32_t)));
+    CU(LutFail,
+       cuMemcpyHtoD(lvl->d_batch_perm, h_perm, lut_len * sizeof(uint32_t)));
+
+    free(h_gather);
+    free(h_perm);
+    continue;
+
+  LutFail:
+    free(h_gather);
+    free(h_perm);
+    goto Fail;
   }
 
   // Seed events
@@ -262,7 +255,10 @@ compress_agg_kick(struct compress_agg_stage* stage,
                         compress_stream) == 0);
   }
 
-  // Per-level batch aggregate on compress stream
+  // Per-level batch aggregate on compress stream.
+  // Always use the batch aggregate path (LUT-based).  When active_count
+  // differs from the pre-computed batch_active_count, recompute host-side
+  // LUTs and upload them before launching the kernel.
   for (int lv = 0; lv < levels->nlod; ++lv) {
     if (!(in->active_levels_mask & (1u << lv)))
       continue;
@@ -270,73 +266,81 @@ compress_agg_kick(struct compress_agg_stage* stage,
     struct level_flush_state* lvl = &stage->levels[lv];
     uint32_t active_count = level_active_epochs(lvl, batch, dims, lv, n_epochs);
 
-    struct aggregate_slot* agg = &lvl->agg[fc];
-    uint64_t chunks_lv = levels->chunk_count[lv];
-
+    // Scan masks to determine active_count and pool epochs.
+    // level_active_epochs returns 0 for infrequent append-downsampled levels
+    // (period > K); in that case we scan masks directly.
+    uint32_t pool_epochs_buf[MAX_BATCH_EPOCHS];
     if (active_count == 0) {
-      // Infrequent append-downsampled level (period > K): scan actual per-epoch
-      // masks.
-      for (uint32_t e = 0; e < n_epochs; ++e) {
-        if (!(in->batch_active_masks[e] & (1u << lv)))
-          continue;
-        active_count++;
-
-        // aggregate_epoch_level but with compress_stream
-        void* d_comp =
-          (char*)stage->d_compressed[fc] +
-          ((uint64_t)e * levels->total_chunks + levels->chunk_offset[lv]) *
-            stage->codec.max_output_size;
-        size_t* d_sizes = stage->codec.d_comp_sizes +
-                          (uint64_t)e * levels->total_chunks +
-                          levels->chunk_offset[lv];
-        CHECK(Error,
-              aggregate_by_shard_async(
-                &lvl->agg_layout, d_comp, d_sizes, agg, compress_stream) == 0);
-      }
+      for (uint32_t e = 0; e < n_epochs; ++e)
+        if (in->batch_active_masks[e] & (1u << lv))
+          pool_epochs_buf[active_count++] = e;
       if (active_count == 0)
         continue;
-    } else {
-      uint64_t batch_chunk_count = (uint64_t)active_count * chunks_lv;
-      uint64_t batch_covering =
-        (uint64_t)active_count * lvl->agg_layout.covering_count;
-
-      int use_luts = (in->epochs_per_batch > 1 && lvl->d_batch_gather &&
-                      active_count == lvl->batch_active_count);
-      if (use_luts) {
-        CHECK(Error,
-              aggregate_batch_by_shard_async(
-                (void*)stage->d_compressed[fc],
-                stage->codec.d_comp_sizes,
-                (const uint32_t*)(uintptr_t)lvl->d_batch_gather,
-                (const uint32_t*)(uintptr_t)lvl->d_batch_perm,
-                batch_chunk_count,
-                batch_covering,
-                stage->codec.max_output_size,
-                &lvl->agg_layout,
-                agg,
-                compress_stream) == 0);
-      } else {
-        // K=1 or partial batch: per-epoch aggregate
-        for (uint32_t a = 0; a < active_count; ++a) {
-          uint32_t period = 1;
-          if (dims->append_downsample && lv > 0)
-            period = 1u << lv;
-          uint32_t pool_epoch = (n_epochs == 1) ? 0 : (a + 1) * period - 1;
-
-          void* d_comp = (char*)stage->d_compressed[fc] +
-                         ((uint64_t)pool_epoch * levels->total_chunks +
-                          levels->chunk_offset[lv]) *
-                           stage->codec.max_output_size;
-          size_t* d_sizes = stage->codec.d_comp_sizes +
-                            (uint64_t)pool_epoch * levels->total_chunks +
-                            levels->chunk_offset[lv];
-          CHECK(Error,
-                aggregate_by_shard_async(
-                  &lvl->agg_layout, d_comp, d_sizes, agg, compress_stream) ==
-                  0);
-        }
-      }
     }
+
+    struct aggregate_slot* agg = &lvl->agg[fc];
+    uint64_t chunks_lv = levels->chunk_count[lv];
+    uint64_t batch_chunk_count = (uint64_t)active_count * chunks_lv;
+    uint64_t batch_covering =
+      (uint64_t)active_count * lvl->agg_layout.covering_count;
+
+    // Recompute LUTs if active_count doesn't match pre-computed.
+    if (active_count != lvl->batch_active_count) {
+      // Scan masks for actual pool positions (unless already done above).
+      {
+        uint32_t ai = 0;
+        for (uint32_t e = 0; e < n_epochs; ++e)
+          if (in->batch_active_masks[e] & (1u << lv))
+            pool_epochs_buf[ai++] = e;
+      }
+
+      uint64_t lut_len = batch_chunk_count;
+      uint32_t* h_gather = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
+      uint32_t* h_perm = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
+      CHECK(LutRecompute, h_gather && h_perm);
+
+      aggregate_batch_luts(&lvl->agg_layout,
+                           levels,
+                           lv,
+                           active_count,
+                           pool_epochs_buf,
+                           h_gather,
+                           h_perm);
+
+      CU(LutRecompute,
+         cuMemcpyHtoDAsync(lvl->d_batch_gather,
+                           h_gather,
+                           lut_len * sizeof(uint32_t),
+                           compress_stream));
+      CU(LutRecompute,
+         cuMemcpyHtoDAsync(lvl->d_batch_perm,
+                           h_perm,
+                           lut_len * sizeof(uint32_t),
+                           compress_stream));
+
+      free(h_gather);
+      free(h_perm);
+      goto LutRecomputeDone;
+
+    LutRecompute:
+      free(h_gather);
+      free(h_perm);
+      goto Error;
+    LutRecomputeDone:;
+    }
+
+    CHECK(Error,
+          aggregate_batch_by_shard_async(
+            (void*)stage->d_compressed[fc],
+            stage->codec.d_comp_sizes,
+            (const uint32_t*)(uintptr_t)lvl->d_batch_gather,
+            (const uint32_t*)(uintptr_t)lvl->d_batch_perm,
+            batch_chunk_count,
+            batch_covering,
+            stage->codec.max_output_size,
+            &lvl->agg_layout,
+            agg,
+            compress_stream) == 0);
   }
 
   CU(Error, cuEventRecord(stage->t_aggregate_end[fc], compress_stream));

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -14,6 +14,8 @@ static struct writer_result
 tile_stream_gpu_append(struct writer* self, struct slice input);
 static struct writer_result
 tile_stream_gpu_flush(struct writer* self);
+static struct writer_result
+tile_stream_gpu_flush_final(struct writer* self);
 
 // --- Helpers ---
 
@@ -65,6 +67,10 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
 {
   struct tile_stream_gpu* s =
     container_of(self, struct tile_stream_gpu, writer);
+
+  if (s->flushed)
+    return writer_finished_at(input.beg, input.end);
+
   const size_t bytes_per_element = dtype_bpe(s->config.dtype);
   const size_t buffer_capacity = s->config.buffer_capacity_bytes;
   const uint8_t* src = (const uint8_t*)input.beg;
@@ -228,9 +234,19 @@ Error:
   return writer_error();
 }
 
+static struct writer_result
+tile_stream_gpu_flush_final(struct writer* self)
+{
+  struct tile_stream_gpu* s =
+    container_of(self, struct tile_stream_gpu, writer);
+  struct writer_result r = tile_stream_gpu_flush(self);
+  s->flushed = 1;
+  return r;
+}
+
 void
 tile_stream_gpu_init_writer(struct tile_stream_gpu* s)
 {
   s->writer.append = tile_stream_gpu_append;
-  s->writer.flush = tile_stream_gpu_flush;
+  s->writer.flush = tile_stream_gpu_flush_final;
 }

--- a/src/gpu/stream.internal.h
+++ b/src/gpu/stream.internal.h
@@ -171,6 +171,8 @@ struct tile_stream_gpu
   struct staging_state stage;
   uint64_t cursor_elements;
   uint64_t max_cursor_elements; // 0 = unbounded
+  int flushed;                  // 1 after flush; append after flush returns
+                                // finished
   struct stream_metrics metrics;
   struct platform_clock metadata_update_clock;
 };

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -56,7 +56,6 @@ struct multiarray_tile_stream_cpu
   size_t* shard_order_sizes;
 
   // Shared LUT storage (recomputed on switch).
-  uint32_t* chunk_to_shard_map[LOD_MAX_LEVELS];
   uint32_t* batch_gather[LOD_MAX_LEVELS];
   uint32_t* batch_chunk_to_shard_map[LOD_MAX_LEVELS];
   uint32_t* scatter_lut;
@@ -107,7 +106,6 @@ struct pool_maxima
   size_t lod_values_bytes;
   size_t agg_data_bytes[LOD_MAX_LEVELS];
   uint64_t agg_batch_C_count[LOD_MAX_LEVELS];
-  size_t chunk_to_shard_map_count[LOD_MAX_LEVELS];
   size_t batch_gather_count[LOD_MAX_LEVELS];
   size_t scatter_lut_count;
   size_t scatter_batch_offsets_count;
@@ -178,8 +176,6 @@ init_array_descriptor(struct array_descriptor* desc,
 
     if (batch_C > maxima->batch_covering_count)
       maxima->batch_covering_count = batch_C;
-    maxima->chunk_to_shard_map_count[lv] =
-      max_sz(maxima->chunk_to_shard_map_count[lv], M_lv);
     if (batch_C > maxima->agg_batch_C_count[lv])
       maxima->agg_batch_C_count[lv] = batch_C;
     maxima->agg_data_bytes[lv] =
@@ -190,9 +186,8 @@ init_array_descriptor(struct array_descriptor* desc,
                             al->cps_inner,
                             al->page_size));
 
-    if (K_l > 1)
-      maxima->batch_gather_count[lv] =
-        max_sz(maxima->batch_gather_count[lv], (uint64_t)K_l * M_lv);
+    maxima->batch_gather_count[lv] =
+      max_sz(maxima->batch_gather_count[lv], (uint64_t)slot_count * M_lv);
 
     if (init_shard_state(&desc->shard[lv], li))
       return 1;
@@ -269,11 +264,6 @@ alloc_shared_buffers(struct multiarray_tile_stream_cpu* ms,
       as->data = malloc(mx->agg_data_bytes[lv]);
       as->data_capacity_bytes = mx->agg_data_bytes[lv];
       CHECK(Fail, as->data);
-    }
-    if (mx->chunk_to_shard_map_count[lv] > 0) {
-      ms->chunk_to_shard_map[lv] =
-        (uint32_t*)malloc(mx->chunk_to_shard_map_count[lv] * sizeof(uint32_t));
-      CHECK(Fail, ms->chunk_to_shard_map[lv]);
     }
     if (mx->batch_gather_count[lv] > 0) {
       ms->batch_gather[lv] =
@@ -417,7 +407,6 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
     free(ms->agg_slots[lv].data);
     free(ms->agg_slots[lv].offsets);
     free(ms->agg_slots[lv].chunk_sizes);
-    free(ms->chunk_to_shard_map[lv]);
     free(ms->batch_gather[lv]);
     free(ms->batch_chunk_to_shard_map[lv]);
     free(ms->morton_lut[lv]);
@@ -455,7 +444,6 @@ recompute_luts(struct multiarray_tile_stream_cpu* ms, int array_index)
     .scatter_batch_offsets = ms->scatter_batch_offsets,
   };
   for (int lv = 0; lv < desc->levels.nlod; ++lv) {
-    luts.chunk_to_shard_map[lv] = ms->chunk_to_shard_map[lv];
     luts.batch_gather[lv] = ms->batch_gather[lv];
     luts.batch_chunk_to_shard_map[lv] = ms->batch_chunk_to_shard_map[lv];
     luts.morton_lut[lv] = ms->morton_lut[lv];
@@ -494,6 +482,8 @@ make_flush_params(struct multiarray_tile_stream_cpu* ms,
     .comp_sizes = ms->comp_sizes,
     .total_chunks = desc->levels.total_chunks,
     .nlod = desc->levels.nlod,
+    .cl = &desc->cl,
+    .levels_geo = &desc->levels,
     .shard_order_sizes_bytes = ms->shard_order_sizes,
     .sink = desc->sink,
     .shard_alignment_bytes = desc->config.shard_alignment,
@@ -504,7 +494,6 @@ make_flush_params(struct multiarray_tile_stream_cpu* ms,
       .agg_layout = &desc->agg_layout[lv],
       .batch_active_count = desc->batch_active_count[lv],
       .chunk_offset = desc->levels.chunk_offset[lv],
-      .chunk_to_shard_map = ms->chunk_to_shard_map[lv],
       .batch_chunk_to_shard_map = ms->batch_chunk_to_shard_map[lv],
       .batch_gather = ms->batch_gather[lv],
       .agg_slot = &ms->agg_slots[lv],

--- a/src/stream/types.aggregate.c
+++ b/src/stream/types.aggregate.c
@@ -1,5 +1,6 @@
 #include "stream/types.aggregate.h"
 
+#include "stream/layouts.h"
 #include "util/index.ops.h"
 #include "util/prelude.h"
 
@@ -21,6 +22,35 @@ agg_pool_bytes(uint64_t chunk_count,
   return bytes;
 Overflow:
   return 0;
+}
+
+void
+aggregate_batch_luts(const struct aggregate_layout* agg,
+                     const struct level_geometry* levels,
+                     int lv,
+                     uint32_t active_count,
+                     const uint32_t* pool_epochs,
+                     uint32_t* out_gather,
+                     uint32_t* out_perm)
+{
+  const uint64_t total_chunks = levels->total_chunks;
+  const uint64_t M_lv = agg->chunks_per_epoch;
+  const uint32_t cps_inner = (uint32_t)agg->cps_inner;
+
+  for (uint32_t a = 0; a < active_count; ++a) {
+    uint32_t pool_epoch = pool_epochs[a];
+    for (uint64_t j = 0; j < M_lv; ++j) {
+      uint64_t idx = (uint64_t)a * M_lv + j;
+      out_gather[idx] =
+        (uint32_t)(pool_epoch * total_chunks + levels->chunk_offset[lv] + j);
+
+      uint32_t perm_pos = (uint32_t)ravel(
+        agg->lifted_rank, agg->lifted_shape, agg->lifted_strides, j);
+      uint32_t si = perm_pos / cps_inner;
+      uint32_t c = perm_pos % cps_inner;
+      out_perm[idx] = si * active_count * cps_inner + a * cps_inner + c;
+    }
+  }
 }
 
 int

--- a/src/stream/types.aggregate.h
+++ b/src/stream/types.aggregate.h
@@ -52,6 +52,19 @@ extern "C"
     size_t* chunk_sizes; // [C] real pre-padding compressed sizes
   };
 
+  // Compute gather + perm LUTs for a batch of active_count epochs.
+  // pool_epochs[a] gives the compressed-pool epoch index for active slot a.
+  // Perm uses epoch-major shard order matching deliver_to_shards_batch():
+  //   target = si * active_count * cps_inner + a * cps_inner + c
+  struct level_geometry;
+  void aggregate_batch_luts(const struct aggregate_layout* agg,
+                            const struct level_geometry* levels,
+                            int lv,
+                            uint32_t active_count,
+                            const uint32_t* pool_epochs,
+                            uint32_t* out_gather,
+                            uint32_t* out_perm);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/writer.h
+++ b/src/writer.h
@@ -19,7 +19,7 @@ enum writer_error_code
   writer_error_ok = 0,
   writer_error_fail = 1,
   writer_error_finished =
-    2, // bounded append dims capacity reached, data flushed
+    2, // stream complete: capacity reached or flush already called
 };
 
 struct writer_result
@@ -31,7 +31,8 @@ struct writer_result
 struct writer
 {
   struct writer_result (*append)(struct writer* self, struct slice data);
-  struct writer_result (*flush)(struct writer* self);
+  struct writer_result (*flush)(struct writer* self); // terminal: append after
+                                                      // flush returns finished
 };
 
 struct shard_writer

--- a/tests/test_cpu_zarr_fs.c
+++ b/tests/test_cpu_zarr_fs.c
@@ -445,7 +445,7 @@ test_batch_readback_impl(const char* tmpdir, int epochs_per_batch)
     snprintf(path, sizeof(path), "%s/0/c/0/0/0", tmpdir);
     CHECK(Fail4, test_file_exists(path));
 
-    uint8_t* shard_data;
+    uint8_t* shard_data = NULL;
     size_t shard_len;
     CHECK(Fail4, read_file_all(path, &shard_data, &shard_len) == 0);
 
@@ -453,14 +453,23 @@ test_batch_readback_impl(const char* tmpdir, int epochs_per_batch)
       (uint64_t*)malloc((size_t)chunks_per_shard_total * sizeof(uint64_t));
     uint64_t* nbytes =
       (uint64_t*)malloc((size_t)chunks_per_shard_total * sizeof(uint64_t));
-    CHECK(Fail5, offsets && nbytes);
+    if (!offsets || !nbytes) {
+      free(offsets);
+      free(nbytes);
+      free(shard_data);
+      goto Fail4;
+    }
 
-    CHECK(Fail5,
-          shard_index_parse(shard_data,
-                            shard_len,
-                            (size_t)chunks_per_shard_total,
-                            offsets,
-                            nbytes) == 0);
+    if (shard_index_parse(shard_data,
+                          shard_len,
+                          (size_t)chunks_per_shard_total,
+                          offsets,
+                          nbytes)) {
+      free(offsets);
+      free(nbytes);
+      free(shard_data);
+      goto Fail4;
+    }
 
     // Verify each chunk: slot (t, j) should decompress to all-t values.
     // Shard index slot = t * cps_inner + j, where cps_inner = 4.
@@ -488,7 +497,8 @@ test_batch_readback_impl(const char* tmpdir, int epochs_per_batch)
     free(offsets);
     free(nbytes);
     free(shard_data);
-    CHECK(Fail4, errors == 0);
+    if (errors)
+      goto Fail4;
   }
 
   tile_stream_cpu_destroy(s);
@@ -496,8 +506,6 @@ test_batch_readback_impl(const char* tmpdir, int epochs_per_batch)
   free(src);
   return 0;
 
-Fail5:
-  // offsets/nbytes freed above if allocated
 Fail4:
   tile_stream_cpu_destroy(s);
 Fail3:

--- a/tests/test_cpu_zarr_fs.c
+++ b/tests/test_cpu_zarr_fs.c
@@ -355,20 +355,202 @@ Fail:
   return 1;
 }
 
+// Readback test: verify chunk data integrity when all epochs fit in one shard.
+// This exercises the batch aggregate perm layout: with chunks_per_shard_append
+// >= total epochs, a perm that produces chunk-major instead of epoch-major
+// order would cause the shard index to point chunks at wrong data.
+//
+// epochs_per_batch controls the batch size:
+//   == n_epochs: full-batch path (pre-computed LUTs)
+//   >  n_epochs: partial-batch path (dynamic LUT recompute at flush)
+static int
+test_batch_readback_impl(const char* tmpdir, int epochs_per_batch)
+{
+  const int n_epochs = 4;
+  const int inner_size[2] = { 8, 12 };
+  const int epoch_elements = inner_size[0] * inner_size[1];
+  const int total_elements = n_epochs * epoch_elements;
+  // chunks_per_shard = [4, 2, 2] => all 4 epochs in one shard, one inner shard
+  const int chunks_per_shard_append = 4;
+  const int chunks_per_shard_total = 4 * 2 * 2; // 16
+
+  // Fill each epoch with a constant: epoch t -> all values = t.
+  uint16_t* src = (uint16_t*)malloc((size_t)total_elements * sizeof(uint16_t));
+  CHECK(Fail, src);
+  for (int t = 0; t < n_epochs; ++t)
+    for (int i = 0; i < epoch_elements; ++i)
+      src[t * epoch_elements + i] = (uint16_t)t;
+
+  struct dimension dims[] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = chunks_per_shard_append,
+      .name = "t",
+      .storage_position = 0 },
+    { .size = inner_size[0],
+      .chunk_size = 4,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = inner_size[1],
+      .chunk_size = 6,
+      .chunks_per_shard = 2,
+      .name = "x",
+      .storage_position = 2 },
+  };
+
+  struct zarr_config zcfg = {
+    .store_path = tmpdir,
+    .array_name = "0",
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = CODEC_ZSTD,
+  };
+
+  struct zarr_fs_sink* zs = zarr_fs_sink_create(&zcfg);
+  CHECK(Fail2, zs);
+
+  const struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = (size_t)total_elements * sizeof(uint16_t),
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = CODEC_ZSTD,
+    .epochs_per_batch = (uint8_t)epochs_per_batch,
+  };
+
+  struct tile_stream_cpu* s =
+    tile_stream_cpu_create(&config, zarr_fs_sink_as_shard_sink(zs));
+  CHECK(Fail3, s);
+
+  const struct tile_stream_layout* lay = tile_stream_cpu_layout(s);
+  size_t chunk_stride_bytes = lay->chunk_stride * sizeof(uint16_t);
+
+  {
+    struct slice input = { .beg = src, .end = src + total_elements };
+    struct writer_result r = writer_append(tile_stream_cpu_writer(s), input);
+    CHECK(Fail4, r.error == 0);
+  }
+  {
+    struct writer_result r = writer_flush(tile_stream_cpu_writer(s));
+    CHECK(Fail4, r.error == 0);
+  }
+  zarr_fs_sink_flush(zs);
+
+  // There should be exactly one shard (all epochs + all inner chunks).
+  {
+    char path[4096];
+    snprintf(path, sizeof(path), "%s/0/c/0/0/0", tmpdir);
+    CHECK(Fail4, test_file_exists(path));
+
+    uint8_t* shard_data;
+    size_t shard_len;
+    CHECK(Fail4, read_file_all(path, &shard_data, &shard_len) == 0);
+
+    uint64_t* offsets =
+      (uint64_t*)malloc((size_t)chunks_per_shard_total * sizeof(uint64_t));
+    uint64_t* nbytes =
+      (uint64_t*)malloc((size_t)chunks_per_shard_total * sizeof(uint64_t));
+    CHECK(Fail5, offsets && nbytes);
+
+    CHECK(Fail5,
+          shard_index_parse(shard_data,
+                            shard_len,
+                            (size_t)chunks_per_shard_total,
+                            offsets,
+                            nbytes) == 0);
+
+    // Verify each chunk: slot (t, j) should decompress to all-t values.
+    // Shard index slot = t * cps_inner + j, where cps_inner = 4.
+    const int cps_inner = 4;
+    int errors = 0;
+    for (int t = 0; t < n_epochs; ++t) {
+      for (int j = 0; j < cps_inner; ++j) {
+        int slot = t * cps_inner + j;
+        if (nbytes[slot] == (uint64_t)-1 || nbytes[slot] == 0) {
+          log_error("  slot (%d,%d): empty", t, j);
+          errors++;
+          continue;
+        }
+        if (chunk_decompress_verify_u16(shard_data + offsets[slot],
+                                        (size_t)nbytes[slot],
+                                        chunk_stride_bytes,
+                                        lay->chunk_stride,
+                                        (uint16_t)t)) {
+          log_error("  slot (%d,%d): data mismatch (expected all %d)", t, j, t);
+          errors++;
+        }
+      }
+    }
+
+    free(offsets);
+    free(nbytes);
+    free(shard_data);
+    CHECK(Fail4, errors == 0);
+  }
+
+  tile_stream_cpu_destroy(s);
+  zarr_fs_sink_destroy(zs);
+  free(src);
+  return 0;
+
+Fail5:
+  // offsets/nbytes freed above if allocated
+Fail4:
+  tile_stream_cpu_destroy(s);
+Fail3:
+  zarr_fs_sink_destroy(zs);
+Fail2:
+  free(src);
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+// Full-batch readback: K == n_epochs, exercises pre-computed LUTs.
+static int
+test_batch_readback(const char* tmpdir)
+{
+  log_info("=== test_cpu_zarr_batch_readback ===");
+  int rc = test_batch_readback_impl(tmpdir, 4);
+  if (rc == 0)
+    log_info("  PASS");
+  return rc;
+}
+
+// Partial-batch readback: K > n_epochs, exercises dynamic LUT recompute.
+static int
+test_partial_batch_readback(const char* tmpdir)
+{
+  log_info("=== test_cpu_zarr_partial_batch_readback ===");
+  int rc = test_batch_readback_impl(tmpdir, 8);
+  if (rc == 0)
+    log_info("  PASS");
+  return rc;
+}
+
 int
 main(void)
 {
   int err = 0;
 
-  char tmpdir1[256], tmpdir2[256];
+  char tmpdir1[256], tmpdir2[256], tmpdir3[256], tmpdir4[256];
   CHECK(Fail, test_tmpdir_create(tmpdir1, sizeof(tmpdir1)) == 0);
   CHECK(Fail, test_tmpdir_create(tmpdir2, sizeof(tmpdir2)) == 0);
+  CHECK(Fail, test_tmpdir_create(tmpdir3, sizeof(tmpdir3)) == 0);
+  CHECK(Fail, test_tmpdir_create(tmpdir4, sizeof(tmpdir4)) == 0);
 
   err |= test_pipeline(tmpdir1);
   err |= test_streaming_append(tmpdir2);
+  err |= test_batch_readback(tmpdir3);
+  err |= test_partial_batch_readback(tmpdir4);
 
   test_tmpdir_remove(tmpdir1);
   test_tmpdir_remove(tmpdir2);
+  test_tmpdir_remove(tmpdir3);
+  test_tmpdir_remove(tmpdir4);
   return err;
 
 Fail:

--- a/tests/test_stream_cpu.c
+++ b/tests/test_stream_cpu.c
@@ -140,6 +140,82 @@ Fail:
   return 1;
 }
 
+// Test that append after flush returns an error.
+static int
+test_append_after_flush(void)
+{
+  log_info("=== test_stream_cpu_append_after_flush ===");
+
+  struct test_shard_sink sink;
+  test_sink_init(&sink, 16, SHARD_CAP);
+
+  struct dimension dims[] = {
+    { .size = 0,
+      .chunk_size = 2,
+      .chunks_per_shard = 1,
+      .storage_position = 0 },
+    { .size = 4,
+      .chunk_size = 2,
+      .chunks_per_shard = 2,
+      .storage_position = 1 },
+    { .size = 6,
+      .chunk_size = 3,
+      .chunks_per_shard = 2,
+      .storage_position = 2 },
+  };
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = CODEC_NONE,
+  };
+
+  struct tile_stream_cpu* s = tile_stream_cpu_create(&config, &sink.base);
+  CHECK(Fail, s);
+
+  const struct tile_stream_layout* lay = tile_stream_cpu_layout(s);
+  uint64_t epoch_elems = lay->epoch_elements;
+  size_t epoch_bytes = epoch_elems * sizeof(uint16_t);
+  uint16_t* data = (uint16_t*)malloc(epoch_bytes);
+  CHECK(Fail, data);
+  for (uint64_t i = 0; i < epoch_elems; ++i)
+    data[i] = (uint16_t)i;
+
+  struct writer* w = tile_stream_cpu_writer(s);
+
+  // Write one epoch, then flush.
+  {
+    struct slice sl = { .beg = data, .end = (const char*)data + epoch_bytes };
+    struct writer_result r = writer_append(w, sl);
+    CHECK(Fail, r.error == 0);
+  }
+  {
+    struct writer_result r = writer_flush(w);
+    CHECK(Fail, r.error == 0);
+  }
+
+  // Append after flush must return "finished" (not a hard error).
+  {
+    struct slice sl = { .beg = data, .end = (const char*)data + epoch_bytes };
+    struct writer_result r = writer_append(w, sl);
+    CHECK(Fail, r.error == writer_error_finished);
+  }
+
+  free(data);
+  tile_stream_cpu_destroy(s);
+  test_sink_free(&sink);
+  log_info("  PASS");
+  return 0;
+
+Fail:
+  tile_stream_cpu_destroy(s);
+  test_sink_free(&sink);
+  log_error("  FAIL");
+  return 1;
+}
+
 int
 main(int ac, char* av[])
 {
@@ -149,5 +225,6 @@ main(int ac, char* av[])
   int rc = 0;
   rc |= test_basic_pipeline();
   rc |= test_f16_rejected();
+  rc |= test_append_after_flush();
   return rc;
 }

--- a/tests/test_stream_cpu.c
+++ b/tests/test_stream_cpu.c
@@ -210,6 +210,7 @@ test_append_after_flush(void)
   return 0;
 
 Fail:
+  free(data);
   tile_stream_cpu_destroy(s);
   test_sink_free(&sink);
   log_error("  FAIL");


### PR DESCRIPTION
## Summary
- Fix shard data corruption when `chunks_per_shard_append >= epochs` by correcting the batch aggregate permutation from chunk-major to epoch-major ordering
- Unify batch and per-epoch aggregate paths into a single batch path, eliminating the layout convention mismatch that caused the bug
- Make flush terminal — append after flush returns `writer_error_finished`

This increases the memory for the LUT because it has to cover epochs across batches but should improve performance by correctly aggregating by shard (across epochs in a batch).

## Test plan
- [x] `test_batch_readback`: full-batch readback with `K == n_epochs` (pre-computed LUTs)
- [x] `test_partial_batch_readback`: partial-batch readback with `K > n_epochs` (dynamic LUT recompute)
- [x] `test_append_after_flush`: append after flush returns `writer_error_finished`

Closes #31