### PR TITLE
Make bounded stream commit point explicit

### DIFF
--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -107,12 +107,13 @@ cpu_stream_append_body(struct cpu_stream_view* v, struct slice input)
   const uint64_t max_cursor = v->max_cursor_elements;
 
   while (src < end) {
-    if (max_cursor > 0 && *v->cursor_elements >= max_cursor) {
-      struct writer_result fr = cpu_stream_flush_body(v);
-      if (fr.error)
-        return writer_error_at(src, end);
+    // Capacity reached: refuse further writes and report `finished` with the
+    // remaining input unconsumed. The terminal flush is NOT run here — it
+    // happens on explicit `writer_flush` or on stream destroy. Keeping the
+    // producer path free of sink finalization means appends never block on
+    // IO the stream's owner hasn't asked for.
+    if (max_cursor > 0 && *v->cursor_elements >= max_cursor)
       return writer_finished_at(src, end);
-    }
 
     const uint64_t epoch_remaining =
       v->layout->epoch_elements -

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -18,6 +18,8 @@ static struct writer_result
 cpu_append(struct writer* self, struct slice input);
 static struct writer_result
 cpu_flush_final(struct writer* self);
+static struct cpu_stream_view
+make_view(struct tile_stream_cpu* s);
 
 // ---- Create / Destroy ----
 
@@ -267,6 +269,15 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
 {
   if (!s)
     return;
+
+  // Auto-finalize any unwritten data so destroy is a safe commit point for
+  // callers that didn't explicitly flush. Errors here are swallowed — the
+  // stream is tearing down, there's no one to report to.
+  if (!s->flushed) {
+    struct cpu_stream_view v = make_view(s);
+    (void)cpu_stream_flush_body(&v);
+    s->flushed = 1;
+  }
 
   for (int lv = 0; lv < s->levels.nlod; ++lv) {
     struct shard_state* ss = &s->shard[lv];
@@ -569,6 +580,11 @@ cpu_flush_final(struct writer* self)
 {
   struct tile_stream_cpu* s =
     container_of(self, struct tile_stream_cpu, writer);
+  // Re-entering the flush body on an already-finalized stream would
+  // re-finalize already-closed sinks — a deadlock on Windows and wasted
+  // work elsewhere.
+  if (s->flushed)
+    return writer_ok();
   struct cpu_stream_view v = make_view(s);
   struct writer_result r = cpu_stream_flush_body(&v);
   s->flushed = 1;

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -92,14 +92,11 @@ stream_append_body(struct stream_engine* e,
   const uint64_t max_cursor_elements = ctx->max_cursor_elements;
 
   while (src < end) {
-    // Bounded append dims: check capacity
-    if (max_cursor_elements > 0 &&
-        ctx->cursor_elements >= max_cursor_elements) {
-      struct writer_result fr = stream_flush_body(e, ctx);
-      if (fr.error)
-        return writer_error_at(src, end);
+    // Capacity reached: refuse further writes and report `finished` with the
+    // remaining input unconsumed. The terminal flush is NOT run here — it
+    // happens on explicit `writer_flush` or on stream destroy.
+    if (max_cursor_elements > 0 && ctx->cursor_elements >= max_cursor_elements)
       return writer_finished_at(src, end);
-    }
 
     const uint64_t epoch_remaining =
       ctx->layout.epoch_elements -
@@ -310,6 +307,9 @@ tile_stream_gpu_flush_final(struct writer* self)
 {
   struct tile_stream_gpu* s =
     container_of(self, struct tile_stream_gpu, writer);
+  // Mirrors the CPU guard: avoid re-finalizing an already-finalized stream.
+  if (s->flushed)
+    return writer_ok();
   struct writer_result r = stream_flush_body(&s->engine, &s->ctx);
   s->flushed = 1;
   return r;

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -1,5 +1,6 @@
 #include "gpu/flush.compress_agg.h"
 #include "gpu/flush.d2h_deliver.h"
+#include "gpu/stream.flush.h"
 #include "gpu/stream.ingest.h"
 #include "gpu/stream.lod.h"
 
@@ -51,6 +52,14 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
 {
   if (!s)
     return;
+
+  // Auto-finalize any unwritten data so destroy is a safe commit point for
+  // callers that didn't explicitly flush. Errors here are swallowed — the
+  // stream is tearing down, there's no one to report to.
+  if (!s->flushed) {
+    (void)stream_flush_body(&s->engine, &s->ctx);
+    s->flushed = 1;
+  }
 
   // Ensure all GPU work completes before tearing down events/memory.
   sync(s->engine.streams.h2d);

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -422,6 +422,11 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
   if (!ms)
     return;
 
+  // Auto-finalize any unflushed arrays so destroy is a safe commit point
+  // for callers that didn't explicitly flush. Errors here are swallowed —
+  // the stream is tearing down, there's no one to report to.
+  (void)flush_impl(&ms->writer);
+
   if (ms->arrays) {
     for (int i = 0; i < ms->n_arrays; ++i) {
       struct array_descriptor* desc = &ms->arrays[i];
@@ -631,13 +636,8 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
   struct cpu_stream_view v = make_multiarray_view(ms, desc);
   struct writer_result r = cpu_stream_append_body(&v, data);
 
-  // `cpu_stream_append_body` runs a terminal flush inline when the array
-  // hits `max_cursor_elements`; capture that so subsequent flushes become
-  // no-ops.
-  if (r.error == multiarray_writer_finished)
-    desc->flushed = 1;
-
-  // Map writer_result → multiarray_writer_result (error codes are identity)
+  // `writer_finished` here means "stream is at capacity"; finalization
+  // happens on explicit `flush()` or on destroy, not here.
   return (struct multiarray_writer_result){
     .error = r.error,
     .rest = r.rest,

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -501,12 +501,8 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct writer_result r = stream_append_body(&ms->engine, &desc->ctx, data);
 
-  // `stream_append_body` runs a terminal flush inline when the array hits
-  // `max_cursor_elements`; capture that so subsequent flushes become no-ops.
-  if (r.error == multiarray_writer_finished)
-    desc->flushed = 1;
-
-  // Map writer_result → multiarray_writer_result (error codes are identity)
+  // `writer_finished` here means "stream is at capacity"; finalization
+  // happens on explicit `flush()` or on destroy, not here.
   return (struct multiarray_writer_result){
     .error = r.error,
     .rest = r.rest,
@@ -579,6 +575,11 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
 {
   if (!ms)
     return;
+
+  // Auto-finalize any unflushed arrays so destroy is a safe commit point
+  // for callers that didn't explicitly flush. Errors here are swallowed —
+  // the stream is tearing down, there's no one to report to.
+  (void)flush_impl(&ms->writer);
 
   sync_all(&ms->engine.streams);
 

--- a/tests/test_multiarray_cpu.c
+++ b/tests/test_multiarray_cpu.c
@@ -917,12 +917,11 @@ Fail:
 
 // ---- Test: flush is idempotent after writer reaches `finished` ----
 //
-// After `cpu_stream_append_body` hits `max_cursor_elements` and runs its
-// inline terminal flush, the writer reports `multiarray_writer_finished`.
-// Subsequent explicit `flush()` calls (or additional `update()` calls) must
-// be no-ops — not re-finalize already-finalized shards. A prior bug caused
-// the destructor's follow-up flush to deadlock on Windows against an
-// already-finalized sink.
+// Once the writer has reached capacity and been finalized (either by an
+// explicit `flush()` or by the destructor's auto-flush), subsequent `flush()`
+// and `update()` calls must be no-ops — not re-finalize already-finalized
+// shards. A prior bug caused the destructor's follow-up flush to deadlock
+// on Windows against an already-finalized sink.
 static int
 test_flush_idempotent_after_finished(void)
 {
@@ -943,13 +942,15 @@ test_flush_idempotent_after_finished(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_cpu_writer(ms);
 
-  // Fill exactly max_cursor. Cursor reaches the cap but loop exits
-  // naturally; no inline flush yet.
+  // Fill exactly max_cursor. Cursor reaches the cap; loop exits naturally.
+  // Batch flushes on epoch boundaries finalize complete shards during the
+  // append; partial shards wait for an explicit flush or destroy.
   CHECK(Fail, write_fill(w, 0, 16, 1, 0xAA).error == multiarray_writer_ok);
+  const int finalize_after_fill = sink.finalize_count;
+  const int open_after_fill = sink.open_count;
 
-  // Probing one more element drives the writer into the `finished` state
-  // and triggers the inline terminal flush. Record the finalize count so
-  // we can assert idempotency below.
+  // Probing one more element finds the stream at capacity; it refuses the
+  // write and reports `finished` with the input untouched.
   {
     uint8_t extra = 0;
     struct slice sl = { .beg = &extra, .end = &extra + 1 };
@@ -957,19 +958,19 @@ test_flush_idempotent_after_finished(void)
     CHECK(Fail, r.error == multiarray_writer_finished);
     CHECK(Fail, r.rest.beg == sl.beg); // nothing consumed
   }
-  const int finalize_after_inline = sink.finalize_count;
-  const int open_after_inline = sink.open_count;
-  CHECK(Fail, finalize_after_inline > 0);
+  CHECK(Fail, sink.finalize_count == finalize_after_fill);
+  CHECK(Fail, sink.open_count == open_after_fill);
 
-  // Explicit flush must succeed and must not re-open or re-finalize shards.
+  // Explicit flush runs the terminal flush. For this config all shards
+  // already finalized during the append, so no new opens/finalizes occur.
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
-  CHECK(Fail, sink.finalize_count == finalize_after_inline);
-  CHECK(Fail, sink.open_count == open_after_inline);
+  const int finalize_after_flush = sink.finalize_count;
+  const int open_after_flush = sink.open_count;
 
-  // Flush again — still a no-op.
+  // Second flush — idempotent: no new sink calls.
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
-  CHECK(Fail, sink.finalize_count == finalize_after_inline);
-  CHECK(Fail, sink.open_count == open_after_inline);
+  CHECK(Fail, sink.finalize_count == finalize_after_flush);
+  CHECK(Fail, sink.open_count == open_after_flush);
 
   // Further updates still report finished with full input unconsumed, and
   // do not touch the sink.
@@ -980,10 +981,13 @@ test_flush_idempotent_after_finished(void)
     CHECK(Fail, r.error == multiarray_writer_finished);
     CHECK(Fail, r.rest.beg == sl.beg);
   }
-  CHECK(Fail, sink.finalize_count == finalize_after_inline);
-  CHECK(Fail, sink.open_count == open_after_inline);
+  CHECK(Fail, sink.finalize_count == finalize_after_flush);
+  CHECK(Fail, sink.open_count == open_after_flush);
 
+  // Destroy runs another auto-flush, also idempotent.
   multiarray_tile_stream_cpu_destroy(ms);
+  CHECK(Fail, sink.finalize_count == finalize_after_flush);
+  CHECK(Fail, sink.open_count == open_after_flush);
   test_sink_free(&sink);
   log_info("  PASS");
   return 0;

--- a/tests/test_multiarray_gpu.c
+++ b/tests/test_multiarray_gpu.c
@@ -602,13 +602,11 @@ Fail:
 }
 
 // ---- Test: flush is idempotent after writer reaches `finished` ----
-//
-// After `stream_append_body` hits `max_cursor_elements` and runs its inline
-// terminal flush, the writer reports `multiarray_writer_finished`.
-// Subsequent explicit `flush()` calls (and further `update()` calls) must
-// be no-ops — not re-finalize already-finalized shards. A prior bug caused
-// the destructor's follow-up flush to deadlock on Windows against an
-// already-finalized sink.
+// Once the writer has reached capacity and been finalized (either by an
+// explicit `flush()` or by the destructor's auto-flush), subsequent `flush()`
+// and `update()` calls must be no-ops — not re-finalize already-finalized
+// shards. A prior bug caused the destructor's follow-up flush to deadlock
+// on Windows against an already-finalized sink.
 static int
 test_flush_idempotent_after_finished(void)
 {
@@ -629,12 +627,15 @@ test_flush_idempotent_after_finished(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(ms);
 
-  // Fill exactly max_cursor. Cursor reaches the cap but loop exits
-  // naturally; no inline flush yet.
+  // Fill exactly max_cursor. Cursor reaches the cap; loop exits naturally.
+  // Batch flushes on epoch boundaries finalize complete shards during the
+  // append; partial shards wait for an explicit flush or destroy.
   CHECK(Fail, write_fill(w, 0, 16, 1, 0xAA).error == multiarray_writer_ok);
+  const int finalize_after_fill = sink.finalize_count;
+  const int open_after_fill = sink.open_count;
 
-  // Probing one more element drives the writer into the `finished` state
-  // and triggers the inline terminal flush.
+  // Probing one more element finds the stream at capacity; it refuses the
+  // write and reports `finished` with the input untouched.
   {
     uint8_t extra = 0;
     struct slice sl = { .beg = &extra, .end = &extra + 1 };
@@ -642,19 +643,19 @@ test_flush_idempotent_after_finished(void)
     CHECK(Fail, r.error == multiarray_writer_finished);
     CHECK(Fail, r.rest.beg == sl.beg); // nothing consumed
   }
-  const int finalize_after_inline = sink.finalize_count;
-  const int open_after_inline = sink.open_count;
-  CHECK(Fail, finalize_after_inline > 0);
+  CHECK(Fail, sink.finalize_count == finalize_after_fill);
+  CHECK(Fail, sink.open_count == open_after_fill);
 
-  // Explicit flush must succeed and must not re-open or re-finalize shards.
+  // Explicit flush runs the terminal flush; any partial shard state is
+  // finalized here.
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
-  CHECK(Fail, sink.finalize_count == finalize_after_inline);
-  CHECK(Fail, sink.open_count == open_after_inline);
+  const int finalize_after_flush = sink.finalize_count;
+  const int open_after_flush = sink.open_count;
 
-  // Flush again — still a no-op.
+  // Second flush — idempotent: no new sink calls.
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
-  CHECK(Fail, sink.finalize_count == finalize_after_inline);
-  CHECK(Fail, sink.open_count == open_after_inline);
+  CHECK(Fail, sink.finalize_count == finalize_after_flush);
+  CHECK(Fail, sink.open_count == open_after_flush);
 
   // Further updates still report finished with full input unconsumed, and
   // do not touch the sink.
@@ -665,10 +666,13 @@ test_flush_idempotent_after_finished(void)
     CHECK(Fail, r.error == multiarray_writer_finished);
     CHECK(Fail, r.rest.beg == sl.beg);
   }
-  CHECK(Fail, sink.finalize_count == finalize_after_inline);
-  CHECK(Fail, sink.open_count == open_after_inline);
+  CHECK(Fail, sink.finalize_count == finalize_after_flush);
+  CHECK(Fail, sink.open_count == open_after_flush);
 
+  // Destroy runs another auto-flush, also idempotent.
   multiarray_tile_stream_gpu_destroy(ms);
+  CHECK(Fail, sink.finalize_count == finalize_after_flush);
+  CHECK(Fail, sink.open_count == open_after_flush);
   test_sink_free(&sink);
   log_info("  PASS");
   return 0;

--- a/tests/test_stream.c
+++ b/tests/test_stream.c
@@ -747,7 +747,8 @@ test_stream_unbounded_requires_tps(void)
   return 1;
 }
 
-// Test: bounded dim0 — append more data than capacity, expect auto-flush.
+// Test: bounded dim0 — appending more than capacity reports `finished`
+// with unconsumed data; finalization happens on explicit flush.
 static int
 test_stream_bounded_dim0(void)
 {
@@ -778,13 +779,13 @@ test_stream_bounded_dim0(void)
     src[i] = (uint16_t)i;
 
   struct slice input = { .beg = src, .end = src + total };
-  struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
+  struct writer* w = tile_stream_gpu_writer(s);
+  struct writer_result r = writer_append(w, input);
 
-  // Should get writer_error_finished (auto-flushed at capacity)
+  // Should get writer_error_finished with unconsumed data.
   CHECK(Fail, r.error == writer_error_finished);
   log_info("  got writer_error_finished as expected");
 
-  // rest should point to unconsumed data
   size_t consumed = (size_t)((const uint16_t*)r.rest.beg - src);
   size_t unconsumed =
     (size_t)((const uint16_t*)r.rest.end - (const uint16_t*)r.rest.beg);
@@ -793,7 +794,8 @@ test_stream_bounded_dim0(void)
   CHECK(Fail, consumed == 96);
   CHECK(Fail, unconsumed == 54);
 
-  // Shard data should have been written
+  // Finalize explicitly. After flush the sink should have shard data.
+  CHECK(Fail, writer_flush(w).error == 0);
   CHECK(Fail, mss.writers[0][0].size > 0);
   log_info("  shard bytes=%zu", mss.writers[0][0].size);
 


### PR DESCRIPTION
## Summary

Removes implicit finalization from the append path. When an append reaches `max_cursor_elements`, the writer body now refuses further writes and reports `writer_finished` *without* running the terminal flush. Finalization happens on the explicit `writer_flush` or on stream destroy — never inside an append.

## Why

Previously, `cpu_stream_append_body` and its GPU twin ran `flush_body` inline when they saw `cursor >= max_cursor` at the top of the loop. That check fires on the *next* call after exact-fill, not during the call that reached capacity. Two bad consequences:

1. A caller that exactly fills capacity and then destroys the stream triggers `flush_body` from the destructor. A caller that exactly fills capacity and then appends one more byte triggers `flush_body` from the next append. Downstream code (e.g. the acquire-zarr test `test_append_throws_on_overflow`) then calls `writer_flush` too — now the sink is finalized twice.
2. On Windows, re-finalizing an already-finalized sink deadlocks (the IO-queue worker never retires the second close job against an already-closed handle). That's what the comment on stream.c:657 warns about for multiarray flush, but the same shape applied to the body's own top-of-loop flush.

Making the commit point explicit (flush or destroy) removes both the implicit-timing surprise and the double-flush exposure.

## Contract

- `append` never invokes sink finalization. It scatters into the pool and runs batch flushes at epoch boundaries (unchanged).
- `append` reaching `max_cursor` returns `writer_finished` with the full remaining input unconsumed; subsequent appends also return `finished`.
- `writer_flush` is the one-shot terminal operation. It's idempotent — calling it a second time is a no-op.
- `destroy` auto-flushes if the caller didn't, so forgetting to flush isn't silent data loss.

Exact-fill (one append that fills capacity exactly) still returns `ok`, preserving the existing API for the common case.

## Changes

- `src/cpu/stream.body.c`: body's top-of-loop capacity check returns `finished` without calling `cpu_stream_flush_body`.
- `src/gpu/stream.c`: mirror change in `stream_append_body`.
- `src/cpu/stream.c`, `src/gpu/stream.c`: `flush_final` short-circuits when `s->flushed`.
- `src/cpu/stream.c`, `src/gpu/stream.init.c`: `destroy` auto-flushes if the stream wasn't explicitly flushed.
- `src/multiarray/stream.c`, `src/multiarray/stream.gpu.c`: multiarray `destroy` calls `flush_impl` (already idempotent via `desc->flushed`). `update_impl` no longer sets `desc->flushed` on `writer_finished` — that flag now means "finalization ran", full stop.
- `tests/test_multiarray_cpu.c`: rewrite `test_flush_idempotent_after_finished` to assert the new contract (no implicit finalization; explicit flush and destroy are idempotent).

## Test plan

- [x] `ctest --test-dir build -E "s3"` passes locally (22/22 non-S3 tests).
- [ ] GPU tests (didn't run locally — no CUDA devshell in this session).
- [ ] Downstream: acquire-zarr's `test_append_throws_on_overflow` no longer hangs on macOS-arm / Windows.