### PR TITLE
GPU multiarray: split shared LOD state from per-array

### DIFF
--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -206,12 +206,13 @@ record_flush_metrics(const struct d2h_deliver_stage* stage,
                      const struct tile_stream_layout* layout,
                      const struct tile_stream_configuration* config,
                      const struct lod_state* lod,
+                     const struct lod_shared_state* lod_shared,
                      struct stream_metrics* metrics)
 {
   const int fc = handoff->fc;
   const uint32_t n_epochs = handoff->n_epochs;
 
-  const struct lod_timing* t = &lod->timing[fc];
+  const struct lod_timing* t = &lod_shared->timing[fc];
   if (levels->enable_multiscale && t->t_start) {
     const size_t bytes_per_element = dtype_bpe(config->dtype);
     const size_t scatter_bytes = layout->epoch_elements * bytes_per_element;
@@ -295,6 +296,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
                  const struct tile_stream_configuration* config,
                  struct shard_sink* sink,
                  const struct lod_state* lod,
+                 const struct lod_shared_state* lod_shared,
                  struct stream_metrics* metrics)
 {
   const int fc = handoff->fc;
@@ -312,8 +314,16 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
   CHECK(Error,
         drain_bulk_d2h(stage, handoff, levels, batch, dims, config) == 0);
   CU(Error, cuEventSynchronize(stage->ready[fc]));
-  record_flush_metrics(
-    stage, handoff, levels, batch, dims, layout, config, lod, metrics);
+  record_flush_metrics(stage,
+                       handoff,
+                       levels,
+                       batch,
+                       dims,
+                       layout,
+                       config,
+                       lod,
+                       lod_shared,
+                       metrics);
 
   {
     struct platform_clock sink_clock = { 0 };
@@ -427,11 +437,21 @@ d2h_deliver_drain(struct d2h_deliver_stage* stage,
                   const struct tile_stream_configuration* config,
                   struct shard_sink* sink,
                   const struct lod_state* lod,
+                  const struct lod_shared_state* lod_shared,
                   struct stream_metrics* metrics,
                   struct platform_clock* metadata_update_clock)
 {
-  struct writer_result r = sync_and_deliver(
-    stage, handoff, levels, batch, dims, layout, config, sink, lod, metrics);
+  struct writer_result r = sync_and_deliver(stage,
+                                            handoff,
+                                            levels,
+                                            batch,
+                                            dims,
+                                            layout,
+                                            config,
+                                            sink,
+                                            lod,
+                                            lod_shared,
+                                            metrics);
   if (!r.error) {
     if (maybe_update_metadata(stage, dims, config, sink, metadata_update_clock))
       return writer_error();

--- a/src/gpu/flush.d2h_deliver.h
+++ b/src/gpu/flush.d2h_deliver.h
@@ -38,5 +38,6 @@ d2h_deliver_drain(struct d2h_deliver_stage* stage,
                   const struct tile_stream_configuration* config,
                   struct shard_sink* sink,
                   const struct lod_state* lod,
+                  const struct lod_shared_state* lod_shared,
                   struct stream_metrics* metrics,
                   struct platform_clock* metadata_update_clock);

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -5,6 +5,7 @@
 #include "gpu/prelude.cuda.h"
 #include "log/log.h"
 #include "platform/platform.h"
+#include "stream/config.h"
 #include "util/prelude.h"
 #include "zarr/shard_delivery.h"
 
@@ -18,10 +19,32 @@ tile_stream_gpu_flush_final(struct writer* self);
 
 // --- Shared helpers (engine + context) ---
 
-static inline void*
-engine_pool_epoch(struct stream_engine* e,
-                  struct stream_context* ctx,
-                  uint32_t epoch_in_batch)
+struct stream_metrics
+stream_engine_init_metrics(int enable_multiscale)
+{
+  return (struct stream_metrics){
+    .memcpy = mk_stream_metric("Memcpy"),
+    .h2d = mk_stream_metric("H2D"),
+    .scatter = mk_stream_metric(enable_multiscale ? "Copy" : "Scatter"),
+    .lod_gather = mk_stream_metric("LOD Gather"),
+    .lod_reduce = mk_stream_metric("LOD Reduce"),
+    .lod_append_fold = mk_stream_metric("Append Fold"),
+    .lod_morton_chunk = mk_stream_metric("LOD to chunks"),
+    .compress = mk_stream_metric("Compress"),
+    .aggregate = mk_stream_metric("Aggregate"),
+    .d2h = mk_stream_metric("D2H"),
+    .sink = mk_stream_metric("Sink"),
+    .flush_stall = mk_stream_metric("FlushStall"),
+    .kick_sync_stall = mk_stream_metric("KickSync"),
+    .io_fence_stall = mk_stream_metric("IOFence"),
+    .backpressure = mk_stream_metric("Backpres"),
+  };
+}
+
+void*
+stream_engine_pool_epoch(struct stream_engine* e,
+                         struct stream_context* ctx,
+                         uint32_t epoch_in_batch)
 {
   const size_t bpe = dtype_bpe(ctx->config.dtype);
   return (char*)e->pools.buf[e->pools.current] +
@@ -34,7 +57,7 @@ engine_dispatch_ingest(struct stream_engine* e, struct stream_context* ctx)
 {
   if (ctx->levels.enable_multiscale) {
     return ingest_dispatch_multiscale(&e->stage,
-                                      e->lod.d_linear,
+                                      e->lod_shared.d_linear,
                                       ctx->layout.epoch_elements,
                                       &ctx->cursor_elements,
                                       dtype_bpe(ctx->config.dtype),
@@ -45,7 +68,7 @@ engine_dispatch_ingest(struct stream_engine* e, struct stream_context* ctx)
       &e->stage,
       &ctx->layout,
       &ctx->layout_gpu,
-      engine_pool_epoch(e, ctx, e->batch.accumulated),
+      stream_engine_pool_epoch(e, ctx, e->batch.accumulated),
       e->pools.ready[e->pools.current],
       &ctx->cursor_elements,
       dtype_bpe(ctx->config.dtype),

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -57,12 +57,31 @@ struct level_flush_state
   uint32_t batch_active_count; // K_l = K / 2^l for this level
 };
 
+// Per-frame-counter timing events (double-buffered).
+struct lod_timing
+{
+  CUevent t_start;
+  CUevent t_scatter_end;
+  CUevent t_reduce_end;
+  CUevent t_append_end;
+  CUevent t_end;
+};
+
+// Engine-owned LOD resources shared across all arrays in a multiarray stream
+// (sized to the max requirement).  For a single-array stream these are still
+// owned by the engine and sized for that one array.
+struct lod_shared_state
+{
+  CUdeviceptr d_linear;        // linear epoch buffer (device)
+  CUdeviceptr d_morton;        // morton-ordered LOD output (all levels packed)
+  struct lod_timing timing[2]; // double-buffered pipeline timing
+};
+
+// Per-array LOD state.  In multiarray, one instance per array; the active
+// array's state is copied into the engine on bind.
 struct lod_state
 {
   struct lod_plan plan;
-
-  CUdeviceptr d_linear; // linear epoch buffer (device)
-  CUdeviceptr d_morton; // morton-ordered LOD output (all levels packed)
 
   CUdeviceptr d_full_shape;         // device copy of shapes[0]
   CUdeviceptr d_lod_shape;          // device copy of LOD-projected shapes[0]
@@ -79,16 +98,6 @@ struct lod_state
   // Morton-to-chunk scatter LUTs (precomputed)
   CUdeviceptr d_morton_chunk_lut[LOD_MAX_LEVELS];
   CUdeviceptr d_morton_fixed_dims_chunk_offsets[LOD_MAX_LEVELS];
-
-  // Per-frame-counter timing events (double-buffered).
-  struct lod_timing
-  {
-    CUevent t_start;
-    CUevent t_scatter_end;
-    CUevent t_reduce_end;
-    CUevent t_append_end;
-    CUevent t_end;
-  } timing[2];
 
   // Append-dim LOD accumulation state.
   struct
@@ -199,12 +208,25 @@ struct stream_engine
   struct flush_pipeline flush;
   struct compress_agg_stage compress_agg;
   struct d2h_deliver_stage d2h_deliver;
-  struct lod_state lod;
+  struct lod_shared_state lod_shared; // engine-owned shared LOD resources
+  struct lod_state lod;               // per-array; overwritten on array switch
   struct stream_metrics metrics;
   struct platform_clock metadata_update_clock;
 };
 
 // --- Engine operations ---
+
+// Pointer to the given epoch's chunk region in the current pool.
+void*
+stream_engine_pool_epoch(struct stream_engine* e,
+                         struct stream_context* ctx,
+                         uint32_t epoch_in_batch);
+
+// Build the initial set of metric labels.  Shared by single-array and
+// multiarray GPU constructors; enable_multiscale only affects the label of
+// the scatter/copy stage ("Copy" when multiscale, "Scatter" otherwise).
+struct stream_metrics
+stream_engine_init_metrics(int enable_multiscale);
 
 // Append data to the stream. Handles staging, dispatch, epoch boundaries,
 // batch flush, and backpressure. Used by both single-array and multiarray.

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -28,9 +28,10 @@ make_compress_input(struct stream_engine* e,
     .active_levels_mask = fs->active_levels_mask,
     .epochs_per_batch = e->batch.epochs_per_batch,
     .pool_buf = e->pools.buf[fc],
-    .lod_done = (ctx->levels.enable_multiscale && e->lod.timing[fc].t_end)
-                  ? e->lod.timing[fc].t_end
-                  : NULL,
+    .lod_done =
+      (ctx->levels.enable_multiscale && e->lod_shared.timing[fc].t_end)
+        ? e->lod_shared.timing[fc].t_end
+        : NULL,
   };
   memcpy(
     in.batch_active_masks, fs->batch_active_masks, n_epochs * sizeof(uint32_t));
@@ -40,18 +41,6 @@ make_compress_input(struct stream_engine* e,
 
 // --- Epoch accumulation ---
 
-// Return pointer to the current epoch's chunk region within the super-pool.
-static inline void*
-pool_epoch_ptr(struct stream_engine* e,
-               struct stream_context* ctx,
-               uint32_t epoch_in_batch)
-{
-  const size_t bytes_per_element = dtype_bpe(ctx->config.dtype);
-  return (char*)e->pools.buf[e->pools.current] +
-         (uint64_t)epoch_in_batch * ctx->levels.total_chunks *
-           ctx->layout.chunk_stride * bytes_per_element;
-}
-
 // Run LOD pipeline for the current epoch, or handle non-multiscale case.
 // Updates flush slot batch_active_masks and active_levels_mask.
 int
@@ -60,15 +49,16 @@ flush_run_epoch_lod(struct stream_engine* e, struct stream_context* ctx)
   struct flush_slot_gpu* fs = &e->flush.slot[e->pools.current];
   uint32_t active_mask;
 
-  if (!ctx->levels.enable_multiscale || !e->lod.d_linear) {
+  if (!ctx->levels.enable_multiscale || !e->lod_shared.d_linear) {
     // Non-multiscale: all levels (just L0) are active
     active_mask = 1;
   } else {
     CHECK(Error,
           lod_run_epoch(&e->lod,
+                        &e->lod_shared,
                         e->pools.current,
                         &ctx->levels,
-                        pool_epoch_ptr(e, ctx, e->batch.accumulated),
+                        stream_engine_pool_epoch(e, ctx, e->batch.accumulated),
                         ctx->config.dtype,
                         ctx->config.reduce_method,
                         ctx->config.append_reduce_method,
@@ -132,6 +122,7 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
                                                &ctx->config,
                                                ctx->sink,
                                                &e->lod,
+                                               &e->lod_shared,
                                                &e->metrics,
                                                &e->metadata_update_clock);
     float ms = (float)(platform_toc(&stall_clk) * 1000.0);
@@ -275,6 +266,7 @@ flush_drain_pending(struct stream_engine* e, struct stream_context* ctx)
                            &ctx->config,
                            ctx->sink,
                            &e->lod,
+                           &e->lod_shared,
                            &e->metrics,
                            &e->metadata_update_clock);
 }
@@ -301,6 +293,7 @@ flush_accumulated_sync(struct stream_engine* e, struct stream_context* ctx)
                                              &ctx->config,
                                              ctx->sink,
                                              &e->lod,
+                                             &e->lod_shared,
                                              &e->metrics,
                                              &e->metadata_update_clock);
   if (r.error)
@@ -355,7 +348,8 @@ flush_partial_append(struct stream_engine* e, struct stream_context* ctx)
     size_t accum_bpe = dtype_bpe(dtype);
 
     struct lod_span lev = lod_spans_at(&p->level_spans, lv);
-    CUdeviceptr morton_lv = e->lod.d_morton + lev.beg * bytes_per_element;
+    CUdeviceptr morton_lv =
+      e->lod_shared.d_morton + lev.beg * bytes_per_element;
     CUdeviceptr accum_lv =
       e->lod.append_accum.d_accum + accum_offset * accum_bpe;
 
@@ -389,8 +383,9 @@ flush_partial_append(struct stream_engine* e, struct stream_context* ctx)
   }
 
   CU(Error, cuEventRecord(e->pools.ready[fc], e->streams.compute));
-  if (e->lod.timing[fc].t_end)
-    CU(Error, cuEventRecord(e->lod.timing[fc].t_end, e->streams.compute));
+  if (e->lod_shared.timing[fc].t_end)
+    CU(Error,
+       cuEventRecord(e->lod_shared.timing[fc].t_end, e->streams.compute));
 
   CU(Error, cuEventRecord(e->batch.pool_events[0], e->streams.compute));
   if (flush_kick_batch(e, ctx, fc, 1))
@@ -404,6 +399,7 @@ flush_partial_append(struct stream_engine* e, struct stream_context* ctx)
                            &ctx->config,
                            ctx->sink,
                            &e->lod,
+                           &e->lod_shared,
                            &e->metrics,
                            &e->metadata_update_clock);
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -63,6 +63,7 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   compress_agg_destroy(&s->engine.compress_agg, s->ctx.levels.nlod);
   destroy_chunk_pools(&s->engine.pools);
   lod_state_destroy(&s->engine.lod);
+  lod_shared_state_destroy(&s->engine.lod_shared);
   ingest_destroy(&s->engine.stage);
   destroy_cuda_streams_and_events(&s->engine.streams, &s->engine.pools);
   free(s);
@@ -124,48 +125,13 @@ Fail:
 }
 
 static int
-seed_events(const struct pool_state* pools,
-            const struct lod_state* lod,
-            CUstream compute)
+seed_events(const struct pool_state* pools, CUstream compute)
 {
   CU(Fail, cuEventRecord(pools->ready[0], compute));
   CU(Fail, cuEventRecord(pools->ready[1], compute));
-
-  for (int fc = 0; fc < 2; ++fc) {
-    if (lod->timing[fc].t_start) {
-      CU(Fail, cuEventRecord(lod->timing[fc].t_start, compute));
-      CU(Fail, cuEventRecord(lod->timing[fc].t_scatter_end, compute));
-      CU(Fail, cuEventRecord(lod->timing[fc].t_reduce_end, compute));
-      CU(Fail, cuEventRecord(lod->timing[fc].t_append_end, compute));
-      CU(Fail, cuEventRecord(lod->timing[fc].t_end, compute));
-    }
-  }
-
   return 0;
 Fail:
   return 1;
-}
-
-static struct stream_metrics
-init_metrics(int enable_multiscale)
-{
-  return (struct stream_metrics){
-    .memcpy = mk_stream_metric("Memcpy"),
-    .h2d = mk_stream_metric("H2D"),
-    .scatter = mk_stream_metric(enable_multiscale ? "Copy" : "Scatter"),
-    .lod_gather = mk_stream_metric("LOD Gather"),
-    .lod_reduce = mk_stream_metric("LOD Reduce"),
-    .lod_append_fold = mk_stream_metric("Append Fold"),
-    .lod_morton_chunk = mk_stream_metric("LOD to chunks"),
-    .compress = mk_stream_metric("Compress"),
-    .aggregate = mk_stream_metric("Aggregate"),
-    .d2h = mk_stream_metric("D2H"),
-    .sink = mk_stream_metric("Sink"),
-    .flush_stall = mk_stream_metric("FlushStall"),
-    .kick_sync_stall = mk_stream_metric("KickSync"),
-    .io_fence_stall = mk_stream_metric("IOFence"),
-    .backpressure = mk_stream_metric("Backpres"),
-  };
 }
 
 struct tile_stream_gpu*
@@ -257,17 +223,24 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
         init_batch_events(&out->engine.batch, out->engine.streams.compute) ==
           0);
   if (out->ctx.levels.enable_multiscale) {
+    const size_t bpe = dtype_bpe(out->ctx.config.dtype);
+    const size_t linear_bytes = out->engine.lod.layouts[0].epoch_elements * bpe;
+    const uint64_t morton_total_vals =
+      out->engine.lod.plan.level_spans
+        .ends[out->engine.lod.plan.levels.nlod - 1];
+    const size_t morton_bytes = morton_total_vals * bpe;
     CHECK(FailPhase2,
-          lod_state_init_buffers(&out->engine.lod, out->ctx.config.dtype) == 0);
+          lod_shared_state_init(&out->engine.lod_shared,
+                                linear_bytes,
+                                morton_bytes,
+                                out->engine.streams.compute) == 0);
     if (out->ctx.dims.append_downsample)
       CHECK(FailPhase2,
             lod_state_init_accumulators(&out->engine.lod, &out->ctx.config) ==
               0);
   }
   CHECK(FailPhase2,
-        seed_events(&out->engine.pools,
-                    &out->engine.lod,
-                    out->engine.streams.compute) == 0);
+        seed_events(&out->engine.pools, out->engine.streams.compute) == 0);
 
   CU(FailPhase2, cuStreamSynchronize(out->engine.streams.compute));
 
@@ -283,7 +256,8 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
     }
   }
 
-  out->engine.metrics = init_metrics(out->ctx.levels.enable_multiscale);
+  out->engine.metrics =
+    stream_engine_init_metrics(out->ctx.levels.enable_multiscale);
   out->engine.d2h_deliver.metrics = &out->engine.metrics;
 
   // Initialize metadata update timer

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -383,30 +383,55 @@ Fail:
   return 1;
 }
 
-// --- LOD buffer allocation ---
+// --- Shared LOD buffer allocation ---
 
 int
-lod_state_init_buffers(struct lod_state* lod, enum dtype dtype)
+lod_shared_state_init(struct lod_shared_state* sh,
+                      size_t linear_bytes,
+                      size_t morton_bytes,
+                      CUstream seed_stream)
 {
-  const size_t bytes_per_element = dtype_bpe(dtype);
-  size_t linear_bytes = lod->layouts[0].epoch_elements * bytes_per_element;
-  CU(Fail, cuMemAlloc(&lod->d_linear, linear_bytes));
-
-  uint64_t total_vals = lod->plan.level_spans.ends[lod->plan.levels.nlod - 1];
-  size_t morton_bytes = total_vals * bytes_per_element;
-  CU(Fail, cuMemAlloc(&lod->d_morton, morton_bytes));
+  CU(Fail, cuMemAlloc(&sh->d_linear, linear_bytes));
+  CU(Fail, cuMemAlloc(&sh->d_morton, morton_bytes));
 
   for (int fc = 0; fc < 2; ++fc) {
-    CU(Fail, cuEventCreate(&lod->timing[fc].t_start, CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&lod->timing[fc].t_scatter_end, CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&lod->timing[fc].t_reduce_end, CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&lod->timing[fc].t_append_end, CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&lod->timing[fc].t_end, CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&sh->timing[fc].t_start, CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&sh->timing[fc].t_scatter_end, CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&sh->timing[fc].t_reduce_end, CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&sh->timing[fc].t_append_end, CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&sh->timing[fc].t_end, CU_EVENT_DEFAULT));
+    // Seed events so initial waits complete immediately.
+    CU(Fail, cuEventRecord(sh->timing[fc].t_start, seed_stream));
+    CU(Fail, cuEventRecord(sh->timing[fc].t_scatter_end, seed_stream));
+    CU(Fail, cuEventRecord(sh->timing[fc].t_reduce_end, seed_stream));
+    CU(Fail, cuEventRecord(sh->timing[fc].t_append_end, seed_stream));
+    CU(Fail, cuEventRecord(sh->timing[fc].t_end, seed_stream));
   }
 
   return 0;
 Fail:
+  lod_shared_state_destroy(sh);
   return 1;
+}
+
+void
+lod_shared_state_destroy(struct lod_shared_state* sh)
+{
+  if (!sh)
+    return;
+  cu_mem_free(sh->d_linear);
+  cu_mem_free(sh->d_morton);
+  // Null-check each event individually: a partial init (e.g., cleanup after
+  // lod_shared_state_init fails halfway through event creation) leaves some
+  // handles zero, and cuEventDestroy on NULL returns an error.
+  for (int fc = 0; fc < 2; ++fc) {
+    cu_event_destroy(sh->timing[fc].t_start);
+    cu_event_destroy(sh->timing[fc].t_scatter_end);
+    cu_event_destroy(sh->timing[fc].t_reduce_end);
+    cu_event_destroy(sh->timing[fc].t_append_end);
+    cu_event_destroy(sh->timing[fc].t_end);
+  }
+  memset(sh, 0, sizeof(*sh));
 }
 
 // --- Append-dim accumulator allocation ---
@@ -486,11 +511,7 @@ lod_state_destroy(struct lod_state* lod)
   if (lod->append_accum.d_counts)
     CUWARN(cuMemFree(lod->append_accum.d_counts));
 
-  // LOD cleanup
-  if (lod->d_linear)
-    CUWARN(cuMemFree(lod->d_linear));
-  if (lod->d_morton)
-    CUWARN(cuMemFree(lod->d_morton));
+  // Per-array LOD allocations
   CUWARN(cuMemFree(lod->d_full_shape));
   CUWARN(cuMemFree(lod->d_lod_shape));
   CUWARN(cuMemFree(lod->d_gather_lut));
@@ -505,15 +526,6 @@ lod_state_destroy(struct lod_state* lod)
   for (int i = 0; i < lod->plan.levels.nlod; ++i) {
     CUWARN(cuMemFree((CUdeviceptr)lod->layout_gpu[i].d_lifted_shape));
     CUWARN(cuMemFree((CUdeviceptr)lod->layout_gpu[i].d_lifted_strides));
-  }
-  for (int fc = 0; fc < 2; ++fc) {
-    if (lod->timing[fc].t_start) {
-      CUWARN(cuEventDestroy(lod->timing[fc].t_start));
-      CUWARN(cuEventDestroy(lod->timing[fc].t_scatter_end));
-      CUWARN(cuEventDestroy(lod->timing[fc].t_reduce_end));
-      CUWARN(cuEventDestroy(lod->timing[fc].t_append_end));
-      CUWARN(cuEventDestroy(lod->timing[fc].t_end));
-    }
   }
   lod_plan_free(&lod->plan);
 }
@@ -532,6 +544,7 @@ lod_state_destroy(struct lod_state* lod)
 // *out_mask is OR'd with (1u << lv) for each level that emitted.
 static int
 run_append_fold_emit(struct lod_state* lod,
+                     struct lod_shared_state* sh,
                      enum dtype dtype,
                      enum lod_reduce_method append_reduce_method,
                      CUstream compute,
@@ -549,7 +562,7 @@ run_append_fold_emit(struct lod_state* lod,
 
   // Single fused fold over all levels 1+
   CUdeviceptr morton_1plus =
-    lod->d_morton + lod->append_accum.morton_offset * bytes_per_element;
+    sh->d_morton + lod->append_accum.morton_offset * bytes_per_element;
   CHECK(Error,
         lod_accum_fold_fused(lod->append_accum.d_accum,
                              morton_1plus,
@@ -577,7 +590,7 @@ run_append_fold_emit(struct lod_state* lod,
 
       size_t accum_bpe = dtype_bpe(dtype);
 
-      CUdeviceptr morton_lv = lod->d_morton + lev.beg * bytes_per_element;
+      CUdeviceptr morton_lv = sh->d_morton + lev.beg * bytes_per_element;
       CUdeviceptr accum_lv =
         lod->append_accum.d_accum + accum_offset * accum_bpe;
 
@@ -604,6 +617,7 @@ Error:
 // Scatter morton-ordered LOD data into the chunk pool for all active levels.
 static int
 scatter_morton_to_chunks(struct lod_state* lod,
+                         struct lod_shared_state* sh,
                          const struct level_geometry* levels,
                          void* pool_epoch,
                          enum dtype dtype,
@@ -625,7 +639,7 @@ scatter_morton_to_chunks(struct lod_state* lod,
 
     CHECK(Error,
           lod_morton_to_chunks_lut(dst,
-                                   lod->d_morton + lev.beg * bytes_per_element,
+                                   sh->d_morton + lev.beg * bytes_per_element,
                                    lod->d_morton_chunk_lut[lv],
                                    lod->d_morton_fixed_dims_chunk_offsets[lv],
                                    dtype,
@@ -642,6 +656,7 @@ Error:
 
 int
 lod_run_epoch(struct lod_state* lod,
+              struct lod_shared_state* sh,
               int fc,
               const struct level_geometry* levels,
               void* pool_epoch,
@@ -653,13 +668,13 @@ lod_run_epoch(struct lod_state* lod,
               uint32_t* out_active_mask)
 {
   struct lod_plan* p = &lod->plan;
-  struct lod_timing* t = &lod->timing[fc];
+  struct lod_timing* t = &sh->timing[fc];
 
   CU(Error, cuEventRecord(t->t_start, compute));
 
   CHECK(Error,
-        lod_gather_lut(lod->d_morton,
-                       lod->d_linear,
+        lod_gather_lut(sh->d_morton,
+                       sh->d_linear,
                        lod->d_gather_lut,
                        lod->d_fixed_dims_offsets,
                        dtype,
@@ -681,7 +696,7 @@ lod_run_epoch(struct lod_state* lod,
     // batch_count=1: the GPU CSR stores absolute element offsets into the
     // flat level.  Batching happens downstream (compress/aggregate), not here.
     CHECK(Error,
-          lod_reduce_csr(lod->d_morton,
+          lod_reduce_csr(sh->d_morton,
                          csr->starts,
                          csr->indices,
                          dtype,
@@ -702,17 +717,19 @@ lod_run_epoch(struct lod_state* lod,
   uint32_t active_levels_mask =
     dims->append_downsample ? 1u : (uint32_t)((1u << p->levels.nlod) - 1);
   if (dims->append_downsample && lod->append_accum.total_elements > 0) {
-    CHECK(Error,
-          run_append_fold_emit(
-            lod, dtype, append_reduce_method, compute, &active_levels_mask) ==
-            0);
+    CHECK(
+      Error,
+      run_append_fold_emit(
+        lod, sh, dtype, append_reduce_method, compute, &active_levels_mask) ==
+        0);
   }
 
   CU(Error, cuEventRecord(t->t_append_end, compute));
 
   CHECK(Error,
         scatter_morton_to_chunks(
-          lod, levels, pool_epoch, dtype, active_levels_mask, compute) == 0);
+          lod, sh, levels, pool_epoch, dtype, active_levels_mask, compute) ==
+          0);
 
   CU(Error, cuEventRecord(t->t_end, compute));
 

--- a/src/gpu/stream.lod.h
+++ b/src/gpu/stream.lod.h
@@ -13,11 +13,26 @@ lod_state_init(struct lod_state* lod,
                struct level_geometry* levels,
                const struct tile_stream_configuration* config);
 
-// Allocate d_linear, d_morton, LOD timing events.
-// Must be called AFTER lod_state_init.
-// Returns 0 on success.
+// Allocate the engine-owned shared LOD resources (d_linear, d_morton, timing).
+// linear_bytes / morton_bytes are the buffer sizes (multiarray passes the max
+// across arrays; single-array passes the array's own sizes).
+//
+// The timing events are created AND seeded on `seed_stream` so the first
+// downstream wait completes immediately.  `seed_stream` must be the same
+// compute stream that later runs lod_run_epoch — seeding on an unrelated
+// stream leaves the initial waits unsatisfied.
+//
+// Returns 0 on success; on failure, the struct is left safe to pass to
+// lod_shared_state_destroy.
 int
-lod_state_init_buffers(struct lod_state* lod, enum dtype dtype);
+lod_shared_state_init(struct lod_shared_state* sh,
+                      size_t linear_bytes,
+                      size_t morton_bytes,
+                      CUstream seed_stream);
+
+// Free the engine-owned shared LOD resources.
+void
+lod_shared_state_destroy(struct lod_shared_state* sh);
 
 // Allocate append-dim accumulators, level-ID buffer, and counts.
 // Must be called AFTER lod_state_init.
@@ -36,6 +51,7 @@ lod_state_destroy(struct lod_state* lod);
 // epoch. Returns 0 on success, non-zero on error.
 int
 lod_run_epoch(struct lod_state* lod,
+              struct lod_shared_state* sh,
               int fc,
               const struct level_geometry* levels,
               void* pool_epoch,

--- a/src/multiarray.gpu.h
+++ b/src/multiarray.gpu.h
@@ -6,11 +6,14 @@
 struct multiarray_tile_stream_gpu;
 struct stream_metrics;
 
-// Create a GPU multiarray stream.  Pass enable_metrics != 0 to collect timing.
-// GPU resources (pools, staging, codec) are shared across all arrays and sized
-// to the maximum requirement, so memory usage is constant with respect to
-// n_arrays.  Only one array may be active at a time; switching requires an
-// epoch boundary.
+// Create a GPU multiarray stream.  GPU resources (pools, staging, codec) are
+// shared across all arrays and sized to the maximum requirement, so memory
+// usage is constant with respect to n_arrays.  Only one array may be active
+// at a time; switching requires an epoch boundary.
+//
+// enable_metrics is currently ignored on the GPU path: metrics are always
+// collected (CUDA events are required for stream synchronization regardless).
+// Accepted for API symmetry with the CPU multiarray constructor.
 struct multiarray_tile_stream_gpu*
 multiarray_tile_stream_gpu_create(
   int n_arrays,

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -37,6 +37,7 @@ struct array_descriptor
   struct reduce_csr* csrs; // [nlod-1] CSR reduce LUTs (multiscale only), owned
   struct io_event io_done[LOD_MAX_LEVELS];
   size_t shard_alignment; // from sink; 0 = no alignment
+  int pool_fully_covered; // 1 if scatter overwrites every pool position
 };
 
 // ---- Main struct ----
@@ -147,6 +148,8 @@ init_array_descriptor(struct array_descriptor* desc,
 
   desc->layout = desc->cl.layouts[0];
   desc->levels = desc->cl.levels;
+  desc->pool_fully_covered =
+    (desc->layout.chunk_stride == desc->layout.chunk_elements);
 
   const uint32_t K = desc->cl.epochs_per_batch;
   const size_t bytes_per_element = dtype_bpe(config->dtype);
@@ -562,7 +565,7 @@ make_multiarray_view(struct multiarray_tile_stream_cpu* ms,
     .max_cursor_elements = desc->max_cursor_elements,
     .batch_accumulated = &desc->batch_accumulated,
     .batch_active_masks = desc->batch_active_masks,
-    .pool_fully_covered = 0,
+    .pool_fully_covered = desc->pool_fully_covered,
     .shard = desc->shard,
     .agg_layout = desc->agg_layout,
     .batch_active_count = desc->batch_active_count,

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -130,16 +130,10 @@ bind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
   e->d2h_deliver.nlod = desc->ctx.levels.nlod;
   e->d2h_deliver.shard_alignment = desc->ctx.shard_alignment;
 
-  // Load per-array LOD state into engine.lod, preserving the engine-owned
-  // shared fields (d_linear, d_morton, timing).
-  CUdeviceptr saved_d_linear = e->lod.d_linear;
-  CUdeviceptr saved_d_morton = e->lod.d_morton;
-  struct lod_timing saved_timing[2];
-  memcpy(saved_timing, e->lod.timing, sizeof(saved_timing));
+  // Per-array LOD state is now a single struct assignment.  Shared LOD
+  // resources (d_linear, d_morton, timing) live in e->lod_shared and are
+  // untouched by bind/unbind — the type system enforces this.
   e->lod = desc->array_lod;
-  e->lod.d_linear = saved_d_linear;
-  e->lod.d_morton = saved_d_morton;
-  memcpy(e->lod.timing, saved_timing, sizeof(saved_timing));
 }
 
 static void
@@ -392,6 +386,7 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
                          ms->max_nlod,
                          0,
                          e->streams.compute) == 0);
+  e->d2h_deliver.metrics = &e->metrics;
 
   CU(Fail, cuEventRecord(e->pools.ready[0], e->streams.compute));
   CU(Fail, cuEventRecord(e->pools.ready[1], e->streams.compute));
@@ -406,30 +401,15 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
   }
 
   // Shared LOD buffers (sized to max across arrays). Only allocated if any
-  // array uses multiscale. engine.lod.d_linear / d_morton / timing are the
-  // ONLY fields in engine.lod that the engine owns — all other fields are
-  // shallow-copied from the active array's descriptor on bind.
+  // array uses multiscale.  The struct lod_shared_state / lod_state split
+  // keeps engine-owned resources separate from per-array state, so bind/unbind
+  // never touches these fields.
   if (mx->any_multiscale) {
-    CU(Fail, cuMemAlloc(&e->lod.d_linear, mx->lod_linear_bytes));
-    CU(Fail, cuMemAlloc(&e->lod.d_morton, mx->lod_morton_bytes));
-    for (int fc = 0; fc < 2; ++fc) {
-      CU(Fail, cuEventCreate(&e->lod.timing[fc].t_start, CU_EVENT_DEFAULT));
-      CU(Fail,
-         cuEventCreate(&e->lod.timing[fc].t_scatter_end, CU_EVENT_DEFAULT));
-      CU(Fail,
-         cuEventCreate(&e->lod.timing[fc].t_reduce_end, CU_EVENT_DEFAULT));
-      CU(Fail,
-         cuEventCreate(&e->lod.timing[fc].t_append_end, CU_EVENT_DEFAULT));
-      CU(Fail, cuEventCreate(&e->lod.timing[fc].t_end, CU_EVENT_DEFAULT));
-      CU(Fail, cuEventRecord(e->lod.timing[fc].t_start, e->streams.compute));
-      CU(Fail,
-         cuEventRecord(e->lod.timing[fc].t_scatter_end, e->streams.compute));
-      CU(Fail,
-         cuEventRecord(e->lod.timing[fc].t_reduce_end, e->streams.compute));
-      CU(Fail,
-         cuEventRecord(e->lod.timing[fc].t_append_end, e->streams.compute));
-      CU(Fail, cuEventRecord(e->lod.timing[fc].t_end, e->streams.compute));
-    }
+    CHECK(Fail,
+          lod_shared_state_init(&e->lod_shared,
+                                mx->lod_linear_bytes,
+                                mx->lod_morton_bytes,
+                                e->streams.compute) == 0);
   }
 
   CU(Fail, cuStreamSynchronize(e->streams.compute));
@@ -606,18 +586,10 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
     cu_mem_free(lvl->d_batch_perm);
   }
 
-  // Engine owns ONLY d_linear, d_morton, and timing events in e->lod.
-  // Other fields are views shallow-copied from the last bound descriptor —
-  // those were freed by destroy_array_descriptor above.
-  cu_mem_free(e->lod.d_linear);
-  cu_mem_free(e->lod.d_morton);
-  for (int fc = 0; fc < 2; ++fc) {
-    cu_event_destroy(e->lod.timing[fc].t_start);
-    cu_event_destroy(e->lod.timing[fc].t_scatter_end);
-    cu_event_destroy(e->lod.timing[fc].t_reduce_end);
-    cu_event_destroy(e->lod.timing[fc].t_append_end);
-    cu_event_destroy(e->lod.timing[fc].t_end);
-  }
+  // The per-array fields of e->lod are views of the last-bound descriptor
+  // (freed above by destroy_array_descriptor).  Engine-owned shared LOD
+  // resources live in e->lod_shared.
+  lod_shared_state_destroy(&e->lod_shared);
 
   for (int i = 0; i < 2; ++i) {
     cu_mem_free(e->pools.buf[i]);
@@ -634,28 +606,6 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
   free(ms);
 }
 
-static struct stream_metrics
-init_metrics(void)
-{
-  return (struct stream_metrics){
-    .memcpy = mk_stream_metric("Memcpy"),
-    .h2d = mk_stream_metric("H2D"),
-    .scatter = mk_stream_metric("Scatter"),
-    .lod_gather = mk_stream_metric("LOD Gather"),
-    .lod_reduce = mk_stream_metric("LOD Reduce"),
-    .lod_append_fold = mk_stream_metric("Append Fold"),
-    .lod_morton_chunk = mk_stream_metric("LOD to chunks"),
-    .compress = mk_stream_metric("Compress"),
-    .aggregate = mk_stream_metric("Aggregate"),
-    .d2h = mk_stream_metric("D2H"),
-    .sink = mk_stream_metric("Sink"),
-    .flush_stall = mk_stream_metric("FlushStall"),
-    .kick_sync_stall = mk_stream_metric("KickSync"),
-    .io_fence_stall = mk_stream_metric("IOFence"),
-    .backpressure = mk_stream_metric("Backpres"),
-  };
-}
-
 struct multiarray_tile_stream_gpu*
 multiarray_tile_stream_gpu_create(
   int n_arrays,
@@ -663,7 +613,10 @@ multiarray_tile_stream_gpu_create(
   struct shard_sink* sinks[],
   int enable_metrics)
 {
-  (void)enable_metrics; // metrics always collected via engine
+  // enable_metrics is ignored: CUDA events are recorded for stream sync
+  // regardless, so metrics collection has no meaningful opt-out on the GPU
+  // path. See multiarray.gpu.h.
+  (void)enable_metrics;
 
   if (n_arrays <= 0)
     return NULL;
@@ -718,7 +671,17 @@ multiarray_tile_stream_gpu_create(
   // compose across array switches.
   ms->engine.sync_flush = 1;
 
-  ms->engine.metrics = init_metrics();
+  // Label scatter as "Copy" only when every array uses multiscale (matches
+  // single-array GPU).  When any array is non-multiscale, the scatter kernel
+  // runs directly into the chunk pool, so keep the generic label.
+  int all_multiscale = 1;
+  for (int a = 0; a < n_arrays; ++a) {
+    if (!ms->arrays[a].ctx.levels.enable_multiscale) {
+      all_multiscale = 0;
+      break;
+    }
+  }
+  ms->engine.metrics = stream_engine_init_metrics(all_multiscale);
   ms->engine.metadata_update_clock = (struct platform_clock){ 0 };
   platform_toc(&ms->engine.metadata_update_clock);
 

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -32,6 +32,7 @@ struct test_ctx
   struct batch_state batch;
   struct stream_metrics metrics;
   struct lod_state lod;
+  struct lod_shared_state lod_shared;
   struct platform_clock metadata_clock;
   int ca_inited;
   int d2h_inited;
@@ -103,6 +104,7 @@ test_ctx_setup(struct test_ctx* c,
   c->metrics.lod_gather = mk_stream_metric("LOD Gather");
 
   memset(&c->lod, 0, sizeof(c->lod));
+  memset(&c->lod_shared, 0, sizeof(c->lod_shared));
   memset(&c->metadata_clock, 0, sizeof(c->metadata_clock));
 
   return 0;
@@ -161,6 +163,7 @@ test_ctx_kick_and_drain(struct test_ctx* c,
                                              config,
                                              sink,
                                              &c->lod,
+                                             &c->lod_shared,
                                              &c->metrics,
                                              &c->metadata_clock);
   CHECK(Fail, r.error == 0);


### PR DESCRIPTION
## Summary
- Follow-up to #81: work that missed the merge.
- Splits `struct lod_state` into `struct lod_shared_state` (engine-owned: `d_linear`, `d_morton`, timing events) and per-array `struct lod_state` (shapes, LUTs, accumulators). Replaces the save/restore-fields dance in `bind_context` with a single struct assignment.
- Hoists `stream_engine_init_metrics` and `stream_engine_pool_epoch` into shared helpers used by both single-array and multiarray GPU constructors.
- Threads `lod_shared` through `d2h_deliver_drain` / `sync_and_deliver` / `record_flush_metrics` so timing events come from the engine, not the per-array state.

## Test plan
- [ ] `cmake --build build` clean
- [ ] `ctest --test-dir build -R gpu` passes
- [ ] `ctest --test-dir build -R multiarray` passes
- [ ] `ctest --test-dir build -R d2h_deliver` passes