### PR TITLE
Add zstd checksum to codec metadata

### DIFF
--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -3,6 +3,7 @@
 #include "dtype.h"
 #include "zarr/json_writer.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -120,6 +121,8 @@ zarr_array_json(char* buf,
     if (codec.id == CODEC_ZSTD) {
       jw_key(&jw, "level");
       jw_int(&jw, codec.level);
+      jw_key(&jw, "checksum");
+      jw_bool(&jw, false);
     }
     if (codec_is_blosc(codec.id)) {
       jw_key(&jw, "cname");

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -219,7 +219,7 @@ test_zarr_array_json_lz4(void)
 
   int len =
     zarr_array_json(buf, sizeof(buf), 3, dims, dtype_u16, 0.0, cps, codec);
-  CHECK(Fail, len > 0);
+  CHECK(Fail, len > 0 && (size_t)len < sizeof(buf));
   buf[len] = '\0';
 
   // The codec name in zarr metadata must be "lz4" (not "lz4_raw")
@@ -246,11 +246,13 @@ test_zarr_array_json_zstd(void)
 
   int len =
     zarr_array_json(buf, sizeof(buf), 3, dims, dtype_u16, 0.0, cps, codec);
-  CHECK(Fail, len > 0);
+  CHECK(Fail, len > 0 && (size_t)len < sizeof(buf));
   buf[len] = '\0';
 
-  CHECK(Fail, strstr(buf, "\"name\":\"zstd\""));
-  CHECK(Fail, strstr(buf, "\"checksum\":false"));
+  CHECK(Fail,
+        strstr(buf,
+               "\"name\":\"zstd\",\"configuration\":"
+               "{\"level\":3,\"checksum\":false}"));
 
   return 0;
 

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -232,6 +232,33 @@ Fail:
   return 1;
 }
 
+static int
+test_zarr_array_json_zstd(void)
+{
+  char buf[4096];
+  struct dimension dims[3] = {
+    { .size = 0, .chunk_size = 1, .chunks_per_shard = 2, .name = "t" },
+    { .size = 64, .chunk_size = 32, .chunks_per_shard = 1, .name = "y" },
+    { .size = 64, .chunk_size = 32, .chunks_per_shard = 1, .name = "x" },
+  };
+  uint64_t cps[3] = { 2, 1, 1 };
+  struct codec_config codec = { .id = CODEC_ZSTD, .level = 3 };
+
+  int len =
+    zarr_array_json(buf, sizeof(buf), 3, dims, dtype_u16, 0.0, cps, codec);
+  CHECK(Fail, len > 0);
+  buf[len] = '\0';
+
+  CHECK(Fail, strstr(buf, "\"name\":\"zstd\""));
+  CHECK(Fail, strstr(buf, "\"checksum\":false"));
+
+  return 0;
+
+Fail:
+  log_error("  got: %.*s", (int)sizeof(buf), buf);
+  return 1;
+}
+
 int
 main(void)
 {
@@ -249,6 +276,7 @@ main(void)
     { "uint", test_uint },
     { "zarr_metadata", test_zarr_metadata },
     { "zarr_array_json_lz4", test_zarr_array_json_lz4 },
+    { "zarr_array_json_zstd", test_zarr_array_json_zstd },
   };
   for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
     int r = tests[i].fn();


### PR DESCRIPTION
## Summary
- Add `"checksum": false` to zstd codec JSON metadata (fixes #43)
- Use `false` instead of bare `0` in `jw_bool` call
- Add `test_zarr_array_json_zstd` unit test asserting `"checksum":false` appears

## Test plan
- [x] `test_json_writer` passes (new `test_zarr_array_json_zstd`)