### PR TITLE
Add attributes to group zarr.json

### DIFF
--- a/src/defs.limits.h
+++ b/src/defs.limits.h
@@ -9,6 +9,9 @@
 #define MAX_BATCH_EPOCHS 128
 #define MAX_ZARR_RANK (HALF_MAX_RANK)
 
+// Zarr group metadata
+#define ZARR_GROUP_JSON_CAP 256
+
 // S3
 #define S3_MAX_PARTS 10000
 #define S3_DEFAULT_PART_SIZE (8 * 1024 * 1024)

--- a/src/defs.limits.h
+++ b/src/defs.limits.h
@@ -10,7 +10,7 @@
 #define MAX_ZARR_RANK (HALF_MAX_RANK)
 
 // Zarr group metadata
-#define ZARR_GROUP_JSON_CAP 256
+#define ZARR_GROUP_JSON_MAX_LENGTH 8192
 
 // S3
 #define S3_MAX_PARTS 10000

--- a/src/zarr/zarr_fs_sink.c
+++ b/src/zarr/zarr_fs_sink.c
@@ -305,7 +305,7 @@ write_root_metadata_file(const char* store_path)
   char path[4096];
   snprintf(path, sizeof(path), "%s/zarr.json", store_path);
 
-  char buf[ZARR_GROUP_JSON_CAP];
+  char buf[ZARR_GROUP_JSON_MAX_LENGTH];
   int len = zarr_root_json(buf, sizeof(buf));
   if (len < 0)
     return -1;
@@ -634,7 +634,7 @@ write_multiscale_group_metadata(const struct zarr_fs_multiscale_sink* ms)
   for (int lv = 0; lv < ms->nlod; ++lv)
     level_ptrs[lv] = ms->levels[lv]->dimensions;
 
-  char buf[8192];
+  char buf[ZARR_GROUP_JSON_MAX_LENGTH];
   int len = zarr_multiscale_group_json(
     buf, sizeof(buf), ms->rank, ms->nlod, level_ptrs);
   if (len < 0)

--- a/src/zarr/zarr_fs_sink.c
+++ b/src/zarr/zarr_fs_sink.c
@@ -305,7 +305,7 @@ write_root_metadata_file(const char* store_path)
   char path[4096];
   snprintf(path, sizeof(path), "%s/zarr.json", store_path);
 
-  char buf[256];
+  char buf[ZARR_GROUP_JSON_CAP];
   int len = zarr_root_json(buf, sizeof(buf));
   if (len < 0)
     return -1;

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -19,6 +19,9 @@ zarr_root_json(char* buf, size_t cap)
   jw_string(&jw, "group");
   jw_key(&jw, "consolidated_metadata");
   jw_null(&jw);
+  jw_key(&jw, "attributes");
+  jw_object_begin(&jw);
+  jw_object_end(&jw);
   jw_object_end(&jw);
 
   if (jw_error(&jw))

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -17,9 +17,6 @@ zarr_root_json(char* buf, size_t cap)
   jw_int(&jw, 3);
   jw_key(&jw, "node_type");
   jw_string(&jw, "group");
-  jw_key(&jw, "attributes");
-  jw_object_begin(&jw);
-  jw_object_end(&jw);
   jw_key(&jw, "consolidated_metadata");
   jw_null(&jw);
   jw_key(&jw, "attributes");

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -17,6 +17,9 @@ zarr_root_json(char* buf, size_t cap)
   jw_int(&jw, 3);
   jw_key(&jw, "node_type");
   jw_string(&jw, "group");
+  jw_key(&jw, "attributes");
+  jw_object_begin(&jw);
+  jw_object_end(&jw);
   jw_key(&jw, "consolidated_metadata");
   jw_null(&jw);
   jw_key(&jw, "attributes");

--- a/src/zarr/zarr_s3_sink.c
+++ b/src/zarr/zarr_s3_sink.c
@@ -436,7 +436,7 @@ zarr_s3_sink_create_with_client(const struct zarr_s3_config* cfg,
 
   // Write root + intermediate group metadata (skipped for sub-sinks)
   if (!skip_group_metadata) {
-    char buf[256];
+    char buf[ZARR_GROUP_JSON_CAP];
     int len = zarr_root_json(buf, sizeof(buf));
     CHECK(Fail_alloc, len >= 0);
     char key[4096];
@@ -724,7 +724,7 @@ zarr_s3_multiscale_sink_create(struct zarr_s3_multiscale_config* cfg)
 
   // Write root + intermediate metadata before creating levels
   if (cfg->array_name) {
-    char buf[256];
+    char buf[ZARR_GROUP_JSON_CAP];
     int len = zarr_root_json(buf, sizeof(buf));
     CHECK(Fail_levels, len >= 0);
     char key[4096];

--- a/src/zarr/zarr_s3_sink.c
+++ b/src/zarr/zarr_s3_sink.c
@@ -436,7 +436,7 @@ zarr_s3_sink_create_with_client(const struct zarr_s3_config* cfg,
 
   // Write root + intermediate group metadata (skipped for sub-sinks)
   if (!skip_group_metadata) {
-    char buf[ZARR_GROUP_JSON_CAP];
+    char buf[ZARR_GROUP_JSON_MAX_LENGTH];
     int len = zarr_root_json(buf, sizeof(buf));
     CHECK(Fail_alloc, len >= 0);
     char key[4096];
@@ -625,7 +625,7 @@ put_multiscale_group_metadata(const struct zarr_s3_multiscale_sink* ms)
   for (int lv = 0; lv < ms->nlod; ++lv)
     level_ptrs[lv] = ms->levels[lv]->dimensions;
 
-  char buf[8192];
+  char buf[ZARR_GROUP_JSON_MAX_LENGTH];
   int len = zarr_multiscale_group_json(
     buf, sizeof(buf), ms->rank, ms->nlod, level_ptrs);
   if (len < 0)
@@ -724,7 +724,7 @@ zarr_s3_multiscale_sink_create(struct zarr_s3_multiscale_config* cfg)
 
   // Write root + intermediate metadata before creating levels
   if (cfg->array_name) {
-    char buf[ZARR_GROUP_JSON_CAP];
+    char buf[ZARR_GROUP_JSON_MAX_LENGTH];
     int len = zarr_root_json(buf, sizeof(buf));
     CHECK(Fail_levels, len >= 0);
     char key[4096];

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -212,15 +212,15 @@ test_zarr_root_json(void)
   char buf[ZARR_GROUP_JSON_MAX_LENGTH];
   int len = zarr_root_json(buf, sizeof(buf));
   CHECK(Fail, len > 0);
-  buf[len] = '\0';
 
-  // Check all required fields are present
-  CHECK(Fail, strstr(buf, "\"zarr_format\":3"));
-  CHECK(Fail, strstr(buf, "\"node_type\":\"group\""));
-  CHECK(Fail, strstr(buf, "\"consolidated_metadata\":null"));
-  CHECK(Fail, strstr(buf, "\"attributes\":{}"));
+  const char* expected =
+    "{\"zarr_format\":3,\"node_type\":\"group\","
+    "\"consolidated_metadata\":null,\"attributes\":{}}";
+  CHECK(Fail, (size_t)len == strlen(expected));
+  CHECK(Fail, memcmp(buf, expected, (size_t)len) == 0);
 
   // Check no duplicate "attributes" key
+  buf[len] = '\0';
   char* first = strstr(buf, "\"attributes\"");
   CHECK(Fail, first);
   CHECK(Fail, !strstr(first + 1, "\"attributes\""));
@@ -228,7 +228,46 @@ test_zarr_root_json(void)
   return 0;
 
 Fail:
-  log_error("  got: %.*s", len, buf);
+  log_error("  got: %.*s", len > 0 ? len : 0, buf);
+  return 1;
+}
+
+static int
+test_zarr_multiscale_group_json(void)
+{
+  // 3-dim config (t/y/x) with 2 LOD levels
+  struct dimension l0_dims[3] = {
+    { .size = 0, .chunk_size = 1, .chunks_per_shard = 4, .name = "t" },
+    { .size = 64, .chunk_size = 8, .chunks_per_shard = 4, .name = "y",
+      .downsample = 1 },
+    { .size = 64, .chunk_size = 8, .chunks_per_shard = 4, .name = "x",
+      .downsample = 1 },
+  };
+  struct dimension l1_dims[3] = {
+    { .size = 0, .chunk_size = 1, .chunks_per_shard = 4, .name = "t" },
+    { .size = 32, .chunk_size = 8, .chunks_per_shard = 2, .name = "y",
+      .downsample = 1 },
+    { .size = 32, .chunk_size = 8, .chunks_per_shard = 2, .name = "x",
+      .downsample = 1 },
+  };
+
+  const struct dimension* levels[2] = { l0_dims, l1_dims };
+
+  char buf[4096];
+  int len = zarr_multiscale_group_json(buf, sizeof(buf), 3, 2, levels);
+  CHECK(Fail, len > 0);
+  buf[len] = '\0';
+
+  CHECK(Fail, strstr(buf, "\"version\":\"0.5\""));
+  CHECK(Fail, strstr(buf, "\"axes\""));
+  CHECK(Fail, strstr(buf, "\"datasets\""));
+  CHECK(Fail, strstr(buf, "\"coordinateTransformations\""));
+  CHECK(Fail, strstr(buf, "\"attributes\":{\"ome\""));
+
+  return 0;
+
+Fail:
+  log_error("  got: %.*s", len > 0 ? len : 0, buf);
   return 1;
 }
 
@@ -276,6 +315,7 @@ main(void)
     { "uint", test_uint },
     { "zarr_metadata", test_zarr_metadata },
     { "zarr_root_json", test_zarr_root_json },
+    { "zarr_multiscale_group_json", test_zarr_multiscale_group_json },
     { "zarr_array_json_lz4", test_zarr_array_json_lz4 },
   };
   for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -1,3 +1,4 @@
+#include "defs.limits.h"
 #include "util/prelude.h"
 #include "zarr/json_writer.h"
 #include "zarr/zarr_metadata.h"
@@ -208,15 +209,21 @@ Fail:
 static int
 test_zarr_root_json(void)
 {
-  char buf[256];
+  char buf[ZARR_GROUP_JSON_CAP];
   int len = zarr_root_json(buf, sizeof(buf));
   CHECK(Fail, len > 0);
   buf[len] = '\0';
 
+  // Check all required fields are present
   CHECK(Fail, strstr(buf, "\"zarr_format\":3"));
   CHECK(Fail, strstr(buf, "\"node_type\":\"group\""));
-  CHECK(Fail, strstr(buf, "\"attributes\":{}"));
   CHECK(Fail, strstr(buf, "\"consolidated_metadata\":null"));
+  CHECK(Fail, strstr(buf, "\"attributes\":{}"));
+
+  // Check no duplicate "attributes" key
+  char* first = strstr(buf, "\"attributes\"");
+  CHECK(Fail, first);
+  CHECK(Fail, !strstr(first + 1, "\"attributes\""));
 
   return 0;
 

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -206,6 +206,26 @@ Fail:
 }
 
 static int
+test_zarr_root_json(void)
+{
+  char buf[256];
+  int len = zarr_root_json(buf, sizeof(buf));
+  CHECK(Fail, len > 0);
+  buf[len] = '\0';
+
+  CHECK(Fail, strstr(buf, "\"zarr_format\":3"));
+  CHECK(Fail, strstr(buf, "\"node_type\":\"group\""));
+  CHECK(Fail, strstr(buf, "\"attributes\":{}"));
+  CHECK(Fail, strstr(buf, "\"consolidated_metadata\":null"));
+
+  return 0;
+
+Fail:
+  log_error("  got: %.*s", len, buf);
+  return 1;
+}
+
+static int
 test_zarr_array_json_lz4(void)
 {
   char buf[4096];
@@ -248,6 +268,7 @@ main(void)
     { "array_commas", test_array_commas },
     { "uint", test_uint },
     { "zarr_metadata", test_zarr_metadata },
+    { "zarr_root_json", test_zarr_root_json },
     { "zarr_array_json_lz4", test_zarr_array_json_lz4 },
   };
   for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -209,7 +209,7 @@ Fail:
 static int
 test_zarr_root_json(void)
 {
-  char buf[ZARR_GROUP_JSON_CAP];
+  char buf[ZARR_GROUP_JSON_MAX_LENGTH];
   int len = zarr_root_json(buf, sizeof(buf));
   CHECK(Fail, len > 0);
   buf[len] = '\0';

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -43,7 +43,7 @@ read_file_all(const char* path, uint8_t** out, size_t* out_len)
 // On success returns 0 and sets *out (caller must free).
 // On failure returns non-zero.
 static int
-check_group_zarr_json(const char* dir, char** out, size_t bufsz)
+check_group_zarr_json(const char* dir, char** out)
 {
   char path[4096];
   snprintf(path, sizeof(path), "%s/zarr.json", dir);
@@ -54,11 +54,11 @@ check_group_zarr_json(const char* dir, char** out, size_t bufsz)
   size_t len;
   if (read_file_all(path, &data, &len))
     return 1;
-  data[len < bufsz - 1 ? len : bufsz - 1] = '\0';
+  data[len] = '\0';
 
   int ok = strstr((char*)data, "\"zarr_format\":3") &&
            strstr((char*)data, "\"node_type\":\"group\"") &&
-           strstr((char*)data, "\"attributes\"") &&
+           strstr((char*)data, "\"attributes\":{") &&
            strstr((char*)data, "\"consolidated_metadata\":null");
   if (!ok) {
     free(data);
@@ -107,7 +107,7 @@ test_metadata(const char* tmpdir)
 
   {
     char* data;
-    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 4096) == 0);
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data) == 0);
     free(data);
   }
 
@@ -404,14 +404,14 @@ test_multiscale_metadata(const char* tmpdir)
   // Check root zarr.json has multiscales attribute
   {
     char* data;
-    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 8192) == 0);
-    CHECK(Fail2, strstr(data, "\"ome\""));
-    CHECK(Fail2, strstr(data, "\"multiscales\""));
-    CHECK(Fail2, strstr(data, "\"version\":\"0.5\""));
-    CHECK(Fail2, strstr(data, "\"path\":\"0\""));
-    CHECK(Fail2, strstr(data, "\"path\":\"1\""));
-    CHECK(Fail2, strstr(data, "\"coordinateTransformations\""));
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data) == 0);
+    int ok = strstr(data, "\"ome\"") && strstr(data, "\"multiscales\"") &&
+             strstr(data, "\"version\":\"0.5\"") &&
+             strstr(data, "\"path\":\"0\"") &&
+             strstr(data, "\"path\":\"1\"") &&
+             strstr(data, "\"coordinateTransformations\"");
     free(data);
+    CHECK(Fail2, ok);
   }
 
   // Check L0 array zarr.json
@@ -499,16 +499,16 @@ test_multiscale_scale_non_pow2(const char* tmpdir)
 
   {
     char* data;
-    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 8192) == 0);
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data) == 0);
 
     // L0: scale [1,1,1]
-    CHECK(Fail2, strstr(data, "\"scale\":[1.0,1.0,1.0]"));
     // L1: z=1, y=2, x=2
-    CHECK(Fail2, strstr(data, "\"scale\":[1.0,2.0,2.0]"));
     // L2: z=1, y=4 (not 3!), x=4 (not 3!)
-    CHECK(Fail2, strstr(data, "\"scale\":[1.0,4.0,4.0]"));
-
+    int ok = strstr(data, "\"scale\":[1.0,1.0,1.0]") &&
+             strstr(data, "\"scale\":[1.0,2.0,2.0]") &&
+             strstr(data, "\"scale\":[1.0,4.0,4.0]");
     free(data);
+    CHECK(Fail2, ok);
   }
 
   zarr_fs_multiscale_sink_destroy(ms);
@@ -566,12 +566,12 @@ test_multiscale_unit_scale(const char* tmpdir)
 
   {
     char* data;
-    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 8192) == 0);
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data) == 0);
 
     // L0 scale: z=0.5*1=0.5, y=0.3*1=0.3, x=1.0*1=1.0
-    CHECK(Fail2, strstr(data, "\"scale\":[0.5,0.3,1.0]"));
-
+    int ok = strstr(data, "\"scale\":[0.5,0.3,1.0]") != NULL;
     free(data);
+    CHECK(Fail2, ok);
   }
 
   zarr_fs_multiscale_sink_destroy(ms);
@@ -631,7 +631,7 @@ test_metadata_two_append(const char* tmpdir)
 
   {
     char* data;
-    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 4096) == 0);
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data) == 0);
     free(data);
   }
 
@@ -846,7 +846,7 @@ test_multiscale_unbounded(const char* tmpdir)
   // Check root zarr.json exists with multiscales
   {
     char* data;
-    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 8192) == 0);
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data) == 0);
     int has_ms = strstr(data, "\"multiscales\"") != NULL;
     int has_p0 = strstr(data, "\"path\":\"0\"") != NULL;
     free(data);
@@ -2013,7 +2013,7 @@ test_nested_array_name(const char* tmpdir)
   // Check root group zarr.json
   {
     char* data;
-    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 4096) == 0);
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data) == 0);
     free(data);
   }
 
@@ -2022,7 +2022,7 @@ test_nested_array_name(const char* tmpdir)
     char dir[4096];
     snprintf(dir, sizeof(dir), "%s/path", tmpdir);
     char* data;
-    CHECK(Fail2, check_group_zarr_json(dir, &data, 4096) == 0);
+    CHECK(Fail2, check_group_zarr_json(dir, &data) == 0);
     free(data);
   }
 
@@ -2031,7 +2031,7 @@ test_nested_array_name(const char* tmpdir)
     char dir[4096];
     snprintf(dir, sizeof(dir), "%s/path/to", tmpdir);
     char* data;
-    CHECK(Fail2, check_group_zarr_json(dir, &data, 4096) == 0);
+    CHECK(Fail2, check_group_zarr_json(dir, &data) == 0);
     free(data);
   }
 
@@ -2098,7 +2098,7 @@ test_nested_multiscale_array_name(const char* tmpdir)
   // Check root group zarr.json
   {
     char* data;
-    CHECK(Fail2, check_group_zarr_json(tmpdir, &data, 4096) == 0);
+    CHECK(Fail2, check_group_zarr_json(tmpdir, &data) == 0);
     free(data);
   }
 
@@ -2107,7 +2107,7 @@ test_nested_multiscale_array_name(const char* tmpdir)
     char dir[4096];
     snprintf(dir, sizeof(dir), "%s/path", tmpdir);
     char* data;
-    CHECK(Fail2, check_group_zarr_json(dir, &data, 4096) == 0);
+    CHECK(Fail2, check_group_zarr_json(dir, &data) == 0);
     free(data);
   }
 
@@ -2116,7 +2116,7 @@ test_nested_multiscale_array_name(const char* tmpdir)
     char dir[4096];
     snprintf(dir, sizeof(dir), "%s/path/to", tmpdir);
     char* data;
-    CHECK(Fail2, check_group_zarr_json(dir, &data, 4096) == 0);
+    CHECK(Fail2, check_group_zarr_json(dir, &data) == 0);
     free(data);
   }
 
@@ -2125,9 +2125,10 @@ test_nested_multiscale_array_name(const char* tmpdir)
     char dir[4096];
     snprintf(dir, sizeof(dir), "%s/path/to/group", tmpdir);
     char* data;
-    CHECK(Fail2, check_group_zarr_json(dir, &data, 8192) == 0);
-    CHECK(Fail2, strstr(data, "\"multiscales\""));
+    CHECK(Fail2, check_group_zarr_json(dir, &data) == 0);
+    int ok = strstr(data, "\"multiscales\"") != NULL;
     free(data);
+    CHECK(Fail2, ok);
   }
 
   zarr_fs_multiscale_sink_destroy(ms);

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -58,6 +58,7 @@ check_group_zarr_json(const char* dir, char** out, size_t bufsz)
 
   int ok = strstr((char*)data, "\"zarr_format\":3") &&
            strstr((char*)data, "\"node_type\":\"group\"") &&
+           strstr((char*)data, "\"attributes\"") &&
            strstr((char*)data, "\"consolidated_metadata\":null");
   if (!ok) {
     free(data);

--- a/tests/test_zarr_s3_sink.c
+++ b/tests/test_zarr_s3_sink.c
@@ -114,7 +114,6 @@ check_group_zarr_json(const char* prefix, char** out)
 {
   char key[4096];
   snprintf(key, sizeof(key), "%s/zarr.json", prefix);
-  CHECK(Fail, s3_exists(key));
 
   uint8_t* data = NULL;
   size_t len = 0;
@@ -126,10 +125,12 @@ check_group_zarr_json(const char* prefix, char** out)
   data = tmp;
   data[len] = '\0';
 
-  CHECK(Fail_data, strstr((char*)data, "\"zarr_format\":3"));
-  CHECK(Fail_data, strstr((char*)data, "\"node_type\":\"group\""));
-  CHECK(Fail_data, strstr((char*)data, "\"consolidated_metadata\":null"));
-  CHECK(Fail_data, strstr((char*)data, "\"attributes\""));
+  int ok = strstr((char*)data, "\"zarr_format\":3") &&
+           strstr((char*)data, "\"node_type\":\"group\"") &&
+           strstr((char*)data, "\"consolidated_metadata\":null") &&
+           strstr((char*)data, "\"attributes\":{");
+  if (!ok)
+    goto Fail_data;
 
   *out = (char*)data;
   return 0;
@@ -453,13 +454,13 @@ test_multiscale_metadata(void)
   {
     char* data;
     CHECK(Fail2, check_group_zarr_json("test-multiscale", &data) == 0);
-    CHECK(Fail2, strstr(data, "\"ome\""));
-    CHECK(Fail2, strstr(data, "\"multiscales\""));
-    CHECK(Fail2, strstr(data, "\"version\":\"0.5\""));
-    CHECK(Fail2, strstr(data, "\"path\":\"0\""));
-    CHECK(Fail2, strstr(data, "\"path\":\"1\""));
-    CHECK(Fail2, strstr(data, "\"coordinateTransformations\""));
+    int ok = strstr(data, "\"ome\"") && strstr(data, "\"multiscales\"") &&
+             strstr(data, "\"version\":\"0.5\"") &&
+             strstr(data, "\"path\":\"0\"") &&
+             strstr(data, "\"path\":\"1\"") &&
+             strstr(data, "\"coordinateTransformations\"");
     free(data);
+    CHECK(Fail2, ok);
   }
 
   // Check L0 array zarr.json
@@ -483,6 +484,86 @@ Fail:
   return 1;
 }
 
+// --- Test: multiscale metadata with array_name ---
+
+static int
+test_multiscale_metadata_named(void)
+{
+  log_info("=== test_s3_multiscale_metadata_named ===");
+
+  struct dimension dims[] = {
+    { .size = 64,
+      .chunk_size = 8,
+      .chunks_per_shard = 4,
+      .name = "z",
+      .downsample = 1,
+      .storage_position = 0 },
+    { .size = 32,
+      .chunk_size = 8,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 64,
+      .chunk_size = 8,
+      .chunks_per_shard = 4,
+      .name = "x",
+      .downsample = 1,
+      .storage_position = 2 },
+  };
+
+  set_s3_creds();
+
+  struct zarr_s3_multiscale_config cfg = {
+    .bucket = S3_BUCKET,
+    .prefix = "test-ms-named",
+    .array_name = "ms",
+    .region = "us-east-1",
+    .endpoint = s3_endpoint(),
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .nlod = 0,
+  };
+
+  struct zarr_s3_multiscale_sink* ms = zarr_s3_multiscale_sink_create(&cfg);
+  CHECK(Fail, ms);
+
+  // Root zarr.json should be a plain group (attributes:{})
+  {
+    char* data;
+    CHECK(Fail_sink,
+          check_group_zarr_json("test-ms-named", &data) == 0);
+    int ok = strstr(data, "\"attributes\":{}") != NULL;
+    free(data);
+    CHECK(Fail_sink, ok);
+  }
+
+  // Sub-group zarr.json should have OME multiscales
+  {
+    char* data;
+    CHECK(Fail_sink,
+          check_group_zarr_json("test-ms-named/ms", &data) == 0);
+    int ok = strstr(data, "\"attributes\":{\"ome\"") != NULL &&
+             strstr(data, "\"multiscales\"") != NULL;
+    free(data);
+    CHECK(Fail_sink, ok);
+  }
+
+  // L0 array zarr.json
+  CHECK(Fail_sink, s3_exists("test-ms-named/ms/0/zarr.json"));
+
+  zarr_s3_multiscale_sink_destroy(ms);
+  log_info("  PASS");
+  return 0;
+
+Fail_sink:
+  zarr_s3_multiscale_sink_destroy(ms);
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
 // --- Main ---
 
 int
@@ -499,5 +580,6 @@ main(void)
   rc |= test_shard_write();
   rc |= test_concurrent_finalize();
   rc |= test_multiscale_metadata();
+  rc |= test_multiscale_metadata_named();
   return rc;
 }

--- a/tests/test_zarr_s3_sink.c
+++ b/tests/test_zarr_s3_sink.c
@@ -78,6 +78,68 @@ s3_exists(const char* key)
   return platform_cmd_run(cmd) == 0;
 }
 
+// Read an S3 object and check that it contains required substrings.
+// needle2 may be NULL to skip the second check.
+// Returns 0 on success.
+static int
+check_array_json(const char* key, const char* needle1, const char* needle2)
+{
+  uint8_t* data = NULL;
+  size_t len = 0;
+  CHECK(Fail, s3_get(key, &data, &len) == 0);
+
+  uint8_t* tmp = (uint8_t*)realloc(data, len + 1);
+  CHECK(Fail_data, tmp);
+  data = tmp;
+  data[len] = '\0';
+
+  CHECK(Fail_data, strstr((char*)data, needle1));
+  if (needle2)
+    CHECK(Fail_data, strstr((char*)data, needle2));
+
+  free(data);
+  return 0;
+
+Fail_data:
+  free(data);
+Fail:
+  return 1;
+}
+
+// Read a group zarr.json at `prefix`/zarr.json and validate common fields.
+// On success returns 0 and sets *out (caller must free).
+// On failure returns non-zero.
+static int
+check_group_zarr_json(const char* prefix, char** out)
+{
+  char key[4096];
+  snprintf(key, sizeof(key), "%s/zarr.json", prefix);
+  CHECK(Fail, s3_exists(key));
+
+  uint8_t* data = NULL;
+  size_t len = 0;
+  CHECK(Fail, s3_get(key, &data, &len) == 0);
+
+  // Null-terminate
+  uint8_t* tmp = (uint8_t*)realloc(data, len + 1);
+  CHECK(Fail_data, tmp);
+  data = tmp;
+  data[len] = '\0';
+
+  CHECK(Fail_data, strstr((char*)data, "\"zarr_format\":3"));
+  CHECK(Fail_data, strstr((char*)data, "\"node_type\":\"group\""));
+  CHECK(Fail_data, strstr((char*)data, "\"consolidated_metadata\":null"));
+  CHECK(Fail_data, strstr((char*)data, "\"attributes\""));
+
+  *out = (char*)data;
+  return 0;
+
+Fail_data:
+  free(data);
+Fail:
+  return 1;
+}
+
 // --- Tests ---
 
 static void
@@ -133,8 +195,12 @@ test_metadata(void)
   struct zarr_s3_sink* sink = zarr_s3_sink_create(&cfg);
   CHECK(Fail, sink);
 
-  // Verify root zarr.json
-  CHECK(Fail_sink, s3_exists("test-meta/zarr.json"));
+  // Verify root zarr.json (group metadata with "attributes")
+  {
+    char* gdata;
+    CHECK(Fail_sink, check_group_zarr_json("test-meta", &gdata) == 0);
+    free(gdata);
+  }
 
   // Verify array zarr.json
   CHECK(Fail_sink, s3_exists("test-meta/0/zarr.json"));
@@ -341,6 +407,82 @@ Fail:
   return 1;
 }
 
+static int
+test_multiscale_metadata(void)
+{
+  log_info("=== test_s3_multiscale_metadata ===");
+
+  struct dimension dims[] = {
+    { .size = 64,
+      .chunk_size = 8,
+      .chunks_per_shard = 4,
+      .name = "z",
+      .downsample = 1,
+      .storage_position = 0 },
+    { .size = 32,
+      .chunk_size = 8,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 64,
+      .chunk_size = 8,
+      .chunks_per_shard = 4,
+      .name = "x",
+      .downsample = 1,
+      .storage_position = 2 },
+  };
+
+  set_s3_creds();
+
+  struct zarr_s3_multiscale_config cfg = {
+    .bucket = S3_BUCKET,
+    .prefix = "test-multiscale",
+    .region = "us-east-1",
+    .endpoint = s3_endpoint(),
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .nlod = 0, // auto
+  };
+
+  struct zarr_s3_multiscale_sink* ms = zarr_s3_multiscale_sink_create(&cfg);
+  CHECK(Fail, ms);
+
+  // Check root zarr.json has multiscales attribute
+  {
+    char* data;
+    CHECK(Fail2, check_group_zarr_json("test-multiscale", &data) == 0);
+    CHECK(Fail2, strstr(data, "\"ome\""));
+    CHECK(Fail2, strstr(data, "\"multiscales\""));
+    CHECK(Fail2, strstr(data, "\"version\":\"0.5\""));
+    CHECK(Fail2, strstr(data, "\"path\":\"0\""));
+    CHECK(Fail2, strstr(data, "\"path\":\"1\""));
+    CHECK(Fail2, strstr(data, "\"coordinateTransformations\""));
+    free(data);
+  }
+
+  // Check L0 array zarr.json
+  CHECK(Fail2,
+        check_array_json("test-multiscale/0/zarr.json",
+                         "\"shape\":[64,32,64]",
+                         "\"data_type\":\"uint16\"") == 0);
+
+  // Check L1 array zarr.json (x halved; z excluded from LOD mask by downsample)
+  CHECK(Fail2,
+        check_array_json(
+          "test-multiscale/1/zarr.json", "\"shape\":[64,32,32]", NULL) == 0);
+  zarr_s3_multiscale_sink_destroy(ms);
+  log_info("  PASS");
+  return 0;
+
+Fail2:
+  zarr_s3_multiscale_sink_destroy(ms);
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
 // --- Main ---
 
 int
@@ -356,5 +498,6 @@ main(void)
   rc |= test_metadata();
   rc |= test_shard_write();
   rc |= test_concurrent_finalize();
+  rc |= test_multiscale_metadata();
   return rc;
 }


### PR DESCRIPTION
## Summary
- Add `"attributes": {}` to `zarr_root_json()` output (fixes #46)
- Reorder fields to match spec and `zarr_multiscale_group_json()` 
- Add `ZARR_GROUP_JSON_CAP` constant in `defs.limits.h`, use at all call sites
- Add unit test for `zarr_root_json` and `strstr` check in `check_group_zarr_json`

## Test plan
- [x] `test_json_writer` passes (new `test_zarr_root_json`)
- [x] `test_zarr_fs_sink` passes (updated `check_group_zarr_json`)