### PR TITLE
Make multiarray flush idempotent

### DIFF
--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -38,6 +38,7 @@ struct array_descriptor
   struct io_event io_done[LOD_MAX_LEVELS];
   size_t shard_alignment; // from sink; 0 = no alignment
   int pool_fully_covered; // 1 if scatter overwrites every pool position
+  int flushed;            // 1 once flush body has run for this array
 };
 
 // ---- Main struct ----
@@ -611,6 +612,15 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct array_descriptor* desc = &ms->arrays[array_index];
 
+  // If this array has already been flushed (capacity reached with inline
+  // flush, or explicit flush), further appends are a no-op that report
+  // `finished` with the full input unconsumed.
+  if (desc->flushed)
+    return (struct multiarray_writer_result){
+      .error = multiarray_writer_finished,
+      .rest = data,
+    };
+
   // Switch arrays if needed.
   if (array_index != ms->active) {
     int err = switch_to_array(ms, array_index);
@@ -620,6 +630,12 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct cpu_stream_view v = make_multiarray_view(ms, desc);
   struct writer_result r = cpu_stream_append_body(&v, data);
+
+  // `cpu_stream_append_body` runs a terminal flush inline when the array
+  // hits `max_cursor_elements`; capture that so subsequent flushes become
+  // no-ops.
+  if (r.error == multiarray_writer_finished)
+    desc->flushed = 1;
 
   // Map writer_result → multiarray_writer_result (error codes are identity)
   return (struct multiarray_writer_result){
@@ -638,8 +654,15 @@ flush_impl(struct multiarray_writer* self)
 
   for (int a = 0; a < ms->n_arrays; ++a) {
     struct array_descriptor* desc = &ms->arrays[a];
-    if (desc->cursor_elements == 0 && desc->batch_accumulated == 0)
+    // Already-flushed arrays (either by inline flush on capacity or by a
+    // prior explicit flush) re-entering the body would re-finalize an
+    // already-finalized sink — on Windows that deadlocks.
+    if (desc->flushed)
       continue;
+    if (desc->cursor_elements == 0 && desc->batch_accumulated == 0) {
+      desc->flushed = 1;
+      continue;
+    }
 
     // Ensure LUTs are computed for this array (shared LUTs may be stale).
     if (a != ms->active)
@@ -650,6 +673,7 @@ flush_impl(struct multiarray_writer* self)
     struct writer_result r = cpu_stream_flush_body(&v);
     if (r.error)
       goto Error;
+    desc->flushed = 1;
   }
 
   return (struct multiarray_writer_result){

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -38,6 +38,7 @@ struct array_descriptor_gpu
   struct shard_state shard[LOD_MAX_LEVELS];
   struct aggregate_layout agg_layout[LOD_MAX_LEVELS];
   uint32_t batch_active_count[LOD_MAX_LEVELS];
+  int flushed; // 1 once flush body has run for this array
 };
 
 // ---- Pool maxima (computed across all arrays) ----
@@ -480,6 +481,17 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
       .rest = data,
     };
 
+  struct array_descriptor_gpu* desc = &ms->arrays[array_index];
+
+  // If this array has already been flushed (capacity reached with inline
+  // flush, or explicit flush), further appends are a no-op that report
+  // `finished` with the full input unconsumed.
+  if (desc->flushed)
+    return (struct multiarray_writer_result){
+      .error = multiarray_writer_finished,
+      .rest = data,
+    };
+
   // Switch arrays if needed
   if (array_index != ms->active) {
     int err = switch_to_array(ms, array_index);
@@ -487,8 +499,12 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
       return (struct multiarray_writer_result){ .error = err, .rest = data };
   }
 
-  struct writer_result r =
-    stream_append_body(&ms->engine, &ms->arrays[array_index].ctx, data);
+  struct writer_result r = stream_append_body(&ms->engine, &desc->ctx, data);
+
+  // `stream_append_body` runs a terminal flush inline when the array hits
+  // `max_cursor_elements`; capture that so subsequent flushes become no-ops.
+  if (r.error == multiarray_writer_finished)
+    desc->flushed = 1;
 
   // Map writer_result → multiarray_writer_result (error codes are identity)
   return (struct multiarray_writer_result){
@@ -512,8 +528,15 @@ flush_impl(struct multiarray_writer* self)
   // Flush each array that has data
   for (int a = 0; a < ms->n_arrays; ++a) {
     struct array_descriptor_gpu* desc = &ms->arrays[a];
-    if (desc->ctx.cursor_elements == 0 && desc->batch_accumulated == 0)
+    // Already-flushed arrays (either by inline flush on capacity or by a
+    // prior explicit flush) re-entering the body would re-finalize an
+    // already-finalized sink.
+    if (desc->flushed)
       continue;
+    if (desc->ctx.cursor_elements == 0 && desc->batch_accumulated == 0) {
+      desc->flushed = 1;
+      continue;
+    }
 
     ms->active = a;
     bind_context(&ms->engine, desc);
@@ -523,6 +546,7 @@ flush_impl(struct multiarray_writer* self)
       goto Error;
 
     unbind_context(&ms->engine, desc);
+    desc->flushed = 1;
   }
 
   ms->active = -1;

--- a/tests/test_multiarray_cpu.c
+++ b/tests/test_multiarray_cpu.c
@@ -915,6 +915,86 @@ Fail:
   return 1;
 }
 
+// ---- Test: flush is idempotent after writer reaches `finished` ----
+//
+// After `cpu_stream_append_body` hits `max_cursor_elements` and runs its
+// inline terminal flush, the writer reports `multiarray_writer_finished`.
+// Subsequent explicit `flush()` calls (or additional `update()` calls) must
+// be no-ops — not re-finalize already-finalized shards. A prior bug caused
+// the destructor's follow-up flush to deadlock on Windows against an
+// already-finalized sink.
+static int
+test_flush_idempotent_after_finished(void)
+{
+  log_info("=== test_flush_idempotent_after_finished ===");
+
+  struct test_shard_sink sink;
+  test_sink_init_1(&sink);
+
+  // 2D 4x4 u8: epoch_elements=8, 2 epochs, max_cursor=16.
+  struct dimension dims[2];
+  struct tile_stream_configuration config = make_2d_config(dims, dtype_u8);
+  struct tile_stream_configuration configs[] = { config };
+  struct shard_sink* sinks[] = { &sink.base };
+
+  struct multiarray_tile_stream_cpu* ms =
+    multiarray_tile_stream_cpu_create(1, configs, sinks, 0);
+  CHECK(Fail, ms);
+
+  struct multiarray_writer* w = multiarray_tile_stream_cpu_writer(ms);
+
+  // Fill exactly max_cursor. Cursor reaches the cap but loop exits
+  // naturally; no inline flush yet.
+  CHECK(Fail, write_fill(w, 0, 16, 1, 0xAA).error == multiarray_writer_ok);
+
+  // Probing one more element drives the writer into the `finished` state
+  // and triggers the inline terminal flush. Record the finalize count so
+  // we can assert idempotency below.
+  {
+    uint8_t extra = 0;
+    struct slice sl = { .beg = &extra, .end = &extra + 1 };
+    struct multiarray_writer_result r = w->update(w, 0, sl);
+    CHECK(Fail, r.error == multiarray_writer_finished);
+    CHECK(Fail, r.rest.beg == sl.beg); // nothing consumed
+  }
+  const int finalize_after_inline = sink.finalize_count;
+  const int open_after_inline = sink.open_count;
+  CHECK(Fail, finalize_after_inline > 0);
+
+  // Explicit flush must succeed and must not re-open or re-finalize shards.
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  CHECK(Fail, sink.finalize_count == finalize_after_inline);
+  CHECK(Fail, sink.open_count == open_after_inline);
+
+  // Flush again — still a no-op.
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  CHECK(Fail, sink.finalize_count == finalize_after_inline);
+  CHECK(Fail, sink.open_count == open_after_inline);
+
+  // Further updates still report finished with full input unconsumed, and
+  // do not touch the sink.
+  {
+    uint8_t extra = 0;
+    struct slice sl = { .beg = &extra, .end = &extra + 1 };
+    struct multiarray_writer_result r = w->update(w, 0, sl);
+    CHECK(Fail, r.error == multiarray_writer_finished);
+    CHECK(Fail, r.rest.beg == sl.beg);
+  }
+  CHECK(Fail, sink.finalize_count == finalize_after_inline);
+  CHECK(Fail, sink.open_count == open_after_inline);
+
+  multiarray_tile_stream_cpu_destroy(ms);
+  test_sink_free(&sink);
+  log_info("  PASS");
+  return 0;
+
+Fail:
+  multiarray_tile_stream_cpu_destroy(ms);
+  test_sink_free(&sink);
+  log_error("  FAIL");
+  return 1;
+}
+
 // ---- Test: metrics enabled ----
 
 static int
@@ -981,6 +1061,7 @@ main(int ac, char* av[])
   rc |= test_mixed_lod();
   rc |= test_write_past_max_cursor();
   rc |= test_flush_no_data();
+  rc |= test_flush_idempotent_after_finished();
   rc |= test_metrics_enabled();
   return rc;
 }

--- a/tests/test_multiarray_gpu.c
+++ b/tests/test_multiarray_gpu.c
@@ -601,6 +601,85 @@ Fail:
   return 1;
 }
 
+// ---- Test: flush is idempotent after writer reaches `finished` ----
+//
+// After `stream_append_body` hits `max_cursor_elements` and runs its inline
+// terminal flush, the writer reports `multiarray_writer_finished`.
+// Subsequent explicit `flush()` calls (and further `update()` calls) must
+// be no-ops — not re-finalize already-finalized shards. A prior bug caused
+// the destructor's follow-up flush to deadlock on Windows against an
+// already-finalized sink.
+static int
+test_flush_idempotent_after_finished(void)
+{
+  log_info("=== test_flush_idempotent_after_finished ===");
+
+  struct test_shard_sink sink;
+  test_sink_init_1(&sink);
+
+  // 2D 4x4 u8: epoch_elements=8, 2 epochs, max_cursor=16.
+  struct dimension dims[2];
+  struct tile_stream_configuration config = make_2d_config(dims, dtype_u8);
+  struct tile_stream_configuration configs[] = { config };
+  struct shard_sink* sinks[] = { &sink.base };
+
+  struct multiarray_tile_stream_gpu* ms =
+    multiarray_tile_stream_gpu_create(1, configs, sinks, 0);
+  CHECK(Fail, ms);
+
+  struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(ms);
+
+  // Fill exactly max_cursor. Cursor reaches the cap but loop exits
+  // naturally; no inline flush yet.
+  CHECK(Fail, write_fill(w, 0, 16, 1, 0xAA).error == multiarray_writer_ok);
+
+  // Probing one more element drives the writer into the `finished` state
+  // and triggers the inline terminal flush.
+  {
+    uint8_t extra = 0;
+    struct slice sl = { .beg = &extra, .end = &extra + 1 };
+    struct multiarray_writer_result r = w->update(w, 0, sl);
+    CHECK(Fail, r.error == multiarray_writer_finished);
+    CHECK(Fail, r.rest.beg == sl.beg); // nothing consumed
+  }
+  const int finalize_after_inline = sink.finalize_count;
+  const int open_after_inline = sink.open_count;
+  CHECK(Fail, finalize_after_inline > 0);
+
+  // Explicit flush must succeed and must not re-open or re-finalize shards.
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  CHECK(Fail, sink.finalize_count == finalize_after_inline);
+  CHECK(Fail, sink.open_count == open_after_inline);
+
+  // Flush again — still a no-op.
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  CHECK(Fail, sink.finalize_count == finalize_after_inline);
+  CHECK(Fail, sink.open_count == open_after_inline);
+
+  // Further updates still report finished with full input unconsumed, and
+  // do not touch the sink.
+  {
+    uint8_t extra = 0;
+    struct slice sl = { .beg = &extra, .end = &extra + 1 };
+    struct multiarray_writer_result r = w->update(w, 0, sl);
+    CHECK(Fail, r.error == multiarray_writer_finished);
+    CHECK(Fail, r.rest.beg == sl.beg);
+  }
+  CHECK(Fail, sink.finalize_count == finalize_after_inline);
+  CHECK(Fail, sink.open_count == open_after_inline);
+
+  multiarray_tile_stream_gpu_destroy(ms);
+  test_sink_free(&sink);
+  log_info("  PASS");
+  return 0;
+
+Fail:
+  multiarray_tile_stream_gpu_destroy(ms);
+  test_sink_free(&sink);
+  log_error("  FAIL");
+  return 1;
+}
+
 // ---- Test: flush with no data written ----
 
 static int
@@ -920,6 +999,7 @@ main(int ac, char* av[])
   ret |= test_content_isolation();
   ret |= test_cross_validate_single_array();
   ret |= test_write_past_max_cursor();
+  ret |= test_flush_idempotent_after_finished();
   ret |= test_flush_no_data();
   ret |= test_metrics_enabled();
   ret |= test_mixed_dtypes();


### PR DESCRIPTION
Fixes #90.

## Summary

- CPU and GPU multiarray writers now track a per-array `flushed` flag.
- `update_impl` short-circuits to `finished` when called on a flushed array
  and marks the array `flushed` on any `multiarray_writer_finished` return
  from the append body (covers the inline terminal flush triggered inside
  `cpu_stream_append_body` / `stream_append_body` when `cursor_elements`
  hits `max_cursor_elements`).
- `flush_impl` skips already-flushed arrays and sets `flushed=1` after a
  successful flush body, so explicit double-flush is also a no-op.

Without this, when an array fills exactly and the caller probes overflow,
the writer's inline flush finalizes the sink, then any follow-up explicit
`flush` (e.g. from a destructor) re-runs `wait_fence` / `finalize_shards`
/ `update_append` on an already-finalized sink. On Windows that deadlocks;
POSIX tolerates it. See acquire-zarr PR discussion on the shim branch for
the downstream hang that surfaced this.

## Test plan

- [x] Added `test_flush_idempotent_after_finished` in `test_multiarray_cpu.c`
  that drives the fill-then-overflow path and asserts:
  - Explicit `flush()` after the writer reaches `finished` returns
    `multiarray_writer_ok`.
  - `sink.finalize_count` and `sink.open_count` do not increase across
    subsequent explicit flushes.
  - Subsequent `update()` calls on the flushed array return `finished`
    with the full slice unconsumed and still do not touch the sink.