### PR TITLE
Fix scale factors for clamped LOD dims

### DIFF
--- a/src/ngff/ngff_metadata.c
+++ b/src/ngff/ngff_metadata.c
@@ -1,6 +1,7 @@
 #include "ngff/ngff_metadata.h"
 #include "defs.limits.h"
 #include "ngff.h"
+#include "util/ceildiv.h"
 #include "zarr/json_writer.h"
 
 #include <stdio.h>
@@ -90,19 +91,19 @@ ngff_multiscale_group_json(char* buf,
     snprintf(lvstr, sizeof(lvstr), "%d", lv);
     jw_string(&jw, lvstr);
 
-    // Precompute per-axis physical scale and downsample factor.
-    // Use the actual ratio of L0 size to level size so that dimensions
-    // which cannot be downsampled further (e.g. size 1) get factor 1.
-    const struct dimension* lv_dims = level_dims[lv];
     double scale[MAX_ZARR_RANK];
     for (int d = 0; d < rank; ++d) {
       double phys = (axes && axes[d].scale > 0) ? axes[d].scale : 1.0;
-      double factor = 1.0;
-      uint64_t l0_size = l0[d].size;
-      uint64_t lv_size = lv_dims[d].size;
-      if (l0_size > 0 && lv_size > 0)
-        factor = (double)l0_size / (double)lv_size;
-      scale[d] = phys * factor;
+      int n_down = 0;
+      if (l0[d].downsample) {
+        for (int k = 0; k < lv; ++k) {
+          uint64_t sz = level_dims[k][d].size;
+          uint64_t cs = level_dims[k][d].chunk_size;
+          if (cs > 0 && sz > 0 && ceildiv(sz, cs) > 1)
+            ++n_down;
+        }
+      }
+      scale[d] = phys * (double)(1 << n_down);
     }
 
     jw_key(&jw, "coordinateTransformations");

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -284,6 +284,49 @@ Fail:
 }
 
 static int
+test_scale_clamped_dim(void)
+{
+  // y has size 10, chunk_size 8 -> ceildiv(10,8)=2 chunks, but halving
+  // clamps to 8 (chunk_size). The scale factor must be 2x (one downsample),
+  // not 10/8=1.25 (the old L0/Ln ratio).
+  struct dimension l0[3] = {
+    { .size = 0, .chunk_size = 1, .name = "t" },
+    { .size = 10, .chunk_size = 8, .name = "y", .downsample = 1 },
+    { .size = 64, .chunk_size = 8, .name = "x", .downsample = 1 },
+  };
+  struct dimension l1[3] = {
+    { .size = 0, .chunk_size = 1, .name = "t" },
+    { .size = 8, .chunk_size = 8, .name = "y", .downsample = 1 },
+    { .size = 32, .chunk_size = 8, .name = "x", .downsample = 1 },
+  };
+  struct dimension l2[3] = {
+    { .size = 0, .chunk_size = 1, .name = "t" },
+    { .size = 8, .chunk_size = 8, .name = "y", .downsample = 1 },
+    { .size = 16, .chunk_size = 8, .name = "x", .downsample = 1 },
+  };
+
+  const struct dimension* levels[3] = { l0, l1, l2 };
+
+  char buf[8192];
+  int len = ngff_multiscale_group_json(buf, sizeof(buf), 3, 3, levels, NULL);
+  CHECK(Fail, len > 0);
+  buf[len] = '\0';
+
+  // L0: scale=[1.0, 1.0, 1.0]
+  CHECK(Fail, strstr(buf, "\"scale\":[1.0,1.0,1.0]"));
+  // L1: t=1, y=2 (one downsample), x=2 (one downsample)
+  CHECK(Fail, strstr(buf, "\"scale\":[1.0,2.0,2.0]"));
+  // L2: t=1, y=2 (still one -- y dropped after L0->L1), x=4 (two downsamples)
+  CHECK(Fail, strstr(buf, "\"scale\":[1.0,2.0,4.0]"));
+
+  return 0;
+
+Fail:
+  log_error("  got: %.*s", len > 0 ? len : 0, buf);
+  return 1;
+}
+
+static int
 test_zarr_array_json_lz4(void)
 {
   char buf[4096];
@@ -357,6 +400,7 @@ main(void)
     { "zarr_metadata", test_zarr_metadata },
     { "zarr_root_json", test_zarr_root_json },
     { "zarr_multiscale_group_json", test_zarr_multiscale_group_json },
+    { "scale_clamped_dim", test_scale_clamped_dim },
     { "zarr_array_json_lz4", test_zarr_array_json_lz4 },
     { "zarr_array_json_zstd", test_zarr_array_json_zstd },
   };


### PR DESCRIPTION
## Summary
- Replace L0/Ln size ratio with downsample-count-based scale factors in `ngff_multiscale_group_json`
- For each dimension, count how many preceding levels had that dim active in LOD (>1 chunk), then use `phys * (1 << n_down)` as the scale
- Add test verifying correct scales when a dimension is clamped at chunk_size during LOD halving

Fixes #68

## Test plan
- [x] `test_scale_clamped_dim`: 3 levels where y (size=10, chunk=8) clamps after one downsample; verifies scales are [1,2,2] and [1,2,4] instead of the old [1,1.25,2] and [1,1.25,4]
- [x] Existing `test_zarr_multiscale_group_json` still passes (uniform halving case)
- [x] `test_ngff_multiscale` and `test_ome_validate` pass