### PR TITLE
Fix epoch LOD shard geometry

### DIFF
--- a/src/lod/lod_plan.c
+++ b/src/lod/lod_plan.c
@@ -490,13 +490,20 @@ static void
 fill_shard_geometry(struct lod_plan* p,
                     const struct dimension* dims,
                     uint8_t rank,
-                    uint8_t n_append)
+                    uint8_t n_append,
+                    const uint64_t* append_sizes)
 {
   int nlod = p->levels.nlod;
   for (int lv = 0; lv < nlod; ++lv) {
     uint64_t cps[LOD_MAX_NDIM];
     for (int d = 0; d < rank; ++d)
       cps[d] = dims[d].chunks_per_shard;
+    // For append dims, restore original size so shard geometry matches
+    // the full array shape rather than the epoch-truncated shape.
+    if (append_sizes) {
+      for (int d = 0; d < n_append; ++d)
+        p->levels.level[lv].dim[d].size = append_sizes[d];
+    }
     dim_extent_compute_shards(p->levels.level[lv].dim, rank, n_append, cps);
   }
 }
@@ -521,7 +528,7 @@ lod_plan_init_from_dims(struct lod_plan* p,
                     max_levels,
                     preserve_aspect_ratio))
     return 1;
-  fill_shard_geometry(p, dims, rank, na);
+  fill_shard_geometry(p, dims, rank, na, NULL);
   return 0;
 }
 
@@ -538,6 +545,10 @@ lod_plan_init_from_epoch_dims(struct lod_plan* p,
   uint64_t chunk_shape[LOD_MAX_NDIM];
   uint32_t lod_mask;
   dims_lod_params(dims, rank, n_append, shape, chunk_shape, &lod_mask);
+  // Save original append-dim sizes before epoch truncation.
+  uint64_t orig_append[LOD_MAX_NDIM];
+  for (int d = 0; d < n_append; ++d)
+    orig_append[d] = shape[d];
   for (int d = 0; d < n_append; ++d)
     shape[d] = dims[d].chunk_size;
   if (lod_plan_init(p,
@@ -548,7 +559,7 @@ lod_plan_init_from_epoch_dims(struct lod_plan* p,
                     max_levels,
                     preserve_aspect_ratio))
     return 1;
-  fill_shard_geometry(p, dims, rank, n_append);
+  fill_shard_geometry(p, dims, rank, n_append, orig_append);
   return 0;
 }
 

--- a/src/stream/config.c
+++ b/src/stream/config.c
@@ -316,8 +316,13 @@ compute_stream_layouts(const struct tile_stream_configuration* config,
     uint64_t lv_shape[HALF_MAX_RANK];
     if (lv == 0)
       memcpy(lv_shape, array_shape, rank * sizeof(uint64_t));
-    else
+    else {
       level_dims_get_shape(&out->plan.levels.level[lv], rank, lv_shape);
+      // Append dims use the original array shape, not the epoch-truncated
+      // plan shape, so shard geometry matches the full array.
+      for (int d = 0; d < na; ++d)
+        lv_shape[d] = array_shape[d];
+    }
     struct dim_extent de[HALF_MAX_RANK];
     for (int d = 0; d < rank; ++d) {
       de[d].size = lv_shape[d];

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -564,6 +564,131 @@ Error:
   return !ok;
 }
 
+// --- LOD epoch shard geometry tests (issue #72) ---
+
+// Helper: build dims, run both full and epoch plans, compare shard geometry.
+// Returns 0 on success.
+static int
+check_epoch_shard_geometry(const struct dimension* dims,
+                           uint8_t rank,
+                           int max_levels)
+{
+  int ok = 0;
+  uint8_t na = dims_n_append(dims, rank);
+
+  struct lod_plan full_plan, epoch_plan;
+  memset(&full_plan, 0, sizeof(full_plan));
+  memset(&epoch_plan, 0, sizeof(epoch_plan));
+
+  CHECK(Error, lod_plan_init_from_dims(&full_plan, dims, rank, max_levels) == 0);
+  CHECK(Error,
+        lod_plan_init_from_epoch_dims(
+          &epoch_plan, dims, rank, na, max_levels) == 0);
+  CHECK(Error, full_plan.levels.nlod == epoch_plan.levels.nlod);
+
+  for (int lv = 0; lv < full_plan.levels.nlod; ++lv) {
+    for (int d = 0; d < rank; ++d) {
+      CHECK(Error,
+            full_plan.levels.level[lv].dim[d].chunks_per_shard ==
+              epoch_plan.levels.level[lv].dim[d].chunks_per_shard);
+      CHECK(Error,
+            full_plan.levels.level[lv].dim[d].shard_count ==
+              epoch_plan.levels.level[lv].dim[d].shard_count);
+      CHECK(Error,
+            full_plan.levels.level[lv].dim[d].chunk_count ==
+              epoch_plan.levels.level[lv].dim[d].chunk_count);
+    }
+  }
+
+  ok = 1;
+Error:
+  lod_plan_free(&full_plan);
+  lod_plan_free(&epoch_plan);
+  return !ok;
+}
+
+static int
+test_epoch_shard_geometry_1_append(void)
+{
+  // n_append=1: t=30, chunk=5, cps=2 -> chunk_count=6, shard_count=3
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 30, 64, 64 };
+  dims_create(dims, "tyx", sizes);
+  uint64_t cs[] = { 5, 32, 32 };
+  dims_set_chunk_sizes(dims, 3, cs);
+  dims[0].chunks_per_shard = 2;
+  dims_set_downsample_by_name(dims, 3, "yx");
+
+  CHECK(Error, check_epoch_shard_geometry(dims, 3, 4) == 0);
+
+  // Also verify absolute values on the epoch plan.
+  struct lod_plan ep;
+  memset(&ep, 0, sizeof(ep));
+  CHECK(Error, lod_plan_init_from_epoch_dims(&ep, dims, 3, 1, 4) == 0);
+  CHECK(Error, ep.levels.level[0].dim[0].chunk_count == 6);
+  CHECK(Error, ep.levels.level[0].dim[0].chunks_per_shard == 2);
+  CHECK(Error, ep.levels.level[0].dim[0].shard_count == 3);
+
+  ok = 1;
+Error:
+  lod_plan_free(&ep);
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_epoch_shard_geometry_2_append(void)
+{
+  // n_append=2: t,z both with chunk_size=1
+  int ok = 0;
+  struct dimension dims[4];
+  uint64_t sizes[] = { 20, 10, 128, 128 };
+  dims_create(dims, "tzyx", sizes);
+  uint64_t cs[] = { 1, 1, 64, 64 };
+  dims_set_chunk_sizes(dims, 4, cs);
+  dims[0].chunks_per_shard = 4;
+  dims[1].chunks_per_shard = 5;
+  dims_set_downsample_by_name(dims, 4, "yx");
+
+  CHECK(Error, check_epoch_shard_geometry(dims, 4, 4) == 0);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_epoch_shard_geometry_cps_zero(void)
+{
+  // cps=0 means "all chunks in one shard". Verify correct resolution.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 30, 64, 64 };
+  dims_create(dims, "tyx", sizes);
+  uint64_t cs[] = { 5, 32, 32 };
+  dims_set_chunk_sizes(dims, 3, cs);
+  dims[0].chunks_per_shard = 0; // all chunks -> 1 shard
+  dims_set_downsample_by_name(dims, 3, "yx");
+
+  CHECK(Error, check_epoch_shard_geometry(dims, 3, 4) == 0);
+
+  // Verify: chunk_count=6, cps=6 (all), shard_count=1
+  struct lod_plan ep;
+  memset(&ep, 0, sizeof(ep));
+  CHECK(Error, lod_plan_init_from_epoch_dims(&ep, dims, 3, 1, 4) == 0);
+  CHECK(Error, ep.levels.level[0].dim[0].chunk_count == 6);
+  CHECK(Error, ep.levels.level[0].dim[0].chunks_per_shard == 6);
+  CHECK(Error, ep.levels.level[0].dim[0].shard_count == 1);
+
+  ok = 1;
+Error:
+  lod_plan_free(&ep);
+  REPORT_TEST(ok);
+  return !ok;
+}
+
 int
 main(void)
 {
@@ -593,6 +718,9 @@ main(void)
       test_dim_info_rejects_unbounded_non_dim0 },
     { "dim_info_final_append_sizes", test_dim_info_final_append_sizes },
     { "dim_info_final_append_sizes_lod", test_dim_info_final_append_sizes_lod },
+    { "epoch_shard_geometry_1_append", test_epoch_shard_geometry_1_append },
+    { "epoch_shard_geometry_2_append", test_epoch_shard_geometry_2_append },
+    { "epoch_shard_geometry_cps_zero", test_epoch_shard_geometry_cps_zero },
   };
   for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
     int r = tests[i].fn();

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -580,10 +580,11 @@ check_epoch_shard_geometry(const struct dimension* dims,
   memset(&full_plan, 0, sizeof(full_plan));
   memset(&epoch_plan, 0, sizeof(epoch_plan));
 
-  CHECK(Error, lod_plan_init_from_dims(&full_plan, dims, rank, max_levels) == 0);
+  CHECK(Error,
+        lod_plan_init_from_dims(&full_plan, dims, rank, max_levels, 0) == 0);
   CHECK(Error,
         lod_plan_init_from_epoch_dims(
-          &epoch_plan, dims, rank, na, max_levels) == 0);
+          &epoch_plan, dims, rank, na, max_levels, 0) == 0);
   CHECK(Error, full_plan.levels.nlod == epoch_plan.levels.nlod);
 
   for (int lv = 0; lv < full_plan.levels.nlod; ++lv) {
@@ -625,7 +626,7 @@ test_epoch_shard_geometry_1_append(void)
   // Also verify absolute values on the epoch plan.
   struct lod_plan ep;
   memset(&ep, 0, sizeof(ep));
-  CHECK(Error, lod_plan_init_from_epoch_dims(&ep, dims, 3, 1, 4) == 0);
+  CHECK(Error, lod_plan_init_from_epoch_dims(&ep, dims, 3, 1, 4, 0) == 0);
   CHECK(Error, ep.levels.level[0].dim[0].chunk_count == 6);
   CHECK(Error, ep.levels.level[0].dim[0].chunks_per_shard == 2);
   CHECK(Error, ep.levels.level[0].dim[0].shard_count == 3);
@@ -677,7 +678,7 @@ test_epoch_shard_geometry_cps_zero(void)
   // Verify: chunk_count=6, cps=6 (all), shard_count=1
   struct lod_plan ep;
   memset(&ep, 0, sizeof(ep));
-  CHECK(Error, lod_plan_init_from_epoch_dims(&ep, dims, 3, 1, 4) == 0);
+  CHECK(Error, lod_plan_init_from_epoch_dims(&ep, dims, 3, 1, 4, 0) == 0);
   CHECK(Error, ep.levels.level[0].dim[0].chunk_count == 6);
   CHECK(Error, ep.levels.level[0].dim[0].chunks_per_shard == 6);
   CHECK(Error, ep.levels.level[0].dim[0].shard_count == 1);


### PR DESCRIPTION
## Summary
- Fixes LOD levels > 0 producing extra time shards (one per epoch instead of combining)
- Root cause: `lod_plan_init_from_epoch_dims` truncated append-dim shape, causing `chunks_per_shard` to clamp to 1
- Passes original full-array sizes for append dims into shard geometry computation
- Also fixes `config.c` where `cps_append` was independently recomputed from epoch shape

Closes #72

## Test plan
- [x] `test_epoch_shard_geometry_1_append` — n_append=1, shard_count=3
- [x] `test_epoch_shard_geometry_2_append` — n_append=2
- [x] `test_epoch_shard_geometry_cps_zero` — cps=0 (all chunks in one shard)