### PR TITLE
Pipeline batch boundaries with 3-phase ordering

### DIFF
--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -12,10 +12,12 @@
 #include "util/metric.h"
 #include "util/prelude.h"
 #include "zarr.h"
+#include "zarr/io_queue.h"
 #include "zarr/json_writer.h"
 #include "zarr/store.h"
 #include "zarr/zarr_metadata.h"
 
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -115,6 +117,192 @@ discard_shard_sink_init(struct discard_shard_sink* s)
               .finalize = discard_shard_finalize },
     .parent = s,
   };
+}
+
+// --- Throttled shard_sink: synthetic IO pressure for measurement ---
+//
+// Same async shape as shard_pool_fs: owns its own io_queue, worker sleeps
+// proportional to bytes+latency instead of doing real IO. Exercises the
+// record_fence/wait_fence/pending_bytes path so stall timing in the GPU
+// flush pipeline can be measured on machines where the real GPU can't
+// saturate disk IO.
+
+struct throttled_shard_sink;
+
+struct throttled_shard_writer
+{
+  struct shard_writer base;
+  struct throttled_shard_sink* parent;
+};
+
+struct throttled_shard_sink
+{
+  struct shard_sink base;
+  struct throttled_shard_writer writer; // single shared writer
+  struct io_queue* queue;               // owned
+  uint64_t queued_bytes;                // main-thread only
+  _Atomic uint64_t retired_bytes;       // worker, atomic
+  _Atomic uint64_t total_bytes;         // reporting
+  uint64_t latency_ns;                  // fixed per-job cost
+  uint64_t bytes_per_sec;               // 0 = no bandwidth cap
+};
+
+struct throttled_job
+{
+  uint64_t nbytes;
+  uint64_t latency_ns;
+  uint64_t bytes_per_sec;
+  _Atomic uint64_t* retired_bytes;
+  _Atomic uint64_t* total_bytes;
+};
+
+static void
+throttled_fn(void* arg)
+{
+  struct throttled_job* j = (struct throttled_job*)arg;
+  int64_t ns = (int64_t)j->latency_ns;
+  if (j->bytes_per_sec > 0)
+    ns += (int64_t)((j->nbytes * 1000000000ull) / j->bytes_per_sec);
+  if (ns > 0)
+    platform_sleep_ns(ns);
+  atomic_fetch_add(j->retired_bytes, j->nbytes);
+  atomic_fetch_add(j->total_bytes, j->nbytes);
+}
+
+static int
+throttled_post(struct throttled_shard_sink* s, size_t nbytes)
+{
+  struct throttled_job* j = (struct throttled_job*)malloc(sizeof(*j));
+  CHECK(Error, j);
+  j->nbytes = nbytes;
+  j->latency_ns = s->latency_ns;
+  j->bytes_per_sec = s->bytes_per_sec;
+  j->retired_bytes = &s->retired_bytes;
+  j->total_bytes = &s->total_bytes;
+  if (io_queue_post(s->queue, throttled_fn, j, free)) {
+    free(j);
+    goto Error;
+  }
+  s->queued_bytes += nbytes;
+  return 0;
+
+Error:
+  return 1;
+}
+
+static int
+throttled_shard_write(struct shard_writer* self,
+                      uint64_t offset,
+                      const void* beg,
+                      const void* end)
+{
+  (void)offset;
+  struct throttled_shard_writer* w = (struct throttled_shard_writer*)self;
+  size_t nbytes = (size_t)((const char*)end - (const char*)beg);
+  return throttled_post(w->parent, nbytes);
+}
+
+static int
+throttled_shard_write_direct(struct shard_writer* self,
+                             uint64_t offset,
+                             const void* beg,
+                             const void* end)
+{
+  (void)offset;
+  struct throttled_shard_writer* w = (struct throttled_shard_writer*)self;
+  size_t nbytes = (size_t)((const char*)end - (const char*)beg);
+  return throttled_post(w->parent, nbytes);
+}
+
+static int
+throttled_shard_finalize(struct shard_writer* self)
+{
+  (void)self;
+  return 0;
+}
+
+static struct shard_writer*
+throttled_shard_open(struct shard_sink* self,
+                     uint8_t level,
+                     uint64_t shard_index)
+{
+  (void)level;
+  (void)shard_index;
+  struct throttled_shard_sink* s = (struct throttled_shard_sink*)self;
+  return &s->writer.base;
+}
+
+static struct io_event
+throttled_shard_record_fence(struct shard_sink* self, uint8_t level)
+{
+  (void)level;
+  struct throttled_shard_sink* s = (struct throttled_shard_sink*)self;
+  return io_queue_record(s->queue);
+}
+
+static void
+throttled_shard_wait_fence(struct shard_sink* self,
+                           uint8_t level,
+                           struct io_event ev)
+{
+  (void)level;
+  struct throttled_shard_sink* s = (struct throttled_shard_sink*)self;
+  io_event_wait(s->queue, ev);
+}
+
+static int
+throttled_shard_has_error(const struct shard_sink* self)
+{
+  (void)self;
+  return 0;
+}
+
+static size_t
+throttled_shard_pending_bytes(const struct shard_sink* self)
+{
+  const struct throttled_shard_sink* s =
+    (const struct throttled_shard_sink*)self;
+  uint64_t retired = atomic_load(&s->retired_bytes);
+  if (s->queued_bytes <= retired)
+    return 0;
+  return (size_t)(s->queued_bytes - retired);
+}
+
+static int
+throttled_shard_sink_init(struct throttled_shard_sink* s,
+                          uint64_t io_bw_mbps,
+                          uint64_t io_latency_us)
+{
+  *s = (struct throttled_shard_sink){ 0 };
+  s->latency_ns = io_latency_us * 1000ull;
+  s->bytes_per_sec = io_bw_mbps * 1024ull * 1024ull;
+  s->queue = io_queue_create();
+  if (!s->queue)
+    return 1;
+
+  s->base.open = throttled_shard_open;
+  s->base.record_fence = throttled_shard_record_fence;
+  s->base.wait_fence = throttled_shard_wait_fence;
+  s->base.has_error = throttled_shard_has_error;
+  s->base.pending_bytes = throttled_shard_pending_bytes;
+
+  s->writer = (struct throttled_shard_writer){
+    .base = { .write = throttled_shard_write,
+              .write_direct = throttled_shard_write_direct,
+              .finalize = throttled_shard_finalize },
+    .parent = s,
+  };
+  return 0;
+}
+
+static void
+throttled_shard_sink_teardown(struct throttled_shard_sink* s)
+{
+  if (s->queue) {
+    io_event_wait(s->queue, io_queue_record(s->queue));
+    io_queue_destroy(s->queue);
+  }
+  *s = (struct throttled_shard_sink){ 0 };
 }
 
 // --- Metering shard_sink wrapper ---
@@ -755,6 +943,8 @@ run_bench(const struct bench_config* cfg)
 
   struct bench_zarr_handle zarr = { 0 };
   struct metering_sink meter = { 0 };
+  struct throttled_shard_sink tss = { 0 };
+  int use_throttled = 0;
   struct shard_sink* sink = &dss.base;
   struct bench_handle h = { .backend = cfg->backend };
 
@@ -788,6 +978,12 @@ run_bench(const struct bench_config* cfg)
                              is_multiscale) == 0);
     metering_sink_init(&meter, bench_zarr_as_shard_sink(&zarr));
     sink = &meter.base;
+  } else if (cfg->io_bw_mbps > 0 || cfg->io_latency_us > 0) {
+    CHECK(Fail,
+          throttled_shard_sink_init(
+            &tss, cfg->io_bw_mbps, cfg->io_latency_us) == 0);
+    sink = &tss.base;
+    use_throttled = 1;
   }
 
   const struct tile_stream_configuration config = {
@@ -913,11 +1109,15 @@ run_bench(const struct bench_config* cfg)
   {
     struct stream_metrics m = bench_get_metrics(&h);
     int has_output = output_path || cfg->s3_bucket;
-    struct sink_stats ss =
-      has_output ? (struct sink_stats){ .total_bytes = meter.total_bytes,
-                                        .total_chunks = est_total_chunks }
-                 : (struct sink_stats){ .total_bytes = dss.total_bytes,
-                                        .total_chunks = est_total_chunks };
+    size_t sink_total_bytes;
+    if (has_output)
+      sink_total_bytes = meter.total_bytes;
+    else if (use_throttled)
+      sink_total_bytes = (size_t)atomic_load(&tss.total_bytes);
+    else
+      sink_total_bytes = dss.total_bytes;
+    struct sink_stats ss = { .total_bytes = sink_total_bytes,
+                             .total_chunks = est_total_chunks };
     print_bench_report(&m,
                        layout,
                        config.dtype,
@@ -1063,6 +1263,8 @@ Cleanup:
   bench_zarr_flush(&zarr);
   bench_destroy(&h);
   bench_zarr_close(&zarr);
+  if (use_throttled)
+    throttled_shard_sink_teardown(&tss);
   return rc;
 }
 
@@ -1202,6 +1404,8 @@ bench_stream_main(int ac,
   size_t memory_budget = 0;
   uint64_t frames = 0;
   int json_output = 0;
+  uint64_t io_bw_mbps = 0;
+  uint64_t io_latency_us = 0;
 
   for (int i = 1; i < ac; ++i) {
     if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
@@ -1240,6 +1444,10 @@ bench_stream_main(int ac,
       s3_endpoint = av[++i];
     } else if (strcmp(av[i], "--s3-throughput-gbps") == 0 && i + 1 < ac) {
       s3_throughput_gbps = strtod(av[++i], NULL);
+    } else if (strcmp(av[i], "--io-bw-mbps") == 0 && i + 1 < ac) {
+      io_bw_mbps = strtoull(av[++i], NULL, 10);
+    } else if (strcmp(av[i], "--io-latency-us") == 0 && i + 1 < ac) {
+      io_latency_us = strtoull(av[++i], NULL, 10);
     } else {
       fprintf(stderr, "Unknown option: %s\n", av[i]);
       fprintf(stderr,
@@ -1248,7 +1456,8 @@ bench_stream_main(int ac,
               "[--backend gpu|cpu] [--dtype u8|u16|...] [--frames N] "
               "[--json] [--chunk-bytes N] [--memory-budget N] [-o path] "
               "[--s3-bucket B --s3-region R --s3-endpoint E [--s3-prefix P] "
-              "[--s3-throughput-gbps N]]\n",
+              "[--s3-throughput-gbps N]] "
+              "[--io-bw-mbps N (MiB/s)] [--io-latency-us N]\n",
               av[0]);
       return 1;
     }
@@ -1299,6 +1508,8 @@ bench_stream_main(int ac,
     .memory_budget = memory_budget,
     .shard_counts = shard_counts,
     .json_output = json_output,
+    .io_bw_mbps = io_bw_mbps,
+    .io_latency_us = io_latency_us,
   };
   ecode = run_bench(&cfg);
 
@@ -1447,10 +1658,13 @@ run_bench_two_streams(const struct bench_config* cfg)
   const size_t total_elements = dim_total_elements(dims, rank);
   const size_t total_bytes = total_elements * bpe;
 
-  // --- Sinks: zarr FS when -o given, discard otherwise ---
+  // --- Sinks: zarr FS when -o given, throttled when flags set, discard else
+  // ---
   struct discard_shard_sink dss[2];
   struct bench_zarr_handle zarr[2] = { { 0 }, { 0 } };
   struct metering_sink meter[2] = { { 0 }, { 0 } };
+  struct throttled_shard_sink tss[2] = { { 0 }, { 0 } };
+  int use_throttled = 0;
   struct shard_sink* sink[2];
 
   if (output_path) {
@@ -1476,6 +1690,14 @@ run_bench_two_streams(const struct bench_config* cfg)
     }
     print_report("  output-0: %s", path0);
     print_report("  output-1: %s", path1);
+  } else if (cfg->io_bw_mbps > 0 || cfg->io_latency_us > 0) {
+    for (int k = 0; k < 2; ++k) {
+      CHECK(Fail,
+            throttled_shard_sink_init(
+              &tss[k], cfg->io_bw_mbps, cfg->io_latency_us) == 0);
+      sink[k] = &tss[k].base;
+    }
+    use_throttled = 1;
   } else {
     discard_shard_sink_init(&dss[0]);
     discard_shard_sink_init(&dss[1]);
@@ -1551,10 +1773,15 @@ run_bench_two_streams(const struct bench_config* cfg)
     tile_stream_gpu_get_metrics(s1),
   };
 
-  size_t sink_bytes[2] = {
-    output_path ? meter[0].total_bytes : dss[0].total_bytes,
-    output_path ? meter[1].total_bytes : dss[1].total_bytes,
-  };
+  size_t sink_bytes[2];
+  for (int k = 0; k < 2; ++k) {
+    if (output_path)
+      sink_bytes[k] = meter[k].total_bytes;
+    else if (use_throttled)
+      sink_bytes[k] = (size_t)atomic_load(&tss[k].total_bytes);
+    else
+      sink_bytes[k] = dss[k].total_bytes;
+  }
 
   const double GIB = 1024.0 * 1024.0 * 1024.0;
   double per_stream_gib = (double)total_bytes / GIB;
@@ -1607,6 +1834,10 @@ run_bench_two_streams(const struct bench_config* cfg)
   tile_stream_gpu_destroy(s0);
   bench_zarr_close(&zarr[0]);
   bench_zarr_close(&zarr[1]);
+  if (use_throttled) {
+    throttled_shard_sink_teardown(&tss[0]);
+    throttled_shard_sink_teardown(&tss[1]);
+  }
   return 0;
 
 Fail:
@@ -1621,6 +1852,10 @@ Fail:
     tile_stream_gpu_destroy(s0);
   bench_zarr_close(&zarr[0]);
   bench_zarr_close(&zarr[1]);
+  if (use_throttled) {
+    throttled_shard_sink_teardown(&tss[0]);
+    throttled_shard_sink_teardown(&tss[1]);
+  }
   return 1;
 }
 
@@ -1642,6 +1877,8 @@ bench_two_streams_main(int ac,
   size_t memory_budget = 0;
   uint64_t frames = 0;
   const char* output_path = NULL;
+  uint64_t io_bw_mbps = 0;
+  uint64_t io_latency_us = 0;
 
   for (int i = 1; i < ac; ++i) {
     if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
@@ -1665,13 +1902,18 @@ bench_two_streams_main(int ac,
       memory_budget = parse_bytes(av[++i]);
     } else if (strcmp(av[i], "-o") == 0 && i + 1 < ac) {
       output_path = av[++i];
+    } else if (strcmp(av[i], "--io-bw-mbps") == 0 && i + 1 < ac) {
+      io_bw_mbps = strtoull(av[++i], NULL, 10);
+    } else if (strcmp(av[i], "--io-latency-us") == 0 && i + 1 < ac) {
+      io_latency_us = strtoull(av[++i], NULL, 10);
     } else {
       fprintf(stderr, "Unknown option: %s\n", av[i]);
       fprintf(stderr,
               "Usage: %s [--fill xor|zeros|rand] [--codec none|lz4|zstd] "
               "[--reduce mean|min|max|median|max_sup|min_sup] "
               "[--dtype u8|u16|...] [--frames N] "
-              "[--chunk-bytes N] [--memory-budget N] [-o path]\n",
+              "[--chunk-bytes N] [--memory-budget N] [-o path] "
+              "[--io-bw-mbps N (MiB/s)] [--io-latency-us N]\n",
               av[0]);
       return 1;
     }
@@ -1711,6 +1953,8 @@ bench_two_streams_main(int ac,
       target_chunk_bytes ? target_chunk_bytes : default_chunk_bytes,
     .memory_budget = memory_budget,
     .shard_counts = shard_counts,
+    .io_bw_mbps = io_bw_mbps,
+    .io_latency_us = io_latency_us,
   };
   int ecode = run_bench_two_streams(&cfg);
 

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -393,6 +393,13 @@ metering_has_error(const struct shard_sink* self)
   return ms->inner->has_error(ms->inner);
 }
 
+static size_t
+metering_pending_bytes(const struct shard_sink* self)
+{
+  const struct metering_sink* ms = (const struct metering_sink*)self;
+  return ms->inner->pending_bytes(ms->inner);
+}
+
 static void
 metering_sink_init(struct metering_sink* ms, struct shard_sink* inner)
 {
@@ -402,6 +409,7 @@ metering_sink_init(struct metering_sink* ms, struct shard_sink* inner)
       .record_fence = inner->record_fence ? metering_record_fence : NULL,
       .wait_fence = inner->wait_fence ? metering_wait_fence : NULL,
       .has_error = inner->has_error ? metering_has_error : NULL,
+      .pending_bytes = inner->pending_bytes ? metering_pending_bytes : NULL,
     },
     .inner = inner,
     .metric = { .name = "Sink", .best_ms = 1e30f },
@@ -770,6 +778,23 @@ print_bench_report(const struct stream_metrics* metrics,
   print_metric_row(&metrics->aggregate);
   print_metric_row(&metrics->d2h);
   print_metric_row(&metrics->sink);
+
+  // Stall stats — wall-clock time the host is blocked waiting. Emitted only
+  // if any stall was observed.
+  int have_stalls =
+    metrics->flush_stall.count > 0 || metrics->kick_sync_stall.count > 0 ||
+    metrics->io_fence_stall.count > 0 || metrics->max_append_ms > 0 ||
+    metrics->peak_pending_bytes > 0;
+  if (have_stalls) {
+    print_report("");
+    print_report("  --- Stall stats ---");
+    print_metric_row(&metrics->flush_stall);
+    print_metric_row(&metrics->kick_sync_stall);
+    print_metric_row(&metrics->io_fence_stall);
+    print_report("  max append ms:   %.2f", (double)metrics->max_append_ms);
+    print_report("  peak pending:    %.2f MiB",
+                 (double)metrics->peak_pending_bytes / (1024.0 * 1024.0));
+  }
 
   double throughput_gib =
     wall_s > 0 ? ((double)total_bytes / (1024.0 * 1024.0 * 1024.0)) / wall_s
@@ -1233,6 +1258,27 @@ run_bench(const struct bench_config* cfg)
         jw_object_end(&jw);
       }
       jw_object_end(&jw); // stages
+
+      // Stall metrics — total wall-clock ms blocked at each sync point.
+      jw_key(&jw, "stalls");
+      jw_object_begin(&jw);
+      jw_key(&jw, "flush_stall_ms");
+      jw_float(&jw, (double)m.flush_stall.ms);
+      jw_key(&jw, "flush_stall_count");
+      jw_uint(&jw, (uint64_t)m.flush_stall.count);
+      jw_key(&jw, "kick_sync_ms");
+      jw_float(&jw, (double)m.kick_sync_stall.ms);
+      jw_key(&jw, "kick_sync_count");
+      jw_uint(&jw, (uint64_t)m.kick_sync_stall.count);
+      jw_key(&jw, "io_fence_ms");
+      jw_float(&jw, (double)m.io_fence_stall.ms);
+      jw_key(&jw, "io_fence_count");
+      jw_uint(&jw, (uint64_t)m.io_fence_stall.count);
+      jw_key(&jw, "max_append_ms");
+      jw_float(&jw, (double)m.max_append_ms);
+      jw_key(&jw, "peak_pending_mib");
+      jw_float(&jw, (double)m.peak_pending_bytes / (1024.0 * 1024.0));
+      jw_object_end(&jw); // stalls
 
       jw_object_end(&jw); // root
       printf("%.*s\n", (int)jw_length(&jw), json_buf);
@@ -1827,6 +1873,21 @@ run_bench_two_streams(const struct bench_config* cfg)
     print_metric_row(&m[k].aggregate);
     print_metric_row(&m[k].d2h);
     print_metric_row(&m[k].sink);
+
+    int have_stalls = m[k].flush_stall.count > 0 ||
+                      m[k].kick_sync_stall.count > 0 ||
+                      m[k].io_fence_stall.count > 0 || m[k].max_append_ms > 0 ||
+                      m[k].peak_pending_bytes > 0;
+    if (have_stalls) {
+      print_report("");
+      print_report("  --- Stall stats (stream-%d) ---", k);
+      print_metric_row(&m[k].flush_stall);
+      print_metric_row(&m[k].kick_sync_stall);
+      print_metric_row(&m[k].io_fence_stall);
+      print_report("  max append ms:   %.2f", (double)m[k].max_append_ms);
+      print_report("  peak pending:    %.2f MiB",
+                   (double)m[k].peak_pending_bytes / (1024.0 * 1024.0));
+    }
   }
 
   print_report("  PASS");

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -783,14 +783,15 @@ print_bench_report(const struct stream_metrics* metrics,
   // if any stall was observed.
   int have_stalls =
     metrics->flush_stall.count > 0 || metrics->kick_sync_stall.count > 0 ||
-    metrics->io_fence_stall.count > 0 || metrics->max_append_ms > 0 ||
-    metrics->peak_pending_bytes > 0;
+    metrics->io_fence_stall.count > 0 || metrics->backpressure.count > 0 ||
+    metrics->max_append_ms > 0 || metrics->peak_pending_bytes > 0;
   if (have_stalls) {
     print_report("");
     print_report("  --- Stall stats ---");
     print_metric_row(&metrics->flush_stall);
     print_metric_row(&metrics->kick_sync_stall);
     print_metric_row(&metrics->io_fence_stall);
+    print_metric_row(&metrics->backpressure);
     print_report("  max append ms:   %.2f", (double)metrics->max_append_ms);
     print_report("  peak pending:    %.2f MiB",
                  (double)metrics->peak_pending_bytes / (1024.0 * 1024.0));
@@ -1022,6 +1023,7 @@ run_bench(const struct bench_config* cfg)
     .target_batch_chunks = 2048,
     .shard_alignment =
       (output_path || cfg->s3_bucket) ? platform_page_size() : 0,
+    .backpressure_bytes = cfg->backpressure_bytes,
   };
 
   uint64_t est_total_chunks = 0;
@@ -1274,6 +1276,10 @@ run_bench(const struct bench_config* cfg)
       jw_float(&jw, (double)m.io_fence_stall.ms);
       jw_key(&jw, "io_fence_count");
       jw_uint(&jw, (uint64_t)m.io_fence_stall.count);
+      jw_key(&jw, "backpressure_ms");
+      jw_float(&jw, (double)m.backpressure.ms);
+      jw_key(&jw, "backpressure_count");
+      jw_uint(&jw, (uint64_t)m.backpressure.count);
       jw_key(&jw, "max_append_ms");
       jw_float(&jw, (double)m.max_append_ms);
       jw_key(&jw, "peak_pending_mib");
@@ -1452,6 +1458,7 @@ bench_stream_main(int ac,
   int json_output = 0;
   uint64_t io_bw_mbps = 0;
   uint64_t io_latency_us = 0;
+  size_t backpressure_bytes = 0;
 
   for (int i = 1; i < ac; ++i) {
     if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
@@ -1494,6 +1501,8 @@ bench_stream_main(int ac,
       io_bw_mbps = strtoull(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--io-latency-us") == 0 && i + 1 < ac) {
       io_latency_us = strtoull(av[++i], NULL, 10);
+    } else if (strcmp(av[i], "--backpressure") == 0 && i + 1 < ac) {
+      backpressure_bytes = parse_bytes(av[++i]);
     } else {
       fprintf(stderr, "Unknown option: %s\n", av[i]);
       fprintf(stderr,
@@ -1503,7 +1512,8 @@ bench_stream_main(int ac,
               "[--json] [--chunk-bytes N] [--memory-budget N] [-o path] "
               "[--s3-bucket B --s3-region R --s3-endpoint E [--s3-prefix P] "
               "[--s3-throughput-gbps N]] "
-              "[--io-bw-mbps N (MiB/s)] [--io-latency-us N]\n",
+              "[--io-bw-mbps N (MiB/s)] [--io-latency-us N] "
+              "[--backpressure N (bytes, e.g. 256M)]\n",
               av[0]);
       return 1;
     }
@@ -1556,6 +1566,7 @@ bench_stream_main(int ac,
     .json_output = json_output,
     .io_bw_mbps = io_bw_mbps,
     .io_latency_us = io_latency_us,
+    .backpressure_bytes = backpressure_bytes,
   };
   ecode = run_bench(&cfg);
 
@@ -1761,6 +1772,7 @@ run_bench_two_streams(const struct bench_config* cfg)
     .append_reduce_method = cfg->append_reduce_method,
     .target_batch_chunks = 2048,
     .shard_alignment = output_path ? platform_page_size() : 0,
+    .backpressure_bytes = cfg->backpressure_bytes,
   };
 
   // Memory estimates
@@ -1874,16 +1886,17 @@ run_bench_two_streams(const struct bench_config* cfg)
     print_metric_row(&m[k].d2h);
     print_metric_row(&m[k].sink);
 
-    int have_stalls = m[k].flush_stall.count > 0 ||
-                      m[k].kick_sync_stall.count > 0 ||
-                      m[k].io_fence_stall.count > 0 || m[k].max_append_ms > 0 ||
-                      m[k].peak_pending_bytes > 0;
+    int have_stalls =
+      m[k].flush_stall.count > 0 || m[k].kick_sync_stall.count > 0 ||
+      m[k].io_fence_stall.count > 0 || m[k].backpressure.count > 0 ||
+      m[k].max_append_ms > 0 || m[k].peak_pending_bytes > 0;
     if (have_stalls) {
       print_report("");
       print_report("  --- Stall stats (stream-%d) ---", k);
       print_metric_row(&m[k].flush_stall);
       print_metric_row(&m[k].kick_sync_stall);
       print_metric_row(&m[k].io_fence_stall);
+      print_metric_row(&m[k].backpressure);
       print_report("  max append ms:   %.2f", (double)m[k].max_append_ms);
       print_report("  peak pending:    %.2f MiB",
                    (double)m[k].peak_pending_bytes / (1024.0 * 1024.0));
@@ -1940,6 +1953,7 @@ bench_two_streams_main(int ac,
   const char* output_path = NULL;
   uint64_t io_bw_mbps = 0;
   uint64_t io_latency_us = 0;
+  size_t backpressure_bytes = 0;
 
   for (int i = 1; i < ac; ++i) {
     if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
@@ -1967,6 +1981,8 @@ bench_two_streams_main(int ac,
       io_bw_mbps = strtoull(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--io-latency-us") == 0 && i + 1 < ac) {
       io_latency_us = strtoull(av[++i], NULL, 10);
+    } else if (strcmp(av[i], "--backpressure") == 0 && i + 1 < ac) {
+      backpressure_bytes = parse_bytes(av[++i]);
     } else {
       fprintf(stderr, "Unknown option: %s\n", av[i]);
       fprintf(stderr,
@@ -1974,7 +1990,8 @@ bench_two_streams_main(int ac,
               "[--reduce mean|min|max|median|max_sup|min_sup] "
               "[--dtype u8|u16|...] [--frames N] "
               "[--chunk-bytes N] [--memory-budget N] [-o path] "
-              "[--io-bw-mbps N (MiB/s)] [--io-latency-us N]\n",
+              "[--io-bw-mbps N (MiB/s)] [--io-latency-us N] "
+              "[--backpressure N]\n",
               av[0]);
       return 1;
     }

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -2033,6 +2033,7 @@ bench_two_streams_main(int ac,
     .shard_counts = shard_counts,
     .io_bw_mbps = io_bw_mbps,
     .io_latency_us = io_latency_us,
+    .backpressure_bytes = backpressure_bytes,
   };
   int ecode = run_bench_two_streams(&cfg);
 

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -45,6 +45,8 @@ struct bench_config
   size_t memory_budget;         // 0 = auto-detect
   const uint64_t* shard_counts; // per-dim target shard counts (NULL = skip)
   int json_output;              // print JSON to stdout after run
+  uint64_t io_bw_mbps;          // 0 = no bandwidth cap (MiB/s)
+  uint64_t io_latency_us;       // 0 = no fixed per-job latency
 };
 
 int

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -47,6 +47,7 @@ struct bench_config
   int json_output;              // print JSON to stdout after run
   uint64_t io_bw_mbps;          // 0 = no bandwidth cap (MiB/s)
   uint64_t io_latency_us;       // 0 = no fixed per-job latency
+  size_t backpressure_bytes;    // 0 = disabled; >0 = stall when pending > N
 };
 
 int

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ add_src_lib(index_ops  SOURCES util/index.ops.c util/index.ops.h)
 add_src_lib(dtype      SOURCES dtype.c dtype.h)
 add_src_lib(dimension  SOURCES dimension.c dimension.h)
 add_src_lib(lod_plan   SOURCES lod/lod_plan.c lod/lod_plan.h LINKS index_ops dimension dtype)
+enable_openmp(lod_plan)
 add_src_lib(crc32c     SOURCES zarr/crc32c.c zarr/crc32c.h)
 
 add_src_lib(platform SOURCES platform/platform.h)

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -211,6 +211,7 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
   s->metrics.flush_stall = mk_stream_metric("flush_stall");
   s->metrics.kick_sync_stall = mk_stream_metric("kick_sync");
   s->metrics.io_fence_stall = mk_stream_metric("io_fence");
+  s->metrics.backpressure = mk_stream_metric("backpressure");
   if (s->levels.enable_multiscale) {
     s->metrics.lod_gather = mk_stream_metric("lod_gather");
     s->metrics.lod_reduce = mk_stream_metric("lod_reduce");

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -207,6 +207,10 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
   s->metrics.compress = mk_stream_metric("compress");
   s->metrics.aggregate = mk_stream_metric("aggregate");
   s->metrics.sink = mk_stream_metric("sink");
+  // GPU-only stall metrics: named but never populated on CPU path.
+  s->metrics.flush_stall = mk_stream_metric("flush_stall");
+  s->metrics.kick_sync_stall = mk_stream_metric("kick_sync");
+  s->metrics.io_fence_stall = mk_stream_metric("io_fence");
   if (s->levels.enable_multiscale) {
     s->metrics.lod_gather = mk_stream_metric("lod_gather");
     s->metrics.lod_reduce = mk_stream_metric("lod_reduce");

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -50,6 +50,7 @@ d2h_deliver_destroy(struct d2h_deliver_stage* stage)
 // --- Internal helpers ---
 
 // Wait for pending IO fences on aggregate slots before reuse.
+// Accumulates wall time into stage->metrics->io_fence_stall (if non-NULL).
 static void
 wait_io_fences(const struct d2h_deliver_stage* stage,
                int fc,
@@ -58,12 +59,18 @@ wait_io_fences(const struct d2h_deliver_stage* stage,
 {
   if (!sink->wait_fence)
     return;
+  struct platform_clock clk = { 0 };
+  platform_toc(&clk);
   for (int lv = 0; lv < stage->nlod; ++lv) {
     if (!(level_mask & (1u << lv)))
       continue;
     struct aggregate_slot* agg = &stage->levels[lv].agg[fc];
     if (agg->io_done.seq > 0)
       sink->wait_fence(sink, (uint8_t)lv, agg->io_done);
+  }
+  if (stage->metrics) {
+    float ms = (float)(platform_toc(&clk) * 1000.0);
+    accumulate_metric_ms(&stage->metrics->io_fence_stall, ms, 0, 0);
   }
 }
 
@@ -107,7 +114,15 @@ two_phase_d2h(const struct d2h_deliver_stage* stage,
                          d2h_stream));
   }
   CU(Error, cuEventRecord(stage->ready[fc], d2h_stream));
-  CU(Error, cuEventSynchronize(stage->ready[fc]));
+  {
+    struct platform_clock sync_clk = { 0 };
+    platform_toc(&sync_clk);
+    CU(Error, cuEventSynchronize(stage->ready[fc]));
+    if (stage->metrics) {
+      float ms = (float)(platform_toc(&sync_clk) * 1000.0);
+      accumulate_metric_ms(&stage->metrics->kick_sync_stall, ms, 0, 0);
+    }
+  }
 
   // Phase 2: D2H only actual compressed bytes per level
   for (int lv = 0; lv < levels->nlod; ++lv) {

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -23,8 +23,10 @@ d2h_deliver_init(struct d2h_deliver_stage* stage,
 
   for (int fc = 0; fc < 2; ++fc) {
     CU(Fail, cuEventCreate(&stage->t_d2h_start[fc], CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&stage->offsets_ready[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->ready[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventRecord(stage->t_d2h_start[fc], compute));
+    CU(Fail, cuEventRecord(stage->offsets_ready[fc], compute));
     CU(Fail, cuEventRecord(stage->ready[fc], compute));
   }
 
@@ -42,6 +44,7 @@ d2h_deliver_destroy(struct d2h_deliver_stage* stage)
     return;
   for (int fc = 0; fc < 2; ++fc) {
     cu_event_destroy(stage->t_d2h_start[fc]);
+    cu_event_destroy(stage->offsets_ready[fc]);
     cu_event_destroy(stage->ready[fc]);
   }
   // levels is borrowed, not destroyed here
@@ -74,22 +77,20 @@ wait_io_fences(const struct d2h_deliver_stage* stage,
   }
 }
 
-// Two-phase D2H: transfer offsets first (small), synchronize, then only
-// actual compressed bytes.
+// Phase 1: D2H offsets only (non-blocking — no host sync).
+// Records offsets_ready[fc] when offsets are on the host.
 static int
-two_phase_d2h(const struct d2h_deliver_stage* stage,
-              const struct flush_handoff* handoff,
-              const struct level_geometry* levels,
-              const struct batch_state* batch,
-              const struct dim_info* dims,
-              const struct tile_stream_configuration* config,
-              CUstream d2h_stream)
+kick_offset_d2h(struct d2h_deliver_stage* stage,
+                const struct flush_handoff* handoff,
+                const struct level_geometry* levels,
+                const struct batch_state* batch,
+                const struct dim_info* dims,
+                CUstream d2h_stream)
 {
   const int fc = handoff->fc;
   const uint32_t n_epochs = handoff->n_epochs;
   const uint32_t level_mask = handoff->active_levels_mask;
 
-  // Phase 1: D2H offsets only
   for (int lv = 0; lv < levels->nlod; ++lv) {
     if (!(level_mask & (1u << lv)))
       continue;
@@ -113,18 +114,41 @@ two_phase_d2h(const struct d2h_deliver_stage* stage,
                          (covering + 1) * sizeof(size_t),
                          d2h_stream));
   }
-  CU(Error, cuEventRecord(stage->ready[fc], d2h_stream));
+  CU(Error, cuEventRecord(stage->offsets_ready[fc], d2h_stream));
+
+  return 0;
+
+Error:
+  return 1;
+}
+
+// Phase 2: sync on offsets, then D2H only the actual compressed bytes.
+// Called from drain after kick has returned. Uses the stashed d2h_stream.
+static int
+drain_bulk_d2h(struct d2h_deliver_stage* stage,
+               const struct flush_handoff* handoff,
+               const struct level_geometry* levels,
+               const struct batch_state* batch,
+               const struct dim_info* dims,
+               const struct tile_stream_configuration* config)
+{
+  const int fc = handoff->fc;
+  const uint32_t n_epochs = handoff->n_epochs;
+  const uint32_t level_mask = handoff->active_levels_mask;
+  CUstream d2h_stream = stage->d2h_stream;
+
+  // Wait for offset D2H to land on the host.
   {
     struct platform_clock sync_clk = { 0 };
     platform_toc(&sync_clk);
-    CU(Error, cuEventSynchronize(stage->ready[fc]));
+    CU(Error, cuEventSynchronize(stage->offsets_ready[fc]));
     if (stage->metrics) {
       float ms = (float)(platform_toc(&sync_clk) * 1000.0);
       accumulate_metric_ms(&stage->metrics->kick_sync_stall, ms, 0, 0);
     }
   }
 
-  // Phase 2: D2H only actual compressed bytes per level
+  // D2H only actual compressed bytes per level.
   for (int lv = 0; lv < levels->nlod; ++lv) {
     if (!(level_mask & (1u << lv)))
       continue;
@@ -255,9 +279,9 @@ record_flush_metrics(const struct d2h_deliver_stage* stage,
   }
 }
 
-// Synchronize D2H, record metrics, deliver to sinks.
+// Issue bulk D2H (phase 2), synchronize, record metrics, deliver to sinks.
 static struct writer_result
-sync_and_deliver(const struct d2h_deliver_stage* stage,
+sync_and_deliver(struct d2h_deliver_stage* stage,
                  const struct flush_handoff* handoff,
                  const struct level_geometry* levels,
                  const struct batch_state* batch,
@@ -271,6 +295,9 @@ sync_and_deliver(const struct d2h_deliver_stage* stage,
   const int fc = handoff->fc;
   const uint32_t n_epochs = handoff->n_epochs;
 
+  // Phase 2: sync on offsets, issue bulk D2H, sync on bulk ready.
+  CHECK(Error,
+        drain_bulk_d2h(stage, handoff, levels, batch, dims, config) == 0);
   CU(Error, cuEventSynchronize(stage->ready[fc]));
   record_flush_metrics(
     stage, handoff, levels, batch, dims, layout, config, lod, metrics);
@@ -363,6 +390,7 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                  struct shard_sink* sink,
                  CUstream d2h_stream)
 {
+  (void)config; // used by drain_bulk_d2h, not kick
   const int fc = handoff->fc;
 
   // Wait for IO fences before reusing aggregate slots
@@ -375,8 +403,10 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
   CU(Error, cuStreamWaitEvent(d2h_stream, handoff->t_aggregate_end, 0));
   CU(Error, cuEventRecord(stage->t_d2h_start[fc], d2h_stream));
   CHECK(Error,
-        two_phase_d2h(
-          stage, handoff, levels, batch, dims, config, d2h_stream) == 0);
+        kick_offset_d2h(stage, handoff, levels, batch, dims, d2h_stream) == 0);
+
+  // Stash d2h_stream so drain can issue bulk D2H on the same stream.
+  stage->d2h_stream = d2h_stream;
 
   return 0;
 

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -279,7 +279,8 @@ record_flush_metrics(const struct d2h_deliver_stage* stage,
   }
 }
 
-// Issue bulk D2H (phase 2), synchronize, record metrics, deliver to sinks.
+// Wait for IO fences, issue bulk D2H (phase 2), synchronize, record metrics,
+// deliver to sinks.
 static struct writer_result
 sync_and_deliver(struct d2h_deliver_stage* stage,
                  const struct flush_handoff* handoff,
@@ -294,6 +295,14 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
 {
   const int fc = handoff->fc;
   const uint32_t n_epochs = handoff->n_epochs;
+
+  // Wait for IO fences before overwriting h_aggregated with bulk D2H.
+  // Moved from kick so that compress+aggregate can run without blocking.
+  wait_io_fences(stage, fc, handoff->active_levels_mask, sink);
+
+  // Fail fast if async IO encountered an error.
+  if (sink->has_error && sink->has_error(sink))
+    goto Error;
 
   // Phase 2: sync on offsets, issue bulk D2H, sync on bulk ready.
   CHECK(Error,
@@ -391,14 +400,8 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                  CUstream d2h_stream)
 {
   (void)config; // used by drain_bulk_d2h, not kick
+  (void)sink;   // IO fences moved to drain (d2h_deliver_drain)
   const int fc = handoff->fc;
-
-  // Wait for IO fences before reusing aggregate slots
-  wait_io_fences(stage, fc, handoff->active_levels_mask, sink);
-
-  // Fail fast if async IO encountered an error.
-  if (sink->has_error && sink->has_error(sink))
-    goto Error;
 
   CU(Error, cuStreamWaitEvent(d2h_stream, handoff->t_aggregate_end, 0));
   CU(Error, cuEventRecord(stage->t_d2h_start[fc], d2h_stream));

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -395,12 +395,8 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                  const struct level_geometry* levels,
                  const struct batch_state* batch,
                  const struct dim_info* dims,
-                 const struct tile_stream_configuration* config,
-                 struct shard_sink* sink,
                  CUstream d2h_stream)
 {
-  (void)config; // used by drain_bulk_d2h, not kick
-  (void)sink;   // IO fences moved to drain (d2h_deliver_drain)
   const int fc = handoff->fc;
 
   CU(Error, cuStreamWaitEvent(d2h_stream, handoff->t_aggregate_end, 0));

--- a/src/gpu/flush.d2h_deliver.h
+++ b/src/gpu/flush.d2h_deliver.h
@@ -23,8 +23,6 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                  const struct level_geometry* levels,
                  const struct batch_state* batch,
                  const struct dim_info* dims,
-                 const struct tile_stream_configuration* config,
-                 struct shard_sink* sink,
                  CUstream d2h_stream);
 
 // Synchronize D2H, record metrics, deliver to sinks.

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -162,6 +162,20 @@ tile_stream_gpu_append_body(struct tile_stream_gpu* s, struct slice input)
       size_t pend = shard_sink_pending_bytes(s->shard_sink);
       if (pend > s->metrics.peak_pending_bytes)
         s->metrics.peak_pending_bytes = pend;
+      // Backpressure: if the sink's IO queue exceeds the watermark,
+      // poll here until it drains below the threshold.  This keeps
+      // the stall at the producer boundary instead of deep inside
+      // the flush pipeline.
+      if (s->config.backpressure_bytes > 0 &&
+          pend > s->config.backpressure_bytes) {
+        struct platform_clock bp_clk = { 0 };
+        platform_toc(&bp_clk);
+        while (shard_sink_pending_bytes(s->shard_sink) >
+               s->config.backpressure_bytes)
+          platform_sleep_ns(100000); // 100 μs
+        float bp_ms = (float)(platform_toc(&bp_clk) * 1000.0);
+        accumulate_metric_ms(&s->metrics.backpressure, bp_ms, 0, 0);
+      }
     }
   }
 

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -62,12 +62,11 @@ tile_stream_gpu_get_metrics(const struct tile_stream_gpu* s)
   return s->metrics;
 }
 
+// Body of tile_stream_gpu_append, factored out so the wrapper can wall-clock
+// the whole thing for max_append_ms.
 static struct writer_result
-tile_stream_gpu_append(struct writer* self, struct slice input)
+tile_stream_gpu_append_body(struct tile_stream_gpu* s, struct slice input)
 {
-  struct tile_stream_gpu* s =
-    container_of(self, struct tile_stream_gpu, writer);
-
   if (s->flushed)
     return writer_finished_at(input.beg, input.end);
 
@@ -159,6 +158,10 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
       struct writer_result fr = flush_accumulate_epoch(s);
       if (fr.error)
         return writer_error_at(src, end);
+      // Sample sink backpressure at epoch boundaries.
+      size_t pend = shard_sink_pending_bytes(s->shard_sink);
+      if (pend > s->metrics.peak_pending_bytes)
+        s->metrics.peak_pending_bytes = pend;
     }
   }
 
@@ -167,6 +170,20 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
 
 Error:
   return writer_error_at(src, end);
+}
+
+static struct writer_result
+tile_stream_gpu_append(struct writer* self, struct slice input)
+{
+  struct tile_stream_gpu* s =
+    container_of(self, struct tile_stream_gpu, writer);
+  struct platform_clock clk = { 0 };
+  platform_toc(&clk);
+  struct writer_result r = tile_stream_gpu_append_body(s, input);
+  float ms = (float)(platform_toc(&clk) * 1000.0);
+  if (ms > s->metrics.max_append_ms)
+    s->metrics.max_append_ms = ms;
+  return r;
 }
 
 static struct writer_result

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -171,17 +171,22 @@ tile_stream_gpu_append_body(struct tile_stream_gpu* s, struct slice input)
           pend > s->config.backpressure_bytes) {
         struct platform_clock bp_clk = { 0 };
         platform_toc(&bp_clk);
+        int64_t start_ns = bp_clk.last_ns;
         const double timeout_s = 30.0;
         int drained = 0;
-        while (platform_toc(&bp_clk) < timeout_s) {
+        for (;;) {
           if (shard_sink_pending_bytes(s->shard_sink) <=
               s->config.backpressure_bytes) {
             drained = 1;
             break;
           }
+          platform_toc(&bp_clk);
+          if ((bp_clk.last_ns - start_ns) / 1e9 >= timeout_s)
+            break;
           platform_sleep_ns(100000); // 100 μs
         }
-        float bp_ms = (float)(platform_toc(&bp_clk) * 1000.0);
+        platform_toc(&bp_clk);
+        float bp_ms = (float)((bp_clk.last_ns - start_ns) / 1e6);
         accumulate_metric_ms(&s->metrics.backpressure, bp_ms, 0, 0);
         if (!drained)
           log_warn("backpressure timeout after %.1fs (pending %zu bytes)",

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -3,6 +3,7 @@
 
 #include "gpu/metric.cuda.h"
 #include "gpu/prelude.cuda.h"
+#include "log/log.h"
 #include "platform/platform.h"
 #include "util/prelude.h"
 #include "zarr/shard_delivery.h"
@@ -170,11 +171,22 @@ tile_stream_gpu_append_body(struct tile_stream_gpu* s, struct slice input)
           pend > s->config.backpressure_bytes) {
         struct platform_clock bp_clk = { 0 };
         platform_toc(&bp_clk);
-        while (shard_sink_pending_bytes(s->shard_sink) >
-               s->config.backpressure_bytes)
+        const double timeout_s = 30.0;
+        int drained = 0;
+        while (platform_toc(&bp_clk) < timeout_s) {
+          if (shard_sink_pending_bytes(s->shard_sink) <=
+              s->config.backpressure_bytes) {
+            drained = 1;
+            break;
+          }
           platform_sleep_ns(100000); // 100 μs
+        }
         float bp_ms = (float)(platform_toc(&bp_clk) * 1000.0);
         accumulate_metric_ms(&s->metrics.backpressure, bp_ms, 0, 0);
+        if (!drained)
+          log_warn("backpressure timeout after %.1fs (pending %zu bytes)",
+                   timeout_s,
+                   shard_sink_pending_bytes(s->shard_sink));
       }
     }
   }

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -144,8 +144,6 @@ drain_kick_and_swap(struct tile_stream_gpu* s)
                          &s->levels,
                          &s->batch,
                          &s->dims,
-                         &s->config,
-                         s->shard_sink,
                          s->streams.d2h) == 0);
 
   // Save handoff for the next drain.
@@ -220,8 +218,6 @@ flush_kick_batch(struct tile_stream_gpu* s, int fc, uint32_t n_epochs)
                          &s->levels,
                          &s->batch,
                          &s->dims,
-                         &s->config,
-                         s->shard_sink,
                          s->streams.d2h) == 0);
 
   // Save handoff for drain
@@ -276,8 +272,6 @@ kick_and_deliver_one_epoch(struct tile_stream_gpu* s,
                          &s->levels,
                          &s->batch,
                          &s->dims,
-                         &s->config,
-                         s->shard_sink,
                          s->streams.d2h) == 0);
 
   return d2h_deliver_drain(&s->d2h_deliver,

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -6,6 +6,8 @@
 
 #include "gpu/lod.h"
 #include "gpu/prelude.cuda.h"
+#include "platform/platform.h"
+#include "util/metric.h"
 #include "util/prelude.h"
 
 #include <string.h>
@@ -87,8 +89,18 @@ drain_kick_and_swap(struct tile_stream_gpu* s)
   const int completed_pool = s->pools.current;
   struct flush_slot_gpu* fs = &s->flush.slot[completed_pool];
 
-  // Wait for any previous flush to finish delivery
+  // Wait for any previous flush to finish delivery.
+  // Measure the stall only when there is actually pending work so that
+  // metrics->flush_stall.count reflects real stalls.
+  int had_pending = s->flush.pending;
+  struct platform_clock stall_clk = { 0 };
+  if (had_pending)
+    platform_toc(&stall_clk);
   struct writer_result r = flush_drain_pending(s);
+  if (had_pending) {
+    float ms = (float)(platform_toc(&stall_clk) * 1000.0);
+    accumulate_metric_ms(&s->metrics.flush_stall, ms, 0, 0);
+  }
   if (r.error)
     return r;
 

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -80,8 +80,11 @@ Error:
   return 1;
 }
 
-// Drain previous flush, kick async pipeline on completed pool,
-// swap to fresh pool, reset batch state.
+// Pipeline the batch boundary: launch compress+aggregate for the new batch
+// on the compress stream, drain the previous batch's bulk D2H + delivery on
+// the d2h stream, then queue the new batch's offset D2H.  This ordering
+// keeps the d2h stream free for the previous batch's bulk transfer before
+// the new batch's aggregate-end wait occupies it.
 static struct writer_result
 drain_kick_and_swap(struct tile_stream_gpu* s)
 {
@@ -89,27 +92,68 @@ drain_kick_and_swap(struct tile_stream_gpu* s)
   const int completed_pool = s->pools.current;
   struct flush_slot_gpu* fs = &s->flush.slot[completed_pool];
 
-  // Wait for any previous flush to finish delivery.
-  // Measure the stall only when there is actually pending work so that
-  // metrics->flush_stall.count reflects real stalls.
+  // Save the previous pending state so we can drain it after the
+  // compress+aggregate kick but before the d2h kick.
+  struct flush_handoff prev_handoff = s->flush.pending_handoff;
   int had_pending = s->flush.pending;
-  struct platform_clock stall_clk = { 0 };
-  if (had_pending)
-    platform_toc(&stall_clk);
-  struct writer_result r = flush_drain_pending(s);
+  s->flush.pending = 0;
+
+  // Phase A: kick compress+aggregate for the new batch (compress stream).
+  // This starts GPU work immediately — no host blocking.
+  fs->batch_epoch_count = (int)s->batch.accumulated;
+  struct compress_agg_input in =
+    make_compress_input(s, completed_pool, s->batch.accumulated);
+  struct flush_handoff new_handoff = { 0 };
+  CHECK(Error,
+        compress_agg_kick(&s->compress_agg,
+                          &in,
+                          &s->levels,
+                          &s->batch,
+                          &s->dims,
+                          s->streams.compress,
+                          &new_handoff) == 0);
+
+  // Phase B: drain the PREVIOUS batch.  This issues bulk D2H on d2h_stream
+  // (unblocked — the new batch's aggregate-end wait hasn't been queued yet).
   if (had_pending) {
+    struct platform_clock stall_clk = { 0 };
+    platform_toc(&stall_clk);
+    struct writer_result r = d2h_deliver_drain(&s->d2h_deliver,
+                                               &prev_handoff,
+                                               &s->levels,
+                                               &s->batch,
+                                               &s->dims,
+                                               &s->layout,
+                                               &s->config,
+                                               s->shard_sink,
+                                               &s->lod,
+                                               &s->metrics,
+                                               &s->metadata_update_clock);
     float ms = (float)(platform_toc(&stall_clk) * 1000.0);
     accumulate_metric_ms(&s->metrics.flush_stall, ms, 0, 0);
+    if (r.error)
+      return r;
   }
-  if (r.error)
-    return r;
 
-  // Launch async compress->aggregate->D2H on completed pool
-  fs->batch_epoch_count = (int)s->batch.accumulated;
-  if (flush_kick_batch(s, completed_pool, s->batch.accumulated))
-    return writer_error();
+  // Phase C: queue the new batch's offset D2H on d2h_stream (non-blocking).
+  // This goes AFTER the previous drain's bulk D2H on d2h_stream, avoiding
+  // the aggregate-end wait from blocking the prior batch's transfer.
+  CHECK(Error,
+        d2h_deliver_kick(&s->d2h_deliver,
+                         &new_handoff,
+                         &s->levels,
+                         &s->batch,
+                         &s->dims,
+                         &s->config,
+                         s->shard_sink,
+                         s->streams.d2h) == 0);
 
-  // Swap to fresh pool and zero it for next batch
+  // Save handoff for the next drain.
+  s->flush.pending_handoff = new_handoff;
+  s->flush.pending = 1;
+  s->flush.current = completed_pool;
+
+  // Swap to fresh pool and zero it for next batch.
   s->pools.current ^= 1;
   size_t pool_bytes = (uint64_t)K * s->levels.total_chunks *
                       s->layout.chunk_stride * dtype_bpe(s->config.dtype);
@@ -117,16 +161,13 @@ drain_kick_and_swap(struct tile_stream_gpu* s)
      cuMemsetD8Async(
        s->pools.buf[s->pools.current], 0, pool_bytes, s->streams.compute));
 
-  // Reset batch accumulation
+  // Reset batch accumulation.
   s->batch.accumulated = 0;
   s->flush.slot[s->pools.current].active_levels_mask = 0;
   memset(s->flush.slot[s->pools.current].batch_active_masks,
          0,
          sizeof(s->flush.slot[s->pools.current].batch_active_masks));
 
-  // Mark completed pool as pending delivery
-  s->flush.pending = 1;
-  s->flush.current = completed_pool;
   return writer_ok();
 
 Error:

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -161,6 +161,9 @@ init_metrics(int enable_multiscale)
     .aggregate = mk_stream_metric("Aggregate"),
     .d2h = mk_stream_metric("D2H"),
     .sink = mk_stream_metric("Sink"),
+    .flush_stall = mk_stream_metric("FlushStall"),
+    .kick_sync_stall = mk_stream_metric("KickSync"),
+    .io_fence_stall = mk_stream_metric("IOFence"),
   };
 }
 
@@ -264,6 +267,7 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
   }
 
   out->metrics = init_metrics(out->levels.enable_multiscale);
+  out->d2h_deliver.metrics = &out->metrics;
 
   // Initialize metadata update timer
   out->metadata_update_clock = (struct platform_clock){ 0 };

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -164,6 +164,7 @@ init_metrics(int enable_multiscale)
     .flush_stall = mk_stream_metric("FlushStall"),
     .kick_sync_stall = mk_stream_metric("KickSync"),
     .io_fence_stall = mk_stream_metric("IOFence"),
+    .backpressure = mk_stream_metric("Backpres"),
   };
 }
 

--- a/src/gpu/stream.internal.h
+++ b/src/gpu/stream.internal.h
@@ -144,11 +144,14 @@ struct compress_agg_stage
 struct d2h_deliver_stage
 {
   CUevent t_d2h_start[2];
-  CUevent ready[2];
+  CUevent
+    offsets_ready[2]; // phase 1 (offset D2H) completion; drain syncs on this
+  CUevent ready[2];   // phase 2 (bulk D2H) completion
 
   struct level_flush_state* levels; // borrowed
   int nlod;
   struct stream_metrics* metrics; // borrowed, for stall-time accumulation
+  CUstream d2h_stream;            // stashed by kick for drain to use
 };
 
 struct flush_pipeline

--- a/src/gpu/stream.internal.h
+++ b/src/gpu/stream.internal.h
@@ -151,7 +151,7 @@ struct d2h_deliver_stage
   struct level_flush_state* levels; // borrowed
   int nlod;
   struct stream_metrics* metrics; // borrowed, for stall-time accumulation
-  CUstream d2h_stream;            // stashed by kick for drain to use
+  CUstream d2h_stream; // set by kick, consumed by drain (always paired)
 };
 
 struct flush_pipeline

--- a/src/gpu/stream.internal.h
+++ b/src/gpu/stream.internal.h
@@ -148,6 +148,7 @@ struct d2h_deliver_stage
 
   struct level_flush_state* levels; // borrowed
   int nlod;
+  struct stream_metrics* metrics; // borrowed, for stall-time accumulation
 };
 
 struct flush_pipeline

--- a/src/lod/lod_plan.c
+++ b/src/lod/lod_plan.c
@@ -5,6 +5,7 @@
 #include "util/prelude.h"
 
 #include <assert.h>
+#include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -161,10 +162,13 @@ build_reduce_csr(struct reduce_csr* csr, const struct lod_plan* p, int l)
 
   // Enumerate ALL source elements across all batches.
   uint64_t* counts = csr->starts + 1;
-  uint64_t gi = 0;
+  uint64_t lod_nelem = src_ld->lod_nelem;
 
-  for (uint64_t src_batch = 0; src_batch < src_ld->fixed_dims_count;
-       ++src_batch) {
+#pragma omp parallel for schedule(static)
+  for (uint64_t gi = 0; gi < src_total; ++gi) {
+    uint64_t src_batch = gi / lod_nelem;
+    uint64_t src_enum = gi % lod_nelem;
+
     // Decompose src_batch into per-dim coords (indexed by full dim d).
     uint64_t fixed_coords[LOD_MAX_NDIM];
     memset(fixed_coords, 0, sizeof(fixed_coords));
@@ -177,50 +181,48 @@ build_reduce_csr(struct reduce_csr* csr, const struct lod_plan* p, int l)
       }
     }
 
-    for (uint64_t src_enum = 0; src_enum < src_ld->lod_nelem; ++src_enum) {
-      uint64_t src_coords[LOD_MAX_NDIM];
-      unravel(src_ld->lod_ndim, src_lod_shape, src_enum, src_coords);
+    uint64_t src_coords[LOD_MAX_NDIM];
+    unravel(src_ld->lod_ndim, src_lod_shape, src_enum, src_coords);
 
-      // Halve LOD coords. Non-dropped → dst LOD, dropped → dst fixed.
-      uint64_t dst_fixed_coords[LOD_MAX_NDIM];
-      memcpy(dst_fixed_coords, fixed_coords, sizeof(dst_fixed_coords));
+    // Halve LOD coords. Non-dropped → dst LOD, dropped → dst fixed.
+    uint64_t dst_fixed_coords[LOD_MAX_NDIM];
+    memcpy(dst_fixed_coords, fixed_coords, sizeof(dst_fixed_coords));
 
-      uint64_t dst_lod_coords[LOD_MAX_NDIM];
-      int si = 0;
-      for (int k = 0; k < src_ld->lod_ndim; ++k) {
-        int d = src_ld->lod_to_dim[k];
-        if (dropped_mask & (1u << d))
-          dst_fixed_coords[d] = src_coords[k] / 2;
-        else
-          dst_lod_coords[si++] = src_coords[k] / 2;
-      }
-
-      uint64_t dst_morton =
-        (dst_ld->lod_ndim > 0)
-          ? morton_rank(dst_ld->lod_ndim, dst_lod_shape, dst_lod_coords, 0)
-          : 0;
-
-      // Ravel dst fixed coords in ascending-d order (matches scatter layout).
-      uint64_t dst_bi = 0;
-      {
-        uint64_t rem = 0;
-        for (int k = 0; k < dst_ld->fixed_dims_ndim; ++k) {
-          rem = rem * dst_ld->fixed_dims_shape[k] +
-                dst_fixed_coords[dst_ld->fixed_dim_to_dim[k]];
-        }
-        dst_bi = rem;
-      }
-
-      uint64_t dst_elem = dst_bi * dst_ld->lod_nelem + dst_morton;
-      uint64_t src_morton =
-        morton_rank(src_ld->lod_ndim, src_lod_shape, src_coords, 0);
-      uint64_t src_elem = src_batch * src_ld->lod_nelem + src_morton;
-
-      map[gi].dst_elem = dst_elem;
-      map[gi].src_elem = src_elem;
-      counts[dst_elem]++;
-      gi++;
+    uint64_t dst_lod_coords[LOD_MAX_NDIM];
+    int si = 0;
+    for (int k = 0; k < src_ld->lod_ndim; ++k) {
+      int d = src_ld->lod_to_dim[k];
+      if (dropped_mask & (1u << d))
+        dst_fixed_coords[d] = src_coords[k] / 2;
+      else
+        dst_lod_coords[si++] = src_coords[k] / 2;
     }
+
+    uint64_t dst_morton =
+      (dst_ld->lod_ndim > 0)
+        ? morton_rank(dst_ld->lod_ndim, dst_lod_shape, dst_lod_coords, 0)
+        : 0;
+
+    // Ravel dst fixed coords in ascending-d order (matches scatter layout).
+    uint64_t dst_bi = 0;
+    {
+      uint64_t rem = 0;
+      for (int k = 0; k < dst_ld->fixed_dims_ndim; ++k) {
+        rem = rem * dst_ld->fixed_dims_shape[k] +
+              dst_fixed_coords[dst_ld->fixed_dim_to_dim[k]];
+      }
+      dst_bi = rem;
+    }
+
+    uint64_t dst_elem = dst_bi * dst_ld->lod_nelem + dst_morton;
+    uint64_t src_morton =
+      morton_rank(src_ld->lod_ndim, src_lod_shape, src_coords, 0);
+    uint64_t src_elem = src_batch * src_ld->lod_nelem + src_morton;
+
+    map[gi].dst_elem = dst_elem;
+    map[gi].src_elem = src_elem;
+#pragma omp atomic
+    counts[dst_elem]++;
   }
 
   // Prefix sum.
@@ -241,8 +243,13 @@ build_reduce_csr(struct reduce_csr* csr, const struct lod_plan* p, int l)
   for (uint64_t i = 0; i < dst_total; ++i)
     write_pos[i] = csr->starts[i];
 
-  for (uint64_t i = 0; i < src_total; ++i)
-    csr->indices[write_pos[map[i].dst_elem]++] = map[i].src_elem;
+#pragma omp parallel for schedule(static)
+  for (uint64_t i = 0; i < src_total; ++i) {
+    uint64_t pos;
+#pragma omp atomic capture
+    pos = write_pos[map[i].dst_elem]++;
+    csr->indices[pos] = map[i].src_elem;
+  }
 
   free(write_pos);
   free(map);

--- a/src/ngff/ngff_metadata.c
+++ b/src/ngff/ngff_metadata.c
@@ -1,6 +1,7 @@
 #include "ngff/ngff_metadata.h"
 #include "defs.limits.h"
 #include "ngff.h"
+#include "util/ceildiv.h"
 #include "zarr/json_writer.h"
 
 #include <stdio.h>
@@ -90,19 +91,19 @@ ngff_multiscale_group_json(char* buf,
     snprintf(lvstr, sizeof(lvstr), "%d", lv);
     jw_string(&jw, lvstr);
 
-    // Precompute per-axis physical scale and downsample factor.
-    // Use the actual ratio of L0 size to level size so that dimensions
-    // which cannot be downsampled further (e.g. size 1) get factor 1.
-    const struct dimension* lv_dims = level_dims[lv];
     double scale[MAX_ZARR_RANK];
     for (int d = 0; d < rank; ++d) {
       double phys = (axes && axes[d].scale > 0) ? axes[d].scale : 1.0;
-      double factor = 1.0;
-      uint64_t l0_size = l0[d].size;
-      uint64_t lv_size = lv_dims[d].size;
-      if (l0_size > 0 && lv_size > 0)
-        factor = (double)l0_size / (double)lv_size;
-      scale[d] = phys * factor;
+      int n_down = 0;
+      if (l0[d].downsample) {
+        for (int k = 0; k < lv; ++k) {
+          uint64_t sz = level_dims[k][d].size;
+          uint64_t cs = level_dims[k][d].chunk_size;
+          if (cs > 0 && sz > 0 && ceildiv(sz, cs) > 1)
+            ++n_down;
+        }
+      }
+      scale[d] = phys * (double)(1 << n_down);
     }
 
     jw_key(&jw, "coordinateTransformations");

--- a/src/ngff/ngff_multiscale.c
+++ b/src/ngff/ngff_multiscale.c
@@ -117,6 +117,14 @@ ngff_multiscale_has_error_fn(const struct shard_sink* self)
   return ms->pool->has_error(ms->pool);
 }
 
+static size_t
+ngff_multiscale_pending_bytes_fn(const struct shard_sink* self)
+{
+  const struct ngff_multiscale* ms =
+    container_of(self, struct ngff_multiscale, base);
+  return ms->pool->pending_bytes(ms->pool);
+}
+
 // --- Shared create logic ---
 
 // Shared init: caller provides a pre-computed LOD plan.
@@ -146,6 +154,7 @@ ngff_multiscale_init(struct store* store,
   ms->base.record_fence = ngff_multiscale_record_fence_fn;
   ms->base.wait_fence = ngff_multiscale_wait_fence_fn;
   ms->base.has_error = ngff_multiscale_has_error_fn;
+  ms->base.pending_bytes = ngff_multiscale_pending_bytes_fn;
 
   // Ensure prefix directory exists (parent handles root/intermediate groups)
   if (prefix && prefix[0])

--- a/src/ngff/ngff_multiscale.c
+++ b/src/ngff/ngff_multiscale.c
@@ -122,7 +122,7 @@ ngff_multiscale_pending_bytes_fn(const struct shard_sink* self)
 {
   const struct ngff_multiscale* ms =
     container_of(self, struct ngff_multiscale, base);
-  return ms->pool->pending_bytes(ms->pool);
+  return shard_pool_pending_bytes(ms->pool);
 }
 
 // --- Shared create logic ---

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -36,10 +36,9 @@ struct stream_metrics
   // Stall metrics — wall-clock time the host is blocked at each sync point.
   // Populated only on the GPU path.
   struct stream_metric
-    flush_stall; // flush_drain_pending in drain_kick_and_swap
-  struct stream_metric kick_sync_stall; // cuEventSynchronize in two_phase_d2h
-  struct stream_metric
-    io_fence_stall;                  // wait_io_fences loop in d2h_deliver_kick
+    flush_stall; // d2h_deliver_drain in drain_kick_and_swap (Phase B)
+  struct stream_metric kick_sync_stall; // cuEventSynchronize in drain_bulk_d2h
+  struct stream_metric io_fence_stall;  // wait_io_fences in d2h_deliver_drain
   struct stream_metric backpressure; // wait at epoch boundary for IO to drain
   float max_append_ms;               // longest tile_stream_gpu_append body
   size_t peak_pending_bytes;         // max sink->pending_bytes seen

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -32,6 +32,16 @@ struct stream_metrics
   struct stream_metric aggregate;
   struct stream_metric d2h;
   struct stream_metric sink;
+
+  // Stall metrics — wall-clock time the host is blocked at each sync point.
+  // Populated only on the GPU path.
+  struct stream_metric
+    flush_stall; // flush_drain_pending in drain_kick_and_swap
+  struct stream_metric kick_sync_stall; // cuEventSynchronize in two_phase_d2h
+  struct stream_metric
+    io_fence_stall;          // wait_io_fences loop in d2h_deliver_kick
+  float max_append_ms;       // longest tile_stream_gpu_append body
+  size_t peak_pending_bytes; // max sink->pending_bytes seen
 };
 
 struct tile_stream_configuration

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -39,9 +39,10 @@ struct stream_metrics
     flush_stall; // flush_drain_pending in drain_kick_and_swap
   struct stream_metric kick_sync_stall; // cuEventSynchronize in two_phase_d2h
   struct stream_metric
-    io_fence_stall;          // wait_io_fences loop in d2h_deliver_kick
-  float max_append_ms;       // longest tile_stream_gpu_append body
-  size_t peak_pending_bytes; // max sink->pending_bytes seen
+    io_fence_stall;                  // wait_io_fences loop in d2h_deliver_kick
+  struct stream_metric backpressure; // wait at epoch boundary for IO to drain
+  float max_append_ms;               // longest tile_stream_gpu_append body
+  size_t peak_pending_bytes;         // max sink->pending_bytes seen
 };
 
 struct tile_stream_configuration
@@ -62,7 +63,9 @@ struct tile_stream_configuration
   float metadata_update_interval_s;
   size_t
     shard_alignment; // 0 = no padding; platform_page_size() for unbuffered IO
-  int max_threads;   // 0 = OpenMP default
+  size_t backpressure_bytes; // 0 = disabled; >0 = stall at epoch boundaries
+                             // when sink->pending_bytes exceeds this watermark
+  int max_threads;           // 0 = OpenMP default
 };
 
 struct tile_stream_status

--- a/src/writer.c
+++ b/src/writer.c
@@ -1,4 +1,5 @@
 #include "writer.h"
+#include "zarr/shard_pool.h"
 
 #include "log/log.h"
 #include "platform/platform.h"
@@ -77,4 +78,16 @@ writer_finished_at(const void* beg, const void* end)
   r.rest.beg = beg;
   r.rest.end = end;
   return r;
+}
+
+size_t
+shard_sink_pending_bytes(const struct shard_sink* s)
+{
+  return (s && s->pending_bytes) ? s->pending_bytes(s) : 0;
+}
+
+size_t
+shard_pool_pending_bytes(const struct shard_pool* p)
+{
+  return (p && p->pending_bytes) ? p->pending_bytes(p) : 0;
 }

--- a/src/writer.h
+++ b/src/writer.h
@@ -74,7 +74,17 @@ struct shard_sink
 
   // Returns non-zero if any async IO has failed. NULL = no async IO.
   int (*has_error)(const struct shard_sink* self);
+
+  // Returns bytes queued but not yet retired on this sink. NULL = treated as 0.
+  size_t (*pending_bytes)(const struct shard_sink* self);
 };
+
+// NULL-tolerant accessor for shard_sink.pending_bytes.
+static inline size_t
+shard_sink_pending_bytes(const struct shard_sink* s)
+{
+  return (s && s->pending_bytes) ? s->pending_bytes(s) : 0;
+}
 
 struct writer_result
 writer_ok(void);

--- a/src/writer.h
+++ b/src/writer.h
@@ -79,12 +79,8 @@ struct shard_sink
   size_t (*pending_bytes)(const struct shard_sink* self);
 };
 
-// NULL-tolerant accessor for shard_sink.pending_bytes.
-static inline size_t
-shard_sink_pending_bytes(const struct shard_sink* s)
-{
-  return (s && s->pending_bytes) ? s->pending_bytes(s) : 0;
-}
+size_t
+shard_sink_pending_bytes(const struct shard_sink* s);
 
 struct writer_result
 writer_ok(void);

--- a/src/zarr/shard_pool.h
+++ b/src/zarr/shard_pool.h
@@ -33,3 +33,6 @@ struct shard_pool
 
   void (*destroy)(struct shard_pool* self);
 };
+
+size_t
+shard_pool_pending_bytes(const struct shard_pool* p);

--- a/src/zarr/zarr_array.c
+++ b/src/zarr/zarr_array.c
@@ -137,6 +137,13 @@ zarr_array_has_error_fn(const struct shard_sink* self)
   return a->pool->has_error(a->pool);
 }
 
+static size_t
+zarr_array_pending_bytes_fn(const struct shard_sink* self)
+{
+  const struct zarr_array* a = container_of(self, struct zarr_array, base);
+  return a->pool->pending_bytes(a->pool);
+}
+
 // --- Core init (geometry already computed) ---
 
 static struct zarr_array*
@@ -176,6 +183,7 @@ zarr_array_init(struct store* store,
   a->base.record_fence = zarr_array_record_fence_fn;
   a->base.wait_fence = zarr_array_wait_fence_fn;
   a->base.has_error = zarr_array_has_error_fn;
+  a->base.pending_bytes = zarr_array_pending_bytes_fn;
 
   // Write array zarr.json
   CHECK(Fail_alloc, write_array_metadata(a) == 0);

--- a/src/zarr/zarr_array.c
+++ b/src/zarr/zarr_array.c
@@ -141,7 +141,7 @@ static size_t
 zarr_array_pending_bytes_fn(const struct shard_sink* self)
 {
   const struct zarr_array* a = container_of(self, struct zarr_array, base);
-  return a->pool->pending_bytes(a->pool);
+  return shard_pool_pending_bytes(a->pool);
 }
 
 // --- Core init (geometry already computed) ---

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -141,15 +141,11 @@ test_ctx_kick_and_drain(struct test_ctx* c,
                           c->compute,
                           handoff) == 0);
 
-  CHECK(Fail,
-        d2h_deliver_kick(&c->d2h,
-                         handoff,
-                         &c->cl.levels,
-                         &c->batch,
-                         &c->cl.dims,
-                         config,
-                         sink,
-                         c->d2h_stream) == 0);
+  CHECK(
+    Fail,
+    d2h_deliver_kick(
+      &c->d2h, handoff, &c->cl.levels, &c->batch, &c->cl.dims, c->d2h_stream) ==
+      0);
 
   struct writer_result r = d2h_deliver_drain(&c->d2h,
                                              handoff,

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -284,6 +284,49 @@ Fail:
 }
 
 static int
+test_scale_clamped_dim(void)
+{
+  // y has size 10, chunk_size 8 -> ceildiv(10,8)=2 chunks, but halving
+  // clamps to 8 (chunk_size). The scale factor must be 2x (one downsample),
+  // not 10/8=1.25 (the old L0/Ln ratio).
+  struct dimension l0[3] = {
+    { .size = 0, .chunk_size = 1, .name = "t" },
+    { .size = 10, .chunk_size = 8, .name = "y", .downsample = 1 },
+    { .size = 64, .chunk_size = 8, .name = "x", .downsample = 1 },
+  };
+  struct dimension l1[3] = {
+    { .size = 0, .chunk_size = 1, .name = "t" },
+    { .size = 8, .chunk_size = 8, .name = "y", .downsample = 1 },
+    { .size = 32, .chunk_size = 8, .name = "x", .downsample = 1 },
+  };
+  struct dimension l2[3] = {
+    { .size = 0, .chunk_size = 1, .name = "t" },
+    { .size = 8, .chunk_size = 8, .name = "y", .downsample = 1 },
+    { .size = 16, .chunk_size = 8, .name = "x", .downsample = 1 },
+  };
+
+  const struct dimension* levels[3] = { l0, l1, l2 };
+
+  char buf[8192];
+  int len = ngff_multiscale_group_json(buf, sizeof(buf), 3, 3, levels, NULL);
+  CHECK(Fail, len > 0);
+  buf[len] = '\0';
+
+  // L0: scale=[1.0, 1.0, 1.0]
+  CHECK(Fail, strstr(buf, "\"scale\":[1.0,1.0,1.0]"));
+  // L1: t=1, y=2 (one downsample), x=2 (one downsample)
+  CHECK(Fail, strstr(buf, "\"scale\":[1.0,2.0,2.0]"));
+  // L2: t=1, y=2 (still one -- y dropped after L0->L1), x=4 (two downsamples)
+  CHECK(Fail, strstr(buf, "\"scale\":[1.0,2.0,4.0]"));
+
+  return 0;
+
+Fail:
+  log_error("  got: %.*s", len > 0 ? len : 0, buf);
+  return 1;
+}
+
+static int
 test_zarr_array_json_lz4(void)
 {
   char buf[4096];
@@ -357,6 +400,7 @@ main(void)
     { "zarr_metadata", test_zarr_metadata },
     { "zarr_root_json", test_zarr_root_json },
     { "zarr_multiscale_group_json", test_zarr_multiscale_group_json },
+    { "scale_clamped_dim", test_scale_clamped_dim },
     { "zarr_array_json_lz4", test_zarr_array_json_lz4 },
     { "zarr_array_json_zstd", test_zarr_array_json_zstd },
   };


### PR DESCRIPTION
## Summary
- Add throttled shard sink for IO-pressure benchmarking without real disk IO
- Add stall metrics (flush_stall, kick_sync, io_fence, max_append_ms, peak_pending_bytes) to stream_metrics
- Split D2H into non-blocking kick (offset-only) + drain (bulk) phases
- Reorder batch boundaries: compress_agg kick → drain previous → d2h kick (3-phase pipeline)

## Measurements

**Discard sink, 256cube, zstd, 32 frames:**

| Metric | Baseline | After fixes |
|---|---|---|
| throughput | 2.18 GiB/s | **2.37 GiB/s (+9%)** |
| wall_s | 1.37 | **1.26 (-8%)** |
| kick_sync_ms | 1062 | 405 |
| max_append_ms | 148 | 120 |

**Throttled sink (200 MiB/s), codec=none, 32 frames:**

| Metric | Baseline | After fixes |
|---|---|---|
| kick_sync_ms | 42 | **0.04** |
| io_fence_ms | 7511 | 7434 |
| max_append_ms | 3771 | 3705 |

## Test plan
- [x] `ctest` — 34/34 pass
- [x] bench_stream_256cube_single with --io-bw-mbps, --io-latency-us flags
- [x] bench_stream_256cube_two_streams with throttle flags
- [x] `-o` path precedence over throttle flags
- [ ] Run on a faster GPU machine to see larger gains from D2H split