### PR TITLE
Add max_nlod config field

### DIFF
--- a/src/stream/config.c
+++ b/src/stream/config.c
@@ -173,6 +173,11 @@ validate_config(const struct tile_stream_configuration* config,
     goto Fail;
   }
 
+  if (config->max_nlod > 0 && config->max_nlod + 1 > LOD_MAX_LEVELS) {
+    log_error("max_nlod %d exceeds limit (%d)", config->max_nlod, LOD_MAX_LEVELS - 1);
+    goto Fail;
+  }
+
   {
     uint8_t na = dim_info_n_append(di);
     if (resolve_storage_order(config->rank, na, config->dimensions, NULL)) {

--- a/src/stream/config.c
+++ b/src/stream/config.c
@@ -173,8 +173,12 @@ validate_config(const struct tile_stream_configuration* config,
     goto Fail;
   }
 
-  if (config->max_nlod > 0 && config->max_nlod + 1 > LOD_MAX_LEVELS) {
-    log_error("max_nlod %d exceeds limit (%d)", config->max_nlod, LOD_MAX_LEVELS - 1);
+  if (config->max_nlod < 0) {
+    log_error("max_nlod must be >= 0 (got %d)", config->max_nlod);
+    goto Fail;
+  }
+  if (config->max_nlod > LOD_MAX_LEVELS) {
+    log_error("max_nlod %d exceeds limit (%d)", config->max_nlod, LOD_MAX_LEVELS);
     goto Fail;
   }
 
@@ -235,12 +239,10 @@ compute_stream_layouts(const struct tile_stream_configuration* config,
 
   // --- LOD plan (always runs) ---
   int max_levels;
-  if (config->max_nlod < 0)
+  if (config->max_nlod == 0)
     max_levels = LOD_MAX_LEVELS;
-  else if (config->max_nlod == 0)
-    max_levels = 1;
   else
-    max_levels = config->max_nlod + 1;
+    max_levels = config->max_nlod;
   CHECK(Fail,
         lod_plan_init_from_epoch_dims(
           &out->plan, dims, rank, na, max_levels) == 0);

--- a/src/stream/config.c
+++ b/src/stream/config.c
@@ -219,9 +219,16 @@ compute_stream_layouts(const struct tile_stream_configuration* config,
   CHECK(Fail, resolve_storage_order(rank, na, dims, storage_order) == 0);
 
   // --- LOD plan (always runs) ---
+  int max_levels;
+  if (config->max_nlod < 0)
+    max_levels = LOD_MAX_LEVELS;
+  else if (config->max_nlod == 0)
+    max_levels = 1;
+  else
+    max_levels = config->max_nlod + 1;
   CHECK(Fail,
         lod_plan_init_from_epoch_dims(
-          &out->plan, dims, rank, na, LOD_MAX_LEVELS) == 0);
+          &out->plan, dims, rank, na, max_levels) == 0);
   int enable_multiscale = out->plan.lod_mask != 0;
   out->levels.enable_multiscale = enable_multiscale;
   out->levels.nlod = enable_multiscale ? out->plan.nlod : 1;

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -42,6 +42,7 @@ struct tile_stream_configuration
   enum compression_codec codec;
   enum lod_reduce_method reduce_method;
   enum lod_reduce_method append_reduce_method;
+  int max_nlod; // <0 = auto, 0 = none, N>0 = N downsampled levels
   uint8_t epochs_per_batch; // K: 0 = auto (target_batch_chunks), must be pow2
   uint32_t
     target_batch_chunks; // minimum chunks per compress batch (default 1024)

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -42,7 +42,7 @@ struct tile_stream_configuration
   struct codec_config codec;
   enum lod_reduce_method reduce_method;
   enum lod_reduce_method append_reduce_method;
-  int max_nlod; // <0 = auto, 0 = none, N>0 = N downsampled levels
+  int max_nlod; // 0 = auto, N>0 = max N total levels (1 = base only)
   uint8_t epochs_per_batch; // K: 0 = auto (target_batch_chunks), must be pow2
   uint32_t
     target_batch_chunks; // minimum chunks per compress batch (default 1024)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,7 +71,7 @@ add_test_exe(test_compress_cpu test_compress_cpu.c compress_cpu chucky_log)
 add_test_exe(test_aggregate_cpu test_aggregate_cpu.c aggregate_cpu stream_config chucky_log)
 
 # CPU LOD test (no CUDA)
-add_test_exe(test_lod_cpu test_lod_cpu.c lod_cpu chucky_log)
+add_test_exe(test_lod_cpu test_lod_cpu.c lod_cpu compress_cpu chucky_log)
 
 # CPU stream end-to-end test (no CUDA)
 add_test_exe(test_stream_cpu test_stream_cpu.c stream_cpu writer test_shard_sink chucky_log)

--- a/tests/test_lod_cpu.c
+++ b/tests/test_lod_cpu.c
@@ -275,6 +275,45 @@ Fail:
   return 1;
 }
 
+// Test max_nlod semantics: negative=auto, 0=none, positive=cap.
+// Uses lod_plan_init_shapes to verify plan computation directly.
+static int
+test_max_nlod_semantics(void)
+{
+  log_info("=== test_max_nlod_semantics ===");
+
+  // shape=256, chunk=1, mask=0x1 → auto gives many levels
+  uint64_t shape[] = { 256 };
+  uint64_t chunk[] = { 1 };
+  uint32_t mask = 0x1;
+  struct lod_plan plan;
+
+  // negative max_nlod → auto (use LOD_MAX_LEVELS=32)
+  // With shape=256, chunk=1, auto should give 9 levels (256→128→64→32→16→8→4→2→1)
+  CHECK(Fail,
+        lod_plan_init_shapes(&plan, 1, shape, chunk, mask, LOD_MAX_LEVELS) == 0);
+  int auto_nlod = plan.nlod;
+  CHECK(Fail, auto_nlod == 9);
+  log_info("  negative (auto): nlod=%d", auto_nlod);
+
+  // max_nlod=0 → max_levels=1 → nlod=1 (no downsampling)
+  CHECK(Fail, lod_plan_init_shapes(&plan, 1, shape, chunk, mask, 1) == 0);
+  CHECK(Fail, plan.nlod == 1);
+  log_info("  zero (none): nlod=%d", plan.nlod);
+
+  // max_nlod=3 → max_levels=4 → nlod capped at 4
+  CHECK(Fail, lod_plan_init_shapes(&plan, 1, shape, chunk, mask, 4) == 0);
+  CHECK(Fail, plan.nlod == 4);
+  CHECK(Fail, plan.nlod < auto_nlod);
+  log_info("  positive (cap=3 downsampled → max_levels=4): nlod=%d", plan.nlod);
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
 int
 main(int ac, char* av[])
 {
@@ -290,5 +329,6 @@ main(int ac, char* av[])
   rc |= test_level_count_regression();
   rc |= test_level_count_shape_le_chunk();
   rc |= test_level_count_max_levels();
+  rc |= test_max_nlod_semantics();
   return rc;
 }

--- a/tests/test_lod_cpu.c
+++ b/tests/test_lod_cpu.c
@@ -1,5 +1,7 @@
+#include "cpu/compress.h"
 #include "cpu/lod.h"
 #include "lod/lod_plan.h"
+#include "stream/config.h"
 #include "util/prelude.h"
 
 #include <math.h>
@@ -314,6 +316,145 @@ Fail:
   return 1;
 }
 
+// Test that max_nlod > LOD_MAX_LEVELS-1 is rejected by compute_stream_layouts.
+static int
+test_max_nlod_validation_rejection(void)
+{
+  log_info("=== test_max_nlod_validation_rejection ===");
+
+  struct dimension dims[] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 1,
+      .storage_position = 0 },
+    { .size = 64,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .downsample = 1,
+      .storage_position = 1 },
+  };
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .max_nlod = 32, // exceeds LOD_MAX_LEVELS - 1
+  };
+
+  struct computed_stream_layouts cl;
+  int rc = compute_stream_layouts(
+    &config, 1, compress_cpu_max_output_size, &cl);
+  CHECK(Fail, rc != 0); // must be rejected
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+// Test that max_nlod=0 through compute_stream_layouts yields nlod==1.
+static int
+test_max_nlod_zero_via_layouts(void)
+{
+  log_info("=== test_max_nlod_zero_via_layouts ===");
+
+  struct dimension dims[] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 1,
+      .storage_position = 0 },
+    { .size = 64,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .downsample = 1,
+      .storage_position = 1 },
+  };
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .max_nlod = 0, // no downsampled levels
+  };
+
+  struct computed_stream_layouts cl;
+  CHECK(Fail,
+        compute_stream_layouts(
+          &config, 1, compress_cpu_max_output_size, &cl) == 0);
+  CHECK(Fail, cl.levels.nlod == 1); // base level only
+  computed_stream_layouts_free(&cl);
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+// Test that positive max_nlod caps the level count via compute_stream_layouts.
+static int
+test_max_nlod_positive_cap_via_layouts(void)
+{
+  log_info("=== test_max_nlod_positive_cap_via_layouts ===");
+
+  struct dimension dims[] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 1,
+      .storage_position = 0 },
+    { .size = 256,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .downsample = 1,
+      .storage_position = 1 },
+  };
+
+  // First, compute with auto to see uncapped nlod.
+  struct tile_stream_configuration config_auto = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .max_nlod = -1, // auto
+  };
+
+  struct computed_stream_layouts cl_auto;
+  CHECK(Fail,
+        compute_stream_layouts(
+          &config_auto, 1, compress_cpu_max_output_size, &cl_auto) == 0);
+  CHECK(Fail, cl_auto.levels.nlod > 3); // auto should produce more than 3
+  computed_stream_layouts_free(&cl_auto);
+
+  // Now cap at max_nlod=2 → expect nlod==3 (base + 2 downsampled).
+  struct tile_stream_configuration config_cap = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .max_nlod = 2,
+  };
+
+  struct computed_stream_layouts cl_cap;
+  CHECK(Fail,
+        compute_stream_layouts(
+          &config_cap, 1, compress_cpu_max_output_size, &cl_cap) == 0);
+  CHECK(Fail, cl_cap.levels.nlod == 3); // base + 2 downsampled
+  computed_stream_layouts_free(&cl_cap);
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
 int
 main(int ac, char* av[])
 {
@@ -330,5 +471,8 @@ main(int ac, char* av[])
   rc |= test_level_count_shape_le_chunk();
   rc |= test_level_count_max_levels();
   rc |= test_max_nlod_semantics();
+  rc |= test_max_nlod_validation_rejection();
+  rc |= test_max_nlod_zero_via_layouts();
+  rc |= test_max_nlod_positive_cap_via_layouts();
   return rc;
 }

--- a/tests/test_lod_cpu.c
+++ b/tests/test_lod_cpu.c
@@ -493,6 +493,89 @@ Fail:
   return 1;
 }
 
+// Test that max_nlod=0 (auto) produces identical results to LOD_MAX_LEVELS.
+// Both should resolve to the natural (uncapped) level count.
+static int
+test_max_nlod_zero_equals_uncapped(void)
+{
+  log_info("=== test_max_nlod_zero_equals_uncapped ===");
+
+  struct dimension dims[] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 1,
+      .storage_position = 0 },
+    { .size = 256,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .downsample = 1,
+      .storage_position = 1 },
+    { .size = 256,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .downsample = 1,
+      .storage_position = 2 },
+  };
+
+  // max_nlod=0 -> auto (should resolve to LOD_MAX_LEVELS internally)
+  struct tile_stream_configuration config_auto = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .max_nlod = 0,
+  };
+
+  // max_nlod=LOD_MAX_LEVELS -> explicitly uncapped
+  struct tile_stream_configuration config_uncapped = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .max_nlod = LOD_MAX_LEVELS,
+  };
+
+  struct computed_stream_layouts cl_auto, cl_uncapped;
+  CHECK(Fail,
+        compute_stream_layouts(
+          &config_auto, 1, compress_cpu_max_output_size, &cl_auto) == 0);
+  CHECK(Fail,
+        compute_stream_layouts(
+          &config_uncapped, 1, compress_cpu_max_output_size, &cl_uncapped) ==
+          0);
+
+  // Both should produce multiple levels (sanity check the config is
+  // interesting)
+  CHECK(Fail, cl_auto.levels.nlod > 1);
+
+  // nlod must match
+  CHECK(Fail, cl_auto.levels.nlod == cl_uncapped.levels.nlod);
+
+  // Per-level chunk counts must match
+  for (int lv = 0; lv < cl_auto.levels.nlod; ++lv)
+    CHECK(Fail,
+          cl_auto.levels.chunk_count[lv] == cl_uncapped.levels.chunk_count[lv]);
+
+  // Total chunks must match
+  CHECK(Fail, cl_auto.levels.total_chunks == cl_uncapped.levels.total_chunks);
+
+  log_info("  nlod=%d (auto=0 and uncapped=%d agree)",
+           cl_auto.levels.nlod,
+           LOD_MAX_LEVELS);
+
+  computed_stream_layouts_free(&cl_auto);
+  computed_stream_layouts_free(&cl_uncapped);
+  log_info("  PASS");
+  return 0;
+Fail:
+  computed_stream_layouts_free(&cl_auto);
+  computed_stream_layouts_free(&cl_uncapped);
+  log_error("  FAIL");
+  return 1;
+}
+
 int
 main(int ac, char* av[])
 {
@@ -512,5 +595,6 @@ main(int ac, char* av[])
   rc |= test_max_nlod_validation_rejection();
   rc |= test_max_nlod_one_via_layouts();
   rc |= test_max_nlod_positive_cap_via_layouts();
+  rc |= test_max_nlod_zero_equals_uncapped();
   return rc;
 }

--- a/tests/test_lod_cpu.c
+++ b/tests/test_lod_cpu.c
@@ -277,37 +277,37 @@ Fail:
   return 1;
 }
 
-// Test max_nlod semantics: negative=auto, 0=none, positive=cap.
+// Test max_nlod semantics: 0=auto, N>0=cap at N total levels.
 // Uses lod_plan_init_shapes to verify plan computation directly.
 static int
 test_max_nlod_semantics(void)
 {
   log_info("=== test_max_nlod_semantics ===");
 
-  // shape=256, chunk=1, mask=0x1 → auto gives many levels
+  // shape=256, chunk=1, mask=0x1 -> auto gives many levels
   uint64_t shape[] = { 256 };
   uint64_t chunk[] = { 1 };
   uint32_t mask = 0x1;
   struct lod_plan plan;
 
-  // negative max_nlod → auto (use LOD_MAX_LEVELS=32)
-  // With shape=256, chunk=1, auto should give 9 levels (256→128→64→32→16→8→4→2→1)
+  // max_nlod=0 -> auto (use LOD_MAX_LEVELS)
+  // With shape=256, chunk=1, auto should give 9 levels (256->128->...->1)
   CHECK(Fail,
         lod_plan_init_shapes(&plan, 1, shape, chunk, mask, LOD_MAX_LEVELS) == 0);
   int auto_nlod = plan.nlod;
   CHECK(Fail, auto_nlod == 9);
-  log_info("  negative (auto): nlod=%d", auto_nlod);
+  log_info("  zero (auto): nlod=%d", auto_nlod);
 
-  // max_nlod=0 → max_levels=1 → nlod=1 (no downsampling)
+  // max_nlod=1 -> max_levels=1 -> nlod=1 (base only, no downsampling)
   CHECK(Fail, lod_plan_init_shapes(&plan, 1, shape, chunk, mask, 1) == 0);
   CHECK(Fail, plan.nlod == 1);
-  log_info("  zero (none): nlod=%d", plan.nlod);
+  log_info("  one (base only): nlod=%d", plan.nlod);
 
-  // max_nlod=3 → max_levels=4 → nlod capped at 4
+  // max_nlod=4 -> max_levels=4 -> nlod capped at 4
   CHECK(Fail, lod_plan_init_shapes(&plan, 1, shape, chunk, mask, 4) == 0);
   CHECK(Fail, plan.nlod == 4);
   CHECK(Fail, plan.nlod < auto_nlod);
-  log_info("  positive (cap=3 downsampled → max_levels=4): nlod=%d", plan.nlod);
+  log_info("  positive (cap=4 total levels): nlod=%d", plan.nlod);
 
   log_info("  PASS");
   return 0;
@@ -316,7 +316,7 @@ Fail:
   return 1;
 }
 
-// Test that max_nlod > LOD_MAX_LEVELS-1 is rejected by compute_stream_layouts.
+// Test that max_nlod > LOD_MAX_LEVELS is rejected by compute_stream_layouts.
 static int
 test_max_nlod_validation_rejection(void)
 {
@@ -334,18 +334,31 @@ test_max_nlod_validation_rejection(void)
       .storage_position = 1 },
   };
 
-  struct tile_stream_configuration config = {
+  struct tile_stream_configuration config_too_big = {
     .buffer_capacity_bytes = 4096,
     .dtype = dtype_u16,
     .rank = 2,
     .dimensions = dims,
     .codec = { .id = CODEC_NONE },
-    .max_nlod = 32, // exceeds LOD_MAX_LEVELS - 1
+    .max_nlod = 33, // exceeds LOD_MAX_LEVELS
   };
 
   struct computed_stream_layouts cl;
   int rc = compute_stream_layouts(
-    &config, 1, compress_cpu_max_output_size, &cl);
+    &config_too_big, 1, compress_cpu_max_output_size, &cl);
+  CHECK(Fail, rc != 0); // must be rejected
+
+  struct tile_stream_configuration config_negative = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .max_nlod = -1, // negative is invalid
+  };
+
+  rc = compute_stream_layouts(
+    &config_negative, 1, compress_cpu_max_output_size, &cl);
   CHECK(Fail, rc != 0); // must be rejected
 
   log_info("  PASS");
@@ -355,11 +368,11 @@ Fail:
   return 1;
 }
 
-// Test that max_nlod=0 through compute_stream_layouts yields nlod==1.
+// Test that max_nlod=1 through compute_stream_layouts yields nlod==1.
 static int
-test_max_nlod_zero_via_layouts(void)
+test_max_nlod_one_via_layouts(void)
 {
-  log_info("=== test_max_nlod_zero_via_layouts ===");
+  log_info("=== test_max_nlod_one_via_layouts ===");
 
   struct dimension dims[] = {
     { .size = 0,
@@ -379,7 +392,7 @@ test_max_nlod_zero_via_layouts(void)
     .rank = 2,
     .dimensions = dims,
     .codec = { .id = CODEC_NONE },
-    .max_nlod = 0, // no downsampled levels
+    .max_nlod = 1, // base level only
   };
 
   struct computed_stream_layouts cl;
@@ -414,14 +427,14 @@ test_max_nlod_positive_cap_via_layouts(void)
       .storage_position = 1 },
   };
 
-  // First, compute with auto to see uncapped nlod.
+  // First, compute with auto (max_nlod=0) to see uncapped nlod.
   struct tile_stream_configuration config_auto = {
     .buffer_capacity_bytes = 4096,
     .dtype = dtype_u16,
     .rank = 2,
     .dimensions = dims,
     .codec = { .id = CODEC_NONE },
-    .max_nlod = -1, // auto
+    .max_nlod = 0, // auto
   };
 
   struct computed_stream_layouts cl_auto;
@@ -431,21 +444,21 @@ test_max_nlod_positive_cap_via_layouts(void)
   CHECK(Fail, cl_auto.levels.nlod > 3); // auto should produce more than 3
   computed_stream_layouts_free(&cl_auto);
 
-  // Now cap at max_nlod=2 → expect nlod==3 (base + 2 downsampled).
+  // Now cap at max_nlod=3 -> expect nlod==3 (3 total levels).
   struct tile_stream_configuration config_cap = {
     .buffer_capacity_bytes = 4096,
     .dtype = dtype_u16,
     .rank = 2,
     .dimensions = dims,
     .codec = { .id = CODEC_NONE },
-    .max_nlod = 2,
+    .max_nlod = 3,
   };
 
   struct computed_stream_layouts cl_cap;
   CHECK(Fail,
         compute_stream_layouts(
           &config_cap, 1, compress_cpu_max_output_size, &cl_cap) == 0);
-  CHECK(Fail, cl_cap.levels.nlod == 3); // base + 2 downsampled
+  CHECK(Fail, cl_cap.levels.nlod == 3); // 3 total levels
   computed_stream_layouts_free(&cl_cap);
 
   log_info("  PASS");
@@ -472,7 +485,7 @@ main(int ac, char* av[])
   rc |= test_level_count_max_levels();
   rc |= test_max_nlod_semantics();
   rc |= test_max_nlod_validation_rejection();
-  rc |= test_max_nlod_zero_via_layouts();
+  rc |= test_max_nlod_one_via_layouts();
   rc |= test_max_nlod_positive_cap_via_layouts();
   return rc;
 }


### PR DESCRIPTION
## Summary
- Adds `int max_nlod` to `tile_stream_configuration`: `<0` = auto, `0` = none, `N>0` = N downsampled levels
- `compute_stream_layouts()` maps config value to `max_levels` for `lod_plan_init_from_epoch_dims`
- New test `test_max_nlod_semantics()` verifying all three modes

Closes #25

## Test plan
- [x] All tests pass (3 pre-existing failures unrelated)
- [x] Verify positive values correctly cap level count