### PR TITLE
Fix CPU multiarray heap overflows with mixed-array configs

### DIFF
--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -229,7 +229,7 @@ init_array_descriptor(struct array_descriptor* desc,
         maxima->morton_lut_count[lv], desc->cl.plan.levels.level[lv].lod_nelem);
       maxima->lod_fixed_dims_offsets_count[lv] =
         max_sz(maxima->lod_fixed_dims_offsets_count[lv],
-               desc->cl.plan.fixed_dims_count);
+               desc->cl.plan.levels.level[lv].fixed_dims_count);
     }
 
     // Append accum: per-array, not shared.
@@ -579,10 +579,11 @@ make_multiarray_view(struct multiarray_tile_stream_cpu* ms,
     .comp_sizes = ms->comp_sizes,
     .agg_slots = ms->agg_slots,
     .shard_order_sizes = ms->shard_order_sizes,
-    .linear = ms->linear,
-    .lod_values = ms->lod_values,
-    .scatter_lut = ms->scatter_lut,
-    .scatter_fixed_dims_offsets = ms->scatter_fixed_dims_offsets,
+    .linear = desc->levels.enable_multiscale ? ms->linear : NULL,
+    .lod_values = desc->levels.enable_multiscale ? ms->lod_values : NULL,
+    .scatter_lut = desc->levels.enable_multiscale ? ms->scatter_lut : NULL,
+    .scatter_fixed_dims_offsets =
+      desc->levels.enable_multiscale ? ms->scatter_fixed_dims_offsets : NULL,
     .nthreads = ms->nthreads,
     .shard_alignment = desc->shard_alignment,
     .metrics = ms->metrics_enabled ? &ms->metrics : NULL,


### PR DESCRIPTION
## Summary

Two heap overflows in `multiarray_tile_stream_cpu` that surface when a single multiarray stream holds arrays with differing kinds or dim-dropping LOD patterns (e.g. the acquire-zarr shim's "one multiscale + several non-multiscale" workload, or multiscale arrays whose fixed-dims-count differs across levels).

Both were found running the shim's integration test suite; one via a NULL-adjacent SIGSEGV in `__memset_avx512_unaligned_erms` and the other via AddressSanitizer's `heap-buffer-overflow` report in `cpu_pipeline_compute_luts`.

## Fixes

### 1. Gate shared LOD buffers on `enable_multiscale`

`ms->linear`, `ms->lod_values`, `ms->scatter_lut`, `ms->scatter_fixed_dims_offsets` are allocated only when at least one array is multiscale, sized to the **max** across those multiscale arrays.

`make_multiarray_view` was previously exposing those pointers to **every** array, including non-multiscale ones. Then in `cpu_stream_append_body`:

```c
if (v->lod_values) {
  size_t lod_bytes = v->cl->plan.level_spans.ends[v->cl->plan.levels.nlod - 1] * bpe;
  memset(v->lod_values, 0, lod_bytes);
}
```

A non-multiscale array would take its own `ends[0] * bpe` (a valid size for *its* single level) and memset that many bytes into a buffer sized for a different (multiscale) array. When the non-multiscale size exceeded the multiscale array's need, the memset ran past the allocation.

Single-array `tile_stream_cpu` avoids this by leaving `s->lod_values = NULL` when `enable_multiscale` is false. This PR mirrors that: pass NULL to non-multiscale arrays' views.

### 2. Per-level `fixed_dims_count` for `lod_fixed_dims_offsets_count[lv]`

`lod_fixed_dims_offsets_count[lv]` was sized from `desc->cl.plan.fixed_dims_count` (top-level scalar), but `cpu_pipeline_compute_luts` iterates `bi` from 0 to `plan->levels.level[lv].fixed_dims_count - 1`. When dimensions drop across levels, the per-level value exceeds the top-level count and the LUT was too small. AddressSanitizer flagged an 8-byte write past a 40-byte region from `out->lod_fixed_dims_offsets[lv][bi] = ...`.

## Test plan
- [x] `shim-test-stream-multiple-arrays-to-filesystem` (triggers both bugs) — passes with fixes, segfaults/aborts without
- [x] `shim-test-stream-pure-hcs-acquisition`, `shim-test-stream-mixed-flat-and-hcs-acquisition` — pass
- [x] AddressSanitizer build: no overflows reported