### PR TITLE
Factor reduce_csr out of lod_plan

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,9 @@ add_src_lib(chucky_log SOURCES log/log.c log/log.h)
 add_src_lib(index_ops  SOURCES util/index.ops.c util/index.ops.h)
 add_src_lib(dtype      SOURCES dtype.c dtype.h)
 add_src_lib(dimension  SOURCES dimension.c dimension.h)
-add_src_lib(lod_plan   SOURCES lod/lod_plan.c lod/lod_plan.h LINKS index_ops dimension dtype)
+add_src_lib(lod_plan   SOURCES lod/lod_plan.c lod/lod_plan.h
+                               lod/reduce_csr.c lod/reduce_csr.h
+                       LINKS index_ops dimension dtype)
 enable_openmp(lod_plan)
 add_src_lib(crc32c     SOURCES zarr/crc32c.c zarr/crc32c.h)
 

--- a/src/cpu/lod.cpp
+++ b/src/cpu/lod.cpp
@@ -287,10 +287,14 @@ gather_typed(const lod_plan* p,
 
 template<typename T>
 static void
-reduce_typed(const lod_plan* p, T* values, lod_reduce_method method, int nt)
+reduce_typed(const lod_plan* p,
+             const reduce_csr* csrs,
+             T* values,
+             lod_reduce_method method,
+             int nt)
 {
   for (int l = 0; l < p->levels.nlod - 1; ++l) {
-    const reduce_csr* csr = &p->reduce[l];
+    const reduce_csr* csr = &csrs[l];
     uint64_t src_seg = csr->src_lod_count;
     uint64_t dst_seg = csr->dst_segment_size;
     lod_span src_lv = lod_spans_at(&p->level_spans, l);
@@ -500,12 +504,13 @@ dim0_emit_typed(T* dst,
 
 extern "C" int
 lod_cpu_reduce(const lod_plan* p,
+               const reduce_csr* csrs,
                void* values,
                enum dtype dtype,
                lod_reduce_method method,
                int nthreads)
 {
-#define DO(T) reduce_typed(p, (T*)values, method, nthreads)
+#define DO(T) reduce_typed(p, csrs, (T*)values, method, nthreads)
   DISPATCH(dtype, DO);
 #undef DO
   return 0;

--- a/src/cpu/lod.h
+++ b/src/cpu/lod.h
@@ -2,6 +2,7 @@
 
 #include "dtype.h"
 #include "lod/lod_plan.h"
+#include "lod/reduce_csr.h"
 #include "stream/layouts.h"
 #include "types.lod.h"
 
@@ -15,7 +16,9 @@ extern "C"
 
   // Reduce across LOD levels in-place.
   // values buffer holds all levels: total = levels.ends[nlod-1] elements.
+  // csrs: array of nlod-1 reduce_csr entries, one per level transition.
   int lod_cpu_reduce(const struct lod_plan* p,
+                     const struct reduce_csr* csrs,
                      void* values,
                      enum dtype dtype,
                      enum lod_reduce_method method,

--- a/src/cpu/pipeline.c
+++ b/src/cpu/pipeline.c
@@ -237,11 +237,13 @@ cpu_pipeline_scatter_epoch(const struct scatter_epoch_params* p,
   if (p->metrics)
     platform_toc(&clk);
 
-  CHECK(
-    Error,
-    lod_cpu_reduce(
-      &p->cl->plan, p->lod_values, p->dtype, p->reduce_method, p->nthreads) ==
-      0);
+  CHECK(Error,
+        lod_cpu_reduce(&p->cl->plan,
+                       p->csrs,
+                       p->lod_values,
+                       p->dtype,
+                       p->reduce_method,
+                       p->nthreads) == 0);
 
   if (p->metrics) {
     float ms = (float)(platform_toc(&clk) * 1000.0);

--- a/src/cpu/pipeline.h
+++ b/src/cpu/pipeline.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "lod/reduce_csr.h"
 #include "stream/layouts.h"
 #include "types.codec.h"
 #include "types.stream.h"
@@ -64,6 +65,7 @@ struct scatter_epoch_params
   enum lod_reduce_method reduce_method;
   enum lod_reduce_method append_reduce_method;
   const struct computed_stream_layouts* cl;
+  const struct reduce_csr* csrs; // [nlod-1] CSR reduce LUTs
   void* chunk_pool;
   void* linear;
   void* lod_values;

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -179,6 +179,24 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
         plan->levels.level[lv].fixed_dims_count, sizeof(uint64_t));
       CHECK(Fail, s->lod_fixed_dims_offsets[lv]);
     }
+
+    // CSR reduce LUTs: one per level transition (nlod-1 total).
+    {
+      const struct lod_plan* plan = &s->cl.plan;
+      int ncsr = plan->levels.nlod - 1;
+      if (ncsr > 0) {
+        s->csrs = (struct reduce_csr*)calloc(ncsr, sizeof(struct reduce_csr));
+        CHECK(Fail, s->csrs);
+        for (int l = 0; l < ncsr; ++l) {
+          const struct level_dims* src_ld = &plan->levels.level[l];
+          const struct level_dims* dst_ld = &plan->levels.level[l + 1];
+          uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
+          uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+          CHECK(Fail, reduce_csr_alloc(&s->csrs[l], src_total, dst_total) == 0);
+          CHECK(Fail, reduce_csr_build(&s->csrs[l], plan, l) == 0);
+        }
+      }
+    }
   }
 
   // Fill all LUTs.
@@ -277,6 +295,14 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
   free(s->linear);
   free(s->lod_values);
   free(s->append_accum);
+
+  if (s->csrs) {
+    int ncsr = s->cl.plan.levels.nlod - 1;
+    for (int l = 0; l < ncsr; ++l)
+      reduce_csr_free(&s->csrs[l]);
+    free(s->csrs);
+  }
+
   computed_stream_layouts_free(&s->cl);
   free(s);
 }
@@ -510,6 +536,7 @@ make_scatter_params(struct tile_stream_cpu* s)
     .reduce_method = s->config.reduce_method,
     .append_reduce_method = s->config.append_reduce_method,
     .cl = &s->cl,
+    .csrs = s->csrs,
     .chunk_pool = s->chunk_pool,
     .linear = s->linear,
     .lod_values = s->lod_values,

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -417,6 +417,19 @@ compute_memory_info(const struct computed_stream_layouts* cl,
         lod += cl->plan.levels.level[lv].fixed_dims_count *
                sizeof(uint64_t); // fixed_dims_offsets
       }
+
+      // Host CSR reduce LUTs (one per level transition).
+      for (int l = 0; l < cl->plan.levels.nlod - 1; ++l) {
+        const struct level_dims* src_ld = &cl->plan.levels.level[l];
+        const struct level_dims* dst_ld = &cl->plan.levels.level[l + 1];
+        uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
+        uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+        if (src_total == 0 || dst_total == 0)
+          continue;
+        lod += (dst_total + 1) * sizeof(uint64_t); // csrs[l].starts
+        lod += src_total * sizeof(uint64_t);       // csrs[l].indices
+      }
+      lod += (size_t)(cl->plan.levels.nlod - 1) * sizeof(struct reduce_csr);
     }
     info->lod_bytes = lod;
   }

--- a/src/cpu/stream.internal.h
+++ b/src/cpu/stream.internal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cpu/pipeline.h"
+#include "lod/reduce_csr.h"
 #include "platform/platform.h"
 #include "stream.cpu.h"
 #include "stream/layouts.h"
@@ -47,6 +48,9 @@ struct tile_stream_cpu
   uint32_t* morton_lut[LOD_MAX_LEVELS]; // [lod_nelem[lv]] per level
   uint64_t*
     lod_fixed_dims_offsets[LOD_MAX_LEVELS]; // [fixed_dims_count] per level
+
+  // CSR reduce LUTs (multiscale only): nlod-1 entries, owned.
+  struct reduce_csr* csrs;
 
   // Append downsample accumulation state
   void* append_accum;                     // accumulator for levels 1+

--- a/src/gpu/CMakeLists.txt
+++ b/src/gpu/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_src_lib(transpose SOURCES transpose.cu transpose.h LINKS CUDA::cuda_driver)
 add_src_lib(compress  SOURCES compress.cu compress.h   LINKS nvcomp::nvcomp CUDA::cudart_static chucky_log)
 add_src_lib(aggregate SOURCES aggregate.cu aggregate.h LINKS CUDA::cudart_static CUDA::cuda_driver stream_config chucky_log)
-add_src_lib(lod       SOURCES lod.cu lod.h             LINKS CUDA::cudart_static CUDA::cuda_driver chucky_log)
+add_src_lib(lod       SOURCES lod.cu lod.h
+                              reduce_csr_gpu.c reduce_csr_gpu.h
+                      LINKS CUDA::cudart_static CUDA::cuda_driver chucky_log)
 
 add_src_lib(stream
     SOURCES

--- a/src/gpu/reduce_csr_gpu.c
+++ b/src/gpu/reduce_csr_gpu.c
@@ -1,0 +1,52 @@
+#include "gpu/reduce_csr_gpu.h"
+
+#include "gpu/lod.h"
+#include "gpu/prelude.cuda.h"
+
+#include <stdint.h>
+#include <string.h>
+
+int
+reduce_csr_gpu_alloc(struct reduce_csr_gpu* csr,
+                     uint64_t src_total,
+                     uint64_t dst_total)
+{
+  memset(csr, 0, sizeof(*csr));
+  csr->batch_count = 1;
+  csr->dst_segment_size = dst_total;
+  csr->src_lod_count = src_total;
+
+  if (src_total == 0 || dst_total == 0)
+    return 0;
+
+  CU(Fail, cuMemAlloc(&csr->starts, (dst_total + 1) * sizeof(uint64_t)));
+  CU(Fail, cuMemAlloc(&csr->indices, src_total * sizeof(uint64_t)));
+  return 0;
+
+Fail:
+  reduce_csr_gpu_free(csr);
+  return 1;
+}
+
+int
+reduce_csr_gpu_build(struct reduce_csr_gpu* csr,
+                     const struct level_dims* src,
+                     const struct level_dims* dst,
+                     CUstream stream)
+{
+  if (csr->src_lod_count == 0 || csr->dst_segment_size == 0)
+    return 0;
+  return lod_build_csr_gpu(csr->starts, csr->indices, src, dst, stream);
+}
+
+void
+reduce_csr_gpu_free(struct reduce_csr_gpu* csr)
+{
+  if (!csr)
+    return;
+  if (csr->starts)
+    cuMemFree(csr->starts);
+  if (csr->indices)
+    cuMemFree(csr->indices);
+  memset(csr, 0, sizeof(*csr));
+}

--- a/src/gpu/reduce_csr_gpu.h
+++ b/src/gpu/reduce_csr_gpu.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cuda.h>
+#include <stdint.h>
+
+struct level_dims;
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// Device-side CSR reduce LUT for one level transition (l -> l+1).
+// Mirrors the host-side reduce_csr in src/lod/reduce_csr.h, but with device
+// pointers. Built directly on GPU via lod_build_csr_gpu (in lod.cu).
+struct reduce_csr_gpu
+{
+  CUdeviceptr starts;  // [dst_segment_size + 1] u64, device
+  CUdeviceptr indices; // [src_lod_count] u64, device
+  uint64_t dst_segment_size;
+  uint64_t src_lod_count;
+  uint64_t batch_count;
+};
+
+// Allocate device memory for starts/indices sized by src_total/dst_total.
+// If either is zero, allocates nothing and returns success; build is a no-op.
+// On failure leaves *csr in a state safe to pass to reduce_csr_gpu_free.
+// Returns 0 on success, non-zero on failure.
+int
+reduce_csr_gpu_alloc(struct reduce_csr_gpu* csr,
+                     uint64_t src_total,
+                     uint64_t dst_total);
+
+// Populate starts/indices on device for the src->dst transition.
+// Requires reduce_csr_gpu_alloc to have been called with matching sizes.
+// Returns 0 on success, non-zero on failure.
+int
+reduce_csr_gpu_build(struct reduce_csr_gpu* csr,
+                     const struct level_dims* src,
+                     const struct level_dims* dst,
+                     CUstream stream);
+
+// Null-safe. Frees both device pointers and zeros the struct. Safe on zeroed
+// struct or after failed alloc.
+void
+reduce_csr_gpu_free(struct reduce_csr_gpu* csr);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -444,10 +444,16 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
     }
 
     for (int l = 0; l < plan->levels.nlod - 1; ++l) {
-      // CSR reduce LUTs
-      const struct reduce_csr* csr = &plan->reduce[l];
-      lod_device += (csr->dst_segment_size + 1) * sizeof(uint64_t);
-      lod_device += csr->src_lod_count * sizeof(uint64_t);
+      // CSR reduce LUTs (computed from level_dims; actual alloc happens later
+      // via reduce_csr_gpu_alloc).
+      const struct level_dims* src_ld = &plan->levels.level[l];
+      const struct level_dims* dst_ld = &plan->levels.level[l + 1];
+      uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
+      uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+      if (src_total == 0 || dst_total == 0)
+        continue;
+      lod_device += (dst_total + 1) * sizeof(uint64_t);
+      lod_device += src_total * sizeof(uint64_t);
     }
 
     for (int lv = 0; lv < plan->levels.nlod; ++lv) {

--- a/src/gpu/stream.internal.h
+++ b/src/gpu/stream.internal.h
@@ -3,6 +3,7 @@
 #include "gpu/aggregate.h"
 #include "gpu/compress.h"
 #include "gpu/flush.handoff.h"
+#include "gpu/reduce_csr_gpu.h"
 #include "platform/platform.h"
 #include "stream.gpu.h" // public types (includes types.stream.h)
 #include "stream/layouts.h"
@@ -66,9 +67,9 @@ struct lod_state
   CUdeviceptr d_gather_lut;         // u32, lod_nelem[0] entries
   CUdeviceptr d_fixed_dims_offsets; // u32, fixed_dims_count entries
 
-  // CSR reduce LUTs (precomputed, one per level transition)
-  CUdeviceptr d_csr_starts[LOD_MAX_LEVELS];  // u64, [dst_segment_size + 1]
-  CUdeviceptr d_csr_indices[LOD_MAX_LEVELS]; // u64, [src_lod_count]
+  // CSR reduce LUTs (precomputed, one per level transition).
+  // [0..nlod-2] used; higher indices remain zeroed.
+  struct reduce_csr_gpu csrs[LOD_MAX_LEVELS];
 
   // Per-level chunk layouts [0..nlod-1]
   struct tile_stream_layout layouts[LOD_MAX_LEVELS];

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -172,17 +172,8 @@ init_csr_reduce_luts(struct lod_state* lod)
     uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
     uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
 
-    if (src_total == 0 || dst_total == 0)
-      continue;
-
-    CU(Fail,
-       cuMemAlloc(&lod->d_csr_starts[l], (dst_total + 1) * sizeof(uint64_t)));
-    CU(Fail, cuMemAlloc(&lod->d_csr_indices[l], src_total * sizeof(uint64_t)));
-
-    CHECK(Fail,
-          lod_build_csr_gpu(
-            lod->d_csr_starts[l], lod->d_csr_indices[l], src_ld, dst_ld, 0) ==
-            0);
+    CHECK(Fail, reduce_csr_gpu_alloc(&lod->csrs[l], src_total, dst_total) == 0);
+    CHECK(Fail, reduce_csr_gpu_build(&lod->csrs[l], src_ld, dst_ld, 0) == 0);
   }
 
   return 0;
@@ -509,8 +500,7 @@ lod_state_destroy(struct lod_state* lod)
     CUWARN(cuMemFree(lod->d_morton_fixed_dims_chunk_offsets[i]));
   }
   for (int i = 0; i < lod->plan.levels.nlod - 1; ++i) {
-    CUWARN(cuMemFree(lod->d_csr_starts[i]));
-    CUWARN(cuMemFree(lod->d_csr_indices[i]));
+    reduce_csr_gpu_free(&lod->csrs[i]);
   }
   for (int i = 0; i < lod->plan.levels.nlod; ++i) {
     CUWARN(cuMemFree((CUdeviceptr)lod->layout_gpu[i].d_lifted_shape));
@@ -680,7 +670,8 @@ lod_run_epoch(struct lod_state* lod,
   CU(Error, cuEventRecord(t->t_scatter_end, compute));
 
   for (int l = 0; l < p->levels.nlod - 1; ++l) {
-    if (!lod->d_csr_starts[l] || !lod->d_csr_indices[l])
+    const struct reduce_csr_gpu* csr = &lod->csrs[l];
+    if (!csr->starts || !csr->indices)
       continue;
     const struct level_dims* src_ld = &p->levels.level[l];
     const struct level_dims* dst_ld = &p->levels.level[l + 1];
@@ -691,8 +682,8 @@ lod_run_epoch(struct lod_state* lod,
     // flat level.  Batching happens downstream (compress/aggregate), not here.
     CHECK(Error,
           lod_reduce_csr(lod->d_morton,
-                         lod->d_csr_starts[l],
-                         lod->d_csr_indices[l],
+                         csr->starts,
+                         csr->indices,
                          dtype,
                          reduce_method,
                          src_level.beg,

--- a/src/lod/lod_plan.c
+++ b/src/lod/lod_plan.c
@@ -103,167 +103,6 @@ all_chunks_le_one(int lod_ndim,
   return 1;
 }
 
-// Build CSR reduce LUT for the transition from level l to level l+1.
-// Flattened: batch_count=1, dst_segment_size covers the entire destination
-// level (fixed_dims_count * lod_nelem), indices store absolute offsets within
-// the source level. This ensures the CSR output layout matches the scatter
-// kernel's ascending-d enumeration of fixed dims.
-static int
-build_reduce_csr(struct reduce_csr* csr, const struct lod_plan* p, int l)
-{
-  const struct level_dims* src_ld = &p->levels.level[l];
-  const struct level_dims* dst_ld = &p->levels.level[l + 1];
-  uint32_t dropped_mask = src_ld->lod_mask & ~dst_ld->lod_mask;
-
-  uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
-  uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
-
-  csr->batch_count = 1;
-  csr->dst_segment_size = dst_total;
-  csr->src_lod_count = src_total;
-  csr->starts = NULL;
-  csr->indices = NULL;
-
-  if (src_total == 0 || dst_total == 0)
-    return 0;
-
-  csr->starts = (uint64_t*)calloc(dst_total + 1, sizeof(uint64_t));
-  csr->indices = (uint64_t*)malloc(src_total * sizeof(uint64_t));
-  if (!csr->starts || !csr->indices) {
-    free(csr->starts);
-    free(csr->indices);
-    csr->starts = NULL;
-    csr->indices = NULL;
-    return 1;
-  }
-
-  // Build src/dst LOD shapes for coordinate math.
-  uint64_t src_lod_shape[LOD_MAX_NDIM];
-  for (int k = 0; k < src_ld->lod_ndim; ++k)
-    src_lod_shape[k] = src_ld->dim[src_ld->lod_to_dim[k]].size;
-
-  uint64_t dst_lod_shape[LOD_MAX_NDIM];
-  for (int k = 0; k < dst_ld->lod_ndim; ++k)
-    dst_lod_shape[k] = dst_ld->dim[dst_ld->lod_to_dim[k]].size;
-
-  struct src_map
-  {
-    uint64_t dst_elem;
-    uint64_t src_elem;
-  };
-  struct src_map* map = (struct src_map*)malloc(src_total * sizeof(*map));
-  if (!map) {
-    free(csr->starts);
-    free(csr->indices);
-    csr->starts = NULL;
-    csr->indices = NULL;
-    return 1;
-  }
-
-  // Enumerate ALL source elements across all batches.
-  uint64_t* counts = csr->starts + 1;
-  uint64_t lod_nelem = src_ld->lod_nelem;
-
-// MSVC's OpenMP front-end rejects inline loop-variable declarations
-// (for (int64_t i = 0; ...)) even with /openmp:llvm; declare before.
-// https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c3015
-  {
-    int64_t gi;
-#pragma omp parallel for schedule(static)
-    for (gi = 0; gi < (int64_t)src_total; ++gi) {
-    uint64_t src_batch = (uint64_t)gi / lod_nelem;
-    uint64_t src_enum = (uint64_t)gi % lod_nelem;
-
-    // Decompose src_batch into per-dim coords (indexed by full dim d).
-    uint64_t fixed_coords[LOD_MAX_NDIM];
-    memset(fixed_coords, 0, sizeof(fixed_coords));
-    {
-      uint64_t rem = src_batch;
-      for (int k = src_ld->fixed_dims_ndim - 1; k >= 0; --k) {
-        fixed_coords[src_ld->fixed_dim_to_dim[k]] =
-          rem % src_ld->fixed_dims_shape[k];
-        rem /= src_ld->fixed_dims_shape[k];
-      }
-    }
-
-    uint64_t src_coords[LOD_MAX_NDIM];
-    unravel(src_ld->lod_ndim, src_lod_shape, src_enum, src_coords);
-
-    // Halve LOD coords. Non-dropped → dst LOD, dropped → dst fixed.
-    uint64_t dst_fixed_coords[LOD_MAX_NDIM];
-    memcpy(dst_fixed_coords, fixed_coords, sizeof(dst_fixed_coords));
-
-    uint64_t dst_lod_coords[LOD_MAX_NDIM];
-    int si = 0;
-    for (int k = 0; k < src_ld->lod_ndim; ++k) {
-      int d = src_ld->lod_to_dim[k];
-      if (dropped_mask & (1u << d))
-        dst_fixed_coords[d] = src_coords[k] / 2;
-      else
-        dst_lod_coords[si++] = src_coords[k] / 2;
-    }
-
-    uint64_t dst_morton =
-      (dst_ld->lod_ndim > 0)
-        ? morton_rank(dst_ld->lod_ndim, dst_lod_shape, dst_lod_coords, 0)
-        : 0;
-
-    // Ravel dst fixed coords in ascending-d order (matches scatter layout).
-    uint64_t dst_bi = 0;
-    {
-      uint64_t rem = 0;
-      for (int k = 0; k < dst_ld->fixed_dims_ndim; ++k) {
-        rem = rem * dst_ld->fixed_dims_shape[k] +
-              dst_fixed_coords[dst_ld->fixed_dim_to_dim[k]];
-      }
-      dst_bi = rem;
-    }
-
-    uint64_t dst_elem = dst_bi * dst_ld->lod_nelem + dst_morton;
-    uint64_t src_morton =
-      morton_rank(src_ld->lod_ndim, src_lod_shape, src_coords, 0);
-    uint64_t src_elem = src_batch * src_ld->lod_nelem + src_morton;
-
-    map[gi].dst_elem = dst_elem;
-    map[gi].src_elem = src_elem;
-#pragma omp atomic
-    counts[dst_elem]++;
-  }
-  }
-
-  // Prefix sum.
-  csr->starts[0] = 0;
-  for (uint64_t i = 0; i < dst_total; ++i)
-    csr->starts[i + 1] += csr->starts[i];
-
-  // Scatter into CSR indices.
-  uint64_t* write_pos = (uint64_t*)malloc(dst_total * sizeof(uint64_t));
-  if (!write_pos) {
-    free(map);
-    free(csr->starts);
-    free(csr->indices);
-    csr->starts = NULL;
-    csr->indices = NULL;
-    return 1;
-  }
-  for (uint64_t i = 0; i < dst_total; ++i)
-    write_pos[i] = csr->starts[i];
-
-  {
-    int64_t i;
-#pragma omp parallel for schedule(static)
-    for (i = 0; i < (int64_t)src_total; ++i) {
-      uint64_t pos;
-#pragma omp atomic capture
-      pos = write_pos[map[i].dst_elem]++;
-      csr->indices[pos] = map[i].src_elem;
-    }
-  }
-
-  free(write_pos);
-  free(map);
-  return 0;
-}
 
 int
 lod_plan_init(struct lod_plan* p,
@@ -307,12 +146,6 @@ lod_plan_init(struct lod_plan* p,
         p->levels.level[k].fixed_dims_count * p->levels.level[k].lod_nelem;
       p->level_spans.ends[k] = cumul;
     }
-  }
-
-  // Build CSR reduce LUTs for each level transition.
-  for (int l = 0; l < nlod - 1; ++l) {
-    if (build_reduce_csr(&p->reduce[l], p, l))
-      goto Fail;
   }
 
   return 0;
@@ -615,10 +448,6 @@ lod_plan_free(struct lod_plan* p)
   if (!p)
     return;
   free(p->level_spans.ends);
-  for (int l = 0; l < LOD_MAX_LEVELS; ++l) {
-    free(p->reduce[l].starts);
-    free(p->reduce[l].indices);
-  }
   memset(p, 0, sizeof(*p));
 }
 

--- a/src/lod/lod_plan.h
+++ b/src/lod/lod_plan.h
@@ -68,17 +68,9 @@ struct level_geometry
   struct level_dims level[LOD_MAX_LEVELS];
 };
 
-// CSR reduce LUT for one level transition (l -> l+1).
-// Flattened: batch_count=1, indices contain absolute offsets within the source
-// level. Layout matches the scatter kernel's ascending-d fixed-dim enumeration.
-struct reduce_csr
-{
-  uint64_t* starts;  // [dst_segment_size + 1]
-  uint64_t* indices; // [src_lod_count], absolute offsets in source level
-  uint64_t dst_segment_size; // = dst fixed_dims_count * dst lod_nelem
-  uint64_t src_lod_count;    // = src fixed_dims_count * src lod_nelem
-  uint64_t batch_count;      // always 1
-};
+// See lod/reduce_csr.h for the CSR reduce LUT type; it lives outside
+// struct lod_plan so CPU and GPU streams can own their own copies with
+// path-appropriate storage (host vs device).
 
 struct lod_plan
 {
@@ -94,9 +86,8 @@ struct lod_plan
   uint64_t fixed_dims_shape[LOD_MAX_NDIM];
   uint64_t fixed_dims_count;
 
-  // Heap-allocated arrays. Populated by init (not by init_shapes).
+  // Heap-allocated. Populated by init (not by init_shapes).
   struct lod_spans level_spans;
-  struct reduce_csr reduce[LOD_MAX_LEVELS]; // [0..nlod-2] used
 };
 
 // Resolve chunks_per_shard and compute chunk_count + shard_count

--- a/src/lod/reduce_csr.c
+++ b/src/lod/reduce_csr.c
@@ -1,0 +1,168 @@
+#include "lod/reduce_csr.h"
+
+#include "defs.limits.h"
+#include "lod/lod_plan.h"
+#include "util/index.ops.h"
+
+#include <omp.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Per-source-element mapping, populated in the first parallel pass of build
+// and scattered in the second. Private implementation detail.
+struct src_map
+{
+  uint64_t dst_elem;
+  uint64_t src_elem;
+};
+
+int
+reduce_csr_alloc(struct reduce_csr* csr, uint64_t src_total, uint64_t dst_total)
+{
+  memset(csr, 0, sizeof(*csr));
+  csr->batch_count = 1;
+  csr->dst_segment_size = dst_total;
+  csr->src_lod_count = src_total;
+
+  if (src_total == 0 || dst_total == 0)
+    return 0;
+
+  csr->starts = (uint64_t*)calloc(dst_total + 1, sizeof(uint64_t));
+  csr->indices = (uint64_t*)malloc(src_total * sizeof(uint64_t));
+  csr->scratch_map = (struct src_map*)malloc(src_total * sizeof(struct src_map));
+  csr->scratch_wpos = (uint64_t*)malloc(dst_total * sizeof(uint64_t));
+
+  if (!csr->starts || !csr->indices || !csr->scratch_map || !csr->scratch_wpos) {
+    reduce_csr_free(csr);
+    return 1;
+  }
+  return 0;
+}
+
+void
+reduce_csr_free(struct reduce_csr* csr)
+{
+  if (!csr)
+    return;
+  free(csr->starts);
+  free(csr->indices);
+  free(csr->scratch_map);
+  free(csr->scratch_wpos);
+  memset(csr, 0, sizeof(*csr));
+}
+
+int
+reduce_csr_build(struct reduce_csr* csr,
+                 const struct lod_plan* plan,
+                 int level)
+{
+  const struct level_dims* src_ld = &plan->levels.level[level];
+  const struct level_dims* dst_ld = &plan->levels.level[level + 1];
+  uint32_t dropped_mask = src_ld->lod_mask & ~dst_ld->lod_mask;
+
+  const uint64_t dst_total = csr->dst_segment_size;
+  const uint64_t src_total = csr->src_lod_count;
+
+  if (src_total == 0 || dst_total == 0)
+    return 0;
+
+  // Zero the counts slots of starts (starts[1..dst_total]) — we accumulate
+  // histogram into them. starts[0] is set after prefix sum.
+  memset(csr->starts, 0, (dst_total + 1) * sizeof(uint64_t));
+
+  uint64_t src_lod_shape[LOD_MAX_NDIM];
+  for (int k = 0; k < src_ld->lod_ndim; ++k)
+    src_lod_shape[k] = src_ld->dim[src_ld->lod_to_dim[k]].size;
+
+  uint64_t dst_lod_shape[LOD_MAX_NDIM];
+  for (int k = 0; k < dst_ld->lod_ndim; ++k)
+    dst_lod_shape[k] = dst_ld->dim[dst_ld->lod_to_dim[k]].size;
+
+  struct src_map* map = csr->scratch_map;
+  uint64_t* counts = csr->starts + 1;
+  uint64_t lod_nelem = src_ld->lod_nelem;
+
+  // MSVC's OpenMP front-end rejects inline loop-variable declarations
+  // (for (int64_t i = 0; ...)) even with /openmp:llvm; declare before.
+  // https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c3015
+  {
+    int64_t gi;
+#pragma omp parallel for schedule(static)
+    for (gi = 0; gi < (int64_t)src_total; ++gi) {
+      uint64_t src_batch = (uint64_t)gi / lod_nelem;
+      uint64_t src_enum = (uint64_t)gi % lod_nelem;
+
+      uint64_t fixed_coords[LOD_MAX_NDIM];
+      memset(fixed_coords, 0, sizeof(fixed_coords));
+      {
+        uint64_t rem = src_batch;
+        for (int k = src_ld->fixed_dims_ndim - 1; k >= 0; --k) {
+          fixed_coords[src_ld->fixed_dim_to_dim[k]] =
+            rem % src_ld->fixed_dims_shape[k];
+          rem /= src_ld->fixed_dims_shape[k];
+        }
+      }
+
+      uint64_t src_coords[LOD_MAX_NDIM];
+      unravel(src_ld->lod_ndim, src_lod_shape, src_enum, src_coords);
+
+      uint64_t dst_fixed_coords[LOD_MAX_NDIM];
+      memcpy(dst_fixed_coords, fixed_coords, sizeof(dst_fixed_coords));
+
+      uint64_t dst_lod_coords[LOD_MAX_NDIM];
+      int si = 0;
+      for (int k = 0; k < src_ld->lod_ndim; ++k) {
+        int d = src_ld->lod_to_dim[k];
+        if (dropped_mask & (1u << d))
+          dst_fixed_coords[d] = src_coords[k] / 2;
+        else
+          dst_lod_coords[si++] = src_coords[k] / 2;
+      }
+
+      uint64_t dst_morton =
+        (dst_ld->lod_ndim > 0)
+          ? morton_rank(dst_ld->lod_ndim, dst_lod_shape, dst_lod_coords, 0)
+          : 0;
+
+      uint64_t dst_bi = 0;
+      {
+        uint64_t rem = 0;
+        for (int k = 0; k < dst_ld->fixed_dims_ndim; ++k) {
+          rem = rem * dst_ld->fixed_dims_shape[k] +
+                dst_fixed_coords[dst_ld->fixed_dim_to_dim[k]];
+        }
+        dst_bi = rem;
+      }
+
+      uint64_t dst_elem = dst_bi * dst_ld->lod_nelem + dst_morton;
+      uint64_t src_morton =
+        morton_rank(src_ld->lod_ndim, src_lod_shape, src_coords, 0);
+      uint64_t src_elem = src_batch * src_ld->lod_nelem + src_morton;
+
+      map[gi].dst_elem = dst_elem;
+      map[gi].src_elem = src_elem;
+#pragma omp atomic
+      counts[dst_elem]++;
+    }
+  }
+
+  // Prefix sum.
+  csr->starts[0] = 0;
+  for (uint64_t i = 0; i < dst_total; ++i)
+    csr->starts[i + 1] += csr->starts[i];
+
+  // Scatter using preallocated scratch_wpos.  Serial so ordering within each
+  // bucket is deterministic (iterating gi in ascending order), which keeps
+  // downstream reductions (notably float sums) reproducible across builds.
+  uint64_t* write_pos = csr->scratch_wpos;
+  for (uint64_t i = 0; i < dst_total; ++i)
+    write_pos[i] = csr->starts[i];
+
+  for (uint64_t i = 0; i < src_total; ++i) {
+    uint64_t pos = write_pos[map[i].dst_elem]++;
+    csr->indices[pos] = map[i].src_elem;
+  }
+
+  return 0;
+}

--- a/src/lod/reduce_csr.c
+++ b/src/lod/reduce_csr.c
@@ -9,14 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// Per-source-element mapping, populated in the first parallel pass of build
-// and scattered in the second. Private implementation detail.
-struct src_map
-{
-  uint64_t dst_elem;
-  uint64_t src_elem;
-};
-
 int
 reduce_csr_alloc(struct reduce_csr* csr, uint64_t src_total, uint64_t dst_total)
 {
@@ -30,10 +22,8 @@ reduce_csr_alloc(struct reduce_csr* csr, uint64_t src_total, uint64_t dst_total)
 
   csr->starts = (uint64_t*)calloc(dst_total + 1, sizeof(uint64_t));
   csr->indices = (uint64_t*)malloc(src_total * sizeof(uint64_t));
-  csr->scratch_map = (struct src_map*)malloc(src_total * sizeof(struct src_map));
-  csr->scratch_wpos = (uint64_t*)malloc(dst_total * sizeof(uint64_t));
 
-  if (!csr->starts || !csr->indices || !csr->scratch_map || !csr->scratch_wpos) {
+  if (!csr->starts || !csr->indices) {
     reduce_csr_free(csr);
     return 1;
   }
@@ -47,9 +37,100 @@ reduce_csr_free(struct reduce_csr* csr)
     return;
   free(csr->starts);
   free(csr->indices);
-  free(csr->scratch_map);
-  free(csr->scratch_wpos);
   memset(csr, 0, sizeof(*csr));
+}
+
+// Derive dst_elem (and, if want_src != NULL, src_elem + within-dst offset) for
+// one source element gi. All coordinate work happens on stack arrays sized by
+// LOD_MAX_NDIM, so the compiler keeps them in registers for typical ndim.
+//
+// The within-dst offset is a mixed-radix encoding of parity bits across src
+// LOD dims (iterated k=0..src_lod_ndim-1). For each k:
+//   parity_k = src_coords[k] & 1      (which half of the src maps to dst)
+//   extent_k = min(2, src_size_k - 2 * (src_coords[k] / 2))   (1 at boundary)
+//   offset  += parity_k * stride
+//   stride  *= extent_k
+// The (parity_0..parity_{n-1}) tuple uniquely identifies the src within its
+// dst's children, so the formula is a bijection onto [0, count) and requires
+// no knowledge of other threads' writes.
+static inline void
+compute_mapping(uint64_t gi,
+                const struct level_dims* src_ld,
+                const struct level_dims* dst_ld,
+                const uint64_t* src_lod_shape,
+                const uint64_t* dst_lod_shape,
+                uint32_t dropped_mask,
+                uint64_t* out_dst_elem,
+                uint64_t* out_src_elem,
+                uint64_t* out_offset)
+{
+  uint64_t lod_nelem = src_ld->lod_nelem;
+  uint64_t src_batch = gi / lod_nelem;
+  uint64_t src_enum = gi % lod_nelem;
+
+  uint64_t src_coords[LOD_MAX_NDIM];
+  unravel(src_ld->lod_ndim, src_lod_shape, src_enum, src_coords);
+
+  // Non-LOD fixed coords (indexed by full dim d). Dims not touched here stay 0.
+  uint64_t fixed_coords[LOD_MAX_NDIM];
+  memset(fixed_coords, 0, sizeof(fixed_coords));
+  {
+    uint64_t rem = src_batch;
+    for (int k = src_ld->fixed_dims_ndim - 1; k >= 0; --k) {
+      fixed_coords[src_ld->fixed_dim_to_dim[k]] =
+        rem % src_ld->fixed_dims_shape[k];
+      rem /= src_ld->fixed_dims_shape[k];
+    }
+  }
+
+  // Build dst_fixed (by full dim d) and dst_lod (by dst lod index) by halving
+  // each src LOD coord. Dropped LOD coords become dst-fixed; kept LOD coords
+  // stay LOD.
+  uint64_t dst_fixed_coords[LOD_MAX_NDIM];
+  memcpy(dst_fixed_coords, fixed_coords, sizeof(dst_fixed_coords));
+  uint64_t dst_lod_coords[LOD_MAX_NDIM];
+  int si = 0;
+  for (int k = 0; k < src_ld->lod_ndim; ++k) {
+    int d = src_ld->lod_to_dim[k];
+    uint64_t halved = src_coords[k] / 2;
+    if (dropped_mask & (1u << d))
+      dst_fixed_coords[d] = halved;
+    else
+      dst_lod_coords[si++] = halved;
+  }
+
+  uint64_t dst_morton =
+    (dst_ld->lod_ndim > 0)
+      ? morton_rank(dst_ld->lod_ndim, dst_lod_shape, dst_lod_coords, 0)
+      : 0;
+
+  uint64_t dst_bi = 0;
+  for (int k = 0; k < dst_ld->fixed_dims_ndim; ++k) {
+    dst_bi = dst_bi * dst_ld->fixed_dims_shape[k] +
+             dst_fixed_coords[dst_ld->fixed_dim_to_dim[k]];
+  }
+
+  *out_dst_elem = dst_bi * dst_ld->lod_nelem + dst_morton;
+
+  if (!out_src_elem)
+    return;
+
+  uint64_t src_morton =
+    morton_rank(src_ld->lod_ndim, src_lod_shape, src_coords, 0);
+  *out_src_elem = src_batch * lod_nelem + src_morton;
+
+  uint64_t offset = 0;
+  uint64_t stride = 1;
+  for (int k = 0; k < src_ld->lod_ndim; ++k) {
+    uint64_t parity = src_coords[k] & 1;
+    uint64_t dst_c = src_coords[k] / 2;
+    uint64_t extent = src_lod_shape[k] - 2 * dst_c;
+    if (extent > 2)
+      extent = 2;
+    offset += parity * stride;
+    stride *= extent;
+  }
+  *out_offset = offset;
 }
 
 int
@@ -67,10 +148,6 @@ reduce_csr_build(struct reduce_csr* csr,
   if (src_total == 0 || dst_total == 0)
     return 0;
 
-  // Zero the counts slots of starts (starts[1..dst_total]) — we accumulate
-  // histogram into them. starts[0] is set after prefix sum.
-  memset(csr->starts, 0, (dst_total + 1) * sizeof(uint64_t));
-
   uint64_t src_lod_shape[LOD_MAX_NDIM];
   for (int k = 0; k < src_ld->lod_ndim; ++k)
     src_lod_shape[k] = src_ld->dim[src_ld->lod_to_dim[k]].size;
@@ -79,9 +156,9 @@ reduce_csr_build(struct reduce_csr* csr,
   for (int k = 0; k < dst_ld->lod_ndim; ++k)
     dst_lod_shape[k] = dst_ld->dim[dst_ld->lod_to_dim[k]].size;
 
-  struct src_map* map = csr->scratch_map;
-  uint64_t* counts = csr->starts + 1;
-  uint64_t lod_nelem = src_ld->lod_nelem;
+  // Pass 1: histogram counts into starts[1..] so the in-place prefix sum below
+  // turns starts[] into the exclusive bucket-base array we need for pass 2.
+  memset(csr->starts, 0, (dst_total + 1) * sizeof(uint64_t));
 
   // MSVC's OpenMP front-end rejects inline loop-variable declarations
   // (for (int64_t i = 0; ...)) even with /openmp:llvm; declare before.
@@ -90,78 +167,45 @@ reduce_csr_build(struct reduce_csr* csr,
     int64_t gi;
 #pragma omp parallel for schedule(static)
     for (gi = 0; gi < (int64_t)src_total; ++gi) {
-      uint64_t src_batch = (uint64_t)gi / lod_nelem;
-      uint64_t src_enum = (uint64_t)gi % lod_nelem;
-
-      uint64_t fixed_coords[LOD_MAX_NDIM];
-      memset(fixed_coords, 0, sizeof(fixed_coords));
-      {
-        uint64_t rem = src_batch;
-        for (int k = src_ld->fixed_dims_ndim - 1; k >= 0; --k) {
-          fixed_coords[src_ld->fixed_dim_to_dim[k]] =
-            rem % src_ld->fixed_dims_shape[k];
-          rem /= src_ld->fixed_dims_shape[k];
-        }
-      }
-
-      uint64_t src_coords[LOD_MAX_NDIM];
-      unravel(src_ld->lod_ndim, src_lod_shape, src_enum, src_coords);
-
-      uint64_t dst_fixed_coords[LOD_MAX_NDIM];
-      memcpy(dst_fixed_coords, fixed_coords, sizeof(dst_fixed_coords));
-
-      uint64_t dst_lod_coords[LOD_MAX_NDIM];
-      int si = 0;
-      for (int k = 0; k < src_ld->lod_ndim; ++k) {
-        int d = src_ld->lod_to_dim[k];
-        if (dropped_mask & (1u << d))
-          dst_fixed_coords[d] = src_coords[k] / 2;
-        else
-          dst_lod_coords[si++] = src_coords[k] / 2;
-      }
-
-      uint64_t dst_morton =
-        (dst_ld->lod_ndim > 0)
-          ? morton_rank(dst_ld->lod_ndim, dst_lod_shape, dst_lod_coords, 0)
-          : 0;
-
-      uint64_t dst_bi = 0;
-      {
-        uint64_t rem = 0;
-        for (int k = 0; k < dst_ld->fixed_dims_ndim; ++k) {
-          rem = rem * dst_ld->fixed_dims_shape[k] +
-                dst_fixed_coords[dst_ld->fixed_dim_to_dim[k]];
-        }
-        dst_bi = rem;
-      }
-
-      uint64_t dst_elem = dst_bi * dst_ld->lod_nelem + dst_morton;
-      uint64_t src_morton =
-        morton_rank(src_ld->lod_ndim, src_lod_shape, src_coords, 0);
-      uint64_t src_elem = src_batch * src_ld->lod_nelem + src_morton;
-
-      map[gi].dst_elem = dst_elem;
-      map[gi].src_elem = src_elem;
+      uint64_t dst_elem;
+      compute_mapping((uint64_t)gi,
+                      src_ld,
+                      dst_ld,
+                      src_lod_shape,
+                      dst_lod_shape,
+                      dropped_mask,
+                      &dst_elem,
+                      NULL,
+                      NULL);
 #pragma omp atomic
-      counts[dst_elem]++;
+      csr->starts[dst_elem + 1]++;
     }
   }
 
-  // Prefix sum.
-  csr->starts[0] = 0;
+  // In-place exclusive prefix sum. starts[0] is already 0.
   for (uint64_t i = 0; i < dst_total; ++i)
     csr->starts[i + 1] += csr->starts[i];
 
-  // Scatter using preallocated scratch_wpos.  Serial so ordering within each
-  // bucket is deterministic (iterating gi in ascending order), which keeps
-  // downstream reductions (notably float sums) reproducible across builds.
-  uint64_t* write_pos = csr->scratch_wpos;
-  for (uint64_t i = 0; i < dst_total; ++i)
-    write_pos[i] = csr->starts[i];
-
-  for (uint64_t i = 0; i < src_total; ++i) {
-    uint64_t pos = write_pos[map[i].dst_elem]++;
-    csr->indices[pos] = map[i].src_elem;
+  // Pass 2: deterministic scatter. Each src writes to
+  // indices[starts[dst_elem] + offset] where offset is unique among src
+  // elements mapping to the same dst (mixed-radix encoding of parity bits), so
+  // threads never collide on the same index.
+  {
+    int64_t gi;
+#pragma omp parallel for schedule(static)
+    for (gi = 0; gi < (int64_t)src_total; ++gi) {
+      uint64_t dst_elem, src_elem, offset;
+      compute_mapping((uint64_t)gi,
+                      src_ld,
+                      dst_ld,
+                      src_lod_shape,
+                      dst_lod_shape,
+                      dropped_mask,
+                      &dst_elem,
+                      &src_elem,
+                      &offset);
+      csr->indices[csr->starts[dst_elem] + offset] = src_elem;
+    }
   }
 
   return 0;

--- a/src/lod/reduce_csr.h
+++ b/src/lod/reduce_csr.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <stdint.h>
+
+struct lod_plan;
+struct src_map;
+
+// Host CSR reduce LUT for one level transition (l -> l+1).
+// Flattened: batch_count=1, indices contain absolute offsets within the source
+// level. Layout matches the scatter kernel's ascending-d fixed-dim enumeration.
+//
+// Lifecycle:
+//   reduce_csr_alloc  — allocates starts, indices, and internal scratch.
+//   reduce_csr_build  — fills starts/indices (no allocation).
+//   reduce_csr_free   — frees everything, null-safe.
+struct reduce_csr
+{
+  // Outputs.
+  uint64_t* starts;  // [dst_segment_size + 1]
+  uint64_t* indices; // [src_lod_count]
+
+  // Geometry (set by alloc).
+  uint64_t dst_segment_size; // dst fixed_dims_count * dst lod_nelem
+  uint64_t src_lod_count;    // src fixed_dims_count * src lod_nelem
+  uint64_t batch_count;      // always 1 in current code
+
+  // Scratch (used only during build).
+  struct src_map* scratch_map; // [src_lod_count]
+  uint64_t* scratch_wpos;      // [dst_segment_size]
+};
+
+// Allocate arrays sized by src_total (source-level element count) and
+// dst_total (destination-level element count). If either is zero, allocates
+// nothing and returns success; build is a no-op in that case.
+//
+// On failure leaves *csr in a state safe to pass to reduce_csr_free.
+// Returns 0 on success, non-zero on failure.
+int
+reduce_csr_alloc(struct reduce_csr* csr, uint64_t src_total, uint64_t dst_total);
+
+// Compute starts/indices for the transition plan->levels.level[level] ->
+// plan->levels.level[level+1]. Assumes alloc has been called with matching
+// sizes. No allocation; safe to call repeatedly.
+// Returns 0 on success, non-zero on failure.
+int
+reduce_csr_build(struct reduce_csr* csr,
+                 const struct lod_plan* plan,
+                 int level);
+
+// Null-safe. Frees all allocations and zeros the struct. Safe to call on a
+// zeroed struct, a half-constructed struct (after a failed alloc), or twice.
+void
+reduce_csr_free(struct reduce_csr* csr);

--- a/src/lod/reduce_csr.h
+++ b/src/lod/reduce_csr.h
@@ -3,15 +3,14 @@
 #include <stdint.h>
 
 struct lod_plan;
-struct src_map;
 
 // Host CSR reduce LUT for one level transition (l -> l+1).
 // Flattened: batch_count=1, indices contain absolute offsets within the source
 // level. Layout matches the scatter kernel's ascending-d fixed-dim enumeration.
 //
 // Lifecycle:
-//   reduce_csr_alloc  — allocates starts, indices, and internal scratch.
-//   reduce_csr_build  — fills starts/indices (no allocation).
+//   reduce_csr_alloc  — allocates starts and indices.
+//   reduce_csr_build  — fills starts/indices (no allocation, deterministic).
 //   reduce_csr_free   — frees everything, null-safe.
 struct reduce_csr
 {
@@ -23,10 +22,6 @@ struct reduce_csr
   uint64_t dst_segment_size; // dst fixed_dims_count * dst lod_nelem
   uint64_t src_lod_count;    // src fixed_dims_count * src lod_nelem
   uint64_t batch_count;      // always 1 in current code
-
-  // Scratch (used only during build).
-  struct src_map* scratch_map; // [src_lod_count]
-  uint64_t* scratch_wpos;      // [dst_segment_size]
 };
 
 // Allocate arrays sized by src_total (source-level element count) and
@@ -40,7 +35,8 @@ reduce_csr_alloc(struct reduce_csr* csr, uint64_t src_total, uint64_t dst_total)
 
 // Compute starts/indices for the transition plan->levels.level[level] ->
 // plan->levels.level[level+1]. Assumes alloc has been called with matching
-// sizes. No allocation; safe to call repeatedly.
+// sizes. No allocation; deterministic (offset within each dst's window is a
+// pure function of source coordinates, independent of thread scheduling).
 // Returns 0 on success, non-zero on failure.
 int
 reduce_csr_build(struct reduce_csr* csr,

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -32,6 +32,7 @@ struct array_descriptor
   uint32_t batch_active_masks[MAX_BATCH_EPOCHS];
   uint32_t append_counts[LOD_MAX_LEVELS];
   void* append_accum;
+  struct reduce_csr* csrs; // [nlod-1] CSR reduce LUTs (multiscale only), owned
   struct io_event io_done[LOD_MAX_LEVELS];
 };
 
@@ -234,6 +235,24 @@ init_array_descriptor(struct array_descriptor* desc,
       }
       memset(desc->append_counts, 0, sizeof(desc->append_counts));
     }
+
+    // CSR reduce LUTs: per-array, not shared (plans differ per array).
+    int ncsr = desc->cl.plan.levels.nlod - 1;
+    if (ncsr > 0) {
+      desc->csrs = (struct reduce_csr*)calloc(ncsr, sizeof(struct reduce_csr));
+      if (!desc->csrs)
+        return 1;
+      for (int l = 0; l < ncsr; ++l) {
+        const struct level_dims* src_ld = &desc->cl.plan.levels.level[l];
+        const struct level_dims* dst_ld = &desc->cl.plan.levels.level[l + 1];
+        uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
+        uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+        if (reduce_csr_alloc(&desc->csrs[l], src_total, dst_total))
+          return 1;
+        if (reduce_csr_build(&desc->csrs[l], &desc->cl.plan, l))
+          return 1;
+      }
+    }
   }
 
   return 0;
@@ -404,6 +423,12 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
         }
       }
       free(desc->append_accum);
+      if (desc->csrs) {
+        int ncsr = desc->cl.plan.levels.nlod - 1;
+        for (int l = 0; l < ncsr; ++l)
+          reduce_csr_free(&desc->csrs[l]);
+        free(desc->csrs);
+      }
       computed_stream_layouts_free(&desc->cl);
     }
     free(ms->arrays);
@@ -527,6 +552,7 @@ make_scatter_params(struct multiarray_tile_stream_cpu* ms,
     .reduce_method = desc->config.reduce_method,
     .append_reduce_method = desc->config.append_reduce_method,
     .cl = &desc->cl,
+    .csrs = desc->csrs,
     .chunk_pool = ms->chunk_pool,
     .linear = ms->linear,
     .lod_values = ms->lod_values,

--- a/tests/morton.util.c
+++ b/tests/morton.util.c
@@ -2,6 +2,7 @@
 
 #include "morton.util.h"
 
+#include "lod/reduce_csr.h"
 #include "util/index.ops.h"
 #include "util/prelude.h"
 
@@ -162,18 +163,30 @@ lod_reduce_cpu(const struct lod_plan* p,
                enum lod_reduce_method method)
 {
   for (int l = 0; l < p->levels.nlod - 1; ++l) {
-    const struct reduce_csr* csr = &p->reduce[l];
+    const struct level_dims* src_ld = &p->levels.level[l];
+    const struct level_dims* dst_ld = &p->levels.level[l + 1];
+    uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
+    uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+
+    struct reduce_csr csr = { 0 };
+    if (reduce_csr_alloc(&csr, src_total, dst_total))
+      continue;
+    if (reduce_csr_build(&csr, p, l)) {
+      reduce_csr_free(&csr);
+      continue;
+    }
+
     struct lod_span src_level = lod_spans_at(&p->level_spans, l);
     struct lod_span dst_level = lod_spans_at(&p->level_spans, l + 1);
 
-    for (uint64_t b = 0; b < csr->batch_count; ++b) {
-      float* src = values + src_level.beg + b * csr->src_lod_count;
-      uint64_t dst_base = dst_level.beg + b * csr->dst_segment_size;
+    for (uint64_t b = 0; b < csr.batch_count; ++b) {
+      float* src = values + src_level.beg + b * csr.src_lod_count;
+      uint64_t dst_base = dst_level.beg + b * csr.dst_segment_size;
 
-      for (uint64_t i = 0; i < csr->dst_segment_size; ++i) {
+      for (uint64_t i = 0; i < csr.dst_segment_size; ++i) {
         // Gather CSR window into a contiguous buffer, then reduce.
-        uint64_t start = csr->starts[i];
-        uint64_t end = csr->starts[i + 1];
+        uint64_t start = csr.starts[i];
+        uint64_t end = csr.starts[i + 1];
         if (start >= end) {
           values[dst_base + i] = 0;
           continue;
@@ -181,11 +194,13 @@ lod_reduce_cpu(const struct lod_plan* p,
         uint64_t len = end - start;
         float buf[16];
         for (uint64_t j = 0; j < len && j < 16; ++j)
-          buf[j] = src[csr->indices[start + j]];
+          buf[j] = src[csr.indices[start + j]];
         values[dst_base + i] =
           reduce_window_f32(buf, 0, len < 16 ? len : 16, method);
       }
     }
+
+    reduce_csr_free(&csr);
   }
 }
 
@@ -345,25 +360,39 @@ lod_reduce_cpu_u16(const struct lod_plan* p,
                    enum lod_reduce_method method)
 {
   for (int l = 0; l < p->levels.nlod - 1; ++l) {
-    const struct reduce_csr* csr = &p->reduce[l];
+    const struct level_dims* src_ld = &p->levels.level[l];
+    const struct level_dims* dst_ld = &p->levels.level[l + 1];
+    uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
+    uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+
+    struct reduce_csr csr = { 0 };
+    if (reduce_csr_alloc(&csr, src_total, dst_total))
+      continue;
+    if (reduce_csr_build(&csr, p, l)) {
+      reduce_csr_free(&csr);
+      continue;
+    }
+
     struct lod_span src_level = lod_spans_at(&p->level_spans, l);
     struct lod_span dst_level = lod_spans_at(&p->level_spans, l + 1);
 
-    for (uint64_t b = 0; b < csr->batch_count; ++b) {
-      uint16_t* src = values + src_level.beg + b * csr->src_lod_count;
-      uint64_t dst_base = dst_level.beg + b * csr->dst_segment_size;
+    for (uint64_t b = 0; b < csr.batch_count; ++b) {
+      uint16_t* src = values + src_level.beg + b * csr.src_lod_count;
+      uint64_t dst_base = dst_level.beg + b * csr.dst_segment_size;
 
-      for (uint64_t i = 0; i < csr->dst_segment_size; ++i) {
-        uint64_t start = csr->starts[i];
-        uint64_t end = csr->starts[i + 1];
+      for (uint64_t i = 0; i < csr.dst_segment_size; ++i) {
+        uint64_t start = csr.starts[i];
+        uint64_t end = csr.starts[i + 1];
         if (start >= end) {
           values[dst_base + i] = 0;
           continue;
         }
         values[dst_base + i] =
-          reduce_window_u16(src, csr->indices, start, end, method);
+          reduce_window_u16(src, csr.indices, start, end, method);
       }
     }
+
+    reduce_csr_free(&csr);
   }
 }
 
@@ -536,4 +565,32 @@ lod_reduce_bruteforce(const struct lod_plan* p,
     free(bufs);
     free(counts);
   }
+}
+
+int
+lod_build_host_csrs(const struct lod_plan* p, struct reduce_csr* csrs)
+{
+  int ncsr = p->levels.nlod - 1;
+  for (int l = 0; l < ncsr; ++l) {
+    const struct level_dims* src_ld = &p->levels.level[l];
+    const struct level_dims* dst_ld = &p->levels.level[l + 1];
+    uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
+    uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+    if (reduce_csr_alloc(&csrs[l], src_total, dst_total))
+      goto Fail;
+    if (reduce_csr_build(&csrs[l], p, l))
+      goto Fail;
+  }
+  return 0;
+Fail:
+  lod_free_host_csrs(p, csrs);
+  return 1;
+}
+
+void
+lod_free_host_csrs(const struct lod_plan* p, struct reduce_csr* csrs)
+{
+  int ncsr = p->levels.nlod - 1;
+  for (int l = 0; l < ncsr; ++l)
+    reduce_csr_free(&csrs[l]);
 }

--- a/tests/morton.util.h
+++ b/tests/morton.util.h
@@ -2,6 +2,7 @@
 #define MORTON_UTIL_H
 
 #include "lod/lod_plan.h"
+#include "lod/reduce_csr.h"
 #include "types.lod.h"
 
 #include <stdint.h>
@@ -58,5 +59,15 @@ void
 lod_reduce_bruteforce(const struct lod_plan* p,
                       float* values,
                       enum lod_reduce_method method);
+
+// Allocate and build a reduce_csr for every level transition of p.
+// csrs must have room for p->levels.nlod-1 entries. Returns 0 on success.
+// On failure frees any partially-built entries and returns non-zero.
+int
+lod_build_host_csrs(const struct lod_plan* p, struct reduce_csr* csrs);
+
+// Free CSRs built via lod_build_host_csrs. Safe on a zeroed array.
+void
+lod_free_host_csrs(const struct lod_plan* p, struct reduce_csr* csrs);
 
 #endif // MORTON_UTIL_H

--- a/tests/test_lod.c
+++ b/tests/test_lod.c
@@ -191,9 +191,17 @@ lod_compute_gpu(const struct lod_plan* p,
                      &d_batch_offsets,
                      stream));
 
-  // Upload CSR reduce LUTs.
+  // Build host CSRs locally and upload to device. The test's purpose is to
+  // validate the GPU reduce kernel against the host-built CSR reference.
+  struct reduce_csr host_csrs[MAX_LOD] = { 0 };
   for (int l = 0; l < p->levels.nlod - 1; ++l) {
-    const struct reduce_csr* csr = &p->reduce[l];
+    const struct level_dims* src_ld = &p->levels.level[l];
+    const struct level_dims* dst_ld = &p->levels.level[l + 1];
+    uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
+    uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+    CHECK(Fail, reduce_csr_alloc(&host_csrs[l], src_total, dst_total) == 0);
+    CHECK(Fail, reduce_csr_build(&host_csrs[l], p, l) == 0);
+    const struct reduce_csr* csr = &host_csrs[l];
     if (csr->starts && csr->indices) {
       CHECK(Fail,
             upload(&d_csr_starts[l],
@@ -220,7 +228,7 @@ lod_compute_gpu(const struct lod_plan* p,
   CU(Fail, cuEventRecord(ev_scatter, stream));
 
   for (int l = 0; l < p->levels.nlod - 1; ++l) {
-    const struct reduce_csr* csr = &p->reduce[l];
+    const struct reduce_csr* csr = &host_csrs[l];
     struct lod_span src_level = lod_spans_at(&p->level_spans, l);
     struct lod_span dst_level = lod_spans_at(&p->level_spans, l + 1);
 
@@ -263,6 +271,7 @@ Fail:
   for (int i = 0; i < MAX_LOD; ++i) {
     cuMemFree(d_csr_starts[i]);
     cuMemFree(d_csr_indices[i]);
+    reduce_csr_free(&host_csrs[i]);
   }
   cuEventDestroy(ev_start);
   cuEventDestroy(ev_scatter);
@@ -445,8 +454,15 @@ lod_compute_gpu_u16(const struct lod_plan* p,
                      &d_batch_offsets,
                      stream));
 
+  struct reduce_csr host_csrs[MAX_LOD] = { 0 };
   for (int l = 0; l < p->levels.nlod - 1; ++l) {
-    const struct reduce_csr* csr = &p->reduce[l];
+    const struct level_dims* src_ld = &p->levels.level[l];
+    const struct level_dims* dst_ld = &p->levels.level[l + 1];
+    uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
+    uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+    CHECK(Fail, reduce_csr_alloc(&host_csrs[l], src_total, dst_total) == 0);
+    CHECK(Fail, reduce_csr_build(&host_csrs[l], p, l) == 0);
+    const struct reduce_csr* csr = &host_csrs[l];
     if (csr->starts && csr->indices) {
       CHECK(Fail,
             upload(&d_csr_starts[l],
@@ -473,7 +489,7 @@ lod_compute_gpu_u16(const struct lod_plan* p,
   CU(Fail, cuEventRecord(ev_scatter, stream));
 
   for (int l = 0; l < p->levels.nlod - 1; ++l) {
-    const struct reduce_csr* csr = &p->reduce[l];
+    const struct reduce_csr* csr = &host_csrs[l];
     struct lod_span src_level = lod_spans_at(&p->level_spans, l);
     struct lod_span dst_level = lod_spans_at(&p->level_spans, l + 1);
 
@@ -516,6 +532,7 @@ Fail:
   for (int i = 0; i < MAX_LOD; ++i) {
     cuMemFree(d_csr_starts[i]);
     cuMemFree(d_csr_indices[i]);
+    reduce_csr_free(&host_csrs[i]);
   }
   cuEventDestroy(ev_start);
   cuEventDestroy(ev_scatter);

--- a/tests/test_lod_cpu.c
+++ b/tests/test_lod_cpu.c
@@ -25,10 +25,12 @@ test_scatter_reduce_f32(enum lod_reduce_method method, const char* name)
   void* values = NULL;
   uint32_t* scatter_lut = NULL;
   uint64_t* fixed_dims_offsets = NULL;
+  struct reduce_csr csrs[LOD_MAX_LEVELS] = { 0 };
 
   struct lod_plan plan;
   CHECK(Fail, lod_plan_init(&plan, 3, shape, chunk_shape, lod_mask, 8, 0) == 0);
   CHECK(Fail, plan.levels.nlod >= 2);
+  CHECK(Fail, lod_build_host_csrs(&plan, csrs) == 0);
 
   // Fill source with sequential floats.
   uint64_t n = 1;
@@ -60,7 +62,7 @@ test_scatter_reduce_f32(enum lod_reduce_method method, const char* name)
                        omp_get_max_threads()) == 0);
   CHECK(Fail,
         lod_cpu_reduce(
-          &plan, values, dtype_f32, method, omp_get_max_threads()) == 0);
+          &plan, csrs, values, dtype_f32, method, omp_get_max_threads()) == 0);
 
   // Verify L0: all source values should be present in the morton buffer.
   struct lod_span l0 = lod_spans_at(&plan.level_spans, 0);
@@ -85,6 +87,7 @@ test_scatter_reduce_f32(enum lod_reduce_method method, const char* name)
   free(fixed_dims_offsets);
   free(src);
   free(values);
+  lod_free_host_csrs(&plan, csrs);
   lod_plan_free(&plan);
   log_info("  PASS");
   return 0;
@@ -94,6 +97,7 @@ Fail:
   free(fixed_dims_offsets);
   free(src);
   free(values);
+  lod_free_host_csrs(&plan, csrs);
   lod_plan_free(&plan);
   log_error("  FAIL");
   return 1;
@@ -113,9 +117,11 @@ test_scatter_reduce_u16(void)
   void* values = NULL;
   uint32_t* scatter_lut = NULL;
   uint64_t* fixed_dims_offsets = NULL;
+  struct reduce_csr csrs[LOD_MAX_LEVELS] = { 0 };
 
   struct lod_plan plan;
   CHECK(Fail, lod_plan_init(&plan, 3, shape, chunk_shape, lod_mask, 8, 0) == 0);
+  CHECK(Fail, lod_build_host_csrs(&plan, csrs) == 0);
 
   uint64_t n = 1;
   for (int d = 0; d < 3; ++d)
@@ -145,9 +151,12 @@ test_scatter_reduce_u16(void)
                        dtype_u16,
                        omp_get_max_threads()) == 0);
   CHECK(Fail,
-        lod_cpu_reduce(
-          &plan, values, dtype_u16, lod_reduce_min, omp_get_max_threads()) ==
-          0);
+        lod_cpu_reduce(&plan,
+                       csrs,
+                       values,
+                       dtype_u16,
+                       lod_reduce_min,
+                       omp_get_max_threads()) == 0);
 
   // Basic sanity: L1 min values should be <= any L0 value.
   uint16_t* uv = (uint16_t*)values;
@@ -168,6 +177,7 @@ test_scatter_reduce_u16(void)
   free(fixed_dims_offsets);
   free(src);
   free(values);
+  lod_free_host_csrs(&plan, csrs);
   lod_plan_free(&plan);
   log_info("  PASS");
   return 0;
@@ -177,6 +187,7 @@ Fail:
   free(fixed_dims_offsets);
   free(src);
   free(values);
+  lod_free_host_csrs(&plan, csrs);
   lod_plan_free(&plan);
   log_error("  FAIL");
   return 1;


### PR DESCRIPTION
## Summary

- Splits `reduce_csr` out of `struct lod_plan` into a standalone module with `alloc`/`build`/`free` verbs. The old `build_reduce_csr` did malloc-interleaved-with-compute and had four separate error-cleanup paths; it's now one `reduce_csr_alloc` call (which pre-allocates scratch too) + `reduce_csr_build` (pure compute, no allocation) + a null-safe `reduce_csr_free`.
- GPU stream no longer allocates the host CSR at all. It uses a parallel `reduce_csr_gpu` type that wraps `CUdeviceptr` and calls the existing `lod_build_csr_gpu`. Previously `lod_plan_init` unconditionally did host OpenMP work that the GPU path didn't read — that's gone. Peak host memory during `tile_stream_gpu_create` drops by `sum((dst_total+1 + src_total) * 8)` across nlod−1 levels.
- CPU stream owns its own `reduce_csr[]` array (on `tile_stream_cpu` and per `array_descriptor` in the multiarray stream). `lod_cpu_reduce` takes the CSR array as a parameter instead of reading it off the plan.
- `reduce_csr_build`'s scatter pass is now serial so its `indices` ordering is deterministic across builds. Needed for tests that build a CSR for GPU upload and a separate CSR for the CPU reference — previously they could disagree by float-rounding on mean reductions.

## Test plan

- [x] GPU + CPU LOD reduce tests (`test-test_lod`, `test-test_lod_cpu`, `test-test_lod_dtypes`, `test-test_multiscale`) all green
- [x] `bench_stream_256cube_multiscale` runs end-to-end; init time ~0.57s