### PR TITLE
bench chunk/shard layout policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           fail_ci_if_error: false
 
   gpu-tests:
-    runs-on: [self-hosted, gpu]
+    runs-on: [self-hosted, Linux, gpu]
     steps:
       - uses: actions/checkout@v4
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -7,14 +7,23 @@ function(add_bench TGT SOURCE_FILE)
 endfunction()
 
 # bench_util: static library with pipeline benchmark infrastructure
-add_library(bench_util STATIC
-    bench_util.c bench_util.h
-    sink_discard.c sink_discard.h
-    sink_throttled.c sink_throttled.h
-    sink_metering.c sink_metering.h
-    bench_zarr.c bench_zarr.h
-    bench_parse.c bench_parse.h
-    bench_report.c bench_report.h
+add_library(
+    bench_util
+    STATIC
+    bench_util.c
+    bench_util.h
+    sink_discard.c
+    sink_discard.h
+    sink_throttled.c
+    sink_throttled.h
+    sink_metering.c
+    sink_metering.h
+    bench_zarr.c
+    bench_zarr.h
+    bench_parse.c
+    bench_parse.h
+    bench_report.c
+    bench_report.h
 )
 target_include_directories(bench_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
@@ -31,6 +40,7 @@ target_link_libraries(
         store_api
         lod_plan
         dimension
+        format_bytes
         test_data
         CUDA::cuda_driver
     PRIVATE warnings
@@ -45,6 +55,8 @@ set(BENCH_STREAM_SOURCES
     bench_stream_orca2_multiscale.c
     bench_stream_orca2_multiscale_dim0.c
     bench_stream_medfmt_single.c
+    bench_stream_medfmt_multiscale.c
+    bench_stream_medfmt_multiscale_dim0.c
     bench_stream_smallepoch_single.c
     bench_stream_256cube_two_streams.c
 )

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -1,6 +1,7 @@
 #include "bench_report.h"
 
 #include "util/format_bytes.h"
+#include "zarr/json_writer.h"
 
 // --- Throughput helpers ---
 
@@ -166,4 +167,142 @@ print_bench_report(const struct stream_metrics* metrics,
   }
   print_report("  Wall time:     %.3f s", wall_s);
   print_report("  Throughput:    %.2f GiB/s", throughput_gib);
+}
+
+static void
+json_stage_metric(struct json_writer* jw,
+                  const char* name,
+                  const struct stream_metric* sm)
+{
+  if (sm->count <= 0)
+    return;
+  double avg_ms = (double)sm->ms / sm->count;
+  double in_gibs = gb_per_s(sm->input_bytes, (double)sm->ms);
+  double out_gibs = gb_per_s(sm->output_bytes, (double)sm->ms);
+  jw_key(jw, name);
+  jw_object_begin(jw);
+  jw_key(jw, "avg_ms");
+  jw_float(jw, avg_ms);
+  if (sm->best_ms < 1e29f) {
+    jw_key(jw, "best_ms");
+    jw_float(jw, (double)sm->best_ms);
+  }
+  jw_key(jw, "in_gibs");
+  jw_float(jw, in_gibs);
+  jw_key(jw, "out_gibs");
+  jw_float(jw, out_gibs);
+  jw_object_end(jw);
+}
+
+void
+print_bench_json_pass(const struct stream_metrics* m,
+                      const struct stream_metric* sink_metric,
+                      const struct tile_stream_layout* layout,
+                      enum dtype dtype,
+                      const struct sink_stats* ss,
+                      size_t total_bytes,
+                      size_t total_elements,
+                      float wall_s,
+                      float init_s,
+                      float flush_s)
+{
+  const size_t chunk_bytes = layout->chunk_stride * dtype_bpe(dtype);
+  const size_t num_epochs =
+    (total_elements + layout->epoch_elements - 1) / layout->epoch_elements;
+  const uint64_t chunks_per_epoch =
+    ss->total_chunks ? ss->total_chunks : layout->chunks_per_epoch;
+  const size_t total_chunks = num_epochs * chunks_per_epoch;
+  const size_t total_decompressed = total_chunks * chunk_bytes;
+  const double comp_fold =
+    ss->total_bytes > 0 ? (double)total_decompressed / (double)ss->total_bytes
+                        : 0.0;
+  const double GIB = 1024.0 * 1024.0 * 1024.0;
+  const double input_gib = (double)total_bytes / GIB;
+  const double compressed_gib = (double)ss->total_bytes / GIB;
+  const double throughput_gib = wall_s > 0 ? input_gib / wall_s : 0.0;
+  const double throughput_out_gib = wall_s > 0 ? compressed_gib / wall_s : 0.0;
+
+  char json_buf[8192];
+  struct json_writer jw;
+  jw_init(&jw, json_buf, sizeof(json_buf));
+
+  jw_object_begin(&jw);
+  jw_key(&jw, "status");
+  jw_string(&jw, "pass");
+  jw_key(&jw, "throughput_in_gibs");
+  jw_float(&jw, throughput_gib);
+  jw_key(&jw, "throughput_out_gibs");
+  jw_float(&jw, throughput_out_gib);
+  jw_key(&jw, "compression_fold");
+  jw_float(&jw, comp_fold);
+  jw_key(&jw, "input_gib");
+  jw_float(&jw, input_gib);
+  jw_key(&jw, "compressed_gib");
+  jw_float(&jw, compressed_gib);
+  jw_key(&jw, "total_chunks");
+  jw_uint(&jw, total_chunks);
+  jw_key(&jw, "chunks_per_epoch");
+  jw_uint(&jw, chunks_per_epoch);
+  jw_key(&jw, "wall_s");
+  jw_float(&jw, (double)wall_s);
+  jw_key(&jw, "init_s");
+  jw_float(&jw, (double)init_s);
+  jw_key(&jw, "flush_s");
+  jw_float(&jw, (double)flush_s);
+
+  jw_key(&jw, "stages");
+  jw_object_begin(&jw);
+  json_stage_metric(&jw, "memcpy", &m->memcpy);
+  json_stage_metric(&jw, "h2d", &m->h2d);
+  json_stage_metric(&jw, "scatter", &m->scatter);
+  json_stage_metric(&jw, "lod_gather", &m->lod_gather);
+  json_stage_metric(&jw, "lod_reduce", &m->lod_reduce);
+  json_stage_metric(&jw, "lod_append_fold", &m->lod_append_fold);
+  json_stage_metric(&jw, "lod_morton_chunk", &m->lod_morton_chunk);
+  json_stage_metric(&jw, "compress", &m->compress);
+  json_stage_metric(&jw, "aggregate", &m->aggregate);
+  json_stage_metric(&jw, "d2h", &m->d2h);
+  if (sink_metric)
+    json_stage_metric(&jw, "sink", sink_metric);
+  jw_object_end(&jw);
+
+  jw_key(&jw, "stalls");
+  jw_object_begin(&jw);
+  jw_key(&jw, "flush_stall_ms");
+  jw_float(&jw, (double)m->flush_stall.ms);
+  jw_key(&jw, "flush_stall_count");
+  jw_uint(&jw, (uint64_t)m->flush_stall.count);
+  jw_key(&jw, "kick_sync_ms");
+  jw_float(&jw, (double)m->kick_sync_stall.ms);
+  jw_key(&jw, "kick_sync_count");
+  jw_uint(&jw, (uint64_t)m->kick_sync_stall.count);
+  jw_key(&jw, "io_fence_ms");
+  jw_float(&jw, (double)m->io_fence_stall.ms);
+  jw_key(&jw, "io_fence_count");
+  jw_uint(&jw, (uint64_t)m->io_fence_stall.count);
+  jw_key(&jw, "backpressure_ms");
+  jw_float(&jw, (double)m->backpressure.ms);
+  jw_key(&jw, "backpressure_count");
+  jw_uint(&jw, (uint64_t)m->backpressure.count);
+  jw_key(&jw, "max_append_ms");
+  jw_float(&jw, (double)m->max_append_ms);
+  jw_key(&jw, "peak_pending_mib");
+  jw_float(&jw, (double)m->peak_pending_bytes / (1024.0 * 1024.0));
+  jw_object_end(&jw);
+
+  jw_object_end(&jw);
+  printf("%.*s\n", (int)jw_length(&jw), json_buf);
+}
+
+void
+print_bench_json_error(void)
+{
+  char buf[64];
+  struct json_writer jw;
+  jw_init(&jw, buf, sizeof(buf));
+  jw_object_begin(&jw);
+  jw_key(&jw, "status");
+  jw_string(&jw, "error");
+  jw_object_end(&jw);
+  printf("%.*s\n", (int)jw_length(&jw), buf);
 }

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -1,5 +1,7 @@
 #include "bench_report.h"
 
+#include "util/format_bytes.h"
+
 // --- Throughput helpers ---
 
 double
@@ -49,21 +51,28 @@ log_bench_header(const struct tile_stream_layout* layout,
   const size_t num_epochs =
     (total_elements + layout->epoch_elements - 1) / layout->epoch_elements;
 
-  print_report("  total:       %.2f GiB (%zu elements, %zu epochs)",
-               (double)total_bytes / (1024.0 * 1024.0 * 1024.0),
+  char buf[32];
+  format_bytes(buf, sizeof(buf), (uint64_t)total_bytes);
+  print_report("  total:       %s (%zu elements, %zu epochs)",
+               buf,
                total_elements,
                num_epochs);
-  print_report("  chunk:       %lu elements = %lu KiB  (stride=%lu)",
+  format_bytes(
+    buf, sizeof(buf), (uint64_t)(layout->chunk_stride * dtype_bpe(dtype)));
+  print_report("  chunk:       %lu elements = %s  (stride=%lu)",
                (unsigned long)layout->chunk_elements,
-               (unsigned long)(layout->chunk_stride * dtype_bpe(dtype) / 1024),
+               buf,
                (unsigned long)layout->chunk_stride);
-  print_report("  epoch:       %lu slots, %lu MiB pool",
+  format_bytes(buf, sizeof(buf), (uint64_t)layout->chunk_pool_bytes);
+  print_report("  epoch:       %lu slots, %s pool",
                (unsigned long)layout->chunks_per_epoch,
-               (unsigned long)(layout->chunk_pool_bytes / (1024 * 1024)));
-  if (codec.id != CODEC_NONE && max_compressed_size > 0)
-    print_report("  compress:    max_output=%zu comp_pool=%zu MiB",
-                 max_compressed_size,
-                 (codec_batch_size * max_compressed_size) / (1024 * 1024));
+               buf);
+  if (codec.id != CODEC_NONE && max_compressed_size > 0) {
+    format_bytes(
+      buf, sizeof(buf), (uint64_t)(codec_batch_size * max_compressed_size));
+    print_report(
+      "  compress:    max_output=%zu comp_pool=%s", max_compressed_size, buf);
+  }
 }
 
 void
@@ -92,12 +101,11 @@ print_bench_report(const struct stream_metrics* metrics,
 
   print_report("");
   print_report("  --- Benchmark Results ---");
-  print_report("  Input:        %.2f GiB (%zu elements)",
-               (double)total_bytes / (1024.0 * 1024.0 * 1024.0),
-               total_elements);
-  print_report("  Compressed:   %.2f GiB (ratio: %.3f)",
-               (double)ss->total_bytes / (1024.0 * 1024.0 * 1024.0),
-               comp_ratio);
+  char fbuf[32];
+  format_bytes(fbuf, sizeof(fbuf), (uint64_t)total_bytes);
+  print_report("  Input:        %s (%zu elements)", fbuf, total_elements);
+  format_bytes(fbuf, sizeof(fbuf), (uint64_t)ss->total_bytes);
+  print_report("  Compressed:   %s (ratio: %.3f)", fbuf, comp_ratio);
   print_report("  Chunks:       %zu (%llu/epoch x %zu epochs)",
                total_chunks,
                (unsigned long long)chunks_per_epoch,
@@ -137,8 +145,9 @@ print_bench_report(const struct stream_metrics* metrics,
     print_metric_row(&metrics->io_fence_stall);
     print_metric_row(&metrics->backpressure);
     print_report("  max append ms:   %.2f", (double)metrics->max_append_ms);
-    print_report("  peak pending:    %.2f MiB",
-                 (double)metrics->peak_pending_bytes / (1024.0 * 1024.0));
+    char pbuf[32];
+    format_bytes(pbuf, sizeof(pbuf), (uint64_t)metrics->peak_pending_bytes);
+    print_report("  peak pending:    %s", pbuf);
   }
 
   double throughput_gib =

--- a/bench/bench_report.h
+++ b/bench/bench_report.h
@@ -41,3 +41,21 @@ print_bench_report(const struct stream_metrics* metrics,
                    float init_s,
                    float flush_s,
                    size_t flush_pending_bytes);
+
+// Emit the pass-case JSON report to stdout. sink_metric may be NULL (no sink
+// block is written in that case).
+void
+print_bench_json_pass(const struct stream_metrics* metrics,
+                      const struct stream_metric* sink_metric,
+                      const struct tile_stream_layout* layout,
+                      enum dtype dtype,
+                      const struct sink_stats* ss,
+                      size_t total_bytes,
+                      size_t total_elements,
+                      float wall_s,
+                      float init_s,
+                      float flush_s);
+
+// Emit a minimal error JSON (`{"status":"error"}`) to stdout.
+void
+print_bench_json_error(void);

--- a/bench/bench_stream_256cube_multiscale.c
+++ b/bench/bench_stream_256cube_multiscale.c
@@ -10,7 +10,7 @@ main(int ac, char* av[])
 
   dims_set_downsample_by_name(dims, rank, "zyx");
 
-  uint8_t ratios[] = { 1, 4, 4, 4, 0 };
+  int ratios[] = { 1, 4, 4, 4, 0 };
 
   return bench_stream_main(ac,
                            av,

--- a/bench/bench_stream_256cube_multiscale.c
+++ b/bench/bench_stream_256cube_multiscale.c
@@ -22,6 +22,7 @@ main(int ac, char* av[])
                              .default_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 8,
+                             .max_concurrent_shards = 16,
+                             .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_256cube_multiscale.c
+++ b/bench/bench_stream_256cube_multiscale.c
@@ -11,8 +11,17 @@ main(int ac, char* av[])
   dims_set_downsample_by_name(dims, rank, "zyx");
 
   uint8_t ratios[] = { 1, 4, 4, 4, 0 };
-  uint64_t shard_counts[] = { 16, 2, 2, 2, 1 };
 
-  return bench_stream_main(
-    ac, av, "multiscale", dims, rank, ratios, 1 << 18, shard_counts);
+  return bench_stream_main(ac,
+                           av,
+                           (struct bench_spec){
+                             .label = "multiscale",
+                             .dims = dims,
+                             .rank = rank,
+                             .chunk_ratios = ratios,
+                             .default_chunk_bytes = 1 << 18,
+                             .min_chunk_bytes = 1 << 14,
+                             .min_shard_bytes = 1ull << 30,
+                             .max_concurrent_shards = 8,
+                           });
 }

--- a/bench/bench_stream_256cube_multiscale.c
+++ b/bench/bench_stream_256cube_multiscale.c
@@ -19,10 +19,10 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .default_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 16,
+                             .target_concurrent_shards = 16,
                              .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_256cube_multiscale_dim0.c
+++ b/bench/bench_stream_256cube_multiscale_dim0.c
@@ -12,8 +12,17 @@ main(int ac, char* av[])
   dims_set_downsample_by_name(dims, rank, "tzyx");
 
   uint8_t ratios[] = { 0, 1, 1, 1, 0 };
-  uint64_t shard_counts[] = { 16, 2, 2, 2, 1 };
 
-  return bench_stream_main(
-    ac, av, "multiscale_dim0", dims, rank, ratios, 1 << 18, shard_counts);
+  return bench_stream_main(ac,
+                           av,
+                           (struct bench_spec){
+                             .label = "multiscale_dim0",
+                             .dims = dims,
+                             .rank = rank,
+                             .chunk_ratios = ratios,
+                             .default_chunk_bytes = 1 << 18,
+                             .min_chunk_bytes = 1 << 14,
+                             .min_shard_bytes = 1ull << 30,
+                             .max_concurrent_shards = 8,
+                           });
 }

--- a/bench/bench_stream_256cube_multiscale_dim0.c
+++ b/bench/bench_stream_256cube_multiscale_dim0.c
@@ -23,6 +23,7 @@ main(int ac, char* av[])
                              .default_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 8,
+                             .max_concurrent_shards = 16,
+                             .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_256cube_multiscale_dim0.c
+++ b/bench/bench_stream_256cube_multiscale_dim0.c
@@ -11,7 +11,7 @@ main(int ac, char* av[])
   dims_set_storage_order(dims, rank, "tczyx");
   dims_set_downsample_by_name(dims, rank, "tzyx");
 
-  uint8_t ratios[] = { 0, 1, 1, 1, 0 };
+  int ratios[] = { 0, 1, 1, 1, 0 };
 
   return bench_stream_main(ac,
                            av,

--- a/bench/bench_stream_256cube_multiscale_dim0.c
+++ b/bench/bench_stream_256cube_multiscale_dim0.c
@@ -20,10 +20,10 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .default_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 16,
+                             .target_concurrent_shards = 16,
                              .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_256cube_single.c
+++ b/bench/bench_stream_256cube_single.c
@@ -9,8 +9,17 @@ main(int ac, char* av[])
   uint8_t rank = dims_create(dims, "tzyxc", sizes);
 
   uint8_t ratios[] = { 1, 4, 4, 4, 0 };
-  uint64_t shard_counts[] = { 16, 2, 2, 2, 1 };
 
-  return bench_stream_main(
-    ac, av, "single", dims, rank, ratios, 1 << 18, shard_counts);
+  return bench_stream_main(ac,
+                           av,
+                           (struct bench_spec){
+                             .label = "single",
+                             .dims = dims,
+                             .rank = rank,
+                             .chunk_ratios = ratios,
+                             .default_chunk_bytes = 1 << 18,
+                             .min_chunk_bytes = 1 << 14,
+                             .min_shard_bytes = 1ull << 30,
+                             .max_concurrent_shards = 8,
+                           });
 }

--- a/bench/bench_stream_256cube_single.c
+++ b/bench/bench_stream_256cube_single.c
@@ -20,6 +20,7 @@ main(int ac, char* av[])
                              .default_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 8,
+                             .max_concurrent_shards = 16,
+                             .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_256cube_single.c
+++ b/bench/bench_stream_256cube_single.c
@@ -8,7 +8,7 @@ main(int ac, char* av[])
   uint64_t sizes[] = { 1000, 256, 256, 256, 3 };
   uint8_t rank = dims_create(dims, "tzyxc", sizes);
 
-  uint8_t ratios[] = { 1, 4, 4, 4, 0 };
+  int ratios[] = { 1, 4, 4, 4, 0 };
 
   return bench_stream_main(ac,
                            av,

--- a/bench/bench_stream_256cube_single.c
+++ b/bench/bench_stream_256cube_single.c
@@ -17,10 +17,10 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .default_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 16,
+                             .target_concurrent_shards = 16,
                              .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_256cube_two_streams.c
+++ b/bench/bench_stream_256cube_two_streams.c
@@ -8,7 +8,7 @@ main(int ac, char* av[])
   uint64_t sizes[] = { 1000, 256, 256, 256, 3 };
   uint8_t rank = dims_create(dims, "tzyxc", sizes);
 
-  uint8_t ratios[] = { 1, 4, 4, 4, 0 };
+  int ratios[] = { 1, 4, 4, 4, 0 };
 
   return bench_two_streams_main(ac,
                                 av,

--- a/bench/bench_stream_256cube_two_streams.c
+++ b/bench/bench_stream_256cube_two_streams.c
@@ -9,8 +9,17 @@ main(int ac, char* av[])
   uint8_t rank = dims_create(dims, "tzyxc", sizes);
 
   uint8_t ratios[] = { 1, 4, 4, 4, 0 };
-  uint64_t shard_counts[] = { 16, 2, 2, 2, 1 };
 
-  return bench_two_streams_main(
-    ac, av, "two-streams", dims, rank, ratios, 1 << 18, shard_counts);
+  return bench_two_streams_main(ac,
+                                av,
+                                (struct bench_spec){
+                                  .label = "two-streams",
+                                  .dims = dims,
+                                  .rank = rank,
+                                  .chunk_ratios = ratios,
+                                  .default_chunk_bytes = 1 << 18,
+                                  .min_chunk_bytes = 1 << 14,
+                                  .min_shard_bytes = 1ull << 30,
+                                  .max_concurrent_shards = 8,
+                                });
 }

--- a/bench/bench_stream_256cube_two_streams.c
+++ b/bench/bench_stream_256cube_two_streams.c
@@ -20,6 +20,7 @@ main(int ac, char* av[])
                                   .default_chunk_bytes = 1 << 18,
                                   .min_chunk_bytes = 1 << 14,
                                   .min_shard_bytes = 1ull << 30,
-                                  .max_concurrent_shards = 8,
+                                  .max_concurrent_shards = 16,
+                                  .min_append_shards = 4,
                                 });
 }

--- a/bench/bench_stream_256cube_two_streams.c
+++ b/bench/bench_stream_256cube_two_streams.c
@@ -17,10 +17,10 @@ main(int ac, char* av[])
                                   .dims = dims,
                                   .rank = rank,
                                   .chunk_ratios = ratios,
-                                  .default_chunk_bytes = 1 << 18,
+                                  .target_chunk_bytes = 1 << 18,
                                   .min_chunk_bytes = 1 << 14,
                                   .min_shard_bytes = 1ull << 30,
-                                  .max_concurrent_shards = 16,
+                                  .target_concurrent_shards = 16,
                                   .min_append_shards = 4,
                                 });
 }

--- a/bench/bench_stream_medfmt_multiscale.c
+++ b/bench/bench_stream_medfmt_multiscale.c
@@ -10,7 +10,7 @@ main(int ac, char* av[])
 
   dims_set_downsample_by_name(dims, rank, "yx");
 
-  uint8_t ratios[] = { 1, 0, 4, 4 };
+  int ratios[] = { 1, 0, 4, 4 };
 
   return bench_stream_main(ac,
                            av,

--- a/bench/bench_stream_medfmt_multiscale.c
+++ b/bench/bench_stream_medfmt_multiscale.c
@@ -8,17 +8,19 @@ main(int ac, char* av[])
   uint64_t sizes[] = { 100, 1, 10240, 15360 };
   uint8_t rank = dims_create(dims, "zcyx", sizes);
 
+  dims_set_downsample_by_name(dims, rank, "yx");
+
   uint8_t ratios[] = { 1, 0, 4, 4 };
 
   return bench_stream_main(ac,
                            av,
                            (struct bench_spec){
-                             .label = "single",
+                             .label = "multiscale",
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
                              .default_chunk_bytes = 1 << 18,
-                             .min_chunk_bytes = 1 << 14,
+                             .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1ull << 30,
                              .max_concurrent_shards = 16,
                            });

--- a/bench/bench_stream_medfmt_multiscale.c
+++ b/bench/bench_stream_medfmt_multiscale.c
@@ -10,7 +10,7 @@ main(int ac, char* av[])
 
   dims_set_downsample_by_name(dims, rank, "yx");
 
-  int ratios[] = { 1, 0, 4, 4 };
+  int ratios[] = { 1, 0, 8, 8 };
 
   return bench_stream_main(ac,
                            av,
@@ -22,6 +22,7 @@ main(int ac, char* av[])
                              .default_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 16,
+                             .max_concurrent_shards = 20,
+                             .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_medfmt_multiscale.c
+++ b/bench/bench_stream_medfmt_multiscale.c
@@ -19,10 +19,10 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .default_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 20,
+                             .target_concurrent_shards = 20,
                              .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_medfmt_multiscale_dim0.c
+++ b/bench/bench_stream_medfmt_multiscale_dim0.c
@@ -8,12 +8,14 @@ main(int ac, char* av[])
   uint64_t sizes[] = { 100, 1, 10240, 15360 };
   uint8_t rank = dims_create(dims, "zcyx", sizes);
 
-  uint8_t ratios[] = { 1, 0, 4, 4 };
+  dims_set_downsample_by_name(dims, rank, "zyx");
+
+  uint8_t ratios[] = { 6, 0, 6, 6 };
 
   return bench_stream_main(ac,
                            av,
                            (struct bench_spec){
-                             .label = "single",
+                             .label = "multiscale_dim0",
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,

--- a/bench/bench_stream_medfmt_multiscale_dim0.c
+++ b/bench/bench_stream_medfmt_multiscale_dim0.c
@@ -10,7 +10,7 @@ main(int ac, char* av[])
 
   dims_set_downsample_by_name(dims, rank, "zyx");
 
-  int ratios[] = { 6, 0, 6, 6 };
+  int ratios[] = { 1, 0, 8, 8 };
 
   return bench_stream_main(ac,
                            av,
@@ -20,8 +20,9 @@ main(int ac, char* av[])
                              .rank = rank,
                              .chunk_ratios = ratios,
                              .default_chunk_bytes = 1 << 18,
-                             .min_chunk_bytes = 1 << 14,
+                             .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 16,
+                             .max_concurrent_shards = 20,
+                             .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_medfmt_multiscale_dim0.c
+++ b/bench/bench_stream_medfmt_multiscale_dim0.c
@@ -10,7 +10,7 @@ main(int ac, char* av[])
 
   dims_set_downsample_by_name(dims, rank, "zyx");
 
-  uint8_t ratios[] = { 6, 0, 6, 6 };
+  int ratios[] = { 6, 0, 6, 6 };
 
   return bench_stream_main(ac,
                            av,

--- a/bench/bench_stream_medfmt_multiscale_dim0.c
+++ b/bench/bench_stream_medfmt_multiscale_dim0.c
@@ -19,10 +19,10 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .default_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 20,
+                             .target_concurrent_shards = 20,
                              .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_medfmt_single.c
+++ b/bench/bench_stream_medfmt_single.c
@@ -8,7 +8,7 @@ main(int ac, char* av[])
   uint64_t sizes[] = { 100, 1, 10240, 15360 };
   uint8_t rank = dims_create(dims, "zcyx", sizes);
 
-  int ratios[] = { 1, 0, 4, 4 };
+  int ratios[] = { 1, 0, 8, 8 };
 
   return bench_stream_main(ac,
                            av,
@@ -18,8 +18,8 @@ main(int ac, char* av[])
                              .rank = rank,
                              .chunk_ratios = ratios,
                              .default_chunk_bytes = 1 << 18,
-                             .min_chunk_bytes = 1 << 14,
-                             .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 16,
+                             .min_chunk_bytes = 1 << 12,
+                             .min_shard_bytes = 1ull << 18,
+                             .max_concurrent_shards = 20,
                            });
 }

--- a/bench/bench_stream_medfmt_single.c
+++ b/bench/bench_stream_medfmt_single.c
@@ -8,7 +8,7 @@ main(int ac, char* av[])
   uint64_t sizes[] = { 100, 1, 10240, 15360 };
   uint8_t rank = dims_create(dims, "zcyx", sizes);
 
-  uint8_t ratios[] = { 1, 0, 4, 4 };
+  int ratios[] = { 1, 0, 4, 4 };
 
   return bench_stream_main(ac,
                            av,

--- a/bench/bench_stream_medfmt_single.c
+++ b/bench/bench_stream_medfmt_single.c
@@ -21,5 +21,6 @@ main(int ac, char* av[])
                              .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1ull << 18,
                              .max_concurrent_shards = 20,
+                             .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_medfmt_single.c
+++ b/bench/bench_stream_medfmt_single.c
@@ -19,7 +19,7 @@ main(int ac, char* av[])
                              .chunk_ratios = ratios,
                              .default_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 12,
-                             .min_shard_bytes = 1ull << 18,
+                             .min_shard_bytes = 1ull << 30,
                              .max_concurrent_shards = 20,
                              .min_append_shards = 4,
                            });

--- a/bench/bench_stream_medfmt_single.c
+++ b/bench/bench_stream_medfmt_single.c
@@ -17,10 +17,10 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .default_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 20,
+                             .target_concurrent_shards = 20,
                              .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_orca2_multiscale.c
+++ b/bench/bench_stream_orca2_multiscale.c
@@ -11,8 +11,17 @@ main(int ac, char* av[])
   dims_set_downsample_by_name(dims, rank, "yx");
 
   uint8_t ratios[] = { 1, 0, 2, 2 };
-  uint64_t shard_counts[] = { 2, 1, 2, 2 };
 
-  return bench_stream_main(
-    ac, av, "multiscale", dims, rank, ratios, 1 << 18, shard_counts);
+  return bench_stream_main(ac,
+                           av,
+                           (struct bench_spec){
+                             .label = "multiscale",
+                             .dims = dims,
+                             .rank = rank,
+                             .chunk_ratios = ratios,
+                             .default_chunk_bytes = 1 << 18,
+                             .min_chunk_bytes = 1 << 14,
+                             .min_shard_bytes = 1ull << 30,
+                             .max_concurrent_shards = 4,
+                           });
 }

--- a/bench/bench_stream_orca2_multiscale.c
+++ b/bench/bench_stream_orca2_multiscale.c
@@ -22,6 +22,7 @@ main(int ac, char* av[])
                              .default_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 4,
+                             .max_concurrent_shards = 16,
+                             .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_orca2_multiscale.c
+++ b/bench/bench_stream_orca2_multiscale.c
@@ -10,7 +10,7 @@ main(int ac, char* av[])
 
   dims_set_downsample_by_name(dims, rank, "yx");
 
-  uint8_t ratios[] = { 1, 0, 2, 2 };
+  int ratios[] = { 1, 0, 2, 2 };
 
   return bench_stream_main(ac,
                            av,

--- a/bench/bench_stream_orca2_multiscale.c
+++ b/bench/bench_stream_orca2_multiscale.c
@@ -19,10 +19,10 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .default_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 16,
+                             .target_concurrent_shards = 16,
                              .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_orca2_multiscale_dim0.c
+++ b/bench/bench_stream_orca2_multiscale_dim0.c
@@ -22,6 +22,7 @@ main(int ac, char* av[])
                              .default_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 20,
+                             .max_concurrent_shards = 16,
+                             .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_orca2_multiscale_dim0.c
+++ b/bench/bench_stream_orca2_multiscale_dim0.c
@@ -10,7 +10,7 @@ main(int ac, char* av[])
 
   dims_set_downsample_by_name(dims, rank, "tyx");
 
-  uint8_t ratios[] = { 6, 0, 6, 6 };
+  int ratios[] = { 6, 0, 6, 6 };
 
   return bench_stream_main(ac,
                            av,

--- a/bench/bench_stream_orca2_multiscale_dim0.c
+++ b/bench/bench_stream_orca2_multiscale_dim0.c
@@ -5,14 +5,23 @@ int
 main(int ac, char* av[])
 {
   struct dimension dims[4];
-  uint64_t sizes[] = { 10000, 2, 2048, 2304 };
+  uint64_t sizes[] = { 1000, 2, 2048, 2304 };
   uint8_t rank = dims_create(dims, "tcyx", sizes);
 
   dims_set_downsample_by_name(dims, rank, "tyx");
 
   uint8_t ratios[] = { 6, 0, 6, 6 };
-  uint64_t shard_counts[] = { 8, 1, 4, 4 };
 
-  return bench_stream_main(
-    ac, av, "multiscale_dim0", dims, rank, ratios, 1 << 18, shard_counts);
+  return bench_stream_main(ac,
+                           av,
+                           (struct bench_spec){
+                             .label = "multiscale_dim0",
+                             .dims = dims,
+                             .rank = rank,
+                             .chunk_ratios = ratios,
+                             .default_chunk_bytes = 1 << 18,
+                             .min_chunk_bytes = 1 << 14,
+                             .min_shard_bytes = 1ull << 30,
+                             .max_concurrent_shards = 16,
+                           });
 }

--- a/bench/bench_stream_orca2_multiscale_dim0.c
+++ b/bench/bench_stream_orca2_multiscale_dim0.c
@@ -10,7 +10,7 @@ main(int ac, char* av[])
 
   dims_set_downsample_by_name(dims, rank, "tyx");
 
-  int ratios[] = { 6, 0, 6, 6 };
+  int ratios[] = { 1, 0, 2, 2 };
 
   return bench_stream_main(ac,
                            av,
@@ -22,6 +22,6 @@ main(int ac, char* av[])
                              .default_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 16,
+                             .max_concurrent_shards = 20,
                            });
 }

--- a/bench/bench_stream_orca2_multiscale_dim0.c
+++ b/bench/bench_stream_orca2_multiscale_dim0.c
@@ -19,10 +19,10 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .default_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 16,
+                             .target_concurrent_shards = 16,
                              .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_orca2_single.c
+++ b/bench/bench_stream_orca2_single.c
@@ -8,7 +8,7 @@ main(int ac, char* av[])
   uint64_t sizes[] = { 1000, 2, 2048, 2304 };
   uint8_t rank = dims_create(dims, "tcyx", sizes);
 
-  uint8_t ratios[] = { 6, 0, 6, 6 };
+  int ratios[] = { 6, 0, 6, 6 };
 
   return bench_stream_main(ac,
                            av,

--- a/bench/bench_stream_orca2_single.c
+++ b/bench/bench_stream_orca2_single.c
@@ -5,12 +5,21 @@ int
 main(int ac, char* av[])
 {
   struct dimension dims[4];
-  uint64_t sizes[] = { 10000, 2, 2048, 2304 };
+  uint64_t sizes[] = { 1000, 2, 2048, 2304 };
   uint8_t rank = dims_create(dims, "tcyx", sizes);
 
   uint8_t ratios[] = { 6, 0, 6, 6 };
-  uint64_t shard_counts[] = { 16, 1, 4, 4 };
 
-  return bench_stream_main(
-    ac, av, "single", dims, rank, ratios, 1 << 18, shard_counts);
+  return bench_stream_main(ac,
+                           av,
+                           (struct bench_spec){
+                             .label = "single",
+                             .dims = dims,
+                             .rank = rank,
+                             .chunk_ratios = ratios,
+                             .default_chunk_bytes = 1 << 18,
+                             .min_chunk_bytes = 1 << 14,
+                             .min_shard_bytes = 1ull << 30,
+                             .max_concurrent_shards = 16,
+                           });
 }

--- a/bench/bench_stream_orca2_single.c
+++ b/bench/bench_stream_orca2_single.c
@@ -8,7 +8,7 @@ main(int ac, char* av[])
   uint64_t sizes[] = { 1000, 2, 2048, 2304 };
   uint8_t rank = dims_create(dims, "tcyx", sizes);
 
-  int ratios[] = { 6, 0, 6, 6 };
+  int ratios[] = { 1, 0, 2, 2 };
 
   return bench_stream_main(ac,
                            av,
@@ -21,5 +21,6 @@ main(int ac, char* av[])
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
                              .max_concurrent_shards = 16,
+                             .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_orca2_single.c
+++ b/bench/bench_stream_orca2_single.c
@@ -17,10 +17,10 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .default_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 18,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
-                             .max_concurrent_shards = 16,
+                             .target_concurrent_shards = 16,
                              .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_smallepoch_single.c
+++ b/bench/bench_stream_smallepoch_single.c
@@ -5,7 +5,7 @@ int
 main(int ac, char* av[])
 {
   struct dimension dims[3];
-  uint64_t sizes[] = { 65536, 16, 16 };
+  uint64_t sizes[] = { 1 << 24, 16, 16 };
   uint8_t rank = dims_create(dims, "tyx", sizes);
 
   uint8_t ratios[] = { 1, 0, 0 };
@@ -18,8 +18,8 @@ main(int ac, char* av[])
                              .rank = rank,
                              .chunk_ratios = ratios,
                              .default_chunk_bytes = 1 << 16,
-                             .min_chunk_bytes = 1 << 16,
-                             .min_shard_bytes = 1ull << 30,
+                             .min_chunk_bytes = 1 << 12,
+                             .min_shard_bytes = 1 << 16,
                              .max_concurrent_shards = 1,
                            });
 }

--- a/bench/bench_stream_smallepoch_single.c
+++ b/bench/bench_stream_smallepoch_single.c
@@ -9,8 +9,17 @@ main(int ac, char* av[])
   uint8_t rank = dims_create(dims, "tyx", sizes);
 
   uint8_t ratios[] = { 1, 0, 0 };
-  uint64_t shard_counts[] = { 64, 1, 1 };
 
-  return bench_stream_main(
-    ac, av, "single", dims, rank, ratios, 1 << 16, shard_counts);
+  return bench_stream_main(ac,
+                           av,
+                           (struct bench_spec){
+                             .label = "single",
+                             .dims = dims,
+                             .rank = rank,
+                             .chunk_ratios = ratios,
+                             .default_chunk_bytes = 1 << 16,
+                             .min_chunk_bytes = 1 << 16,
+                             .min_shard_bytes = 1ull << 30,
+                             .max_concurrent_shards = 1,
+                           });
 }

--- a/bench/bench_stream_smallepoch_single.c
+++ b/bench/bench_stream_smallepoch_single.c
@@ -8,7 +8,7 @@ main(int ac, char* av[])
   uint64_t sizes[] = { 1 << 24, 16, 16 };
   uint8_t rank = dims_create(dims, "tyx", sizes);
 
-  uint8_t ratios[] = { 1, 0, 0 };
+  int ratios[] = { 1, -1, -1 };
 
   return bench_stream_main(ac,
                            av,

--- a/bench/bench_stream_smallepoch_single.c
+++ b/bench/bench_stream_smallepoch_single.c
@@ -21,5 +21,6 @@ main(int ac, char* av[])
                              .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1 << 16,
                              .max_concurrent_shards = 1,
+                             .min_append_shards = 4,
                            });
 }

--- a/bench/bench_stream_smallepoch_single.c
+++ b/bench/bench_stream_smallepoch_single.c
@@ -17,10 +17,10 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .default_chunk_bytes = 1 << 16,
+                             .target_chunk_bytes = 1 << 16,
                              .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1 << 16,
-                             .max_concurrent_shards = 1,
+                             .target_concurrent_shards = 1,
                              .min_append_shards = 4,
                            });
 }

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -250,6 +250,33 @@ print_advise_failure(const struct advise_layout_diagnostic* diag,
   }
 }
 
+// Print aggregate shard geometry: uncompressed bytes per shard (append-outer
+// close), total shards. Complements dims_print, which shows per-dim values.
+static void
+print_shard_summary(const struct dimension* dims,
+                    uint8_t rank,
+                    size_t bytes_per_element)
+{
+  uint64_t chunk_elements = 1;
+  uint64_t cps_total = 1;
+  uint64_t total_shards = 1;
+  for (uint8_t d = 0; d < rank; ++d) {
+    chunk_elements *= dims[d].chunk_size;
+    uint64_t tc = ceildiv(dims[d].size, dims[d].chunk_size);
+    uint64_t cps = dims[d].chunks_per_shard ? dims[d].chunks_per_shard : tc;
+    cps_total *= cps;
+    total_shards *= tc ? ceildiv(tc, cps) : 1;
+  }
+  const uint64_t chunk_bytes = chunk_elements * bytes_per_element;
+  const uint64_t shard_bytes = chunk_bytes * cps_total;
+  char buf[32];
+  format_bytes(buf, sizeof(buf), shard_bytes);
+  print_report("  shard:       %s uncompressed (%llu chunks), %llu total",
+               buf,
+               (unsigned long long)cps_total,
+               (unsigned long long)total_shards);
+}
+
 // --- Fill-pattern init (deferred until after chunk-fit succeeds) ---
 //
 // Pattern buffers can be several GiB for large arrays; initializing them in
@@ -307,6 +334,7 @@ run_bench(const struct bench_config* cfg)
     return 1;
 
   dims_print(dims, rank);
+  print_shard_summary(dims, rank, dtype_bpe(dtype));
 
   init_fill_pattern(fill, dims, rank);
 
@@ -802,6 +830,7 @@ run_bench_two_streams(const struct bench_config* cfg)
     return 1;
 
   dims_print(dims, rank);
+  print_shard_summary(dims, rank, dtype_bpe(dtype));
 
   init_fill_pattern(fill, dims, rank);
 

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -505,137 +505,18 @@ run_bench(const struct bench_config* cfg)
                        pending_bytes);
 
     if (cfg->json_output) {
-      const size_t chunk_bytes = layout->chunk_stride * dtype_bpe(dtype);
-      const size_t num_epochs =
-        (total_elements + layout->epoch_elements - 1) / layout->epoch_elements;
-      const uint64_t chunks_per_epoch =
-        ss.total_chunks ? ss.total_chunks : layout->chunks_per_epoch;
-      const size_t total_chunks = num_epochs * chunks_per_epoch;
-      const size_t total_decompressed = total_chunks * chunk_bytes;
-      const double comp_fold =
-        ss.total_bytes > 0 ? (double)total_decompressed / (double)ss.total_bytes
-                           : 0.0;
-      const double GIB = 1024.0 * 1024.0 * 1024.0;
-      double input_gib = (double)total_bytes / GIB;
-      double compressed_gib = (double)ss.total_bytes / GIB;
-      double throughput_gib = wall_s > 0 ? input_gib / wall_s : 0.0;
-      double throughput_out_gib = wall_s > 0 ? compressed_gib / wall_s : 0.0;
-
-      char json_buf[8192];
-      struct json_writer jw;
-      jw_init(&jw, json_buf, sizeof(json_buf));
-
-      jw_object_begin(&jw);
-      jw_key(&jw, "status");
-      jw_string(&jw, "pass");
-      jw_key(&jw, "throughput_in_gibs");
-      jw_float(&jw, throughput_gib);
-      jw_key(&jw, "throughput_out_gibs");
-      jw_float(&jw, throughput_out_gib);
-      jw_key(&jw, "compression_fold");
-      jw_float(&jw, comp_fold);
-      jw_key(&jw, "input_gib");
-      jw_float(&jw, input_gib);
-      jw_key(&jw, "compressed_gib");
-      jw_float(&jw, compressed_gib);
-      jw_key(&jw, "total_chunks");
-      jw_uint(&jw, total_chunks);
-      jw_key(&jw, "chunks_per_epoch");
-      jw_uint(&jw, chunks_per_epoch);
-      jw_key(&jw, "wall_s");
-      jw_float(&jw, (double)wall_s);
-      jw_key(&jw, "init_s");
-      jw_float(&jw, (double)init_s);
-      jw_key(&jw, "flush_s");
-      jw_float(&jw, (double)flush_s);
-
-      // Per-stage metrics
-      jw_key(&jw, "stages");
-      jw_object_begin(&jw);
-      const char* stage_names[] = {
-        "memcpy",           "h2d",
-        "scatter",          "lod_gather",
-        "lod_reduce",       "lod_append_fold",
-        "lod_morton_chunk", "compress",
-        "aggregate",        "d2h",
-      };
-      const struct stream_metric* stage_ptrs[] = {
-        &m.memcpy,           &m.h2d,
-        &m.scatter,          &m.lod_gather,
-        &m.lod_reduce,       &m.lod_append_fold,
-        &m.lod_morton_chunk, &m.compress,
-        &m.aggregate,        &m.d2h,
-      };
-      int nstages = sizeof(stage_ptrs) / sizeof(stage_ptrs[0]);
-      for (int si = 0; si < nstages; ++si) {
-        if (stage_ptrs[si]->count <= 0)
-          continue;
-        const struct stream_metric* sm = stage_ptrs[si];
-        double avg_ms = (double)sm->ms / sm->count;
-        double in_gibs = gb_per_s(sm->input_bytes, (double)sm->ms);
-        double out_gibs = gb_per_s(sm->output_bytes, (double)sm->ms);
-        jw_key(&jw, stage_names[si]);
-        jw_object_begin(&jw);
-        jw_key(&jw, "avg_ms");
-        jw_float(&jw, avg_ms);
-        if (sm->best_ms < 1e29f) {
-          jw_key(&jw, "best_ms");
-          jw_float(&jw, (double)sm->best_ms);
-        }
-        jw_key(&jw, "in_gibs");
-        jw_float(&jw, in_gibs);
-        jw_key(&jw, "out_gibs");
-        jw_float(&jw, out_gibs);
-        jw_object_end(&jw);
-      }
-      if (meter.metric.count > 0) {
-        const struct stream_metric* sm = &meter.metric;
-        double avg_ms = (double)sm->ms / sm->count;
-        double in_gibs = gb_per_s(sm->input_bytes, (double)sm->ms);
-        double out_gibs = gb_per_s(sm->output_bytes, (double)sm->ms);
-        jw_key(&jw, "sink");
-        jw_object_begin(&jw);
-        jw_key(&jw, "avg_ms");
-        jw_float(&jw, avg_ms);
-        if (sm->best_ms < 1e29f) {
-          jw_key(&jw, "best_ms");
-          jw_float(&jw, (double)sm->best_ms);
-        }
-        jw_key(&jw, "in_gibs");
-        jw_float(&jw, in_gibs);
-        jw_key(&jw, "out_gibs");
-        jw_float(&jw, out_gibs);
-        jw_object_end(&jw);
-      }
-      jw_object_end(&jw); // stages
-
-      // Stall metrics — total wall-clock ms blocked at each sync point.
-      jw_key(&jw, "stalls");
-      jw_object_begin(&jw);
-      jw_key(&jw, "flush_stall_ms");
-      jw_float(&jw, (double)m.flush_stall.ms);
-      jw_key(&jw, "flush_stall_count");
-      jw_uint(&jw, (uint64_t)m.flush_stall.count);
-      jw_key(&jw, "kick_sync_ms");
-      jw_float(&jw, (double)m.kick_sync_stall.ms);
-      jw_key(&jw, "kick_sync_count");
-      jw_uint(&jw, (uint64_t)m.kick_sync_stall.count);
-      jw_key(&jw, "io_fence_ms");
-      jw_float(&jw, (double)m.io_fence_stall.ms);
-      jw_key(&jw, "io_fence_count");
-      jw_uint(&jw, (uint64_t)m.io_fence_stall.count);
-      jw_key(&jw, "backpressure_ms");
-      jw_float(&jw, (double)m.backpressure.ms);
-      jw_key(&jw, "backpressure_count");
-      jw_uint(&jw, (uint64_t)m.backpressure.count);
-      jw_key(&jw, "max_append_ms");
-      jw_float(&jw, (double)m.max_append_ms);
-      jw_key(&jw, "peak_pending_mib");
-      jw_float(&jw, (double)m.peak_pending_bytes / (1024.0 * 1024.0));
-      jw_object_end(&jw); // stalls
-
-      jw_object_end(&jw); // root
-      printf("%.*s\n", (int)jw_length(&jw), json_buf);
+      const struct stream_metric* sink_metric =
+        meter.metric.count > 0 ? &meter.metric : NULL;
+      print_bench_json_pass(&m,
+                            sink_metric,
+                            layout,
+                            config.dtype,
+                            &ss,
+                            total_bytes,
+                            total_elements,
+                            wall_s,
+                            init_s,
+                            flush_s);
     }
   }
 
@@ -644,16 +525,8 @@ run_bench(const struct bench_config* cfg)
   goto Cleanup;
 
 Fail:
-  if (cfg->json_output) {
-    char err_buf[64];
-    struct json_writer ejw;
-    jw_init(&ejw, err_buf, sizeof(err_buf));
-    jw_object_begin(&ejw);
-    jw_key(&ejw, "status");
-    jw_string(&ejw, "error");
-    jw_object_end(&ejw);
-    printf("%.*s\n", (int)jw_length(&ejw), err_buf);
-  }
+  if (cfg->json_output)
+    print_bench_json_error();
   print_report("  FAIL");
   rc = 1;
 

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -78,6 +78,61 @@ bench_destroy(struct bench_handle* h)
     tile_stream_gpu_destroy(h->gpu);
 }
 
+// Emit a reason-specific explanation after advise_layout fails.
+static void
+print_advise_failure(const struct advise_layout_diagnostic* diag,
+                     size_t budget,
+                     size_t min_shard_bytes)
+{
+  char budget_buf[32], shard_buf[32], chunk_buf[32], dev_buf[32];
+  format_bytes(budget_buf, sizeof(budget_buf), budget);
+  format_bytes(shard_buf, sizeof(shard_buf), min_shard_bytes);
+  format_bytes(chunk_buf, sizeof(chunk_buf), diag->chunk_bytes);
+  format_bytes(dev_buf, sizeof(dev_buf), diag->device_bytes);
+
+  switch (diag->reason) {
+    case ADVISE_BUDGET_EXCEEDED:
+      print_report(
+        "  auto-fit: ERROR -- memory budget exceeded at floor chunk size");
+      print_report("    needed %s at chunk=%s, K=%u; budget=%s",
+                   dev_buf,
+                   chunk_buf,
+                   diag->epochs_per_batch,
+                   budget_buf);
+      print_report(
+        "    fix: raise memory_budget, lower min_chunk_bytes, or simplify "
+        "codec/LOD");
+      break;
+    case ADVISE_PARTS_LIMIT_EXCEEDED:
+      print_report("  auto-fit: ERROR -- %llu chunks per shard exceeds backend "
+                   "limit of %llu",
+                   (unsigned long long)diag->chunks_per_shard_total,
+                   (unsigned long long)diag->parts_limit);
+      print_report("    at chunk=%s, min_shard_bytes=%s", chunk_buf, shard_buf);
+      print_report(
+        "    fix: lower min_shard_bytes, raise max_concurrent_shards, "
+        "or lower min_chunk_bytes");
+      break;
+    case ADVISE_MIN_SHARD_TOO_SMALL:
+      print_report(
+        "  auto-fit: ERROR -- min_shard_bytes (%s) is smaller than one chunk "
+        "(%s)",
+        shard_buf,
+        chunk_buf);
+      print_report("    fix: raise min_shard_bytes or lower target chunk size");
+      break;
+    case ADVISE_INVALID_CONFIG:
+      print_report(
+        "  auto-fit: ERROR -- invalid configuration rejected by memory "
+        "estimate");
+      break;
+    default:
+      print_report("  auto-fit: ERROR -- unknown failure (reason=%d)",
+                   (int)diag->reason);
+      break;
+  }
+}
+
 // --- Fill-pattern init (deferred until after chunk-fit succeeds) ---
 //
 // Pattern buffers can be several GiB for large arrays; initializing them in
@@ -128,6 +183,7 @@ run_bench(const struct bench_config* cfg)
   }
 
   const enum dtype dtype = cfg->dtype ? cfg->dtype : dtype_u16;
+  uint8_t chosen_epochs_per_batch = 0; // 0 = auto; set by advise_layout on fit
 
   // --- Chunk sizing ---
   if (cfg->chunk_ratios) {
@@ -175,6 +231,7 @@ run_bench(const struct bench_config* cfg)
         .target_batch_chunks = 2048,
       };
       int advise_ok;
+      struct advise_layout_diagnostic diag = { 0 };
       if (cfg->backend == BENCH_GPU) {
         advise_ok = tile_stream_gpu_advise_layout(&fit_config,
                                                   target,
@@ -183,7 +240,8 @@ run_bench(const struct bench_config* cfg)
                                                   budget,
                                                   cfg->min_shard_bytes,
                                                   cfg->max_concurrent_shards,
-                                                  0);
+                                                  0,
+                                                  &diag);
       } else {
         advise_ok = tile_stream_cpu_advise_layout(&fit_config,
                                                   target,
@@ -192,25 +250,20 @@ run_bench(const struct bench_config* cfg)
                                                   budget,
                                                   cfg->min_shard_bytes,
                                                   cfg->max_concurrent_shards,
-                                                  0);
+                                                  0,
+                                                  &diag);
       }
       if (advise_ok == 0) {
         fitted = 1;
+        chosen_epochs_per_batch = fit_config.epochs_per_batch;
         uint64_t vol = 1;
         for (uint8_t d = 0; d < rank; ++d)
           vol *= dims[d].chunk_size;
-        print_report("  auto-fit: %zu bytes/chunk",
-                     (size_t)(vol * bytes_per_element));
+        print_report("  auto-fit: %zu bytes/chunk (batch=%u)",
+                     (size_t)(vol * bytes_per_element),
+                     (unsigned)chosen_epochs_per_batch);
       } else {
-        char budget_buf[32], shard_buf[32];
-        format_bytes(budget_buf, sizeof(budget_buf), budget);
-        format_bytes(shard_buf, sizeof(shard_buf), cfg->min_shard_bytes);
-        print_report(
-          "  auto-fit: ERROR -- no chunk size >= %zu bytes fits in budget "
-          "(%s) with min_shard_bytes=%s",
-          cfg->min_chunk_bytes ? cfg->min_chunk_bytes : bytes_per_element,
-          budget_buf,
-          shard_buf);
+        print_advise_failure(&diag, budget, cfg->min_shard_bytes);
         return 1;
       }
     }
@@ -295,6 +348,7 @@ run_bench(const struct bench_config* cfg)
     .codec = cfg->codec,
     .reduce_method = cfg->reduce_method,
     .append_reduce_method = cfg->append_reduce_method,
+    .epochs_per_batch = chosen_epochs_per_batch,
     .target_batch_chunks = 2048,
     .backpressure_bytes = cfg->backpressure_bytes,
   };
@@ -818,6 +872,7 @@ run_bench_two_streams(const struct bench_config* cfg)
 
   const enum dtype dtype = cfg->dtype ? cfg->dtype : dtype_u16;
   const size_t bpe = dtype_bpe(dtype);
+  uint8_t chosen_epochs_per_batch = 0; // 0 = auto; set by advise_layout on fit
 
   // --- Chunk sizing (shared config, applied once) ---
   if (cfg->chunk_ratios) {
@@ -850,6 +905,7 @@ run_bench_two_streams(const struct bench_config* cfg)
 
     int fitted = 0;
     if (budget > 0) {
+      struct advise_layout_diagnostic diag = { 0 };
       fitted = tile_stream_gpu_advise_layout(&fit_config,
                                              target,
                                              cfg->min_chunk_bytes,
@@ -857,22 +913,18 @@ run_bench_two_streams(const struct bench_config* cfg)
                                              budget,
                                              cfg->min_shard_bytes,
                                              cfg->max_concurrent_shards,
-                                             0) == 0;
+                                             0,
+                                             &diag) == 0;
       if (fitted) {
+        chosen_epochs_per_batch = fit_config.epochs_per_batch;
         uint64_t vol = 1;
         for (uint8_t d = 0; d < rank; ++d)
           vol *= dims[d].chunk_size;
-        print_report("  auto-fit: %zu bytes/chunk", (size_t)(vol * bpe));
+        print_report("  auto-fit: %zu bytes/chunk (batch=%u)",
+                     (size_t)(vol * bpe),
+                     (unsigned)chosen_epochs_per_batch);
       } else {
-        char budget_buf[32], shard_buf[32];
-        format_bytes(budget_buf, sizeof(budget_buf), budget);
-        format_bytes(shard_buf, sizeof(shard_buf), cfg->min_shard_bytes);
-        print_report(
-          "  auto-fit: ERROR -- no chunk size >= %zu bytes fits in budget "
-          "(%s) with min_shard_bytes=%s",
-          cfg->min_chunk_bytes ? cfg->min_chunk_bytes : bpe,
-          budget_buf,
-          shard_buf);
+        print_advise_failure(&diag, budget, cfg->min_shard_bytes);
         return 1;
       }
     }
@@ -953,6 +1005,7 @@ run_bench_two_streams(const struct bench_config* cfg)
     .codec = cfg->codec,
     .reduce_method = cfg->reduce_method,
     .append_reduce_method = cfg->append_reduce_method,
+    .epochs_per_batch = chosen_epochs_per_batch,
     .target_batch_chunks = 2048,
     .backpressure_bytes = cfg->backpressure_bytes,
   };

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -656,7 +656,7 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
   const char* label = spec.label;
   struct dimension* dims = spec.dims;
   uint8_t rank = spec.rank;
-  const uint8_t* chunk_ratios = spec.chunk_ratios;
+  const int* chunk_ratios = spec.chunk_ratios;
   size_t default_chunk_bytes = spec.default_chunk_bytes;
   size_t min_chunk_bytes = spec.min_chunk_bytes;
   size_t min_shard_bytes = spec.min_shard_bytes;
@@ -1181,7 +1181,7 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
   const char* label = spec.label;
   struct dimension* dims = spec.dims;
   uint8_t rank = spec.rank;
-  const uint8_t* chunk_ratios = spec.chunk_ratios;
+  const int* chunk_ratios = spec.chunk_ratios;
   size_t default_chunk_bytes = spec.default_chunk_bytes;
   size_t min_chunk_bytes = spec.min_chunk_bytes;
   size_t min_shard_bytes = spec.min_shard_bytes;

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -152,6 +152,7 @@ resolve_chunk_sizing(const struct bench_config* cfg,
                                                 budget,
                                                 cfg->min_shard_bytes,
                                                 cfg->max_concurrent_shards,
+                                                cfg->min_append_shards,
                                                 0,
                                                 &diag);
     } else {
@@ -162,6 +163,7 @@ resolve_chunk_sizing(const struct bench_config* cfg,
                                                 budget,
                                                 cfg->min_shard_bytes,
                                                 cfg->max_concurrent_shards,
+                                                cfg->min_append_shards,
                                                 0,
                                                 &diag);
     }
@@ -187,6 +189,7 @@ resolve_chunk_sizing(const struct bench_config* cfg,
                               rank,
                               cfg->min_shard_bytes,
                               cfg->max_concurrent_shards,
+                              cfg->min_append_shards,
                               bytes_per_element)) {
     print_report(
       "  shard geometry: ERROR -- min_shard_bytes is smaller than one chunk");
@@ -730,6 +733,7 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
     .memory_budget = a.memory_budget,
     .min_shard_bytes = spec.min_shard_bytes,
     .max_concurrent_shards = spec.max_concurrent_shards,
+    .min_append_shards = spec.min_append_shards,
     .json_output = a.json_output,
     .io_bw_mbps = a.io_bw_mbps,
     .io_latency_us = a.io_latency_us,
@@ -1099,6 +1103,7 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
     .memory_budget = a.memory_budget,
     .min_shard_bytes = spec.min_shard_bytes,
     .max_concurrent_shards = spec.max_concurrent_shards,
+    .min_append_shards = spec.min_append_shards,
     .io_bw_mbps = a.io_bw_mbps,
     .io_latency_us = a.io_latency_us,
     .backpressure_bytes = a.backpressure_bytes,

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -671,80 +671,100 @@ Cleanup:
 
 // --- CLI driver ---
 
-int
-bench_stream_main(int ac, char* av[], struct bench_spec spec)
+struct bench_cli_args
 {
-  const char* label = spec.label;
-  struct dimension* dims = spec.dims;
-  uint8_t rank = spec.rank;
-  const int* chunk_ratios = spec.chunk_ratios;
-  size_t default_chunk_bytes = spec.default_chunk_bytes;
-  size_t min_chunk_bytes = spec.min_chunk_bytes;
-  size_t min_shard_bytes = spec.min_shard_bytes;
-  uint32_t max_concurrent_shards = spec.max_concurrent_shards;
+  fill_fn fill;
+  struct codec_config codec;
+  enum lod_reduce_method reduce;
+  enum bench_backend backend;
+  enum dtype dtype;
+  size_t target_chunk_bytes;
+  size_t memory_budget;
+  uint64_t frames;
+  int json_output;
+  const char* output_path;
+  const char* s3_bucket;
+  const char* s3_prefix;
+  const char* s3_region;
+  const char* s3_endpoint;
+  double s3_throughput_gbps;
+  uint64_t io_bw_mbps;
+  uint64_t io_latency_us;
+  size_t backpressure_bytes;
+};
 
-  fill_fn fill = fill_xor;
-  struct codec_config codec = { .id = CODEC_ZSTD };
-  enum lod_reduce_method reduce = lod_reduce_mean;
-  const char* output_path = NULL;
-  const char* s3_bucket = NULL;
-  const char* s3_prefix = NULL;
-  const char* s3_region = NULL;
-  const char* s3_endpoint = NULL;
-  double s3_throughput_gbps = 0;
-  enum bench_backend backend = BENCH_GPU;
-  enum dtype dtype = dtype_u16;
-  size_t target_chunk_bytes = 0;
-  size_t memory_budget = 0;
-  uint64_t frames = 0;
-  int json_output = 0;
-  uint64_t io_bw_mbps = 0;
-  uint64_t io_latency_us = 0;
-  size_t backpressure_bytes = 0;
+// Parse the shared bench CLI flags into out. Unknown options print a usage
+// string and return 1. Flags accepted:
+//   --fill --codec --reduce --backend --dtype --frames --json --chunk-bytes
+//   --memory-budget -o --s3-bucket --s3-prefix --s3-region --s3-endpoint
+//   --s3-throughput-gbps --io-bw-mbps --io-latency-us --backpressure.
+// Drivers that don't honor a given flag (e.g. two-streams ignores --backend)
+// just don't read the corresponding field afterward.
+static int
+parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
+{
+  out->fill = fill_xor;
+  out->codec = (struct codec_config){ .id = CODEC_ZSTD };
+  out->reduce = lod_reduce_mean;
+  out->backend = BENCH_GPU;
+  out->dtype = dtype_u16;
+  out->target_chunk_bytes = 0;
+  out->memory_budget = 0;
+  out->frames = 0;
+  out->json_output = 0;
+  out->output_path = NULL;
+  out->s3_bucket = NULL;
+  out->s3_prefix = NULL;
+  out->s3_region = NULL;
+  out->s3_endpoint = NULL;
+  out->s3_throughput_gbps = 0;
+  out->io_bw_mbps = 0;
+  out->io_latency_us = 0;
+  out->backpressure_bytes = 0;
 
   for (int i = 1; i < ac; ++i) {
     if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
-      fill = parse_fill(av[++i]);
-      if (!fill)
+      out->fill = parse_fill(av[++i]);
+      if (!out->fill)
         return 1;
     } else if (strcmp(av[i], "--codec") == 0 && i + 1 < ac) {
-      if (!parse_codec(av[++i], &codec))
+      if (!parse_codec(av[++i], &out->codec))
         return 1;
     } else if (strcmp(av[i], "--reduce") == 0 && i + 1 < ac) {
-      if (!parse_reduce(av[++i], &reduce))
+      if (!parse_reduce(av[++i], &out->reduce))
         return 1;
     } else if (strcmp(av[i], "--backend") == 0 && i + 1 < ac) {
-      if (!parse_backend(av[++i], &backend))
+      if (!parse_backend(av[++i], &out->backend))
         return 1;
     } else if (strcmp(av[i], "--dtype") == 0 && i + 1 < ac) {
-      if (!parse_dtype(av[++i], &dtype))
+      if (!parse_dtype(av[++i], &out->dtype))
         return 1;
     } else if (strcmp(av[i], "--frames") == 0 && i + 1 < ac) {
-      frames = (uint64_t)strtoull(av[++i], NULL, 10);
+      out->frames = (uint64_t)strtoull(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--json") == 0) {
-      json_output = 1;
+      out->json_output = 1;
     } else if (strcmp(av[i], "--chunk-bytes") == 0 && i + 1 < ac) {
-      target_chunk_bytes = parse_bytes(av[++i]);
+      out->target_chunk_bytes = parse_bytes(av[++i]);
     } else if (strcmp(av[i], "--memory-budget") == 0 && i + 1 < ac) {
-      memory_budget = parse_bytes(av[++i]);
+      out->memory_budget = parse_bytes(av[++i]);
     } else if (strcmp(av[i], "-o") == 0 && i + 1 < ac) {
-      output_path = av[++i];
+      out->output_path = av[++i];
     } else if (strcmp(av[i], "--s3-bucket") == 0 && i + 1 < ac) {
-      s3_bucket = av[++i];
+      out->s3_bucket = av[++i];
     } else if (strcmp(av[i], "--s3-prefix") == 0 && i + 1 < ac) {
-      s3_prefix = av[++i];
+      out->s3_prefix = av[++i];
     } else if (strcmp(av[i], "--s3-region") == 0 && i + 1 < ac) {
-      s3_region = av[++i];
+      out->s3_region = av[++i];
     } else if (strcmp(av[i], "--s3-endpoint") == 0 && i + 1 < ac) {
-      s3_endpoint = av[++i];
+      out->s3_endpoint = av[++i];
     } else if (strcmp(av[i], "--s3-throughput-gbps") == 0 && i + 1 < ac) {
-      s3_throughput_gbps = strtod(av[++i], NULL);
+      out->s3_throughput_gbps = strtod(av[++i], NULL);
     } else if (strcmp(av[i], "--io-bw-mbps") == 0 && i + 1 < ac) {
-      io_bw_mbps = strtoull(av[++i], NULL, 10);
+      out->io_bw_mbps = strtoull(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--io-latency-us") == 0 && i + 1 < ac) {
-      io_latency_us = strtoull(av[++i], NULL, 10);
+      out->io_latency_us = strtoull(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--backpressure") == 0 && i + 1 < ac) {
-      backpressure_bytes = parse_bytes(av[++i]);
+      out->backpressure_bytes = parse_bytes(av[++i]);
     } else {
       fprintf(stderr, "Unknown option: %s\n", av[i]);
       fprintf(stderr,
@@ -760,15 +780,24 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
       return 1;
     }
   }
+  return 0;
+}
 
-  // Override frame count (dim 0 size) if requested
-  if (frames > 0)
-    dims[0].size = frames;
+int
+bench_stream_main(int ac, char* av[], struct bench_spec spec)
+{
+  struct bench_cli_args a;
+  if (parse_bench_cli_args(ac, av, &a))
+    return 1;
+
+  struct dimension* dims = spec.dims;
+  if (a.frames > 0)
+    dims[0].size = a.frames;
 
   int ecode = 0;
   CUcontext ctx = 0;
 
-  if (backend == BENCH_GPU) {
+  if (a.backend == BENCH_GPU) {
     CUdevice dev;
     CU(Fail, cuInit(0));
     CU(Fail, cuDeviceGet(&dev, 0));
@@ -776,44 +805,44 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
   }
 
   struct bench_config cfg = {
-    .label = label,
+    .label = spec.label,
     .dims = dims,
-    .rank = rank,
-    .fill = fill,
-    .output_path = output_path,
-    .array_name = label,
-    .s3_bucket = s3_bucket,
-    .s3_prefix = s3_prefix,
-    .s3_region = s3_region,
-    .s3_endpoint = s3_endpoint,
-    .s3_throughput_gbps = s3_throughput_gbps,
-    .codec = codec,
-    .reduce_method = reduce,
+    .rank = spec.rank,
+    .fill = a.fill,
+    .output_path = a.output_path,
+    .array_name = spec.label,
+    .s3_bucket = a.s3_bucket,
+    .s3_prefix = a.s3_prefix,
+    .s3_region = a.s3_region,
+    .s3_endpoint = a.s3_endpoint,
+    .s3_throughput_gbps = a.s3_throughput_gbps,
+    .codec = a.codec,
+    .reduce_method = a.reduce,
     .append_reduce_method =
-      reduce == lod_reduce_median ? lod_reduce_max : reduce,
-    .backend = backend,
-    .dtype = dtype,
-    .chunk_ratios = chunk_ratios,
+      a.reduce == lod_reduce_median ? lod_reduce_max : a.reduce,
+    .backend = a.backend,
+    .dtype = a.dtype,
+    .chunk_ratios = spec.chunk_ratios,
     .target_chunk_bytes =
-      target_chunk_bytes ? target_chunk_bytes : default_chunk_bytes,
-    .min_chunk_bytes = min_chunk_bytes,
-    .memory_budget = memory_budget,
-    .min_shard_bytes = min_shard_bytes,
-    .max_concurrent_shards = max_concurrent_shards,
-    .json_output = json_output,
-    .io_bw_mbps = io_bw_mbps,
-    .io_latency_us = io_latency_us,
-    .backpressure_bytes = backpressure_bytes,
+      a.target_chunk_bytes ? a.target_chunk_bytes : spec.default_chunk_bytes,
+    .min_chunk_bytes = spec.min_chunk_bytes,
+    .memory_budget = a.memory_budget,
+    .min_shard_bytes = spec.min_shard_bytes,
+    .max_concurrent_shards = spec.max_concurrent_shards,
+    .json_output = a.json_output,
+    .io_bw_mbps = a.io_bw_mbps,
+    .io_latency_us = a.io_latency_us,
+    .backpressure_bytes = a.backpressure_bytes,
   };
   ecode = run_bench(&cfg);
 
-  if (backend == BENCH_GPU)
+  if (a.backend == BENCH_GPU)
     cuCtxDestroy(ctx);
   return ecode;
 
 Fail:
   printf("FAIL\n");
-  if (backend == BENCH_GPU)
+  if (a.backend == BENCH_GPU)
     cuCtxDestroy(ctx);
   return 1;
 }
@@ -1134,71 +1163,13 @@ Fail:
 int
 bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
 {
-  const char* label = spec.label;
+  struct bench_cli_args a;
+  if (parse_bench_cli_args(ac, av, &a))
+    return 1;
+
   struct dimension* dims = spec.dims;
-  uint8_t rank = spec.rank;
-  const int* chunk_ratios = spec.chunk_ratios;
-  size_t default_chunk_bytes = spec.default_chunk_bytes;
-  size_t min_chunk_bytes = spec.min_chunk_bytes;
-  size_t min_shard_bytes = spec.min_shard_bytes;
-  uint32_t max_concurrent_shards = spec.max_concurrent_shards;
-
-  fill_fn fill = fill_xor;
-  struct codec_config codec = { .id = CODEC_ZSTD };
-  enum lod_reduce_method reduce = lod_reduce_mean;
-  enum dtype dtype = dtype_u16;
-  size_t target_chunk_bytes = 0;
-  size_t memory_budget = 0;
-  uint64_t frames = 0;
-  const char* output_path = NULL;
-  uint64_t io_bw_mbps = 0;
-  uint64_t io_latency_us = 0;
-  size_t backpressure_bytes = 0;
-
-  for (int i = 1; i < ac; ++i) {
-    if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
-      fill = parse_fill(av[++i]);
-      if (!fill)
-        return 1;
-    } else if (strcmp(av[i], "--codec") == 0 && i + 1 < ac) {
-      if (!parse_codec(av[++i], &codec))
-        return 1;
-    } else if (strcmp(av[i], "--reduce") == 0 && i + 1 < ac) {
-      if (!parse_reduce(av[++i], &reduce))
-        return 1;
-    } else if (strcmp(av[i], "--dtype") == 0 && i + 1 < ac) {
-      if (!parse_dtype(av[++i], &dtype))
-        return 1;
-    } else if (strcmp(av[i], "--frames") == 0 && i + 1 < ac) {
-      frames = (uint64_t)strtoull(av[++i], NULL, 10);
-    } else if (strcmp(av[i], "--chunk-bytes") == 0 && i + 1 < ac) {
-      target_chunk_bytes = parse_bytes(av[++i]);
-    } else if (strcmp(av[i], "--memory-budget") == 0 && i + 1 < ac) {
-      memory_budget = parse_bytes(av[++i]);
-    } else if (strcmp(av[i], "-o") == 0 && i + 1 < ac) {
-      output_path = av[++i];
-    } else if (strcmp(av[i], "--io-bw-mbps") == 0 && i + 1 < ac) {
-      io_bw_mbps = strtoull(av[++i], NULL, 10);
-    } else if (strcmp(av[i], "--io-latency-us") == 0 && i + 1 < ac) {
-      io_latency_us = strtoull(av[++i], NULL, 10);
-    } else if (strcmp(av[i], "--backpressure") == 0 && i + 1 < ac) {
-      backpressure_bytes = parse_bytes(av[++i]);
-    } else {
-      fprintf(stderr, "Unknown option: %s\n", av[i]);
-      fprintf(stderr,
-              "Usage: %s [--fill xor|zeros|rand] [--codec none|lz4|zstd] "
-              "[--reduce mean|min|max|median|max_sup|min_sup] "
-              "[--dtype u8|u16|...] [--frames N] "
-              "[--chunk-bytes N] [--memory-budget N] [-o path] "
-              "[--io-bw-mbps N (MiB/s)] [--io-latency-us N] "
-              "[--backpressure N]\n",
-              av[0]);
-      return 1;
-    }
-  }
-
-  if (frames > 0)
-    dims[0].size = frames;
+  if (a.frames > 0)
+    dims[0].size = a.frames;
 
   CUdevice dev;
   CUcontext ctx = 0;
@@ -1207,28 +1178,28 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
   CU(Fail, cuCtxCreate(&ctx, 0, dev));
 
   struct bench_config cfg = {
-    .label = label,
+    .label = spec.label,
     .dims = dims,
-    .rank = rank,
-    .fill = fill,
-    .output_path = output_path,
-    .array_name = label,
-    .codec = codec,
-    .reduce_method = reduce,
+    .rank = spec.rank,
+    .fill = a.fill,
+    .output_path = a.output_path,
+    .array_name = spec.label,
+    .codec = a.codec,
+    .reduce_method = a.reduce,
     .append_reduce_method =
-      reduce == lod_reduce_median ? lod_reduce_max : reduce,
-    .backend = BENCH_GPU,
-    .dtype = dtype,
-    .chunk_ratios = chunk_ratios,
+      a.reduce == lod_reduce_median ? lod_reduce_max : a.reduce,
+    .backend = BENCH_GPU, // two-streams is GPU-only
+    .dtype = a.dtype,
+    .chunk_ratios = spec.chunk_ratios,
     .target_chunk_bytes =
-      target_chunk_bytes ? target_chunk_bytes : default_chunk_bytes,
-    .min_chunk_bytes = min_chunk_bytes,
-    .memory_budget = memory_budget,
-    .min_shard_bytes = min_shard_bytes,
-    .max_concurrent_shards = max_concurrent_shards,
-    .io_bw_mbps = io_bw_mbps,
-    .io_latency_us = io_latency_us,
-    .backpressure_bytes = backpressure_bytes,
+      a.target_chunk_bytes ? a.target_chunk_bytes : spec.default_chunk_bytes,
+    .min_chunk_bytes = spec.min_chunk_bytes,
+    .memory_budget = a.memory_budget,
+    .min_shard_bytes = spec.min_shard_bytes,
+    .max_concurrent_shards = spec.max_concurrent_shards,
+    .io_bw_mbps = a.io_bw_mbps,
+    .io_latency_us = a.io_latency_us,
+    .backpressure_bytes = a.backpressure_bytes,
   };
   int ecode = run_bench_two_streams(&cfg);
 

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -13,6 +13,7 @@
 #include "sink_throttled.h"
 #include "stream.cpu.h"
 #include "stream/layouts.h"
+#include "util/format_bytes.h"
 #include "util/metric.h"
 #include "util/prelude.h"
 #include "zarr/json_writer.h"
@@ -77,6 +78,29 @@ bench_destroy(struct bench_handle* h)
     tile_stream_gpu_destroy(h->gpu);
 }
 
+// --- Fill-pattern init (deferred until after chunk-fit succeeds) ---
+//
+// Pattern buffers can be several GiB for large arrays; initializing them in
+// the CLI driver would pay that cost even for runs that fail at auto-fit.
+
+static void
+init_fill_pattern(fill_fn fill, const struct dimension* dims, uint8_t rank)
+{
+  if (fill == fill_xor)
+    xor_pattern_init(dims, rank, 16);
+  else if (fill == fill_rand)
+    rand_pattern_init(dims, rank, 16);
+}
+
+static void
+free_fill_pattern(fill_fn fill)
+{
+  if (fill == fill_xor)
+    xor_pattern_free();
+  else if (fill == fill_rand)
+    rand_pattern_free();
+}
+
 // --- Reusable bench driver ---
 //
 // Runs a single benchmark with the given dimensions and fill function.
@@ -114,22 +138,23 @@ run_bench(const struct bench_config* cfg)
 
     // Auto-detect memory budget
     if (budget == 0) {
+      char buf[32];
       if (cfg->backend == BENCH_GPU) {
         size_t free_mem = 0, total_mem = 0;
         if (cuMemGetInfo(&free_mem, &total_mem) == CUDA_SUCCESS &&
             free_mem > 0) {
           budget = (size_t)((double)free_mem * 0.8);
-          print_report(
-            "  auto-detect: %.2f GiB free GPU memory (restrict to <80%%)",
-            (double)free_mem / (1024.0 * 1024.0 * 1024.0));
+          format_bytes(buf, sizeof(buf), free_mem);
+          print_report("  auto-detect: %s free GPU memory (restrict to <80%%)",
+                       buf);
         }
       } else {
         size_t avail = platform_available_memory();
         if (avail > 0) {
           budget = (size_t)((double)avail * 0.8);
-          print_report(
-            "  auto-detect: %.2f GiB available RAM (restrict to <80%%)",
-            (double)avail / (1024.0 * 1024.0 * 1024.0));
+          format_bytes(buf, sizeof(buf), avail);
+          print_report("  auto-detect: %s available RAM (restrict to <80%%)",
+                       buf);
         }
       }
     }
@@ -151,11 +176,23 @@ run_bench(const struct bench_config* cfg)
       };
       int advise_ok;
       if (cfg->backend == BENCH_GPU) {
-        advise_ok = tile_stream_gpu_advise_chunk_sizes(
-          &fit_config, target, cfg->chunk_ratios, budget, 0);
+        advise_ok = tile_stream_gpu_advise_layout(&fit_config,
+                                                  target,
+                                                  cfg->min_chunk_bytes,
+                                                  cfg->chunk_ratios,
+                                                  budget,
+                                                  cfg->min_shard_bytes,
+                                                  cfg->max_concurrent_shards,
+                                                  0);
       } else {
-        advise_ok = tile_stream_cpu_advise_chunk_sizes(
-          &fit_config, target, cfg->chunk_ratios, budget, 0);
+        advise_ok = tile_stream_cpu_advise_layout(&fit_config,
+                                                  target,
+                                                  cfg->min_chunk_bytes,
+                                                  cfg->chunk_ratios,
+                                                  budget,
+                                                  cfg->min_shard_bytes,
+                                                  cfg->max_concurrent_shards,
+                                                  0);
       }
       if (advise_ok == 0) {
         fitted = 1;
@@ -165,21 +202,39 @@ run_bench(const struct bench_config* cfg)
         print_report("  auto-fit: %zu bytes/chunk",
                      (size_t)(vol * bytes_per_element));
       } else {
-        print_report("  auto-fit: WARNING -- no chunk size fits in budget");
+        char budget_buf[32], shard_buf[32];
+        format_bytes(budget_buf, sizeof(budget_buf), budget);
+        format_bytes(shard_buf, sizeof(shard_buf), cfg->min_shard_bytes);
+        print_report(
+          "  auto-fit: ERROR -- no chunk size >= %zu bytes fits in budget "
+          "(%s) with min_shard_bytes=%s",
+          cfg->min_chunk_bytes ? cfg->min_chunk_bytes : bytes_per_element,
+          budget_buf,
+          shard_buf);
+        return 1;
       }
     }
 
-    // Fallback: just budget chunk sizes without memory constraint
-    if (!fitted)
+    // No budget specified: apply chunk budget + shard geometry directly.
+    if (!fitted) {
       dims_budget_chunk_bytes(
         dims, rank, target, bytes_per_element, cfg->chunk_ratios);
-
-    // Set shard counts after chunk sizing
-    if (cfg->shard_counts)
-      dims_set_shard_counts(dims, rank, cfg->shard_counts);
+      if (cfg->min_shard_bytes > 0 &&
+          dims_set_shard_geometry(dims,
+                                  rank,
+                                  cfg->min_shard_bytes,
+                                  cfg->max_concurrent_shards,
+                                  bytes_per_element)) {
+        print_report("  shard geometry: ERROR -- min_shard_bytes is smaller "
+                     "than one chunk");
+        return 1;
+      }
+    }
   }
 
   dims_print(dims, rank);
+
+  init_fill_pattern(fill, dims, rank);
 
   const size_t total_elements = dim_total_elements(dims, rank);
   const size_t total_bytes = total_elements * dtype_bpe(dtype);
@@ -250,19 +305,19 @@ run_bench(const struct bench_config* cfg)
     struct tile_stream_memory_info mem;
     if (tile_stream_gpu_memory_estimate(&config, 0, &mem) == 0) {
       est_total_chunks = mem.total_chunks;
-      print_report("  GPU memory:  %.2f GiB device, %.2f GiB pinned",
-                   (double)mem.device_bytes / (1024.0 * 1024.0 * 1024.0),
-                   (double)mem.host_pinned_bytes / (1024.0 * 1024.0 * 1024.0));
-      print_report("    staging:   %.2f MiB   chunk_pool: %.2f GiB",
-                   (double)mem.staging_bytes / (1024.0 * 1024.0),
-                   (double)mem.chunk_pool_bytes / (1024.0 * 1024.0 * 1024.0));
-      print_report("    comp_pool: %.2f GiB   aggregate: %.2f GiB",
-                   (double)mem.compressed_pool_bytes /
-                     (1024.0 * 1024.0 * 1024.0),
-                   (double)mem.aggregate_bytes / (1024.0 * 1024.0 * 1024.0));
-      print_report("    lod:       %.2f MiB   codec:     %.2f MiB",
-                   (double)mem.lod_bytes / (1024.0 * 1024.0),
-                   (double)mem.codec_bytes / (1024.0 * 1024.0));
+      char a[32], b[32];
+      format_bytes(a, sizeof(a), mem.device_bytes);
+      format_bytes(b, sizeof(b), mem.host_pinned_bytes);
+      print_report("  GPU memory:  %s device, %s pinned", a, b);
+      format_bytes(a, sizeof(a), mem.staging_bytes);
+      format_bytes(b, sizeof(b), mem.chunk_pool_bytes);
+      print_report("    staging:   %s   chunk_pool: %s", a, b);
+      format_bytes(a, sizeof(a), mem.compressed_pool_bytes);
+      format_bytes(b, sizeof(b), mem.aggregate_bytes);
+      print_report("    comp_pool: %s   aggregate: %s", a, b);
+      format_bytes(a, sizeof(a), mem.lod_bytes);
+      format_bytes(b, sizeof(b), mem.codec_bytes);
+      print_report("    lod:       %s   codec:     %s", a, b);
       print_report(
         "    chunks:    %llu/epoch, %llu total (%d LOD levels, batch=%u)",
         (unsigned long long)mem.chunks_per_epoch,
@@ -276,18 +331,18 @@ run_bench(const struct bench_config* cfg)
     struct tile_stream_cpu_memory_info mem;
     if (tile_stream_cpu_memory_estimate(&config, 0, &mem) == 0) {
       est_total_chunks = mem.total_chunks;
-      print_report("  CPU memory:  %.2f GiB heap",
-                   (double)mem.heap_bytes / (1024.0 * 1024.0 * 1024.0));
-      print_report("    chunk_pool: %.2f GiB   comp_pool: %.2f GiB",
-                   (double)mem.chunk_pool_bytes / (1024.0 * 1024.0 * 1024.0),
-                   (double)mem.compressed_pool_bytes /
-                     (1024.0 * 1024.0 * 1024.0));
-      print_report("    comp_sizes: %.2f MiB   aggregate: %.2f MiB",
-                   (double)mem.comp_sizes_bytes / (1024.0 * 1024.0),
-                   (double)mem.aggregate_bytes / (1024.0 * 1024.0));
-      print_report("    lod:       %.2f MiB   shards:    %.2f MiB",
-                   (double)mem.lod_bytes / (1024.0 * 1024.0),
-                   (double)mem.shard_bytes / (1024.0 * 1024.0));
+      char a[32], b[32];
+      format_bytes(a, sizeof(a), mem.heap_bytes);
+      print_report("  CPU memory:  %s heap", a);
+      format_bytes(a, sizeof(a), mem.chunk_pool_bytes);
+      format_bytes(b, sizeof(b), mem.compressed_pool_bytes);
+      print_report("    chunk_pool: %s   comp_pool: %s", a, b);
+      format_bytes(a, sizeof(a), mem.comp_sizes_bytes);
+      format_bytes(b, sizeof(b), mem.aggregate_bytes);
+      print_report("    comp_sizes: %s   aggregate: %s", a, b);
+      format_bytes(a, sizeof(a), mem.lod_bytes);
+      format_bytes(b, sizeof(b), mem.shard_bytes);
+      print_report("    lod:       %s   shards:    %s", a, b);
       print_report(
         "    chunks:    %llu/epoch, %llu total (%d LOD levels, batch=%u)",
         (unsigned long long)mem.chunks_per_epoch,
@@ -535,21 +590,24 @@ Cleanup:
   bench_zarr_close(&zarr);
   if (use_throttled)
     throttled_shard_sink_teardown(&tss);
+  free_fill_pattern(fill);
   return rc;
 }
 
 // --- CLI driver ---
 
 int
-bench_stream_main(int ac,
-                  char* av[],
-                  const char* label,
-                  struct dimension* dims,
-                  uint8_t rank,
-                  const uint8_t* chunk_ratios,
-                  size_t default_chunk_bytes,
-                  const uint64_t* shard_counts)
+bench_stream_main(int ac, char* av[], struct bench_spec spec)
 {
+  const char* label = spec.label;
+  struct dimension* dims = spec.dims;
+  uint8_t rank = spec.rank;
+  const uint8_t* chunk_ratios = spec.chunk_ratios;
+  size_t default_chunk_bytes = spec.default_chunk_bytes;
+  size_t min_chunk_bytes = spec.min_chunk_bytes;
+  size_t min_shard_bytes = spec.min_shard_bytes;
+  uint32_t max_concurrent_shards = spec.max_concurrent_shards;
+
   fill_fn fill = fill_xor;
   struct codec_config codec = { .id = CODEC_ZSTD };
   enum lod_reduce_method reduce = lod_reduce_mean;
@@ -642,13 +700,6 @@ bench_stream_main(int ac,
     CU(Fail, cuCtxCreate(&ctx, 0, dev));
   }
 
-  int need_xor = (fill == fill_xor);
-  int need_rand = (fill == fill_rand);
-  if (need_xor)
-    xor_pattern_init(dims, rank, 16);
-  if (need_rand)
-    rand_pattern_init(dims, rank, 16);
-
   struct bench_config cfg = {
     .label = label,
     .dims = dims,
@@ -670,19 +721,16 @@ bench_stream_main(int ac,
     .chunk_ratios = chunk_ratios,
     .target_chunk_bytes =
       target_chunk_bytes ? target_chunk_bytes : default_chunk_bytes,
+    .min_chunk_bytes = min_chunk_bytes,
     .memory_budget = memory_budget,
-    .shard_counts = shard_counts,
+    .min_shard_bytes = min_shard_bytes,
+    .max_concurrent_shards = max_concurrent_shards,
     .json_output = json_output,
     .io_bw_mbps = io_bw_mbps,
     .io_latency_us = io_latency_us,
     .backpressure_bytes = backpressure_bytes,
   };
   ecode = run_bench(&cfg);
-
-  if (need_xor)
-    xor_pattern_free();
-  if (need_rand)
-    rand_pattern_free();
 
   if (backend == BENCH_GPU)
     cuCtxDestroy(ctx);
@@ -782,9 +830,10 @@ run_bench_two_streams(const struct bench_config* cfg)
       if (cuMemGetInfo(&free_mem, &total_mem) == CUDA_SUCCESS && free_mem > 0) {
         // Reserve half for each stream (80% total, split two ways)
         budget = (size_t)((double)free_mem * 0.4);
+        char buf[32];
+        format_bytes(buf, sizeof(buf), free_mem);
         print_report(
-          "  auto-detect: %.2f GiB free GPU memory (2 streams, ~40%% each)",
-          (double)free_mem / (1024.0 * 1024.0 * 1024.0));
+          "  auto-detect: %s free GPU memory (2 streams, ~40%% each)", buf);
       }
     }
 
@@ -801,25 +850,50 @@ run_bench_two_streams(const struct bench_config* cfg)
 
     int fitted = 0;
     if (budget > 0) {
-      fitted = tile_stream_gpu_advise_chunk_sizes(
-                 &fit_config, target, cfg->chunk_ratios, budget, 0) == 0;
+      fitted = tile_stream_gpu_advise_layout(&fit_config,
+                                             target,
+                                             cfg->min_chunk_bytes,
+                                             cfg->chunk_ratios,
+                                             budget,
+                                             cfg->min_shard_bytes,
+                                             cfg->max_concurrent_shards,
+                                             0) == 0;
       if (fitted) {
         uint64_t vol = 1;
         for (uint8_t d = 0; d < rank; ++d)
           vol *= dims[d].chunk_size;
         print_report("  auto-fit: %zu bytes/chunk", (size_t)(vol * bpe));
       } else {
-        print_report("  auto-fit: WARNING -- no chunk size fits in budget");
+        char budget_buf[32], shard_buf[32];
+        format_bytes(budget_buf, sizeof(budget_buf), budget);
+        format_bytes(shard_buf, sizeof(shard_buf), cfg->min_shard_bytes);
+        print_report(
+          "  auto-fit: ERROR -- no chunk size >= %zu bytes fits in budget "
+          "(%s) with min_shard_bytes=%s",
+          cfg->min_chunk_bytes ? cfg->min_chunk_bytes : bpe,
+          budget_buf,
+          shard_buf);
+        return 1;
       }
     }
-    if (!fitted)
+    if (!fitted) {
       dims_budget_chunk_bytes(dims, rank, target, bpe, cfg->chunk_ratios);
-
-    if (cfg->shard_counts)
-      dims_set_shard_counts(dims, rank, cfg->shard_counts);
+      if (cfg->min_shard_bytes > 0 &&
+          dims_set_shard_geometry(dims,
+                                  rank,
+                                  cfg->min_shard_bytes,
+                                  cfg->max_concurrent_shards,
+                                  bpe)) {
+        print_report("  shard geometry: ERROR -- min_shard_bytes is smaller "
+                     "than one chunk");
+        return 1;
+      }
+    }
   }
 
   dims_print(dims, rank);
+
+  init_fill_pattern(fill, dims, rank);
 
   const size_t total_elements = dim_total_elements(dims, rank);
   const size_t total_bytes = total_elements * bpe;
@@ -887,14 +961,13 @@ run_bench_two_streams(const struct bench_config* cfg)
   {
     struct tile_stream_memory_info mem;
     if (tile_stream_gpu_memory_estimate(&config, 0, &mem) == 0) {
-      print_report(
-        "  GPU memory (per stream): %.2f GiB device, %.2f GiB pinned",
-        (double)mem.device_bytes / (1024.0 * 1024.0 * 1024.0),
-        (double)mem.host_pinned_bytes / (1024.0 * 1024.0 * 1024.0));
-      print_report(
-        "  GPU memory (total x2):   %.2f GiB device, %.2f GiB pinned",
-        2.0 * (double)mem.device_bytes / (1024.0 * 1024.0 * 1024.0),
-        2.0 * (double)mem.host_pinned_bytes / (1024.0 * 1024.0 * 1024.0));
+      char a[32], b[32];
+      format_bytes(a, sizeof(a), mem.device_bytes);
+      format_bytes(b, sizeof(b), mem.host_pinned_bytes);
+      print_report("  GPU memory (per stream): %s device, %s pinned", a, b);
+      format_bytes(a, sizeof(a), 2 * mem.device_bytes);
+      format_bytes(b, sizeof(b), 2 * mem.host_pinned_bytes);
+      print_report("  GPU memory (total x2):   %s device, %s pinned", a, b);
     }
   }
 
@@ -956,11 +1029,14 @@ run_bench_two_streams(const struct bench_config* cfg)
   // --- Combined summary ---
   print_report("");
   print_report("  --- Combined ---");
-  print_report("  Input:        %.2f GiB (%zu elements x 2 streams)",
-               combined_gib,
-               total_elements);
-  print_report("  Compressed:   %.2f GiB",
-               (double)(sink_bytes[0] + sink_bytes[1]) / GIB);
+  {
+    char buf[32];
+    format_bytes(buf, sizeof(buf), 2 * (uint64_t)total_bytes);
+    print_report(
+      "  Input:        %s (%zu elements x 2 streams)", buf, total_elements);
+    format_bytes(buf, sizeof(buf), (uint64_t)(sink_bytes[0] + sink_bytes[1]));
+    print_report("  Compressed:   %s", buf);
+  }
   print_report("  Init time:     %.3f s", (double)init_s);
   if (flush_s > 0)
     print_report("  Flush time:    %.3f s", (double)flush_s);
@@ -974,7 +1050,9 @@ run_bench_two_streams(const struct bench_config* cfg)
     print_report("  --- stream-%d ---", k);
     print_report("  Throughput:    %.2f GiB/s",
                  wall_s > 0 ? per_stream_gib / wall_s : 0.0);
-    print_report("  Compressed:    %.2f GiB", (double)sink_bytes[k] / GIB);
+    char cbuf[32];
+    format_bytes(cbuf, sizeof(cbuf), (uint64_t)sink_bytes[k]);
+    print_report("  Compressed:    %s", cbuf);
     print_report("");
     print_report("  %-12s %8s %8s %10s %10s",
                  "Stage",
@@ -1006,8 +1084,9 @@ run_bench_two_streams(const struct bench_config* cfg)
       print_metric_row(&m[k].io_fence_stall);
       print_metric_row(&m[k].backpressure);
       print_report("  max append ms:   %.2f", (double)m[k].max_append_ms);
-      print_report("  peak pending:    %.2f MiB",
-                   (double)m[k].peak_pending_bytes / (1024.0 * 1024.0));
+      char pbuf[32];
+      format_bytes(pbuf, sizeof(pbuf), (uint64_t)m[k].peak_pending_bytes);
+      print_report("  peak pending:    %s", pbuf);
     }
   }
 
@@ -1020,6 +1099,7 @@ run_bench_two_streams(const struct bench_config* cfg)
     throttled_shard_sink_teardown(&tss[0]);
     throttled_shard_sink_teardown(&tss[1]);
   }
+  free_fill_pattern(fill);
   return 0;
 
 Fail:
@@ -1038,19 +1118,22 @@ Fail:
     throttled_shard_sink_teardown(&tss[0]);
     throttled_shard_sink_teardown(&tss[1]);
   }
+  free_fill_pattern(fill);
   return 1;
 }
 
 int
-bench_two_streams_main(int ac,
-                       char* av[],
-                       const char* label,
-                       struct dimension* dims,
-                       uint8_t rank,
-                       const uint8_t* chunk_ratios,
-                       size_t default_chunk_bytes,
-                       const uint64_t* shard_counts)
+bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
 {
+  const char* label = spec.label;
+  struct dimension* dims = spec.dims;
+  uint8_t rank = spec.rank;
+  const uint8_t* chunk_ratios = spec.chunk_ratios;
+  size_t default_chunk_bytes = spec.default_chunk_bytes;
+  size_t min_chunk_bytes = spec.min_chunk_bytes;
+  size_t min_shard_bytes = spec.min_shard_bytes;
+  uint32_t max_concurrent_shards = spec.max_concurrent_shards;
+
   fill_fn fill = fill_xor;
   struct codec_config codec = { .id = CODEC_ZSTD };
   enum lod_reduce_method reduce = lod_reduce_mean;
@@ -1114,13 +1197,6 @@ bench_two_streams_main(int ac,
   CU(Fail, cuDeviceGet(&dev, 0));
   CU(Fail, cuCtxCreate(&ctx, 0, dev));
 
-  int need_xor = (fill == fill_xor);
-  int need_rand = (fill == fill_rand);
-  if (need_xor)
-    xor_pattern_init(dims, rank, 16);
-  if (need_rand)
-    rand_pattern_init(dims, rank, 16);
-
   struct bench_config cfg = {
     .label = label,
     .dims = dims,
@@ -1137,18 +1213,15 @@ bench_two_streams_main(int ac,
     .chunk_ratios = chunk_ratios,
     .target_chunk_bytes =
       target_chunk_bytes ? target_chunk_bytes : default_chunk_bytes,
+    .min_chunk_bytes = min_chunk_bytes,
     .memory_budget = memory_budget,
-    .shard_counts = shard_counts,
+    .min_shard_bytes = min_shard_bytes,
+    .max_concurrent_shards = max_concurrent_shards,
     .io_bw_mbps = io_bw_mbps,
     .io_latency_us = io_latency_us,
     .backpressure_bytes = backpressure_bytes,
   };
   int ecode = run_bench_two_streams(&cfg);
-
-  if (need_xor)
-    xor_pattern_free();
-  if (need_rand)
-    rand_pattern_free();
 
   cuCtxDestroy(ctx);
   return ecode;

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -78,6 +78,123 @@ bench_destroy(struct bench_handle* h)
     tile_stream_gpu_destroy(h->gpu);
 }
 
+static void
+print_advise_failure(const struct advise_layout_diagnostic* diag,
+                     size_t budget,
+                     size_t min_shard_bytes);
+
+// Resolve the chunk + shard geometry for cfg->dims using cfg->chunk_ratios.
+// When cfg->memory_budget is 0, auto-detects from backend free memory using
+// budget_fraction (e.g. 0.8 for single-stream, 0.4 per stream for the
+// two-stream driver). auto_detect_suffix is appended to the auto-detect log
+// message (e.g. "(restrict to <80%)" or "(2 streams, ~40% each)").
+// On success returns 0 and writes the chosen epochs_per_batch (0 if no
+// auto-fit ran) to *out_epb. On failure returns 1 (message already printed).
+// No-op if cfg->chunk_ratios is NULL.
+static int
+resolve_chunk_sizing(const struct bench_config* cfg,
+                     enum dtype dtype,
+                     double budget_fraction,
+                     const char* auto_detect_suffix,
+                     uint8_t* out_epb)
+{
+  *out_epb = 0;
+  if (!cfg->chunk_ratios)
+    return 0;
+
+  const size_t bytes_per_element = dtype_bpe(dtype);
+  const size_t target =
+    cfg->target_chunk_bytes ? cfg->target_chunk_bytes : (1 << 20);
+  size_t budget = cfg->memory_budget;
+
+  if (budget == 0) {
+    char buf[32];
+    if (cfg->backend == BENCH_GPU) {
+      size_t free_mem = 0, total_mem = 0;
+      if (cuMemGetInfo(&free_mem, &total_mem) == CUDA_SUCCESS && free_mem > 0) {
+        budget = (size_t)((double)free_mem * budget_fraction);
+        format_bytes(buf, sizeof(buf), free_mem);
+        print_report(
+          "  auto-detect: %s free GPU memory %s", buf, auto_detect_suffix);
+      }
+    } else {
+      size_t avail = platform_available_memory();
+      if (avail > 0) {
+        budget = (size_t)((double)avail * budget_fraction);
+        format_bytes(buf, sizeof(buf), avail);
+        print_report(
+          "  auto-detect: %s available RAM %s", buf, auto_detect_suffix);
+      }
+    }
+  }
+
+  struct dimension* dims = cfg->dims;
+  const uint8_t rank = cfg->rank;
+
+  if (budget > 0) {
+    struct tile_stream_configuration fit_config = {
+      .buffer_capacity_bytes = 128 << 20,
+      .dtype = dtype,
+      .rank = rank,
+      .dimensions = dims,
+      .codec = cfg->codec,
+      .reduce_method = cfg->reduce_method,
+      .append_reduce_method = cfg->append_reduce_method,
+      .target_batch_chunks = 2048,
+    };
+    struct advise_layout_diagnostic diag = { 0 };
+    int advise_ok;
+    if (cfg->backend == BENCH_GPU) {
+      advise_ok = tile_stream_gpu_advise_layout(&fit_config,
+                                                target,
+                                                cfg->min_chunk_bytes,
+                                                cfg->chunk_ratios,
+                                                budget,
+                                                cfg->min_shard_bytes,
+                                                cfg->max_concurrent_shards,
+                                                0,
+                                                &diag);
+    } else {
+      advise_ok = tile_stream_cpu_advise_layout(&fit_config,
+                                                target,
+                                                cfg->min_chunk_bytes,
+                                                cfg->chunk_ratios,
+                                                budget,
+                                                cfg->min_shard_bytes,
+                                                cfg->max_concurrent_shards,
+                                                0,
+                                                &diag);
+    }
+    if (advise_ok != 0) {
+      print_advise_failure(&diag, budget, cfg->min_shard_bytes);
+      return 1;
+    }
+    *out_epb = fit_config.epochs_per_batch;
+    uint64_t vol = 1;
+    for (uint8_t d = 0; d < rank; ++d)
+      vol *= dims[d].chunk_size;
+    print_report("  auto-fit: %zu bytes/chunk (batch=%u)",
+                 (size_t)(vol * bytes_per_element),
+                 (unsigned)*out_epb);
+    return 0;
+  }
+
+  // No budget: apply chunk budget + shard geometry directly.
+  dims_budget_chunk_bytes(
+    dims, rank, target, bytes_per_element, cfg->chunk_ratios);
+  if (cfg->min_shard_bytes > 0 &&
+      dims_set_shard_geometry(dims,
+                              rank,
+                              cfg->min_shard_bytes,
+                              cfg->max_concurrent_shards,
+                              bytes_per_element)) {
+    print_report(
+      "  shard geometry: ERROR -- min_shard_bytes is smaller than one chunk");
+    return 1;
+  }
+  return 0;
+}
+
 // Emit a reason-specific explanation after advise_layout fails.
 static void
 print_advise_failure(const struct advise_layout_diagnostic* diag,
@@ -185,105 +302,9 @@ run_bench(const struct bench_config* cfg)
   const enum dtype dtype = cfg->dtype ? cfg->dtype : dtype_u16;
   uint8_t chosen_epochs_per_batch = 0; // 0 = auto; set by advise_layout on fit
 
-  // --- Chunk sizing ---
-  if (cfg->chunk_ratios) {
-    size_t bytes_per_element = dtype_bpe(dtype);
-    size_t target =
-      cfg->target_chunk_bytes ? cfg->target_chunk_bytes : (1 << 20);
-    size_t budget = cfg->memory_budget;
-
-    // Auto-detect memory budget
-    if (budget == 0) {
-      char buf[32];
-      if (cfg->backend == BENCH_GPU) {
-        size_t free_mem = 0, total_mem = 0;
-        if (cuMemGetInfo(&free_mem, &total_mem) == CUDA_SUCCESS &&
-            free_mem > 0) {
-          budget = (size_t)((double)free_mem * 0.8);
-          format_bytes(buf, sizeof(buf), free_mem);
-          print_report("  auto-detect: %s free GPU memory (restrict to <80%%)",
-                       buf);
-        }
-      } else {
-        size_t avail = platform_available_memory();
-        if (avail > 0) {
-          budget = (size_t)((double)avail * 0.8);
-          format_bytes(buf, sizeof(buf), avail);
-          print_report("  auto-detect: %s available RAM (restrict to <80%%)",
-                       buf);
-        }
-      }
-    }
-
-    // Auto-fit: try shrinking chunks to fit budget
-    int fitted = 0;
-    if (budget > 0) {
-      struct discard_shard_sink fit_dss;
-      discard_shard_sink_init(&fit_dss);
-      struct tile_stream_configuration fit_config = {
-        .buffer_capacity_bytes = 128 << 20,
-        .dtype = dtype,
-        .rank = rank,
-        .dimensions = dims,
-        .codec = cfg->codec,
-        .reduce_method = cfg->reduce_method,
-        .append_reduce_method = cfg->append_reduce_method,
-        .target_batch_chunks = 2048,
-      };
-      int advise_ok;
-      struct advise_layout_diagnostic diag = { 0 };
-      if (cfg->backend == BENCH_GPU) {
-        advise_ok = tile_stream_gpu_advise_layout(&fit_config,
-                                                  target,
-                                                  cfg->min_chunk_bytes,
-                                                  cfg->chunk_ratios,
-                                                  budget,
-                                                  cfg->min_shard_bytes,
-                                                  cfg->max_concurrent_shards,
-                                                  0,
-                                                  &diag);
-      } else {
-        advise_ok = tile_stream_cpu_advise_layout(&fit_config,
-                                                  target,
-                                                  cfg->min_chunk_bytes,
-                                                  cfg->chunk_ratios,
-                                                  budget,
-                                                  cfg->min_shard_bytes,
-                                                  cfg->max_concurrent_shards,
-                                                  0,
-                                                  &diag);
-      }
-      if (advise_ok == 0) {
-        fitted = 1;
-        chosen_epochs_per_batch = fit_config.epochs_per_batch;
-        uint64_t vol = 1;
-        for (uint8_t d = 0; d < rank; ++d)
-          vol *= dims[d].chunk_size;
-        print_report("  auto-fit: %zu bytes/chunk (batch=%u)",
-                     (size_t)(vol * bytes_per_element),
-                     (unsigned)chosen_epochs_per_batch);
-      } else {
-        print_advise_failure(&diag, budget, cfg->min_shard_bytes);
-        return 1;
-      }
-    }
-
-    // No budget specified: apply chunk budget + shard geometry directly.
-    if (!fitted) {
-      dims_budget_chunk_bytes(
-        dims, rank, target, bytes_per_element, cfg->chunk_ratios);
-      if (cfg->min_shard_bytes > 0 &&
-          dims_set_shard_geometry(dims,
-                                  rank,
-                                  cfg->min_shard_bytes,
-                                  cfg->max_concurrent_shards,
-                                  bytes_per_element)) {
-        print_report("  shard geometry: ERROR -- min_shard_bytes is smaller "
-                     "than one chunk");
-        return 1;
-      }
-    }
-  }
+  if (resolve_chunk_sizing(
+        cfg, dtype, 0.8, "(restrict to <80%)", &chosen_epochs_per_batch))
+    return 1;
 
   dims_print(dims, rank);
 
@@ -874,74 +895,9 @@ run_bench_two_streams(const struct bench_config* cfg)
   const size_t bpe = dtype_bpe(dtype);
   uint8_t chosen_epochs_per_batch = 0; // 0 = auto; set by advise_layout on fit
 
-  // --- Chunk sizing (shared config, applied once) ---
-  if (cfg->chunk_ratios) {
-    size_t target =
-      cfg->target_chunk_bytes ? cfg->target_chunk_bytes : (1 << 20);
-    size_t budget = cfg->memory_budget;
-
-    if (budget == 0) {
-      size_t free_mem = 0, total_mem = 0;
-      if (cuMemGetInfo(&free_mem, &total_mem) == CUDA_SUCCESS && free_mem > 0) {
-        // Reserve half for each stream (80% total, split two ways)
-        budget = (size_t)((double)free_mem * 0.4);
-        char buf[32];
-        format_bytes(buf, sizeof(buf), free_mem);
-        print_report(
-          "  auto-detect: %s free GPU memory (2 streams, ~40%% each)", buf);
-      }
-    }
-
-    struct tile_stream_configuration fit_config = {
-      .buffer_capacity_bytes = 128 << 20,
-      .dtype = dtype,
-      .rank = rank,
-      .dimensions = dims,
-      .codec = cfg->codec,
-      .reduce_method = cfg->reduce_method,
-      .append_reduce_method = cfg->append_reduce_method,
-      .target_batch_chunks = 2048,
-    };
-
-    int fitted = 0;
-    if (budget > 0) {
-      struct advise_layout_diagnostic diag = { 0 };
-      fitted = tile_stream_gpu_advise_layout(&fit_config,
-                                             target,
-                                             cfg->min_chunk_bytes,
-                                             cfg->chunk_ratios,
-                                             budget,
-                                             cfg->min_shard_bytes,
-                                             cfg->max_concurrent_shards,
-                                             0,
-                                             &diag) == 0;
-      if (fitted) {
-        chosen_epochs_per_batch = fit_config.epochs_per_batch;
-        uint64_t vol = 1;
-        for (uint8_t d = 0; d < rank; ++d)
-          vol *= dims[d].chunk_size;
-        print_report("  auto-fit: %zu bytes/chunk (batch=%u)",
-                     (size_t)(vol * bpe),
-                     (unsigned)chosen_epochs_per_batch);
-      } else {
-        print_advise_failure(&diag, budget, cfg->min_shard_bytes);
-        return 1;
-      }
-    }
-    if (!fitted) {
-      dims_budget_chunk_bytes(dims, rank, target, bpe, cfg->chunk_ratios);
-      if (cfg->min_shard_bytes > 0 &&
-          dims_set_shard_geometry(dims,
-                                  rank,
-                                  cfg->min_shard_bytes,
-                                  cfg->max_concurrent_shards,
-                                  bpe)) {
-        print_report("  shard geometry: ERROR -- min_shard_bytes is smaller "
-                     "than one chunk");
-        return 1;
-      }
-    }
-  }
+  if (resolve_chunk_sizing(
+        cfg, dtype, 0.4, "(2 streams, ~40% each)", &chosen_epochs_per_batch))
+    return 1;
 
   dims_print(dims, rank);
 

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -151,7 +151,7 @@ resolve_chunk_sizing(const struct bench_config* cfg,
                                                 cfg->chunk_ratios,
                                                 budget,
                                                 cfg->min_shard_bytes,
-                                                cfg->max_concurrent_shards,
+                                                cfg->target_concurrent_shards,
                                                 cfg->min_append_shards,
                                                 0,
                                                 &diag);
@@ -162,7 +162,7 @@ resolve_chunk_sizing(const struct bench_config* cfg,
                                                 cfg->chunk_ratios,
                                                 budget,
                                                 cfg->min_shard_bytes,
-                                                cfg->max_concurrent_shards,
+                                                cfg->target_concurrent_shards,
                                                 cfg->min_append_shards,
                                                 0,
                                                 &diag);
@@ -188,7 +188,7 @@ resolve_chunk_sizing(const struct bench_config* cfg,
       dims_set_shard_geometry(dims,
                               rank,
                               cfg->min_shard_bytes,
-                              cfg->max_concurrent_shards,
+                              cfg->target_concurrent_shards,
                               cfg->min_append_shards,
                               bytes_per_element)) {
     print_report(
@@ -230,7 +230,7 @@ print_advise_failure(const struct advise_layout_diagnostic* diag,
                    (unsigned long long)diag->parts_limit);
       print_report("    at chunk=%s, min_shard_bytes=%s", chunk_buf, shard_buf);
       print_report(
-        "    fix: lower min_shard_bytes, raise max_concurrent_shards, "
+        "    fix: lower min_shard_bytes, raise target_concurrent_shards, "
         "or lower min_chunk_bytes");
       break;
     case ADVISE_MIN_SHARD_TOO_SMALL:
@@ -728,11 +728,11 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
     .dtype = a.dtype,
     .chunk_ratios = spec.chunk_ratios,
     .target_chunk_bytes =
-      a.target_chunk_bytes ? a.target_chunk_bytes : spec.default_chunk_bytes,
+      a.target_chunk_bytes ? a.target_chunk_bytes : spec.target_chunk_bytes,
     .min_chunk_bytes = spec.min_chunk_bytes,
     .memory_budget = a.memory_budget,
     .min_shard_bytes = spec.min_shard_bytes,
-    .max_concurrent_shards = spec.max_concurrent_shards,
+    .target_concurrent_shards = spec.target_concurrent_shards,
     .min_append_shards = spec.min_append_shards,
     .json_output = a.json_output,
     .io_bw_mbps = a.io_bw_mbps,
@@ -1098,11 +1098,11 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
     .dtype = a.dtype,
     .chunk_ratios = spec.chunk_ratios,
     .target_chunk_bytes =
-      a.target_chunk_bytes ? a.target_chunk_bytes : spec.default_chunk_bytes,
+      a.target_chunk_bytes ? a.target_chunk_bytes : spec.target_chunk_bytes,
     .min_chunk_bytes = spec.min_chunk_bytes,
     .memory_budget = a.memory_budget,
     .min_shard_bytes = spec.min_shard_bytes,
-    .max_concurrent_shards = spec.max_concurrent_shards,
+    .target_concurrent_shards = spec.target_concurrent_shards,
     .min_append_shards = spec.min_append_shards,
     .io_bw_mbps = a.io_bw_mbps,
     .io_latency_us = a.io_latency_us,

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -182,8 +182,11 @@ resolve_chunk_sizing(const struct bench_config* cfg,
   }
 
   // No budget: apply chunk budget + shard geometry directly.
-  dims_budget_chunk_bytes(
-    dims, rank, target, bytes_per_element, cfg->chunk_ratios);
+  if (dims_budget_chunk_bytes(
+        dims, rank, target, bytes_per_element, cfg->chunk_ratios)) {
+    print_report("  chunk budget: ERROR -- invalid input");
+    return 1;
+  }
   if (cfg->min_shard_bytes > 0 &&
       dims_set_shard_geometry(dims,
                               rank,

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -247,7 +247,12 @@ print_advise_failure(const struct advise_layout_diagnostic* diag,
     case ADVISE_INVALID_CONFIG:
       print_report(
         "  auto-fit: ERROR -- invalid configuration rejected by memory "
-        "estimate");
+        "estimate or shard geometry");
+      break;
+    case ADVISE_CHUNK_BUDGET_INFEASIBLE:
+      print_report("  auto-fit: ERROR -- chunk budget infeasible at chunk=%s",
+                   chunk_buf);
+      print_report("    fix: raise target_chunk_bytes, or reduce pinned dims");
       break;
     default:
       print_report("  auto-fit: ERROR -- unknown failure (reason=%d)",

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -43,6 +43,10 @@ struct bench_config
   size_t memory_budget;           // 0 = auto-detect
   size_t min_shard_bytes;         // minimum uncompressed bytes per shard
   uint32_t max_concurrent_shards; // cap on inner shard product (active files)
+  uint32_t min_append_shards;     // require at least N shards along the outer
+                                  // append dim (0 = no minimum). Forces
+                                  // shard-switching in benchmarks that would
+                                  // otherwise collapse to a single shard.
   int json_output;                // print JSON to stdout after run
   uint64_t io_bw_mbps;            // 0 = no bandwidth cap (MiB/s)
   uint64_t io_latency_us;         // 0 = no fixed per-job latency
@@ -64,6 +68,7 @@ struct bench_spec
                                   // can't meet it (0 = no floor)
   size_t min_shard_bytes;         // minimum uncompressed bytes per shard
   uint32_t max_concurrent_shards; // cap on inner shard product (active files)
+  uint32_t min_append_shards;     // 0 = no minimum (see bench_config)
 };
 
 // CLI driver: parses --fill, --codec, --reduce, --dtype, --frames, --json,

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -35,7 +35,9 @@ struct bench_config
   enum lod_reduce_method append_reduce_method;
   enum bench_backend backend;
   enum dtype dtype;               // element type (default dtype_u16)
-  const uint8_t* chunk_ratios;    // power-of-2 distribution ratios
+  const int* chunk_ratios;        // power-of-2 distribution ratios; see
+                                  // dims_budget_chunk_size for the -1/0/>0
+                                  // conventions
   size_t target_chunk_bytes;      // 0 = use 1MB default
   size_t min_chunk_bytes;         // auto-fit floor; 0 = no floor
   size_t memory_budget;           // 0 = auto-detect
@@ -56,7 +58,7 @@ struct bench_spec
   const char* label;
   struct dimension* dims;
   uint8_t rank;
-  const uint8_t* chunk_ratios;
+  const int* chunk_ratios;
   size_t default_chunk_bytes;
   size_t min_chunk_bytes;         // auto-fit floor; bench fails if budget
                                   // can't meet it (0 = no floor)

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -34,40 +34,42 @@ struct bench_config
   enum lod_reduce_method reduce_method;
   enum lod_reduce_method append_reduce_method;
   enum bench_backend backend;
-  enum dtype dtype;             // element type (default dtype_u16)
-  const uint8_t* chunk_ratios;  // power-of-2 distribution ratios
-  size_t target_chunk_bytes;    // 0 = use 1MB default
-  size_t memory_budget;         // 0 = auto-detect
-  const uint64_t* shard_counts; // per-dim target shard counts (NULL = skip)
-  int json_output;              // print JSON to stdout after run
-  uint64_t io_bw_mbps;          // 0 = no bandwidth cap (MiB/s)
-  uint64_t io_latency_us;       // 0 = no fixed per-job latency
-  size_t backpressure_bytes;    // 0 = disabled; >0 = stall when pending > N
+  enum dtype dtype;               // element type (default dtype_u16)
+  const uint8_t* chunk_ratios;    // power-of-2 distribution ratios
+  size_t target_chunk_bytes;      // 0 = use 1MB default
+  size_t min_chunk_bytes;         // auto-fit floor; 0 = no floor
+  size_t memory_budget;           // 0 = auto-detect
+  size_t min_shard_bytes;         // minimum uncompressed bytes per shard
+  uint32_t max_concurrent_shards; // cap on inner shard product (active files)
+  int json_output;                // print JSON to stdout after run
+  uint64_t io_bw_mbps;            // 0 = no bandwidth cap (MiB/s)
+  uint64_t io_latency_us;         // 0 = no fixed per-job latency
+  size_t backpressure_bytes;      // 0 = disabled; >0 = stall when pending > N
 };
 
 int
 run_bench(const struct bench_config* cfg);
 
+// Bench-author-facing spec: everything a bench main() picks before CLI parsing.
+struct bench_spec
+{
+  const char* label;
+  struct dimension* dims;
+  uint8_t rank;
+  const uint8_t* chunk_ratios;
+  size_t default_chunk_bytes;
+  size_t min_chunk_bytes;         // auto-fit floor; bench fails if budget
+                                  // can't meet it (0 = no floor)
+  size_t min_shard_bytes;         // minimum uncompressed bytes per shard
+  uint32_t max_concurrent_shards; // cap on inner shard product (active files)
+};
+
 // CLI driver: parses --fill, --codec, --reduce, --dtype, --frames, --json,
 // -o flags, inits CUDA, calls run_bench, handles xor_pattern_init/free.
 int
-bench_stream_main(int ac,
-                  char* av[],
-                  const char* label,
-                  struct dimension* dims,
-                  uint8_t rank,
-                  const uint8_t* chunk_ratios,
-                  size_t default_chunk_bytes,
-                  const uint64_t* shard_counts);
+bench_stream_main(int ac, char* av[], struct bench_spec spec);
 
 // Two-stream variant: creates two GPU pipelines on the same CUDA context and
 // interleaves writer_append calls for balanced GPU utilisation.
 int
-bench_two_streams_main(int ac,
-                       char* av[],
-                       const char* label,
-                       struct dimension* dims,
-                       uint8_t rank,
-                       const uint8_t* chunk_ratios,
-                       size_t default_chunk_bytes,
-                       const uint64_t* shard_counts);
+bench_two_streams_main(int ac, char* av[], struct bench_spec spec);

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -34,23 +34,24 @@ struct bench_config
   enum lod_reduce_method reduce_method;
   enum lod_reduce_method append_reduce_method;
   enum bench_backend backend;
-  enum dtype dtype;               // element type (default dtype_u16)
-  const int* chunk_ratios;        // power-of-2 distribution ratios; see
-                                  // dims_budget_chunk_size for the -1/0/>0
-                                  // conventions
-  size_t target_chunk_bytes;      // 0 = use 1MB default
-  size_t min_chunk_bytes;         // auto-fit floor; 0 = no floor
-  size_t memory_budget;           // 0 = auto-detect
-  size_t min_shard_bytes;         // minimum uncompressed bytes per shard
-  uint32_t max_concurrent_shards; // cap on inner shard product (active files)
-  uint32_t min_append_shards;     // require at least N shards along the outer
-                                  // append dim (0 = no minimum). Forces
-                                  // shard-switching in benchmarks that would
-                                  // otherwise collapse to a single shard.
-  int json_output;                // print JSON to stdout after run
-  uint64_t io_bw_mbps;            // 0 = no bandwidth cap (MiB/s)
-  uint64_t io_latency_us;         // 0 = no fixed per-job latency
-  size_t backpressure_bytes;      // 0 = disabled; >0 = stall when pending > N
+  enum dtype dtype;          // element type (default dtype_u16)
+  const int* chunk_ratios;   // power-of-2 distribution ratios; see
+                             // dims_budget_chunk_size for the -1/0/>0
+                             // conventions
+  size_t target_chunk_bytes; // 0 = use 1MB default
+  size_t min_chunk_bytes;    // auto-fit floor; 0 = no floor
+  size_t memory_budget;      // 0 = auto-detect
+  size_t min_shard_bytes;    // minimum uncompressed bytes per shard
+  uint32_t
+    target_concurrent_shards; // cap on inner shard product (active files)
+  uint32_t min_append_shards; // require at least N shards along the outer
+                              // append dim (0 = no minimum). Forces
+                              // shard-switching in benchmarks that would
+                              // otherwise collapse to a single shard.
+  int json_output;            // print JSON to stdout after run
+  uint64_t io_bw_mbps;        // 0 = no bandwidth cap (MiB/s)
+  uint64_t io_latency_us;     // 0 = no fixed per-job latency
+  size_t backpressure_bytes;  // 0 = disabled; >0 = stall when pending > N
 };
 
 int
@@ -63,12 +64,13 @@ struct bench_spec
   struct dimension* dims;
   uint8_t rank;
   const int* chunk_ratios;
-  size_t default_chunk_bytes;
-  size_t min_chunk_bytes;         // auto-fit floor; bench fails if budget
-                                  // can't meet it (0 = no floor)
-  size_t min_shard_bytes;         // minimum uncompressed bytes per shard
-  uint32_t max_concurrent_shards; // cap on inner shard product (active files)
-  uint32_t min_append_shards;     // 0 = no minimum (see bench_config)
+  size_t target_chunk_bytes;
+  size_t min_chunk_bytes; // auto-fit floor; bench fails if budget
+                          // can't meet it (0 = no floor)
+  size_t min_shard_bytes; // minimum uncompressed bytes per shard
+  uint32_t
+    target_concurrent_shards; // cap on inner shard product (active files)
+  uint32_t min_append_shards; // 0 = no minimum (see bench_config)
 };
 
 // CLI driver: parses --fill, --codec, --reduce, --dtype, --frames, --json,

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -18,7 +18,7 @@ Given an array's shape and dtype, pick:
 |---|---|---|
 | `size[d]`, `downsample[d]`, append-prefix | array geometry | caller |
 | `bytes_per_element` | dtype size | caller |
-| `chunk_ratios[d]` | per-dim chunk-size preference (power-of-2 distribution) | caller |
+| `chunk_ratios[d]` | per-dim chunk-size preference (power-of-2 distribution). `-1` pins chunk_size to full size (for bounded dims; unbounded treated as weight 1). `0` means chunk_size = 1. `>0` = bit-budget weight. | caller |
 | `min_chunk_bytes` | chunk-size floor; solve fails if budget can't meet this | caller |
 | `target_chunk_bytes` | starting chunk size for the auto-fit loop | caller |
 | `memory_max_bytes` | device / heap memory ceiling | caller, or auto-detected |

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -1,0 +1,213 @@
+# Bench layout policy — chunk & shard solve procedure
+
+This document describes how benchmarks (and callers in general) pick chunk sizes
+and shard geometry. The solve is structured as two sequential phases because the
+problem mostly decouples — see "Why the problem decouples" below.
+
+## Problem
+
+Given an array's shape and dtype, pick:
+
+- `chunk_size[d]` — per-dim chunk size (the unit of compression and GPU transfer).
+- `shards[d]` for inner dims — number of shards along each non-append dim.
+- `cps_append` — chunks-per-shard along the outer append dim (shard close cadence).
+
+### Inputs
+
+| Variable | Meaning | Source |
+|---|---|---|
+| `size[d]`, `downsample[d]`, append-prefix | array geometry | caller |
+| `bytes_per_element` | dtype size | caller |
+| `chunk_ratios[d]` | per-dim chunk-size preference (power-of-2 distribution) | caller |
+| `min_chunk_bytes` | chunk-size floor; solve fails if budget can't meet this | caller |
+| `target_chunk_bytes` | starting chunk size for the auto-fit loop | caller |
+| `memory_max_bytes` | device / heap memory ceiling | caller, or auto-detected |
+| `max_concurrent_shards` | cap on concurrently-open shards (fs pressure) | caller |
+| `min_shard_bytes` | minimum uncompressed bytes per shard (cadence floor) | caller |
+| `max_parts_per_shard` | backend part-count limit (e.g. S3 multipart = 10000); 0 = unlimited | sink |
+| `max_bytes_per_part` | backend per-part byte limit (e.g. S3 = 5 GiB); 0 = unlimited | sink |
+
+### Derived quantities
+
+- `n_chunks[d] = ceildiv(size[d], chunk_size[d])` — chunk count per dim.
+- `chunk_bytes = bytes_per_element · Π chunk_size[d]` — bytes per chunk.
+- `concurrent_shards = Π shards[d]` for `d ∈ inner` — open-file count at steady state.
+- `inner_cps_prod = Π ceildiv(n_chunks[d], shards[d])` for `d ∈ inner` — chunks-per-shard across inner dims.
+- `append_row_bytes = chunk_bytes · inner_cps_prod · Π n_chunks[d]` for `d ∈ append, d > 0` — bytes written per append step across one inner shard.
+- `shard_size_bytes = cps_append · append_row_bytes` — uncompressed bytes per closed shard.
+- `chunks_per_shard_total = cps_append · inner_cps_prod · Π n_chunks[d]` for `d ∈ append, d > 0` — chunk count in one closed shard.
+- `device_bytes` — GPU memory estimate for the configuration (from
+  `tile_stream_gpu_memory_estimate`).
+
+### Constraints
+
+Hard:
+
+1. `chunk_bytes ≥ min_chunk_bytes` and `chunk_bytes ≤ max_bytes_per_part`.
+2. `device_bytes ≤ memory_max_bytes`.
+3. `1 ≤ shards[d] ≤ n_chunks[d]` for inner dims, and `concurrent_shards ≤ max_concurrent_shards`.
+4. `cps_append ≥ 1`.
+5. `chunks_per_shard_total ≤ max_parts_per_shard` (if nonzero).
+
+Preference:
+
+- `shard_size_bytes ≥ min_shard_bytes`.
+
+## Why the problem decouples
+
+`device_bytes` is dominated by the chunk pool and per-chunk pipeline state;
+shards contribute only small index buffers. Constraint (2) is therefore
+effectively a chunk-only constraint.
+
+Shard variables don't appear in constraints (1) or (2) at all. Chunk variables
+appear in shard constraints only through `chunk_bytes`, `n_chunks[d]`, and the
+product limit (5).
+
+So the optimization is separable: pick chunks first (constraints 1, 2), then
+pick shards (constraints 3, 4) from the resulting `n_chunks[d]`. The only
+coupling is constraint (5), `chunks_per_shard_total ≤ max_parts_per_shard`,
+which is checked at the phase boundary — if violated, we shrink chunks and
+retry.
+
+## Lexicographic objective
+
+1. **Maximize `chunk_bytes`** subject to (1) and (2). Larger chunks give better
+   compression ratios, lower per-chunk pipeline overhead, and less bookkeeping.
+2. **Maximize `concurrent_shards`** subject to (3). Use the fs-concurrency
+   budget the caller specified; more inner shards produce finer shard cadence
+   without inflating individual shards.
+3. **Minimize `shard_size_bytes`** subject to `shard_size_bytes ≥ min_shard_bytes`
+   and constraint (5). Smallest shard cadence that clears the byte floor.
+
+## Procedure
+
+```
+# --- Phase 1: chunks (auto-fit loop) ---
+target = target_chunk_bytes
+loop:
+    distribute log2(target / bytes_per_element) bits across dims per chunk_ratios
+    → sets chunk_size[d] and thus chunk_bytes, n_chunks[d]
+
+    if chunk_bytes > max_bytes_per_part:   halve target, continue
+    if device_bytes > memory_max_bytes:    halve target, continue
+    break
+    # If target falls below min_chunk_bytes before breaking:
+    # ERROR "no chunk size ≥ min_chunk_bytes fits in budget".
+
+# --- Phase 2: shards (closed-form given chunks) ---
+shards[d] = 1 for d in inner
+
+# Bit-greedy doubling: each step doubles the inner dim with the largest
+# remaining n_chunks[d]/shards[d] ratio, capped at n_chunks[d].
+while concurrent_shards · 2 ≤ max_concurrent_shards:
+    d* = argmax over d in inner where shards[d] · 2 ≤ n_chunks[d]
+          of n_chunks[d] / shards[d]
+    if no such d*: break
+    shards[d*] *= 2
+
+# Append cadence from byte floor.
+cps_append = max(1, ceildiv(min_shard_bytes, append_row_bytes))
+
+# --- Cross-phase check: backend parts limit ---
+if max_parts_per_shard > 0 and chunks_per_shard_total > max_parts_per_shard:
+    # Two remedies: shrink chunks (cheapest — lowers append_row_bytes and
+    # relaxes the product), or raise max_concurrent_shards (caller policy).
+    halve target, restart Phase 1
+    # If already at min_chunk_bytes: ERROR with a message indicating both
+    # min_chunk_bytes and max_concurrent_shards should be revisited.
+```
+
+## Worked example
+
+Inputs (roughly the `medfmt_single` bench on a machine with plenty of GPU memory):
+
+- Array: `zcyx` with `size = (100, 1, 10240, 15360)`, `dtype = u16` → `bytes_per_element = 2`
+- `chunk_ratios = (1, 0, 4, 4)`, `target_chunk_bytes = 256 KiB`, `min_chunk_bytes = 16 KiB`
+- `memory_max_bytes = 8 GiB`
+- `max_concurrent_shards = 16`, `min_shard_bytes = 1 GiB`
+- Filesystem sink: `max_parts_per_shard = 0`, `max_bytes_per_part = 0` (unlimited)
+
+**Phase 1.** Distribute `log2(256 KiB / 2) = 17` bits across `ratios (1, 0, 4, 4)`.
+Bit-greedy (each step goes to the inner dim with the smallest `bits/ratio`,
+ties to the higher-indexed dim) yields `bits = (2, 0, 7, 8)`:
+
+```
+chunk_size  = (4, 1, 128, 256)
+chunk_bytes = 4 · 1 · 128 · 256 · 2 = 262 144   (256 KiB)
+n_chunks    = (25, 1, 80, 60)
+```
+
+Assume `device_bytes ≤ 8 GiB` holds at this configuration → Phase 1 accepts.
+
+**Phase 2.** `n_append = 1` (only `z`; `chunk_size[z] = 4 ≠ 1`). Inner dims are
+`c, y, x`. Start `shards = (·, 1, 1, 1)`, `concurrent_shards = 1`. Double greedily
+while `concurrent_shards · 2 ≤ 16`:
+
+| Step | Candidate (largest `n_chunks/shards`) | Action | `concurrent_shards` |
+|---|---|---|---|
+| 1 | `y: 80/1 = 80` | `shards[y] = 2` | 2 |
+| 2 | `x: 60/1 = 60` | `shards[x] = 2` | 4 |
+| 3 | `y: 80/2 = 40` | `shards[y] = 4` | 8 |
+| 4 | `x: 60/2 = 30` | `shards[x] = 4` | 16 |
+
+(Dim `c` is skipped throughout — `n_chunks[c] = 1` can't be halved.)
+
+```
+shards          = (·, c=1, y=4, x=4)     concurrent_shards = 16
+inner_cps       = (c=1, y=ceildiv(80,4)=20, x=ceildiv(60,4)=15)
+inner_cps_prod  = 1 · 20 · 15 = 300
+append_row_bytes = 262 144 · 300 = 78 643 200   (75 MiB)
+
+cps_append       = max(1, ceildiv(1 GiB, 75 MiB)) = ceildiv(1073741824, 78643200) = 14
+shard_size_bytes = 14 · 78 643 200 ≈ 1.03 GiB      (just above the 1 GiB floor)
+```
+
+**Cross-phase check.** `chunks_per_shard_total = 14 · 300 = 4 200`. The filesystem sink imposes no parts limit, so accepted.
+
+**Final output:**
+
+```
+chunk_size         = (4, 1, 128, 256)
+chunks_per_shard   = (z=14, c=1, y=20, x=15)   (dim z is the outer append dim)
+shard_size_bytes   ≈ 1.03 GiB
+
+# Total shards: ceildiv(25, 14) append-slots × 16 inner = 2 × 16 = 32 shards.
+# Total data:   100 · 10240 · 15360 · 2 B ≈ 30 GiB (matches 32 · ~1 GiB).
+```
+
+## Edge cases
+
+- **`append_row_bytes > min_shard_bytes`** — `cps_append = 1` and the shard is
+  exactly `append_row_bytes`, larger than the floor. This is correct:
+  `min_shard_bytes` is a floor, not a target.
+- **`append_row_bytes · 1 > max_bytes_per_part · max_parts_per_shard`** — a
+  single append-row already exceeds the backend's total shard capacity. Phase 1
+  retry. If chunks are already at `min_chunk_bytes`, error cleanly and ask the
+  caller to raise `max_concurrent_shards` or lower `min_chunk_bytes`.
+- **`max_concurrent_shards = 1`** with a large inner grid — one shard covers
+  the whole inner volume. Respects the caller's explicit concurrency policy;
+  resulting shards may be large.
+- **A downsample dim gets `chunk_size = 1`** — allowed (the configuration is
+  interpreted as an append-accumulator case, see `dims_n_append` in
+  `src/lod/lod_plan.c`). Callers who don't want this should set
+  `min_chunk_bytes` high enough to prevent the shrink.
+
+## Entry points
+
+- `dims_budget_chunk_bytes` (`src/dimension.h`) — Phase 1 primitive:
+  distributes bits into `chunk_size[d]` per `chunk_ratios`.
+- `dims_set_shard_geometry` (`src/dimension.h`) — Phase 2 primitive:
+  shard geometry given chunks, `min_shard_bytes`, and
+  `max_concurrent_shards`. Returns non-zero if `min_shard_bytes` is smaller
+  than one chunk.
+- `dims_set_layout` (`src/dimension.h`) — convenience wrapper that runs
+  both phases from a single `dims_layout_policy` struct.
+- `tile_stream_gpu_advise_layout` (`src/stream.gpu.h`) /
+  `tile_stream_cpu_advise_layout` (`src/stream.cpu.h`) — combined solve
+  with auto-fit loop, memory budget, and cross-phase parts check. Halves
+  the chunk target until all constraints are met; bails below
+  `min_chunk_bytes`.
+- Backend constants (`src/defs.limits.h`) — `MAX_PARTS_PER_SHARD` and
+  `MAX_BYTES_PER_PART`, applied uniformly across sinks.
+- `run_bench` in `bench/bench_util.c` — wires these into the benchmark
+  driver and reports auto-fit outcome or a clean failure.

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -118,13 +118,18 @@ while concurrent_shards · 2 ≤ max_concurrent_shards:
 # Append cadence from byte floor.
 cps_append = max(1, ceildiv(min_shard_bytes, append_row_bytes))
 
+# If min_shard_bytes < chunk_bytes at this target, Phase 2 rejects. The outer
+# loop halves `target` and retries; this naturally recovers once chunk_bytes
+# drops below min_shard_bytes. If the loop exhausts `floor`, the solver
+# returns reason = ADVISE_MIN_SHARD_TOO_SMALL.
+
 # --- Cross-phase check: backend parts limit ---
 if max_parts_per_shard > 0 and chunks_per_shard_total > max_parts_per_shard:
     # Two remedies: shrink chunks (cheapest — lowers append_row_bytes and
     # relaxes the product), or raise max_concurrent_shards (caller policy).
     halve target, restart Phase 1
-    # If already at min_chunk_bytes: ERROR with a message indicating both
-    # min_chunk_bytes and max_concurrent_shards should be revisited.
+    # If already at min_chunk_bytes: ERROR with reason
+    # ADVISE_PARTS_LIMIT_EXCEEDED.
 ```
 
 ## Worked example
@@ -201,6 +206,11 @@ shard_size_bytes   ≈ 1.03 GiB
   interpreted as an append-accumulator case, see `dims_n_append` in
   `src/lod/lod_plan.c`). Callers who don't want this should set
   `min_chunk_bytes` high enough to prevent the shrink.
+- **Pinning a dim with `chunk_ratios[d] == -1`** — bounded dims pin at
+  `size[d]`; unbounded dim 0 (`size == 0`) falls back to weight-1 so it
+  absorbs the remaining bit budget. Mixed example: `{1, -1, -1}` on
+  `(t=16M, y=16, x=16)` pins y/x at 16 each and lets t soak the chunk
+  byte budget.
 
 ## Entry points
 
@@ -215,8 +225,13 @@ shard_size_bytes   ≈ 1.03 GiB
 - `tile_stream_gpu_advise_layout` (`src/stream.gpu.h`) /
   `tile_stream_cpu_advise_layout` (`src/stream.cpu.h`) — combined solve
   with auto-fit loop, memory budget, and cross-phase parts check. Halves
-  the chunk target until all constraints are met; bails below
-  `min_chunk_bytes`.
+  `epochs_per_batch` (K) before shrinking chunks when the memory budget
+  binds; halves the chunk target when either K at floor=1 still overshoots
+  or a cross-phase constraint fails; bails below `min_chunk_bytes`. On
+  failure, fills an optional `struct advise_layout_diagnostic` with a
+  reason code (`ADVISE_BUDGET_EXCEEDED`, `ADVISE_PARTS_LIMIT_EXCEEDED`,
+  `ADVISE_MIN_SHARD_TOO_SMALL`, `ADVISE_INVALID_CONFIG`) and the relevant
+  last-iteration context.
 - Backend constants (`src/defs.limits.h`) — `MAX_PARTS_PER_SHARD` and
   `MAX_BYTES_PER_PART`, applied uniformly across sinks.
 - `run_bench` in `bench/bench_util.c` — wires these into the benchmark

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -82,14 +82,24 @@ retry.
 ## Procedure
 
 ```
-# --- Phase 1: chunks (auto-fit loop) ---
+# --- Phase 1: chunks + K (auto-fit loop) ---
 target = target_chunk_bytes
 loop:
     distribute log2(target / bytes_per_element) bits across dims per chunk_ratios
     → sets chunk_size[d] and thus chunk_bytes, n_chunks[d]
 
     if chunk_bytes > max_bytes_per_part:   halve target, continue
-    if device_bytes > memory_max_bytes:    halve target, continue
+
+    # K sub-loop: start with auto-derived K (ceildiv(target_batch_chunks,
+    # chunks_per_epoch), pow2, clamped to MAX_BATCH_EPOCHS). If device_bytes
+    # exceeds memory_max_bytes, halve K (down to 1) and re-estimate. Pools
+    # scale linearly in K, so this is the cheapest relief before shrinking
+    # chunks. A user-supplied K is authoritative and is not reduced.
+    K = auto_K(target_batch_chunks, chunks_per_epoch)
+    while device_bytes(K) > memory_max_bytes:
+        if K == 1: break    # K-alone can't fit, shrink chunks instead
+        K /= 2
+    if device_bytes(K) > memory_max_bytes: halve target, continue
     break
     # If target falls below min_chunk_bytes before breaking:
     # ERROR "no chunk size ≥ min_chunk_bytes fits in budget".

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -76,8 +76,11 @@ retry.
 2. **Maximize `concurrent_shards`** subject to (3). Use the fs-concurrency
    budget the caller specified; more inner shards produce finer shard cadence
    without inflating individual shards.
-3. **Minimize `shard_size_bytes`** subject to `shard_size_bytes ≥ min_shard_bytes`
-   and constraint (5). Smallest shard cadence that clears the byte floor.
+3. **Maximize `cps_append`** subject to `shard_size_bytes ≥ min_shard_bytes`
+   (byte floor) and `chunks_per_shard_total ≤ max_parts_per_shard` (parts cap)
+   and `cps_append ≤ n_chunks[0]`. Largest shards that stay inside the backend
+   parts limit; `min_shard_bytes` acts as a floor, not a target, so shards end
+   up as big as the parts cap (and dim extent) allow.
 
 ## Procedure
 
@@ -115,8 +118,12 @@ while concurrent_shards · 2 ≤ max_concurrent_shards:
     if no such d*: break
     shards[d*] *= 2
 
-# Append cadence from byte floor.
-cps_append = max(1, ceildiv(min_shard_bytes, append_row_bytes))
+# Append cadence: maximize subject to parts cap and byte floor.
+cps_floor = max(1, ceildiv(min_shard_bytes, append_row_bytes))
+cps_cap   = min(max_parts_per_shard / inner_prod, n_chunks[0] or ∞)
+cps_append = max(cps_floor, cps_cap)   # floor wins if parts cap can't
+                                        # accommodate it; cross-phase
+                                        # check below then retries.
 
 # If min_shard_bytes < chunk_bytes at this target, Phase 2 rejects. The outer
 # loop halves `target` and retries; this naturally recovers once chunk_bytes
@@ -173,21 +180,23 @@ inner_cps       = (c=1, y=ceildiv(80,4)=20, x=ceildiv(60,4)=15)
 inner_cps_prod  = 1 · 20 · 15 = 300
 append_row_bytes = 262 144 · 300 = 78 643 200   (75 MiB)
 
-cps_append       = max(1, ceildiv(1 GiB, 75 MiB)) = ceildiv(1073741824, 78643200) = 14
-shard_size_bytes = 14 · 78 643 200 ≈ 1.03 GiB      (just above the 1 GiB floor)
+cps_floor        = ceildiv(1 GiB, 75 MiB) = 14
+cps_cap          = min(10000/300 = 33, n_chunks[z] = 25) = 25
+cps_append       = max(14, 25) = 25
+shard_size_bytes = 25 · 78 643 200 ≈ 1.83 GiB      (above the 1 GiB floor)
 ```
 
-**Cross-phase check.** `chunks_per_shard_total = 14 · 300 = 4 200`. The filesystem sink imposes no parts limit, so accepted.
+**Cross-phase check.** `chunks_per_shard_total = 25 · 300 = 7 500 ≤ 10 000`, accepted.
 
 **Final output:**
 
 ```
 chunk_size         = (4, 1, 128, 256)
-chunks_per_shard   = (z=14, c=1, y=20, x=15)   (dim z is the outer append dim)
-shard_size_bytes   ≈ 1.03 GiB
+chunks_per_shard   = (z=25, c=1, y=20, x=15)   (dim z is the outer append dim)
+shard_size_bytes   ≈ 1.83 GiB
 
-# Total shards: ceildiv(25, 14) append-slots × 16 inner = 2 × 16 = 32 shards.
-# Total data:   100 · 10240 · 15360 · 2 B ≈ 30 GiB (matches 32 · ~1 GiB).
+# Total shards: ceildiv(25, 25) append-slots × 16 inner = 1 × 16 = 16 shards.
+# Total data:   100 · 10240 · 15360 · 2 B ≈ 30 GiB (matches 16 · ~1.8 GiB).
 ```
 
 ## Edge cases

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -24,6 +24,7 @@ Given an array's shape and dtype, pick:
 | `memory_max_bytes` | device / heap memory ceiling | caller, or auto-detected |
 | `max_concurrent_shards` | cap on concurrently-open shards (fs pressure) | caller |
 | `min_shard_bytes` | minimum uncompressed bytes per shard (cadence floor) | caller |
+| `min_append_shards` | minimum number of shards along the outer append dim; 0 = no minimum. Forces shard-switching in benches that would otherwise collapse to a single shard. | caller |
 | `max_parts_per_shard` | backend part-count limit (e.g. S3 multipart = 10000); 0 = unlimited | sink |
 | `max_bytes_per_part` | backend per-part byte limit (e.g. S3 = 5 GiB); 0 = unlimited | sink |
 
@@ -121,6 +122,8 @@ while concurrent_shards · 2 ≤ max_concurrent_shards:
 # Append cadence: maximize subject to parts cap and byte floor.
 cps_floor = max(1, ceildiv(min_shard_bytes, append_row_bytes))
 cps_cap   = min(max_parts_per_shard / inner_prod, n_chunks[0] or ∞)
+if min_append_shards > 1 and n_chunks[0] > 0:
+    cps_cap = min(cps_cap, floor(n_chunks[0] / min_append_shards))
 cps_append = max(cps_floor, cps_cap)   # floor wins if parts cap can't
                                         # accommodate it; cross-phase
                                         # check below then retries.

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -112,35 +112,43 @@ loop:
 # --- Phase 2: shards (closed-form given chunks) ---
 shards[d] = 1 for d in inner
 
-# Bit-greedy doubling: each step doubles the inner dim with the largest
-# remaining n_chunks[d]/shards[d] ratio, capped at n_chunks[d].
-while concurrent_shards · 2 ≤ target_concurrent_shards:
-    d* = argmax over d in inner where shards[d] · 2 ≤ n_chunks[d]
+# Phase 2A: fill the concurrency target. Integer-greedy, no pow2 waste.
+while Π shards[d] < target_concurrent_shards:
+    d* = argmax over d in inner where shards[d]+1 ≤ n_chunks[d] and
+          shards[d]+1 keeps Π shards[d] ≤ target_concurrent_shards
           of n_chunks[d] / shards[d]
     if no such d*: break
-    shards[d*] *= 2
+    shards[d*] += 1
 
-# Append cadence: maximize subject to parts cap and byte floor.
-cps_floor = max(1, ceildiv(min_shard_bytes, append_row_bytes))
+# Phase 2B: enforce parts budget. If inner_cps_prod is too big for the parts
+# cap given the cps_append target, keep splitting past the target
+# (target_concurrent_shards is soft — a preference, not a hard cap).
+cps_append_target = ...   # cps_floor if min_shard_bytes > 0,
+                           # floor(n_chunks[0]/min_append_shards) if set,
+                           # else 1.
+while inner_cps_prod · others_prod · cps_append_target > max_parts_per_shard:
+    d* = argmax over d in inner where splitting reduces ceildiv(n_chunks[d],
+          shards[d]+1) < ceildiv(n_chunks[d], shards[d])
+          of current cps[d]
+    if no such d*: break     # can't reduce inner_cps_prod further.
+    shards[d*] += 1
+    refresh cps_append_target (depends on inner_cps_prod in Mode 2)
+
+# If after Phase 2B, inner_cps_prod · others_prod > max_parts_per_shard,
+# the config is infeasible at this chunk size: return error PARTS_LIMIT.
+# Halving chunks doesn't help — it grows n_chunks, not shrinks it.
+
+# Append cadence: maximize within the parts cap that Phase 2B reserved.
 cps_cap   = min(max_parts_per_shard / inner_prod, n_chunks[0] or ∞)
 if min_append_shards > 1 and n_chunks[0] > 0:
     cps_cap = min(cps_cap, floor(n_chunks[0] / min_append_shards))
-cps_append = max(cps_floor, cps_cap)   # floor wins if parts cap can't
-                                        # accommodate it; cross-phase
-                                        # check below then retries.
+cps_append = cps_cap        # min_shard_bytes is soft: may be unmet if Phase 2B
+                             # couldn't reserve enough budget.
 
 # If min_shard_bytes < chunk_bytes at this target, Phase 2 rejects. The outer
 # loop halves `target` and retries; this naturally recovers once chunk_bytes
 # drops below min_shard_bytes. If the loop exhausts `floor`, the solver
 # returns reason = ADVISE_MIN_SHARD_TOO_SMALL.
-
-# --- Cross-phase check: backend parts limit ---
-if max_parts_per_shard > 0 and chunks_per_shard_total > max_parts_per_shard:
-    # Two remedies: shrink chunks (cheapest — lowers append_row_bytes and
-    # relaxes the product), or raise target_concurrent_shards (caller policy).
-    halve target, restart Phase 1
-    # If already at min_chunk_bytes: ERROR with reason
-    # ADVISE_PARTS_LIMIT_EXCEEDED.
 ```
 
 ## Worked example

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -22,7 +22,7 @@ Given an array's shape and dtype, pick:
 | `min_chunk_bytes` | chunk-size floor; solve fails if budget can't meet this | caller |
 | `target_chunk_bytes` | starting chunk size for the auto-fit loop | caller |
 | `memory_max_bytes` | device / heap memory ceiling | caller, or auto-detected |
-| `max_concurrent_shards` | cap on concurrently-open shards (fs pressure) | caller |
+| `target_concurrent_shards` | preferred number of concurrently-open shards (fs pressure). Soft: the solver aims for this value, but may exceed it when a hard constraint (e.g. `max_parts_per_shard`) requires more inner splitting. A future `max_concurrent_shards` would be the hard ceiling. | caller |
 | `min_shard_bytes` | minimum uncompressed bytes per shard (cadence floor) | caller |
 | `min_append_shards` | minimum number of shards along the outer append dim; 0 = no minimum. Forces shard-switching in benches that would otherwise collapse to a single shard. | caller |
 | `max_parts_per_shard` | backend part-count limit (e.g. S3 multipart = 10000); 0 = unlimited | sink |
@@ -42,17 +42,18 @@ Given an array's shape and dtype, pick:
 
 ### Constraints
 
-Hard:
+Hard (feasibility — solver must satisfy or fail with a specific reason):
 
-1. `chunk_bytes ≥ min_chunk_bytes` and `chunk_bytes ≤ max_bytes_per_part`.
+1. `chunk_bytes ≥ min_chunk_bytes` and `chunk_bytes ≤ max_bytes_per_part` (if nonzero).
 2. `device_bytes ≤ memory_max_bytes`.
-3. `1 ≤ shards[d] ≤ n_chunks[d]` for inner dims, and `concurrent_shards ≤ max_concurrent_shards`.
-4. `cps_append ≥ 1`.
+3. `1 ≤ shards[d] ≤ n_chunks[d]` for inner dims.
+4. `cps_append ≥ 1` and `cps_append ≤ n_chunks[0]` when `n_chunks[0] > 0`.
 5. `chunks_per_shard_total ≤ max_parts_per_shard` (if nonzero).
 
-Preference:
+Soft (preferences — solver optimizes for these but yields to any hard constraint):
 
-- `shard_size_bytes ≥ min_shard_bytes`.
+- `shard_size_bytes ≥ min_shard_bytes` — byte floor on closed shards. Ignored when `min_append_shards > 1` (the caller's shard-switching request wins).
+- `concurrent_shards ≤ target_concurrent_shards` — concurrency target. The greedy fills up to this value; may be exceeded if a hard constraint (H5 in particular) demands more inner splitting to shrink `inner_cps_prod`. Violations are reported in the diagnostic.
 
 ## Why the problem decouples
 
@@ -113,7 +114,7 @@ shards[d] = 1 for d in inner
 
 # Bit-greedy doubling: each step doubles the inner dim with the largest
 # remaining n_chunks[d]/shards[d] ratio, capped at n_chunks[d].
-while concurrent_shards · 2 ≤ max_concurrent_shards:
+while concurrent_shards · 2 ≤ target_concurrent_shards:
     d* = argmax over d in inner where shards[d] · 2 ≤ n_chunks[d]
           of n_chunks[d] / shards[d]
     if no such d*: break
@@ -136,7 +137,7 @@ cps_append = max(cps_floor, cps_cap)   # floor wins if parts cap can't
 # --- Cross-phase check: backend parts limit ---
 if max_parts_per_shard > 0 and chunks_per_shard_total > max_parts_per_shard:
     # Two remedies: shrink chunks (cheapest — lowers append_row_bytes and
-    # relaxes the product), or raise max_concurrent_shards (caller policy).
+    # relaxes the product), or raise target_concurrent_shards (caller policy).
     halve target, restart Phase 1
     # If already at min_chunk_bytes: ERROR with reason
     # ADVISE_PARTS_LIMIT_EXCEEDED.
@@ -149,7 +150,7 @@ Inputs (roughly the `medfmt_single` bench on a machine with plenty of GPU memory
 - Array: `zcyx` with `size = (100, 1, 10240, 15360)`, `dtype = u16` → `bytes_per_element = 2`
 - `chunk_ratios = (1, 0, 4, 4)`, `target_chunk_bytes = 256 KiB`, `min_chunk_bytes = 16 KiB`
 - `memory_max_bytes = 8 GiB`
-- `max_concurrent_shards = 16`, `min_shard_bytes = 1 GiB`
+- `target_concurrent_shards = 16`, `min_shard_bytes = 1 GiB`
 - Filesystem sink: `max_parts_per_shard = 0`, `max_bytes_per_part = 0` (unlimited)
 
 **Phase 1.** Distribute `log2(256 KiB / 2) = 17` bits across `ratios (1, 0, 4, 4)`.
@@ -210,8 +211,8 @@ shard_size_bytes   ≈ 1.83 GiB
 - **`append_row_bytes · 1 > max_bytes_per_part · max_parts_per_shard`** — a
   single append-row already exceeds the backend's total shard capacity. Phase 1
   retry. If chunks are already at `min_chunk_bytes`, error cleanly and ask the
-  caller to raise `max_concurrent_shards` or lower `min_chunk_bytes`.
-- **`max_concurrent_shards = 1`** with a large inner grid — one shard covers
+  caller to raise `target_concurrent_shards` or lower `min_chunk_bytes`.
+- **`target_concurrent_shards = 1`** with a large inner grid — one shard covers
   the whole inner volume. Respects the caller's explicit concurrency policy;
   resulting shards may be large.
 - **A downsample dim gets `chunk_size = 1`** — allowed (the configuration is
@@ -230,7 +231,7 @@ shard_size_bytes   ≈ 1.83 GiB
   distributes bits into `chunk_size[d]` per `chunk_ratios`.
 - `dims_set_shard_geometry` (`src/dimension.h`) — Phase 2 primitive:
   shard geometry given chunks, `min_shard_bytes`, and
-  `max_concurrent_shards`. Returns non-zero if `min_shard_bytes` is smaller
+  `target_concurrent_shards`. Returns non-zero if `min_shard_bytes` is smaller
   than one chunk.
 - `dims_set_layout` (`src/dimension.h`) — convenience wrapper that runs
   both phases from a single `dims_layout_policy` struct.

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -236,7 +236,9 @@ shard_size_bytes   ≈ 1.83 GiB
 ## Entry points
 
 - `dims_budget_chunk_bytes` (`src/dimension.h`) — Phase 1 primitive:
-  distributes bits into `chunk_size[d]` per `chunk_ratios`.
+  distributes bits into `chunk_size[d]` per `chunk_ratios`. Participants are
+  clamped to dim extent. Returns non-zero on invalid input (`bpe == 0`,
+  `target < bpe`, pinned dims exceed budget).
 - `dims_set_shard_geometry` (`src/dimension.h`) — Phase 2 primitive:
   shard geometry given chunks, `min_shard_bytes`, and
   `target_concurrent_shards`. Returns non-zero if `min_shard_bytes` is smaller

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -84,6 +84,20 @@ retry.
    parts limit; `min_shard_bytes` acts as a floor, not a target, so shards end
    up as big as the parts cap (and dim extent) allow.
 
+### Tiebreakers
+
+When multiple dims are equally preferred at a greedy step, the choice is
+deterministic:
+
+- **Phase 1 bit allocation** (chunks): on equal `bits[i]/ratio[i]`, the
+  higher-indexed dim wins (extra bits go to inner/spatial dims, which are
+  typically rightmost).
+- **Phase 2A ratio greedy** (inner shards): on equal
+  `n_chunks[d]/shards[d]`, the lower-indexed dim wins.
+- **Phase 2B largest-cps** (parts-budget split): on equal current
+  `cps[d]`, the lower-indexed dim wins. Dims where incrementing shards
+  does not reduce `cps` (ceildiv roundoff stall) are skipped.
+
 ## Procedure
 
 ```
@@ -250,11 +264,18 @@ shard_size_bytes   ≈ 1.83 GiB
   with auto-fit loop, memory budget, and cross-phase parts check. Halves
   `epochs_per_batch` (K) before shrinking chunks when the memory budget
   binds; halves the chunk target when either K at floor=1 still overshoots
-  or a cross-phase constraint fails; bails below `min_chunk_bytes`. On
-  failure, fills an optional `struct advise_layout_diagnostic` with a
-  reason code (`ADVISE_BUDGET_EXCEEDED`, `ADVISE_PARTS_LIMIT_EXCEEDED`,
-  `ADVISE_MIN_SHARD_TOO_SMALL`, `ADVISE_INVALID_CONFIG`) and the relevant
-  last-iteration context.
+  or a cross-phase constraint fails; bails below `min_chunk_bytes`. Fills
+  an optional `struct advise_layout_diagnostic`:
+  - On **failure**, `reason` is one of `ADVISE_BUDGET_EXCEEDED`,
+    `ADVISE_PARTS_LIMIT_EXCEEDED`, `ADVISE_MIN_SHARD_TOO_SMALL`, or
+    `ADVISE_INVALID_CONFIG`, with last-iteration context.
+  - On **success**, `reason = ADVISE_OK`. `actual_concurrent_shards` and
+    `actual_shard_bytes` let the caller detect soft-constraint
+    compromises: `actual_concurrent_shards > target_concurrent_shards`
+    means Phase B split past the target to fit the parts budget;
+    `actual_shard_bytes < min_shard_bytes` means the floor was not
+    reached (either because the parts cap bound or because
+    `min_append_shards > 1` overrode it).
 - Backend constants (`src/defs.limits.h`) — `MAX_PARTS_PER_SHARD` and
   `MAX_BYTES_PER_PART`, applied uniformly across sinks.
 - `run_bench` in `bench/bench_util.c` — wires these into the benchmark

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -266,16 +266,21 @@ shard_size_bytes   ≈ 1.83 GiB
   binds; halves the chunk target when either K at floor=1 still overshoots
   or a cross-phase constraint fails; bails below `min_chunk_bytes`. Fills
   an optional `struct advise_layout_diagnostic`:
-  - On **failure**, `reason` is one of `ADVISE_BUDGET_EXCEEDED`,
-    `ADVISE_PARTS_LIMIT_EXCEEDED`, `ADVISE_MIN_SHARD_TOO_SMALL`, or
-    `ADVISE_INVALID_CONFIG`, with last-iteration context.
+  - On **failure**, `reason` is one of:
+    - `ADVISE_BUDGET_EXCEEDED` — no (chunk, K) pair fit memory budget
+    - `ADVISE_PARTS_LIMIT_EXCEEDED` — parts cap infeasible even after Phase B
+    - `ADVISE_MIN_SHARD_TOO_SMALL` — `min_shard_bytes < chunk_bytes`
+    - `ADVISE_CHUNK_BUDGET_INFEASIBLE` — pinned dims or input rejected the
+      chunk target (not recoverable by halving)
+    - `ADVISE_INVALID_CONFIG` — caller-level config or shard-geometry rejection
   - On **success**, `reason = ADVISE_OK`. `actual_concurrent_shards` and
     `actual_shard_bytes` let the caller detect soft-constraint
     compromises: `actual_concurrent_shards > target_concurrent_shards`
     means Phase B split past the target to fit the parts budget;
     `actual_shard_bytes < min_shard_bytes` means the floor was not
-    reached (either because the parts cap bound or because
-    `min_append_shards > 1` overrode it).
+    reached. `min_append_shards_overrode_min_shard_bytes` is `1` when
+    both knobs were set (caller asked for N append shards *and* a byte
+    floor) — `min_append_shards` wins per the spec, floor may be unmet.
 - Backend constants (`src/defs.limits.h`) — `MAX_PARTS_PER_SHARD` and
   `MAX_BYTES_PER_PART`, applied uniformly across sinks.
 - `run_bench` in `bench/bench_util.c` — wires these into the benchmark

--- a/docs/s3-guide.md
+++ b/docs/s3-guide.md
@@ -226,7 +226,7 @@ struct tile_stream_configuration stream_cfg = {
   .codec      = CODEC_ZSTD,
 };
 
-uint8_t ratios[] = { 0, 1, 1 };
+int ratios[] = { 0, 1, 1 };
 tile_stream_gpu_advise_chunk_sizes(
   &stream_cfg, 128 * 1024, ratios, 2ULL << 30, 0);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ endfunction()
 
 add_src_lib(chucky_log SOURCES log/log.c log/log.h chucky_log.h)
 add_src_lib(index_ops  SOURCES util/index.ops.c util/index.ops.h)
+add_src_lib(format_bytes SOURCES util/format_bytes.c util/format_bytes.h)
 add_src_lib(dtype      SOURCES dtype.c dtype.h)
 add_src_lib(dimension  SOURCES dimension.c dimension.h)
 add_src_lib(lod_plan   SOURCES lod/lod_plan.c lod/lod_plan.h

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -547,6 +547,7 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
         break;
       }
       last_reason = ADVISE_BUDGET_EXCEEDED;
+      last_cps_total = 0;
       if (user_k || mem.epochs_per_batch <= 1)
         break;
       config->epochs_per_batch = (uint8_t)(mem.epochs_per_batch / 2);
@@ -554,18 +555,16 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
     if (!fit)
       continue;
 
-    // Phase 2: shard geometry.
+    // Phase 2: shard geometry. If min_shard_bytes < chunk_bytes at this
+    // target, shrink chunks and retry.
     if (dims_set_shard_geometry(config->dimensions,
                                 config->rank,
                                 min_shard_bytes,
                                 max_concurrent_shards,
                                 bytes_per_element)) {
-      if (diag) {
-        diag->reason = ADVISE_MIN_SHARD_TOO_SMALL;
-        diag->chunk_bytes = last_chunk_bytes;
-        diag->epochs_per_batch = last_k;
-      }
-      return 1;
+      last_reason = ADVISE_MIN_SHARD_TOO_SMALL;
+      last_cps_total = 0;
+      continue;
     }
 
     // Cross-phase (5): chunks_per_shard_total <= MAX_PARTS_PER_SHARD.

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -483,7 +483,7 @@ int
 tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                               size_t target_chunk_bytes,
                               size_t min_chunk_bytes,
-                              const uint8_t* ratios,
+                              const int* ratios,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -4,6 +4,7 @@
 #include "cpu/compress.h"
 #include "cpu/compress_blosc.h"
 #include "cpu/transpose.h"
+#include "defs.limits.h"
 #include "platform/platform.h"
 #include "util/metric.h"
 #include "util/prelude.h"
@@ -479,25 +480,51 @@ tile_stream_cpu_memory_estimate(const struct tile_stream_configuration* config,
 }
 
 int
-tile_stream_cpu_advise_chunk_sizes(struct tile_stream_configuration* config,
-                                   size_t target_chunk_bytes,
-                                   const uint8_t* ratios,
-                                   size_t budget_bytes,
-                                   size_t shard_alignment)
+tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
+                              size_t target_chunk_bytes,
+                              size_t min_chunk_bytes,
+                              const uint8_t* ratios,
+                              size_t budget_bytes,
+                              size_t min_shard_bytes,
+                              uint32_t max_concurrent_shards,
+                              size_t shard_alignment)
 {
   const size_t bytes_per_element = dtype_bpe(config->dtype);
   if (bytes_per_element == 0 || budget_bytes == 0)
     return 1;
 
-  for (size_t target = target_chunk_bytes; target >= bytes_per_element;
-       target >>= 1) {
+  size_t floor =
+    min_chunk_bytes > bytes_per_element ? min_chunk_bytes : bytes_per_element;
+  for (size_t target = target_chunk_bytes; target >= floor; target >>= 1) {
+    // Phase 1: fit chunks to memory budget.
     dims_budget_chunk_bytes(
       config->dimensions, config->rank, target, bytes_per_element, ratios);
     struct tile_stream_cpu_memory_info mem;
     if (tile_stream_cpu_memory_estimate(config, shard_alignment, &mem))
       return 1;
-    if (mem.heap_bytes <= budget_bytes)
-      return 0;
+    if (mem.heap_bytes > budget_bytes)
+      continue;
+
+    // Phase 2: shard geometry.
+    if (dims_set_shard_geometry(config->dimensions,
+                                config->rank,
+                                min_shard_bytes,
+                                max_concurrent_shards,
+                                bytes_per_element))
+      return 1;
+
+    // Cross-phase (5): chunks_per_shard_total <= MAX_PARTS_PER_SHARD.
+    uint64_t cps_total = 1;
+    for (uint8_t d = 0; d < config->rank; ++d) {
+      uint64_t cps = config->dimensions[d].chunks_per_shard;
+      if (cps == 0)
+        cps = 1;
+      cps_total *= cps;
+    }
+    if (cps_total > MAX_PARTS_PER_SHARD)
+      continue;
+
+    return 0;
   }
   return 1;
 }

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -487,22 +487,71 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,
-                              size_t shard_alignment)
+                              size_t shard_alignment,
+                              struct advise_layout_diagnostic* diag)
 {
-  const size_t bytes_per_element = dtype_bpe(config->dtype);
-  if (bytes_per_element == 0 || budget_bytes == 0)
-    return 1;
+  if (diag) {
+    memset(diag, 0, sizeof(*diag));
+    diag->budget_bytes = budget_bytes;
+    diag->parts_limit = MAX_PARTS_PER_SHARD;
+  }
 
-  size_t floor =
+  const size_t bytes_per_element = dtype_bpe(config->dtype);
+  if (bytes_per_element == 0 || budget_bytes == 0) {
+    if (diag)
+      diag->reason = ADVISE_INVALID_CONFIG;
+    return 1;
+  }
+
+  const uint8_t user_k = config->epochs_per_batch;
+  const size_t floor =
     min_chunk_bytes > bytes_per_element ? min_chunk_bytes : bytes_per_element;
+  if (diag)
+    diag->floor_chunk_bytes = floor;
+
+  enum advise_layout_reason last_reason = ADVISE_BUDGET_EXCEEDED;
+  size_t last_chunk_bytes = 0;
+  uint32_t last_k = 0;
+  size_t last_heap_bytes = 0;
+  uint64_t last_cps_total = 0;
+
   for (size_t target = target_chunk_bytes; target >= floor; target >>= 1) {
-    // Phase 1: fit chunks to memory budget.
+    // Phase 1: fit chunks + K to memory budget. Start with auto-derived K
+    // (or user-supplied K if non-zero); if heap_bytes exceeds budget, halve K
+    // and retry. User-supplied K is authoritative and isn't reduced.
     dims_budget_chunk_bytes(
       config->dimensions, config->rank, target, bytes_per_element, ratios);
-    struct tile_stream_cpu_memory_info mem;
-    if (tile_stream_cpu_memory_estimate(config, shard_alignment, &mem))
-      return 1;
-    if (mem.heap_bytes > budget_bytes)
+
+    uint64_t chunk_vol = 1;
+    for (uint8_t d = 0; d < config->rank; ++d)
+      chunk_vol *= config->dimensions[d].chunk_size;
+    last_chunk_bytes = (size_t)(chunk_vol * bytes_per_element);
+
+    config->epochs_per_batch = user_k;
+    int fit = 0;
+    for (;;) {
+      struct tile_stream_cpu_memory_info mem;
+      if (tile_stream_cpu_memory_estimate(config, shard_alignment, &mem)) {
+        if (diag) {
+          diag->reason = ADVISE_INVALID_CONFIG;
+          diag->chunk_bytes = last_chunk_bytes;
+          diag->epochs_per_batch = config->epochs_per_batch;
+        }
+        return 1;
+      }
+      last_k = mem.epochs_per_batch;
+      last_heap_bytes = mem.heap_bytes;
+      if (mem.heap_bytes <= budget_bytes) {
+        config->epochs_per_batch = (uint8_t)mem.epochs_per_batch;
+        fit = 1;
+        break;
+      }
+      last_reason = ADVISE_BUDGET_EXCEEDED;
+      if (user_k || mem.epochs_per_batch <= 1)
+        break;
+      config->epochs_per_batch = (uint8_t)(mem.epochs_per_batch / 2);
+    }
+    if (!fit)
       continue;
 
     // Phase 2: shard geometry.
@@ -510,8 +559,14 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                                 config->rank,
                                 min_shard_bytes,
                                 max_concurrent_shards,
-                                bytes_per_element))
+                                bytes_per_element)) {
+      if (diag) {
+        diag->reason = ADVISE_MIN_SHARD_TOO_SMALL;
+        diag->chunk_bytes = last_chunk_bytes;
+        diag->epochs_per_batch = last_k;
+      }
       return 1;
+    }
 
     // Cross-phase (5): chunks_per_shard_total <= MAX_PARTS_PER_SHARD.
     uint64_t cps_total = 1;
@@ -521,10 +576,22 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
         cps = 1;
       cps_total *= cps;
     }
-    if (cps_total > MAX_PARTS_PER_SHARD)
+    if (cps_total > MAX_PARTS_PER_SHARD) {
+      last_reason = ADVISE_PARTS_LIMIT_EXCEEDED;
+      last_cps_total = cps_total;
       continue;
+    }
 
     return 0;
+  }
+
+  config->epochs_per_batch = user_k;
+  if (diag) {
+    diag->reason = last_reason;
+    diag->chunk_bytes = last_chunk_bytes;
+    diag->epochs_per_batch = last_k;
+    diag->device_bytes = last_heap_bytes;
+    diag->chunks_per_shard_total = last_cps_total;
   }
   return 1;
 }

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -487,6 +487,7 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,
+                              uint32_t min_append_shards,
                               size_t shard_alignment,
                               struct advise_layout_diagnostic* diag)
 {
@@ -561,6 +562,7 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                                 config->rank,
                                 min_shard_bytes,
                                 max_concurrent_shards,
+                                min_append_shards,
                                 bytes_per_element)) {
       last_reason = ADVISE_MIN_SHARD_TOO_SMALL;
       last_cps_total = 0;

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -528,7 +528,7 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                                 ratios)) {
       // Non-recoverable input (e.g. pinned dims exceed target at this step).
       // Halving target can only make it worse — bail.
-      last_reason = ADVISE_INVALID_CONFIG;
+      last_reason = ADVISE_CHUNK_BUDGET_INFEASIBLE;
       last_chunk_bytes = target;
       break;
     }
@@ -624,6 +624,8 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
       diag->chunks_per_shard_total = cps_total;
       diag->actual_concurrent_shards = inner_shards_prod;
       diag->actual_shard_bytes = last_chunk_bytes * cps_total;
+      diag->min_append_shards_overrode_min_shard_bytes =
+        (min_append_shards > 1 && min_shard_bytes > 0) ? 1 : 0;
     }
     return 0;
   }

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -556,31 +556,36 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
     if (!fit)
       continue;
 
-    // Phase 2: shard geometry. If min_shard_bytes < chunk_bytes at this
-    // target, shrink chunks and retry.
-    if (dims_set_shard_geometry(config->dimensions,
-                                config->rank,
-                                min_shard_bytes,
-                                target_concurrent_shards,
-                                min_append_shards,
-                                bytes_per_element)) {
+    // Phase 2: shard geometry (parts budget + concurrency target + byte floor).
+    // Return 1 = MIN_SHARD_TOO_SMALL (retryable by shrinking chunks);
+    // return 2 = PARTS_LIMIT infeasible even with inner fully split — halving
+    // chunks only grows inner_cps_prod, so bail immediately.
+    int sg = dims_set_shard_geometry(config->dimensions,
+                                     config->rank,
+                                     min_shard_bytes,
+                                     target_concurrent_shards,
+                                     min_append_shards,
+                                     bytes_per_element);
+    if (sg == 1) {
       last_reason = ADVISE_MIN_SHARD_TOO_SMALL;
       last_cps_total = 0;
       continue;
     }
-
-    // Cross-phase (5): chunks_per_shard_total <= MAX_PARTS_PER_SHARD.
-    uint64_t cps_total = 1;
-    for (uint8_t d = 0; d < config->rank; ++d) {
-      uint64_t cps = config->dimensions[d].chunks_per_shard;
-      if (cps == 0)
-        cps = 1;
-      cps_total *= cps;
-    }
-    if (cps_total > MAX_PARTS_PER_SHARD) {
+    if (sg == 2) {
       last_reason = ADVISE_PARTS_LIMIT_EXCEEDED;
+      uint64_t cps_total = 1;
+      for (uint8_t d = 0; d < config->rank; ++d) {
+        uint64_t cps = config->dimensions[d].chunks_per_shard;
+        if (cps == 0)
+          cps = 1;
+        cps_total *= cps;
+      }
       last_cps_total = cps_total;
-      continue;
+      break;
+    }
+    if (sg != 0) {
+      last_reason = ADVISE_INVALID_CONFIG;
+      break;
     }
 
     return 0;

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -486,7 +486,7 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                               const int* ratios,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
-                              uint32_t max_concurrent_shards,
+                              uint32_t target_concurrent_shards,
                               uint32_t min_append_shards,
                               size_t shard_alignment,
                               struct advise_layout_diagnostic* diag)
@@ -561,7 +561,7 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
     if (dims_set_shard_geometry(config->dimensions,
                                 config->rank,
                                 min_shard_bytes,
-                                max_concurrent_shards,
+                                target_concurrent_shards,
                                 min_append_shards,
                                 bytes_per_element)) {
       last_reason = ADVISE_MIN_SHARD_TOO_SMALL;

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -5,6 +5,7 @@
 #include "cpu/compress_blosc.h"
 #include "cpu/transpose.h"
 #include "defs.limits.h"
+#include "lod/lod_plan.h"
 #include "platform/platform.h"
 #include "util/metric.h"
 #include "util/prelude.h"
@@ -597,6 +598,33 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
       break;
     }
 
+    if (diag) {
+      uint64_t cps_total = 1;
+      for (uint8_t d = 0; d < config->rank; ++d) {
+        uint64_t cps = config->dimensions[d].chunks_per_shard;
+        if (cps == 0)
+          cps = 1;
+        cps_total *= cps;
+      }
+      uint8_t na = dims_n_append(config->dimensions, config->rank);
+      uint64_t inner_shards_prod = 1;
+      for (uint8_t d = na; d < config->rank; ++d) {
+        uint64_t size = config->dimensions[d].size;
+        uint64_t cs = config->dimensions[d].chunk_size;
+        uint64_t cps = config->dimensions[d].chunks_per_shard;
+        if (cs == 0 || cps == 0)
+          continue;
+        uint64_t n_chunks = (size + cs - 1) / cs;
+        inner_shards_prod *= (n_chunks + cps - 1) / cps;
+      }
+      diag->reason = ADVISE_OK;
+      diag->chunk_bytes = last_chunk_bytes;
+      diag->epochs_per_batch = config->epochs_per_batch;
+      diag->device_bytes = last_heap_bytes;
+      diag->chunks_per_shard_total = cps_total;
+      diag->actual_concurrent_shards = inner_shards_prod;
+      diag->actual_shard_bytes = last_chunk_bytes * cps_total;
+    }
     return 0;
   }
 

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -520,8 +520,17 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
     // Phase 1: fit chunks + K to memory budget. Start with auto-derived K
     // (or user-supplied K if non-zero); if heap_bytes exceeds budget, halve K
     // and retry. User-supplied K is authoritative and isn't reduced.
-    dims_budget_chunk_bytes(
-      config->dimensions, config->rank, target, bytes_per_element, ratios);
+    if (dims_budget_chunk_bytes(config->dimensions,
+                                config->rank,
+                                target,
+                                bytes_per_element,
+                                ratios)) {
+      // Non-recoverable input (e.g. pinned dims exceed target at this step).
+      // Halving target can only make it worse — bail.
+      last_reason = ADVISE_INVALID_CONFIG;
+      last_chunk_bytes = target;
+      break;
+    }
 
     uint64_t chunk_vol = 1;
     for (uint8_t d = 0; d < config->rank; ++d)

--- a/src/defs.limits.h
+++ b/src/defs.limits.h
@@ -16,3 +16,8 @@
 #define S3_MAX_PARTS 10000
 #define S3_DEFAULT_PART_SIZE (8 * 1024 * 1024)
 #define S3_DEFAULT_THROUGHPUT_GBPS 10.0
+
+// Shard backend limits — applied uniformly across sinks (conservative).
+// One chunk per upload part, so parts-count = chunks per shard.
+#define MAX_PARTS_PER_SHARD S3_MAX_PARTS
+#define MAX_BYTES_PER_PART (5ull * 1024 * 1024 * 1024) // S3 single-part ceiling

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -183,6 +183,9 @@ dims_set_shard_geometry(struct dimension* dims,
 {
   if (!dims || rank == 0 || bytes_per_element == 0)
     return 1;
+  for (uint8_t d = 0; d < rank; ++d)
+    if (dims[d].chunk_size == 0)
+      return 1;
 
   size_t chunk_bytes = bytes_per_element;
   for (uint8_t d = 0; d < rank; ++d)
@@ -242,13 +245,16 @@ dims_set_shard_geometry(struct dimension* dims,
     others_prod *= dims[d].chunks_per_shard;
   }
 
-  uint64_t row_bytes = (uint64_t)chunk_bytes * inner_cps_prod * others_prod;
-  uint64_t cps_0 =
-    row_bytes ? ceildiv((uint64_t)min_shard_bytes, row_bytes) : 1;
-  if (cps_0 < 1)
-    cps_0 = 1;
-  if (na > 0)
+  // min_shard_bytes == 0 means "no byte floor": leave dims[0].chunks_per_shard
+  // as the caller set it (0 means full span downstream).
+  if (min_shard_bytes > 0) {
+    uint64_t row_bytes = (uint64_t)chunk_bytes * inner_cps_prod * others_prod;
+    uint64_t cps_0 =
+      row_bytes ? ceildiv((uint64_t)min_shard_bytes, row_bytes) : 1;
+    if (cps_0 < 1)
+      cps_0 = 1;
     dims[0].chunks_per_shard = cps_0;
+  }
 
   return 0;
 }

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -173,3 +173,99 @@ dims_set_shard_counts(struct dimension* dims,
     dims[i].chunks_per_shard = ceildiv(n_chunks, shard_counts[i]);
   }
 }
+
+int
+dims_set_shard_geometry(struct dimension* dims,
+                        uint8_t rank,
+                        size_t min_shard_bytes,
+                        uint32_t max_concurrent_shards,
+                        size_t bytes_per_element)
+{
+  if (!dims || rank == 0 || bytes_per_element == 0)
+    return 1;
+
+  size_t chunk_bytes = bytes_per_element;
+  for (uint8_t d = 0; d < rank; ++d)
+    chunk_bytes *= dims[d].chunk_size;
+
+  if (min_shard_bytes > 0 && min_shard_bytes < chunk_bytes) {
+    log_error("min_shard_bytes (%zu) is smaller than one chunk (%zu bytes)",
+              min_shard_bytes,
+              chunk_bytes);
+    return 1;
+  }
+
+  uint8_t na = dims_n_append(dims, rank);
+  uint32_t M = max_concurrent_shards ? max_concurrent_shards : 1;
+
+  uint64_t n_chunks[HALF_MAX_RANK];
+  uint64_t shards[HALF_MAX_RANK];
+  for (uint8_t d = 0; d < rank; ++d) {
+    n_chunks[d] = ceildiv(dims[d].size, dims[d].chunk_size);
+    shards[d] = 1;
+  }
+
+  // Integer-greedy allocation across inner dims: each step increments the
+  // inner dim with the largest remaining n_chunks/shards ratio, provided
+  // incrementing stays within its chunk count and the running product stays
+  // within max_concurrent_shards. Gives any M_active in [1, M_max] — no
+  // power-of-2 rounding waste.
+  uint64_t prod = 1;
+  while (prod < (uint64_t)M) {
+    int best = -1;
+    for (uint8_t d = na; d < rank; ++d) {
+      if (shards[d] + 1 > n_chunks[d])
+        continue;
+      if (prod / shards[d] * (shards[d] + 1) > (uint64_t)M)
+        continue;
+      if (best < 0 || n_chunks[d] * shards[best] > n_chunks[best] * shards[d])
+        best = d;
+    }
+    if (best < 0)
+      break;
+    prod = prod / shards[best] * (shards[best] + 1);
+    shards[best] += 1;
+  }
+
+  uint64_t inner_cps_prod = 1;
+  for (uint8_t d = na; d < rank; ++d) {
+    dims[d].chunks_per_shard = ceildiv(n_chunks[d], shards[d]);
+    inner_cps_prod *= dims[d].chunks_per_shard;
+  }
+
+  // For multi-append configs (na > 1), the outer append dim gets the
+  // byte-target cadence; inner append dims pass through at full span so
+  // the downstream product (config.c:361) evaluates to the intended total.
+  uint64_t others_prod = 1;
+  for (uint8_t d = 1; d < na; ++d) {
+    dims[d].chunks_per_shard = n_chunks[d] ? n_chunks[d] : 1;
+    others_prod *= dims[d].chunks_per_shard;
+  }
+
+  uint64_t row_bytes = (uint64_t)chunk_bytes * inner_cps_prod * others_prod;
+  uint64_t cps_0 =
+    row_bytes ? ceildiv((uint64_t)min_shard_bytes, row_bytes) : 1;
+  if (cps_0 < 1)
+    cps_0 = 1;
+  if (na > 0)
+    dims[0].chunks_per_shard = cps_0;
+
+  return 0;
+}
+
+int
+dims_set_layout(struct dimension* dims,
+                uint8_t rank,
+                const struct dims_layout_policy* p)
+{
+  if (!dims || !p || rank == 0)
+    return 1;
+  if (p->chunk_ratios)
+    dims_budget_chunk_bytes(
+      dims, rank, p->target_chunk_bytes, p->bytes_per_element, p->chunk_ratios);
+  return dims_set_shard_geometry(dims,
+                                 rank,
+                                 p->min_shard_bytes,
+                                 p->max_concurrent_shards,
+                                 p->bytes_per_element);
+}

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -280,15 +280,29 @@ dims_set_shard_geometry(struct dimension* dims,
     others_prod *= dims[d].chunks_per_shard;
   }
 
+  // Maximize cps_append subject to the byte floor and the backend parts cap.
+  //   - cps_floor = ceildiv(min_shard_bytes, row_bytes) respects the floor.
+  //   - cps_cap   = min(MAX_PARTS_PER_SHARD / inner_prod, n_chunks[0]) caps
+  //     the chunks-per-shard product and the actual dim extent.
+  // If cps_cap < cps_floor the two constraints conflict; we keep the floor
+  // and let advise_layout's cross-phase check signal PARTS_LIMIT_EXCEEDED so
+  // the outer loop retries with smaller chunks.
   // min_shard_bytes == 0 means "no byte floor": leave dims[0].chunks_per_shard
   // as the caller set it (0 means full span downstream).
   if (min_shard_bytes > 0) {
-    uint64_t row_bytes = (uint64_t)chunk_bytes * inner_cps_prod * others_prod;
-    uint64_t cps_0 =
+    const uint64_t row_bytes =
+      (uint64_t)chunk_bytes * inner_cps_prod * others_prod;
+    const uint64_t inner_prod = inner_cps_prod * others_prod;
+    uint64_t cps_floor =
       row_bytes ? ceildiv((uint64_t)min_shard_bytes, row_bytes) : 1;
-    if (cps_0 < 1)
-      cps_0 = 1;
-    dims[0].chunks_per_shard = cps_0;
+    if (cps_floor < 1)
+      cps_floor = 1;
+    uint64_t cps_cap = inner_prod ? (MAX_PARTS_PER_SHARD / inner_prod) : 1;
+    if (n_chunks[0] > 0 && cps_cap > n_chunks[0])
+      cps_cap = n_chunks[0];
+    if (cps_cap < 1)
+      cps_cap = 1;
+    dims[0].chunks_per_shard = cps_cap >= cps_floor ? cps_cap : cps_floor;
   }
 
   return 0;

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -301,11 +301,13 @@ dims_set_shard_geometry(struct dimension* dims,
     uint64_t cps_cap = inner_prod ? (MAX_PARTS_PER_SHARD / inner_prod) : 1;
     if (n_chunks[0] > 0 && cps_cap > n_chunks[0])
       cps_cap = n_chunks[0];
-    // Enforce minimum number of append-direction shards: ceildiv(n_chunks[0],
-    // cps_cap) >= min_append_shards. Only meaningful for bounded dim 0.
-    const uint32_t min_shards = min_append_shards ? min_append_shards : 1;
-    if (min_shards > 1 && n_chunks[0] > 0) {
-      uint64_t cap_for_shards = n_chunks[0] / min_shards;
+    // When min_append_shards > 1 the caller has asked for at least N
+    // append-direction shards; clamp cps_cap accordingly and let it override
+    // the byte floor on conflict (the caller's shard-switching ask is hard,
+    // the byte floor is soft).
+    const int min_shards_set = min_append_shards > 1;
+    if (min_shards_set && n_chunks[0] > 0) {
+      uint64_t cap_for_shards = n_chunks[0] / min_append_shards;
       if (cap_for_shards < 1)
         cap_for_shards = 1; // can't get N shards; fall back to cps=1.
       if (cps_cap > cap_for_shards)
@@ -313,7 +315,10 @@ dims_set_shard_geometry(struct dimension* dims,
     }
     if (cps_cap < 1)
       cps_cap = 1;
-    dims[0].chunks_per_shard = cps_cap >= cps_floor ? cps_cap : cps_floor;
+    if (min_shards_set)
+      dims[0].chunks_per_shard = cps_cap;
+    else
+      dims[0].chunks_per_shard = cps_cap >= cps_floor ? cps_cap : cps_floor;
   }
 
   return 0;

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -214,6 +214,7 @@ dims_set_shard_geometry(struct dimension* dims,
                         uint8_t rank,
                         size_t min_shard_bytes,
                         uint32_t max_concurrent_shards,
+                        uint32_t min_append_shards,
                         size_t bytes_per_element)
 {
   if (!dims || rank == 0 || bytes_per_element == 0)
@@ -300,6 +301,16 @@ dims_set_shard_geometry(struct dimension* dims,
     uint64_t cps_cap = inner_prod ? (MAX_PARTS_PER_SHARD / inner_prod) : 1;
     if (n_chunks[0] > 0 && cps_cap > n_chunks[0])
       cps_cap = n_chunks[0];
+    // Enforce minimum number of append-direction shards: ceildiv(n_chunks[0],
+    // cps_cap) >= min_append_shards. Only meaningful for bounded dim 0.
+    const uint32_t min_shards = min_append_shards ? min_append_shards : 1;
+    if (min_shards > 1 && n_chunks[0] > 0) {
+      uint64_t cap_for_shards = n_chunks[0] / min_shards;
+      if (cap_for_shards < 1)
+        cap_for_shards = 1; // can't get N shards; fall back to cps=1.
+      if (cps_cap > cap_for_shards)
+        cps_cap = cap_for_shards;
+    }
     if (cps_cap < 1)
       cps_cap = 1;
     dims[0].chunks_per_shard = cps_cap >= cps_floor ? cps_cap : cps_floor;
@@ -322,5 +333,6 @@ dims_set_layout(struct dimension* dims,
                                  rank,
                                  p->min_shard_bytes,
                                  p->max_concurrent_shards,
+                                 p->min_append_shards,
                                  p->bytes_per_element);
 }

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -115,37 +115,72 @@ void
 dims_budget_chunk_size(struct dimension* dims,
                        uint8_t rank,
                        uint64_t nelem,
-                       const uint8_t* ratios)
+                       const int* ratios)
 {
   if (nelem == 0)
     return;
 
-  // total_bits = floor(log2(nelem))
-  int total_bits = 63 - clzll(nelem);
+  // Classify dims. effective[i]:
+  //   >0  : bit-budget participant with this weight
+  //    0  : chunk_size = 1 (no bits)
+  //   -1  : pin at dims[i].size (only for bounded dims; unbounded falls back
+  //         to weight=1 so the dim absorbs the remaining budget).
+  int effective[HALF_MAX_RANK];
+  uint64_t pinned_prod = 1;
+  int any_participant = 0;
 
-  uint32_t sum_ratios = 0;
+  for (uint8_t i = 0; i < rank; ++i) {
+    if (ratios[i] == -1) {
+      if (dims[i].size == 0) {
+        effective[i] = 1; // unbounded: absorb remaining budget
+        any_participant = 1;
+      } else {
+        effective[i] = -1; // pin at size
+        pinned_prod *= dims[i].size;
+      }
+    } else if (ratios[i] == 0) {
+      effective[i] = 0;
+    } else {
+      effective[i] = ratios[i];
+      any_participant = 1;
+    }
+  }
+
+  // Apply pins.
   for (uint8_t i = 0; i < rank; ++i)
-    sum_ratios += ratios[i];
+    if (effective[i] == -1)
+      dims[i].chunk_size = dims[i].size;
 
-  if (sum_ratios == 0)
+  if (!any_participant)
     return;
 
+  // Remaining element budget for participants.
+  uint64_t remaining = pinned_prod ? nelem / pinned_prod : nelem;
+  if (remaining < 1)
+    remaining = 1;
+  int total_bits = 63 - clzll(remaining);
+
   // Greedy bit allocation: each bit goes to the most underserved
-  // dimension (lowest bits[i]/ratio[i]). Ties favor higher indices.
+  // participant (lowest bits[i]/effective[i]). Ties favor higher indices.
   int bits[HALF_MAX_RANK] = { 0 };
   for (int b = 0; b < total_bits; ++b) {
     int best = -1;
     for (uint8_t i = 0; i < rank; ++i) {
-      if (ratios[i] == 0)
+      if (effective[i] <= 0)
         continue;
-      if (best < 0 || bits[i] * ratios[best] <= bits[best] * ratios[i])
+      if (best < 0 || bits[i] * effective[best] <= bits[best] * effective[i])
         best = i;
     }
     bits[best]++;
   }
 
-  for (uint8_t i = 0; i < rank; ++i)
-    dims[i].chunk_size = (uint64_t)1 << bits[i];
+  for (uint8_t i = 0; i < rank; ++i) {
+    if (effective[i] > 0)
+      dims[i].chunk_size = (uint64_t)1 << bits[i];
+    else if (effective[i] == 0)
+      dims[i].chunk_size = 1;
+    // effective == -1: already set to size above.
+  }
 }
 
 void
@@ -153,7 +188,7 @@ dims_budget_chunk_bytes(struct dimension* dims,
                         uint8_t rank,
                         size_t target_chunk_bytes,
                         size_t bytes_per_element,
-                        const uint8_t* ratios)
+                        const int* ratios)
 {
   if (bytes_per_element == 0 || target_chunk_bytes < bytes_per_element)
     return;

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -111,14 +111,24 @@ dims_set_chunk_sizes(struct dimension* dims,
     dims[i].chunk_size = chunk_sizes[i];
 }
 
-void
-dims_budget_chunk_size(struct dimension* dims,
-                       uint8_t rank,
-                       uint64_t nelem,
-                       const int* ratios)
+int
+dims_budget_chunk_bytes(struct dimension* dims,
+                        uint8_t rank,
+                        size_t target_chunk_bytes,
+                        size_t bytes_per_element,
+                        const int* ratios)
 {
-  if (nelem == 0)
-    return;
+  if (bytes_per_element == 0) {
+    log_error("bytes_per_element must be > 0");
+    return 1;
+  }
+  if (target_chunk_bytes < bytes_per_element) {
+    log_error("target_chunk_bytes (%zu) < bytes_per_element (%zu)",
+              target_chunk_bytes,
+              bytes_per_element);
+    return 1;
+  }
+  const uint64_t nelem = target_chunk_bytes / bytes_per_element;
 
   // Classify dims. effective[i]:
   //   >0  : bit-budget participant with this weight
@@ -146,19 +156,25 @@ dims_budget_chunk_size(struct dimension* dims,
     }
   }
 
+  if (pinned_prod > nelem) {
+    log_error("pinned dims product (%" PRIu64
+              " elements) exceeds budget (%" PRIu64 ")",
+              pinned_prod,
+              nelem);
+    return 1;
+  }
+
   // Apply pins.
   for (uint8_t i = 0; i < rank; ++i)
     if (effective[i] == -1)
       dims[i].chunk_size = dims[i].size;
 
   if (!any_participant)
-    return;
+    return 0;
 
-  // Remaining element budget for participants.
-  uint64_t remaining = pinned_prod ? nelem / pinned_prod : nelem;
-  if (remaining < 1)
-    remaining = 1;
-  int total_bits = 63 - clzll(remaining);
+  // Remaining element budget for participants. pinned_prod <= nelem guaranteed.
+  const uint64_t remaining = nelem / pinned_prod;
+  const int total_bits = 63 - clzll(remaining);
 
   // Greedy bit allocation: each bit goes to the most underserved
   // participant (lowest bits[i]/effective[i]). Ties favor higher indices.
@@ -175,25 +191,19 @@ dims_budget_chunk_size(struct dimension* dims,
   }
 
   for (uint8_t i = 0; i < rank; ++i) {
-    if (effective[i] > 0)
-      dims[i].chunk_size = (uint64_t)1 << bits[i];
-    else if (effective[i] == 0)
+    if (effective[i] > 0) {
+      uint64_t cs = (uint64_t)1 << bits[i];
+      // Clamp participants to dim extent (skip unbounded dim 0).
+      if (dims[i].size > 0 && cs > dims[i].size)
+        cs = dims[i].size;
+      dims[i].chunk_size = cs;
+    } else if (effective[i] == 0) {
       dims[i].chunk_size = 1;
+    }
     // effective == -1: already set to size above.
   }
-}
 
-void
-dims_budget_chunk_bytes(struct dimension* dims,
-                        uint8_t rank,
-                        size_t target_chunk_bytes,
-                        size_t bytes_per_element,
-                        const int* ratios)
-{
-  if (bytes_per_element == 0 || target_chunk_bytes < bytes_per_element)
-    return;
-  dims_budget_chunk_size(
-    dims, rank, target_chunk_bytes / bytes_per_element, ratios);
+  return 0;
 }
 
 void
@@ -398,9 +408,12 @@ dims_set_layout(struct dimension* dims,
 {
   if (!dims || !p || rank == 0)
     return 1;
-  if (p->chunk_ratios)
-    dims_budget_chunk_bytes(
+  if (p->chunk_ratios) {
+    int r = dims_budget_chunk_bytes(
       dims, rank, p->target_chunk_bytes, p->bytes_per_element, p->chunk_ratios);
+    if (r)
+      return r;
+  }
   return dims_set_shard_geometry(dims,
                                  rank,
                                  p->min_shard_bytes,

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -228,10 +228,10 @@ dims_set_shard_geometry(struct dimension* dims,
                         size_t bytes_per_element)
 {
   if (!dims || rank == 0 || bytes_per_element == 0)
-    return 1;
+    return 3;
   for (uint8_t d = 0; d < rank; ++d)
     if (dims[d].chunk_size == 0)
-      return 1;
+      return 3;
 
   size_t chunk_bytes = bytes_per_element;
   for (uint8_t d = 0; d < rank; ++d)

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -213,7 +213,7 @@ int
 dims_set_shard_geometry(struct dimension* dims,
                         uint8_t rank,
                         size_t min_shard_bytes,
-                        uint32_t max_concurrent_shards,
+                        uint32_t target_concurrent_shards,
                         uint32_t min_append_shards,
                         size_t bytes_per_element)
 {
@@ -235,7 +235,7 @@ dims_set_shard_geometry(struct dimension* dims,
   }
 
   uint8_t na = dims_n_append(dims, rank);
-  uint32_t M = max_concurrent_shards ? max_concurrent_shards : 1;
+  uint32_t M = target_concurrent_shards ? target_concurrent_shards : 1;
 
   uint64_t n_chunks[HALF_MAX_RANK];
   uint64_t shards[HALF_MAX_RANK];
@@ -247,7 +247,7 @@ dims_set_shard_geometry(struct dimension* dims,
   // Integer-greedy allocation across inner dims: each step increments the
   // inner dim with the largest remaining n_chunks/shards ratio, provided
   // incrementing stays within its chunk count and the running product stays
-  // within max_concurrent_shards. Gives any M_active in [1, M_max] — no
+  // within target_concurrent_shards. Gives any M_active in [1, M_max] — no
   // power-of-2 rounding waste.
   uint64_t prod = 1;
   while (prod < (uint64_t)M) {
@@ -337,7 +337,7 @@ dims_set_layout(struct dimension* dims,
   return dims_set_shard_geometry(dims,
                                  rank,
                                  p->min_shard_bytes,
-                                 p->max_concurrent_shards,
+                                 p->target_concurrent_shards,
                                  p->min_append_shards,
                                  p->bytes_per_element);
 }

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -3,8 +3,8 @@
 #include "lod/lod_plan.h"
 #include "util/prelude.h"
 
+#include <inttypes.h>
 #include <stdio.h>
-
 #include <string.h>
 
 #ifdef _MSC_VER
@@ -236,6 +236,7 @@ dims_set_shard_geometry(struct dimension* dims,
 
   uint8_t na = dims_n_append(dims, rank);
   uint32_t M = target_concurrent_shards ? target_concurrent_shards : 1;
+  const int min_shards_set = min_append_shards > 1;
 
   uint64_t n_chunks[HALF_MAX_RANK];
   uint64_t shards[HALF_MAX_RANK];
@@ -244,11 +245,17 @@ dims_set_shard_geometry(struct dimension* dims,
     shards[d] = 1;
   }
 
-  // Integer-greedy allocation across inner dims: each step increments the
-  // inner dim with the largest remaining n_chunks/shards ratio, provided
-  // incrementing stays within its chunk count and the running product stays
-  // within target_concurrent_shards. Gives any M_active in [1, M_max] — no
-  // power-of-2 rounding waste.
+  // Inner append dims (1..na-1) pass through at their full span — they are
+  // part of the parts-budget product but aren't split here.
+  uint64_t others_prod = 1;
+  for (uint8_t d = 1; d < na; ++d)
+    others_prod *= n_chunks[d] ? n_chunks[d] : 1;
+  if (others_prod < 1)
+    others_prod = 1;
+
+  // Phase A: fill the concurrency target. Integer-greedy (no pow2 waste) —
+  // each step grows the inner dim with the largest remaining n_chunks/shards
+  // ratio, bounded by Π shards ≤ M.
   uint64_t prod = 1;
   while (prod < (uint64_t)M) {
     int best = -1;
@@ -267,58 +274,118 @@ dims_set_shard_geometry(struct dimension* dims,
   }
 
   uint64_t inner_cps_prod = 1;
-  for (uint8_t d = na; d < rank; ++d) {
+  for (uint8_t d = na; d < rank; ++d)
+    inner_cps_prod *= ceildiv(n_chunks[d], shards[d]);
+
+  // cps_append_target: the minimum cps_append that the caller's constraints
+  // require us to leave room for in the parts budget.
+  //   Mode 1 (min_shards_set):  target = floor(n_chunks[0] / min_append_shards)
+  //                             — this is the exact cps_append we'll commit to.
+  //   Mode 2 (min_shard_bytes): target = cps_floor (depends on inner_cps_prod;
+  //                             refreshed inside Phase B as inner shrinks).
+  //   Mode 3 (neither):         target = 1.
+  uint64_t cps_append_target = 1;
+  if (min_shards_set && n_chunks[0] > 0) {
+    cps_append_target = n_chunks[0] / min_append_shards;
+    if (cps_append_target < 1)
+      cps_append_target = 1;
+  } else if (min_shard_bytes > 0) {
+    uint64_t row_bytes = (uint64_t)chunk_bytes * inner_cps_prod * others_prod;
+    if (row_bytes > 0)
+      cps_append_target = ceildiv((uint64_t)min_shard_bytes, row_bytes);
+    if (cps_append_target < 1)
+      cps_append_target = 1;
+    if (n_chunks[0] > 0 && cps_append_target > n_chunks[0])
+      cps_append_target = n_chunks[0];
+  }
+
+  // Phase B: if inner_cps_prod is too big for the parts budget at our target,
+  // keep splitting inner dims (past M — target_concurrent_shards is soft).
+  // Pick the dim with the largest current cps for the biggest per-split drop.
+  // In Mode 2, refresh cps_append_target as inner_cps_prod (and therefore
+  // cps_floor) shrinks — this monotonically grows inner_cps_limit.
+  for (;;) {
+    uint64_t denom = others_prod * cps_append_target;
+    if (denom < 1)
+      denom = 1;
+    uint64_t inner_cps_limit = MAX_PARTS_PER_SHARD / denom;
+    if (inner_cps_limit < 1)
+      inner_cps_limit = 1;
+    if (inner_cps_prod <= inner_cps_limit)
+      break;
+
+    // Pick the dim with the largest current cps (biggest per-split absolute
+    // reduction) — minimizes final Π shards, keeping us close to the target.
+    // Skip dims where ceildiv keeps cps unchanged (integer roundoff stalls).
+    int best = -1;
+    uint64_t best_cps = 0;
+    for (uint8_t d = na; d < rank; ++d) {
+      if (shards[d] + 1 > n_chunks[d])
+        continue;
+      uint64_t cur = ceildiv(n_chunks[d], shards[d]);
+      uint64_t nxt = ceildiv(n_chunks[d], shards[d] + 1);
+      if (nxt >= cur)
+        continue;
+      if (cur > best_cps) {
+        best = d;
+        best_cps = cur;
+      }
+    }
+    if (best < 0)
+      break; // no progress possible — can't reduce inner_cps_prod further.
+    shards[best] += 1;
+    inner_cps_prod = 1;
+    for (uint8_t d = na; d < rank; ++d)
+      inner_cps_prod *= ceildiv(n_chunks[d], shards[d]);
+
+    if (!min_shards_set && min_shard_bytes > 0) {
+      uint64_t row_bytes = (uint64_t)chunk_bytes * inner_cps_prod * others_prod;
+      uint64_t t =
+        row_bytes ? ceildiv((uint64_t)min_shard_bytes, row_bytes) : 1;
+      if (t < 1)
+        t = 1;
+      if (n_chunks[0] > 0 && t > n_chunks[0])
+        t = n_chunks[0];
+      cps_append_target = t;
+    }
+  }
+
+  // Hard failure: if cps_append=1 still exceeds the parts budget after Phase B
+  // exhausted all inner splits, the config is genuinely infeasible.
+  if (inner_cps_prod * others_prod > MAX_PARTS_PER_SHARD) {
+    log_error("cannot satisfy parts budget even at cps_append=1 "
+              "(inner_cps_prod=%" PRIu64 ", others_prod=%" PRIu64
+              ", MAX_PARTS_PER_SHARD=%d)",
+              inner_cps_prod,
+              others_prod,
+              MAX_PARTS_PER_SHARD);
+    return 2;
+  }
+
+  // Commit inner cps and inner-append pass-through.
+  for (uint8_t d = na; d < rank; ++d)
     dims[d].chunks_per_shard = ceildiv(n_chunks[d], shards[d]);
-    inner_cps_prod *= dims[d].chunks_per_shard;
-  }
-
-  // For multi-append configs (na > 1), the outer append dim gets the
-  // byte-target cadence; inner append dims pass through at full span so
-  // the downstream product (config.c:361) evaluates to the intended total.
-  uint64_t others_prod = 1;
-  for (uint8_t d = 1; d < na; ++d) {
+  for (uint8_t d = 1; d < na; ++d)
     dims[d].chunks_per_shard = n_chunks[d] ? n_chunks[d] : 1;
-    others_prod *= dims[d].chunks_per_shard;
-  }
 
-  // Maximize cps_append subject to the byte floor and the backend parts cap.
-  //   - cps_floor = ceildiv(min_shard_bytes, row_bytes) respects the floor.
-  //   - cps_cap   = min(MAX_PARTS_PER_SHARD / inner_prod, n_chunks[0]) caps
-  //     the chunks-per-shard product and the actual dim extent.
-  // If cps_cap < cps_floor the two constraints conflict; we keep the floor
-  // and let advise_layout's cross-phase check signal PARTS_LIMIT_EXCEEDED so
-  // the outer loop retries with smaller chunks.
-  // min_shard_bytes == 0 means "no byte floor": leave dims[0].chunks_per_shard
-  // as the caller set it (0 means full span downstream).
+  // cps_append: maximize within the hard parts cap. min_shard_bytes (soft) is
+  // met when Phase B succeeded in reserving enough budget; if it couldn't,
+  // we silently accept smaller shards rather than violate the parts cap.
   if (min_shard_bytes > 0) {
-    const uint64_t row_bytes =
-      (uint64_t)chunk_bytes * inner_cps_prod * others_prod;
     const uint64_t inner_prod = inner_cps_prod * others_prod;
-    uint64_t cps_floor =
-      row_bytes ? ceildiv((uint64_t)min_shard_bytes, row_bytes) : 1;
-    if (cps_floor < 1)
-      cps_floor = 1;
     uint64_t cps_cap = inner_prod ? (MAX_PARTS_PER_SHARD / inner_prod) : 1;
     if (n_chunks[0] > 0 && cps_cap > n_chunks[0])
       cps_cap = n_chunks[0];
-    // When min_append_shards > 1 the caller has asked for at least N
-    // append-direction shards; clamp cps_cap accordingly and let it override
-    // the byte floor on conflict (the caller's shard-switching ask is hard,
-    // the byte floor is soft).
-    const int min_shards_set = min_append_shards > 1;
     if (min_shards_set && n_chunks[0] > 0) {
       uint64_t cap_for_shards = n_chunks[0] / min_append_shards;
       if (cap_for_shards < 1)
-        cap_for_shards = 1; // can't get N shards; fall back to cps=1.
+        cap_for_shards = 1;
       if (cps_cap > cap_for_shards)
         cps_cap = cap_for_shards;
     }
     if (cps_cap < 1)
       cps_cap = 1;
-    if (min_shards_set)
-      dims[0].chunks_per_shard = cps_cap;
-    else
-      dims[0].chunks_per_shard = cps_cap >= cps_floor ? cps_cap : cps_floor;
+    dims[0].chunks_per_shard = cps_cap;
   }
 
   return 0;

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -51,15 +51,19 @@ dims_set_chunk_sizes(struct dimension* dims,
 
 // Distribute nelem across dims using power-of-2 ratios.
 //
-// ratio 0 -> chunk_size = 1 (that dim doesn't contribute to chunk volume).
-// For non-zero ratios: bits_per_part = ceil(log2(nelem) / sum(ratios)).
-// Each dim gets chunk_size = 1 << (ratio[i] * bits_per_part).
-// Remainder bits (may be negative) go to the lowest-indexed non-zero-ratio dim.
+// ratios[i] > 0  -> participates in the bit budget with this weight.
+// ratios[i] == 0 -> chunk_size = 1 (no bits allocated).
+// ratios[i] == -1-> pin chunk_size at dims[i].size. If dims[i].size == 0
+//                  (unbounded dim 0), treated as weight=1: the dim absorbs
+//                  the remaining bit budget. Only dim 0 may be unbounded.
+//
+// Bit allocation is greedy over budget participants. The remaining element
+// budget for participants is nelem / prod(pinned sizes).
 void
 dims_budget_chunk_size(struct dimension* dims,
                        uint8_t rank,
                        uint64_t nelem,
-                       const uint8_t* ratios);
+                       const int* ratios);
 
 // Set chunks_per_shard to achieve target shard counts.
 // shard_counts has rank elements. 0 means "skip" (don't modify).
@@ -103,8 +107,8 @@ dims_set_shard_geometry(struct dimension* dims,
 struct dims_layout_policy
 {
   size_t bytes_per_element;
-  size_t target_chunk_bytes;   // ignored when chunk_ratios == NULL
-  const uint8_t* chunk_ratios; // NULL = leave chunk_size unchanged
+  size_t target_chunk_bytes; // ignored when chunk_ratios == NULL
+  const int* chunk_ratios;   // NULL = leave chunk_size unchanged
   size_t min_shard_bytes;
   uint32_t max_concurrent_shards;
 };
@@ -122,4 +126,4 @@ dims_budget_chunk_bytes(struct dimension* dims,
                         uint8_t rank,
                         size_t target_chunk_bytes,
                         size_t bytes_per_element,
-                        const uint8_t* ratios);
+                        const int* ratios);

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -82,12 +82,12 @@ dims_set_shard_counts(struct dimension* dims,
 //     remaining n_chunks[d]/shards[d] ratio while staying within
 //     n_chunks[d].
 //   - Outer append dim (d = 0): chunks_per_shard is maximized subject to
-//     (a) shard_bytes >= min_shard_bytes (byte floor), (b) chunks_per_shard
-//     total <= MAX_PARTS_PER_SHARD (backend parts cap), (c) cps <=
-//     n_chunks[0] (dim extent), and (d) ceildiv(n_chunks[0], cps) >=
-//     min_append_shards when set — forces at least N append-direction
-//     shards so benches exercise shard switching. Ignored for unbounded
-//     dim 0 (size == 0).
+//     (a) chunks_per_shard_total <= MAX_PARTS_PER_SHARD (backend parts cap)
+//     and (b) cps <= n_chunks[0] (dim extent). When min_append_shards > 1
+//     it's an authoritative cap (ceildiv(n_chunks[0], cps) >= N); it wins
+//     over the byte floor if they conflict. When unset, min_shard_bytes is
+//     a byte floor: cps >= ceildiv(min_shard_bytes, row_bytes).
+//     Unbounded dim 0 (size == 0) ignores the min_append_shards cap.
 //   - Inner append dims (d in 1..na-1): pass through at chunks_per_shard =
 //     n_chunks[d] so the downstream product (config.c) evaluates correctly.
 //

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -69,6 +69,51 @@ dims_set_shard_counts(struct dimension* dims,
                       uint8_t rank,
                       const uint64_t* shard_counts);
 
+// Choose shard geometry from a byte floor and a concurrency bound.
+//
+// Policy:
+//   - Inner dims (d >= n_append): integer-greedy allocation of shard count
+//     to dims, bounded so the product <= max_concurrent_shards (no pow2
+//     rounding). Each step increments the inner dim with the largest
+//     remaining n_chunks[d]/shards[d] ratio while staying within
+//     n_chunks[d].
+//   - Outer append dim (d = 0): chunks_per_shard = ceildiv(min_shard_bytes,
+//     row_bytes), where row_bytes is the bytes written per append step
+//     across one inner shard. Clamped to >= 1.
+//   - Inner append dims (d in 1..na-1): pass through at chunks_per_shard =
+//     n_chunks[d] so the downstream product (config.c) evaluates correctly.
+//
+// Requires chunk_size to be set first (e.g. via dims_budget_chunk_bytes).
+// max_concurrent_shards of 0 is treated as 1 (no multiplexing).
+//
+// Returns 0 on success, non-zero if min_shard_bytes < chunk_bytes (floor
+// is meaningless below one chunk).
+int
+dims_set_shard_geometry(struct dimension* dims,
+                        uint8_t rank,
+                        size_t min_shard_bytes,
+                        uint32_t max_concurrent_shards,
+                        size_t bytes_per_element);
+
+// Combined chunk + shard layout policy.
+//
+// When chunk_ratios != NULL: runs dims_budget_chunk_bytes first.
+// Always runs dims_set_shard_geometry second. No ordering concerns
+// for callers.
+struct dims_layout_policy
+{
+  size_t bytes_per_element;
+  size_t target_chunk_bytes;   // ignored when chunk_ratios == NULL
+  const uint8_t* chunk_ratios; // NULL = leave chunk_size unchanged
+  size_t min_shard_bytes;
+  uint32_t max_concurrent_shards;
+};
+
+int
+dims_set_layout(struct dimension* dims,
+                uint8_t rank,
+                const struct dims_layout_policy* p);
+
 // Distribute target_chunk_bytes across dims using power-of-2 ratios.
 // Like dims_budget_chunk_size but accepts a byte target instead of elements.
 // Computes nelem = target_chunk_bytes / bytes_per_element, then delegates.

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -81,14 +81,19 @@ dims_set_shard_counts(struct dimension* dims,
 //     rounding). Each step increments the inner dim with the largest
 //     remaining n_chunks[d]/shards[d] ratio while staying within
 //     n_chunks[d].
-//   - Outer append dim (d = 0): chunks_per_shard = ceildiv(min_shard_bytes,
-//     row_bytes), where row_bytes is the bytes written per append step
-//     across one inner shard. Clamped to >= 1.
+//   - Outer append dim (d = 0): chunks_per_shard is maximized subject to
+//     (a) shard_bytes >= min_shard_bytes (byte floor), (b) chunks_per_shard
+//     total <= MAX_PARTS_PER_SHARD (backend parts cap), (c) cps <=
+//     n_chunks[0] (dim extent), and (d) ceildiv(n_chunks[0], cps) >=
+//     min_append_shards when set — forces at least N append-direction
+//     shards so benches exercise shard switching. Ignored for unbounded
+//     dim 0 (size == 0).
 //   - Inner append dims (d in 1..na-1): pass through at chunks_per_shard =
 //     n_chunks[d] so the downstream product (config.c) evaluates correctly.
 //
 // Requires chunk_size to be set first (e.g. via dims_budget_chunk_bytes).
 // max_concurrent_shards of 0 is treated as 1 (no multiplexing).
+// min_append_shards of 0 is treated as 1 (no minimum).
 //
 // Returns 0 on success, non-zero if min_shard_bytes < chunk_bytes (floor
 // is meaningless below one chunk).
@@ -97,6 +102,7 @@ dims_set_shard_geometry(struct dimension* dims,
                         uint8_t rank,
                         size_t min_shard_bytes,
                         uint32_t max_concurrent_shards,
+                        uint32_t min_append_shards,
                         size_t bytes_per_element);
 
 // Combined chunk + shard layout policy.
@@ -111,6 +117,7 @@ struct dims_layout_policy
   const int* chunk_ratios;   // NULL = leave chunk_size unchanged
   size_t min_shard_bytes;
   uint32_t max_concurrent_shards;
+  uint32_t min_append_shards; // 0 = no minimum
 };
 
 int

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -73,30 +73,38 @@ dims_set_shard_counts(struct dimension* dims,
                       uint8_t rank,
                       const uint64_t* shard_counts);
 
-// Choose shard geometry from a byte floor and a concurrency bound.
+// Choose shard geometry from a byte floor, concurrency target, and
+// append-shard floor, respecting the backend parts cap as a hard constraint.
 //
-// Policy:
-//   - Inner dims (d >= n_append): integer-greedy allocation of shard count
-//     to dims, bounded so the product <= target_concurrent_shards (no pow2
-//     rounding). Each step increments the inner dim with the largest
-//     remaining n_chunks[d]/shards[d] ratio while staying within
+// Policy (two-phase):
+//   Phase A — fill target_concurrent_shards. Integer-greedy across inner
+//     dims (d >= n_append): each step grows the dim with the largest
+//     remaining n_chunks[d]/shards[d] ratio while Π shards[d] <= target.
+//   Phase B — enforce parts budget. If inner_cps_prod is too big for the
+//     parts cap given the required cps_append, keep splitting inner dims
+//     past the target (target_concurrent_shards is soft). Picks the inner
+//     dim with the largest current cps each step.
+//
+//   Outer append dim (d = 0): chunks_per_shard maximized within
+//     MAX_PARTS_PER_SHARD / (inner_cps_prod · others_prod) and <= n_chunks[0].
+//     When min_append_shards > 1, capped at floor(n_chunks[0] / N) —
+//     authoritative over the byte floor. When min_shard_bytes > 0, Phase B
+//     reserves budget for cps_append >= cps_floor when achievable; if not,
+//     min_shard_bytes silently yields (soft).
+//   Inner append dims (d in 1..na-1): pass through at chunks_per_shard =
 //     n_chunks[d].
-//   - Outer append dim (d = 0): chunks_per_shard is maximized subject to
-//     (a) chunks_per_shard_total <= MAX_PARTS_PER_SHARD (backend parts cap)
-//     and (b) cps <= n_chunks[0] (dim extent). When min_append_shards > 1
-//     it's an authoritative cap (ceildiv(n_chunks[0], cps) >= N); it wins
-//     over the byte floor if they conflict. When unset, min_shard_bytes is
-//     a byte floor: cps >= ceildiv(min_shard_bytes, row_bytes).
-//     Unbounded dim 0 (size == 0) ignores the min_append_shards cap.
-//   - Inner append dims (d in 1..na-1): pass through at chunks_per_shard =
-//     n_chunks[d] so the downstream product (config.c) evaluates correctly.
 //
 // Requires chunk_size to be set first (e.g. via dims_budget_chunk_bytes).
-// target_concurrent_shards of 0 is treated as 1 (no multiplexing).
-// min_append_shards of 0 is treated as 1 (no minimum).
+// target_concurrent_shards of 0 is treated as 1.
+// min_append_shards of 0 or 1 is treated as "no minimum".
 //
-// Returns 0 on success, non-zero if min_shard_bytes < chunk_bytes (floor
-// is meaningless below one chunk).
+// Returns:
+//   0 = success
+//   1 = invalid argument, or min_shard_bytes < chunk_bytes (floor meaningless
+//       below one chunk).
+//   2 = parts budget infeasible even with inner fully split. Caller can retry
+//       with larger chunks, lower target_concurrent_shards, or lower
+//       min_append_shards.
 int
 dims_set_shard_geometry(struct dimension* dims,
                         uint8_t rank,

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -84,11 +84,12 @@ dims_set_shard_counts(struct dimension* dims,
 //
 // Returns:
 //   0 = success
-//   1 = invalid argument, or min_shard_bytes < chunk_bytes (floor meaningless
-//       below one chunk).
+//   1 = min_shard_bytes < chunk_bytes (floor meaningless below one chunk).
+//       Caller can retry with smaller chunks or no floor.
 //   2 = parts budget infeasible even with inner fully split. Caller can retry
 //       with larger chunks, lower target_concurrent_shards, or lower
 //       min_append_shards.
+//   3 = invalid argument (null dims, rank==0, zero chunk_size, zero bpe).
 int
 dims_set_shard_geometry(struct dimension* dims,
                         uint8_t rank,

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -77,7 +77,7 @@ dims_set_shard_counts(struct dimension* dims,
 //
 // Policy:
 //   - Inner dims (d >= n_append): integer-greedy allocation of shard count
-//     to dims, bounded so the product <= max_concurrent_shards (no pow2
+//     to dims, bounded so the product <= target_concurrent_shards (no pow2
 //     rounding). Each step increments the inner dim with the largest
 //     remaining n_chunks[d]/shards[d] ratio while staying within
 //     n_chunks[d].
@@ -92,7 +92,7 @@ dims_set_shard_counts(struct dimension* dims,
 //     n_chunks[d] so the downstream product (config.c) evaluates correctly.
 //
 // Requires chunk_size to be set first (e.g. via dims_budget_chunk_bytes).
-// max_concurrent_shards of 0 is treated as 1 (no multiplexing).
+// target_concurrent_shards of 0 is treated as 1 (no multiplexing).
 // min_append_shards of 0 is treated as 1 (no minimum).
 //
 // Returns 0 on success, non-zero if min_shard_bytes < chunk_bytes (floor
@@ -101,7 +101,7 @@ int
 dims_set_shard_geometry(struct dimension* dims,
                         uint8_t rank,
                         size_t min_shard_bytes,
-                        uint32_t max_concurrent_shards,
+                        uint32_t target_concurrent_shards,
                         uint32_t min_append_shards,
                         size_t bytes_per_element);
 
@@ -116,7 +116,7 @@ struct dims_layout_policy
   size_t target_chunk_bytes; // ignored when chunk_ratios == NULL
   const int* chunk_ratios;   // NULL = leave chunk_size unchanged
   size_t min_shard_bytes;
-  uint32_t max_concurrent_shards;
+  uint32_t target_concurrent_shards;
   uint32_t min_append_shards; // 0 = no minimum
 };
 

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -49,22 +49,6 @@ dims_set_chunk_sizes(struct dimension* dims,
                      uint8_t rank,
                      const uint64_t* chunk_sizes);
 
-// Distribute nelem across dims using power-of-2 ratios.
-//
-// ratios[i] > 0  -> participates in the bit budget with this weight.
-// ratios[i] == 0 -> chunk_size = 1 (no bits allocated).
-// ratios[i] == -1-> pin chunk_size at dims[i].size. If dims[i].size == 0
-//                  (unbounded dim 0), treated as weight=1: the dim absorbs
-//                  the remaining bit budget. Only dim 0 may be unbounded.
-//
-// Bit allocation is greedy over budget participants. The remaining element
-// budget for participants is nelem / prod(pinned sizes).
-void
-dims_budget_chunk_size(struct dimension* dims,
-                       uint8_t rank,
-                       uint64_t nelem,
-                       const int* ratios);
-
 // Set chunks_per_shard to achieve target shard counts.
 // shard_counts has rank elements. 0 means "skip" (don't modify).
 // Requires chunk_size to be set first.
@@ -134,9 +118,23 @@ dims_set_layout(struct dimension* dims,
                 const struct dims_layout_policy* p);
 
 // Distribute target_chunk_bytes across dims using power-of-2 ratios.
-// Like dims_budget_chunk_size but accepts a byte target instead of elements.
-// Computes nelem = target_chunk_bytes / bytes_per_element, then delegates.
-void
+//
+// ratios[i] > 0  -> bit-budget participant with this weight.
+// ratios[i] == 0 -> chunk_size = 1 (no bits allocated).
+// ratios[i] == -1-> pin chunk_size at dims[i].size. If dims[i].size == 0
+//                  (unbounded dim 0), treated as weight=1: the dim absorbs
+//                  the remaining bit budget. Only dim 0 may be unbounded.
+//
+// Bit allocation is greedy over participants; remaining element budget is
+// nelem / prod(pinned sizes). Participant chunk_size is clamped to dim size
+// for bounded dims (no clamp for unbounded dim 0).
+//
+// Returns:
+//   0 = success.
+//   1 = invalid input: bytes_per_element == 0, target_chunk_bytes <
+//       bytes_per_element (budget smaller than one element), or pinned dims
+//       alone exceed the budget.
+int
 dims_budget_chunk_bytes(struct dimension* dims,
                         uint8_t rank,
                         size_t target_chunk_bytes,

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -502,7 +502,7 @@ int
 tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                               size_t target_chunk_bytes,
                               size_t min_chunk_bytes,
-                              const uint8_t* ratios,
+                              const int* ratios,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -506,6 +506,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,
+                              uint32_t min_append_shards,
                               size_t shard_alignment,
                               struct advise_layout_diagnostic* diag)
 {
@@ -582,6 +583,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                                 config->rank,
                                 min_shard_bytes,
                                 max_concurrent_shards,
+                                min_append_shards,
                                 bytes_per_element)) {
       last_reason = ADVISE_MIN_SHARD_TOO_SMALL;
       last_cps_total = 0;

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -568,6 +568,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
         break;
       }
       last_reason = ADVISE_BUDGET_EXCEEDED;
+      last_cps_total = 0;
       if (user_k || mem.epochs_per_batch <= 1)
         break;
       config->epochs_per_batch = (uint8_t)(mem.epochs_per_batch / 2);
@@ -575,18 +576,16 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
     if (!fit)
       continue;
 
-    // Phase 2: shard geometry (byte floor + concurrency bound).
+    // Phase 2: shard geometry (byte floor + concurrency bound). If
+    // min_shard_bytes < chunk_bytes at this target, shrink chunks and retry.
     if (dims_set_shard_geometry(config->dimensions,
                                 config->rank,
                                 min_shard_bytes,
                                 max_concurrent_shards,
                                 bytes_per_element)) {
-      if (diag) {
-        diag->reason = ADVISE_MIN_SHARD_TOO_SMALL;
-        diag->chunk_bytes = last_chunk_bytes;
-        diag->epochs_per_batch = last_k;
-      }
-      return 1;
+      last_reason = ADVISE_MIN_SHARD_TOO_SMALL;
+      last_cps_total = 0;
+      continue;
     }
 
     // Cross-phase (5): chunks_per_shard_total <= MAX_PARTS_PER_SHARD.

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -506,22 +506,73 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,
-                              size_t shard_alignment)
+                              size_t shard_alignment,
+                              struct advise_layout_diagnostic* diag)
 {
-  const size_t bytes_per_element = dtype_bpe(config->dtype);
-  if (bytes_per_element == 0 || budget_bytes == 0)
-    return 1;
+  if (diag) {
+    memset(diag, 0, sizeof(*diag));
+    diag->budget_bytes = budget_bytes;
+    diag->parts_limit = MAX_PARTS_PER_SHARD;
+  }
 
-  size_t floor =
+  const size_t bytes_per_element = dtype_bpe(config->dtype);
+  if (bytes_per_element == 0 || budget_bytes == 0) {
+    if (diag)
+      diag->reason = ADVISE_INVALID_CONFIG;
+    return 1;
+  }
+
+  const uint8_t user_k = config->epochs_per_batch;
+  const size_t floor =
     min_chunk_bytes > bytes_per_element ? min_chunk_bytes : bytes_per_element;
+  if (diag)
+    diag->floor_chunk_bytes = floor;
+
+  // Track last-iteration context so the diagnostic can describe the reason the
+  // solver bailed after exhausting all chunk sizes.
+  enum advise_layout_reason last_reason = ADVISE_BUDGET_EXCEEDED;
+  size_t last_chunk_bytes = 0;
+  uint32_t last_k = 0;
+  size_t last_device_bytes = 0;
+  uint64_t last_cps_total = 0;
+
   for (size_t target = target_chunk_bytes; target >= floor; target >>= 1) {
-    // Phase 1: fit chunks to memory budget.
+    // Phase 1: fit chunks + K to memory budget. Start with auto-derived K
+    // (or user-supplied K if non-zero); if device_bytes exceeds budget, halve
+    // K and retry. User-supplied K is authoritative and isn't reduced.
     dims_budget_chunk_bytes(
       config->dimensions, config->rank, target, bytes_per_element, ratios);
-    struct tile_stream_memory_info mem;
-    if (tile_stream_gpu_memory_estimate(config, shard_alignment, &mem))
-      return 1;
-    if (mem.device_bytes > budget_bytes)
+
+    uint64_t chunk_vol = 1;
+    for (uint8_t d = 0; d < config->rank; ++d)
+      chunk_vol *= config->dimensions[d].chunk_size;
+    last_chunk_bytes = (size_t)(chunk_vol * bytes_per_element);
+
+    config->epochs_per_batch = user_k;
+    int fit = 0;
+    for (;;) {
+      struct tile_stream_memory_info mem;
+      if (tile_stream_gpu_memory_estimate(config, shard_alignment, &mem)) {
+        if (diag) {
+          diag->reason = ADVISE_INVALID_CONFIG;
+          diag->chunk_bytes = last_chunk_bytes;
+          diag->epochs_per_batch = config->epochs_per_batch;
+        }
+        return 1;
+      }
+      last_k = mem.epochs_per_batch;
+      last_device_bytes = mem.device_bytes;
+      if (mem.device_bytes <= budget_bytes) {
+        config->epochs_per_batch = (uint8_t)mem.epochs_per_batch;
+        fit = 1;
+        break;
+      }
+      last_reason = ADVISE_BUDGET_EXCEEDED;
+      if (user_k || mem.epochs_per_batch <= 1)
+        break;
+      config->epochs_per_batch = (uint8_t)(mem.epochs_per_batch / 2);
+    }
+    if (!fit)
       continue;
 
     // Phase 2: shard geometry (byte floor + concurrency bound).
@@ -529,8 +580,14 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                                 config->rank,
                                 min_shard_bytes,
                                 max_concurrent_shards,
-                                bytes_per_element))
+                                bytes_per_element)) {
+      if (diag) {
+        diag->reason = ADVISE_MIN_SHARD_TOO_SMALL;
+        diag->chunk_bytes = last_chunk_bytes;
+        diag->epochs_per_batch = last_k;
+      }
       return 1;
+    }
 
     // Cross-phase (5): chunks_per_shard_total <= MAX_PARTS_PER_SHARD.
     uint64_t cps_total = 1;
@@ -540,10 +597,22 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
         cps = 1;
       cps_total *= cps;
     }
-    if (cps_total > MAX_PARTS_PER_SHARD)
+    if (cps_total > MAX_PARTS_PER_SHARD) {
+      last_reason = ADVISE_PARTS_LIMIT_EXCEEDED;
+      last_cps_total = cps_total;
       continue;
+    }
 
     return 0;
+  }
+
+  config->epochs_per_batch = user_k;
+  if (diag) {
+    diag->reason = last_reason;
+    diag->chunk_bytes = last_chunk_bytes;
+    diag->epochs_per_batch = last_k;
+    diag->device_bytes = last_device_bytes;
+    diag->chunks_per_shard_total = last_cps_total;
   }
   return 1;
 }

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -3,6 +3,7 @@
 #include "gpu/stream.ingest.h"
 #include "gpu/stream.lod.h"
 
+#include "defs.limits.h"
 #include "gpu/prelude.cuda.h"
 #include "platform/platform.h"
 #include "stream/config.h"
@@ -498,25 +499,51 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
 }
 
 int
-tile_stream_gpu_advise_chunk_sizes(struct tile_stream_configuration* config,
-                                   size_t target_chunk_bytes,
-                                   const uint8_t* ratios,
-                                   size_t budget_bytes,
-                                   size_t shard_alignment)
+tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
+                              size_t target_chunk_bytes,
+                              size_t min_chunk_bytes,
+                              const uint8_t* ratios,
+                              size_t budget_bytes,
+                              size_t min_shard_bytes,
+                              uint32_t max_concurrent_shards,
+                              size_t shard_alignment)
 {
   const size_t bytes_per_element = dtype_bpe(config->dtype);
   if (bytes_per_element == 0 || budget_bytes == 0)
     return 1;
 
-  for (size_t target = target_chunk_bytes; target >= bytes_per_element;
-       target >>= 1) {
+  size_t floor =
+    min_chunk_bytes > bytes_per_element ? min_chunk_bytes : bytes_per_element;
+  for (size_t target = target_chunk_bytes; target >= floor; target >>= 1) {
+    // Phase 1: fit chunks to memory budget.
     dims_budget_chunk_bytes(
       config->dimensions, config->rank, target, bytes_per_element, ratios);
     struct tile_stream_memory_info mem;
     if (tile_stream_gpu_memory_estimate(config, shard_alignment, &mem))
       return 1;
-    if (mem.device_bytes <= budget_bytes)
-      return 0;
+    if (mem.device_bytes > budget_bytes)
+      continue;
+
+    // Phase 2: shard geometry (byte floor + concurrency bound).
+    if (dims_set_shard_geometry(config->dimensions,
+                                config->rank,
+                                min_shard_bytes,
+                                max_concurrent_shards,
+                                bytes_per_element))
+      return 1;
+
+    // Cross-phase (5): chunks_per_shard_total <= MAX_PARTS_PER_SHARD.
+    uint64_t cps_total = 1;
+    for (uint8_t d = 0; d < config->rank; ++d) {
+      uint64_t cps = config->dimensions[d].chunks_per_shard;
+      if (cps == 0)
+        cps = 1;
+      cps_total *= cps;
+    }
+    if (cps_total > MAX_PARTS_PER_SHARD)
+      continue;
+
+    return 0;
   }
   return 1;
 }

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -541,8 +541,17 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
     // Phase 1: fit chunks + K to memory budget. Start with auto-derived K
     // (or user-supplied K if non-zero); if device_bytes exceeds budget, halve
     // K and retry. User-supplied K is authoritative and isn't reduced.
-    dims_budget_chunk_bytes(
-      config->dimensions, config->rank, target, bytes_per_element, ratios);
+    if (dims_budget_chunk_bytes(config->dimensions,
+                                config->rank,
+                                target,
+                                bytes_per_element,
+                                ratios)) {
+      // Non-recoverable input (e.g. pinned dims exceed target at this step).
+      // Halving target can only make it worse — bail.
+      last_reason = ADVISE_INVALID_CONFIG;
+      last_chunk_bytes = target;
+      break;
+    }
 
     uint64_t chunk_vol = 1;
     for (uint8_t d = 0; d < config->rank; ++d)

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -5,6 +5,7 @@
 
 #include "defs.limits.h"
 #include "gpu/prelude.cuda.h"
+#include "lod/lod_plan.h"
 #include "platform/platform.h"
 #include "stream/config.h"
 #include "util/prelude.h"
@@ -618,6 +619,33 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
       break;
     }
 
+    if (diag) {
+      uint64_t cps_total = 1;
+      for (uint8_t d = 0; d < config->rank; ++d) {
+        uint64_t cps = config->dimensions[d].chunks_per_shard;
+        if (cps == 0)
+          cps = 1;
+        cps_total *= cps;
+      }
+      uint8_t na = dims_n_append(config->dimensions, config->rank);
+      uint64_t inner_shards_prod = 1;
+      for (uint8_t d = na; d < config->rank; ++d) {
+        uint64_t size = config->dimensions[d].size;
+        uint64_t cs = config->dimensions[d].chunk_size;
+        uint64_t cps = config->dimensions[d].chunks_per_shard;
+        if (cs == 0 || cps == 0)
+          continue;
+        uint64_t n_chunks = (size + cs - 1) / cs;
+        inner_shards_prod *= (n_chunks + cps - 1) / cps;
+      }
+      diag->reason = ADVISE_OK;
+      diag->chunk_bytes = last_chunk_bytes;
+      diag->epochs_per_batch = config->epochs_per_batch;
+      diag->device_bytes = last_device_bytes;
+      diag->chunks_per_shard_total = cps_total;
+      diag->actual_concurrent_shards = inner_shards_prod;
+      diag->actual_shard_bytes = last_chunk_bytes * cps_total;
+    }
     return 0;
   }
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -505,7 +505,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                               const int* ratios,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
-                              uint32_t max_concurrent_shards,
+                              uint32_t target_concurrent_shards,
                               uint32_t min_append_shards,
                               size_t shard_alignment,
                               struct advise_layout_diagnostic* diag)
@@ -582,7 +582,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
     if (dims_set_shard_geometry(config->dimensions,
                                 config->rank,
                                 min_shard_bytes,
-                                max_concurrent_shards,
+                                target_concurrent_shards,
                                 min_append_shards,
                                 bytes_per_element)) {
       last_reason = ADVISE_MIN_SHARD_TOO_SMALL;

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -549,7 +549,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                                 ratios)) {
       // Non-recoverable input (e.g. pinned dims exceed target at this step).
       // Halving target can only make it worse — bail.
-      last_reason = ADVISE_INVALID_CONFIG;
+      last_reason = ADVISE_CHUNK_BUDGET_INFEASIBLE;
       last_chunk_bytes = target;
       break;
     }
@@ -645,6 +645,8 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
       diag->chunks_per_shard_total = cps_total;
       diag->actual_concurrent_shards = inner_shards_prod;
       diag->actual_shard_bytes = last_chunk_bytes * cps_total;
+      diag->min_append_shards_overrode_min_shard_bytes =
+        (min_append_shards > 1 && min_shard_bytes > 0) ? 1 : 0;
     }
     return 0;
   }

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -577,31 +577,36 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
     if (!fit)
       continue;
 
-    // Phase 2: shard geometry (byte floor + concurrency bound). If
-    // min_shard_bytes < chunk_bytes at this target, shrink chunks and retry.
-    if (dims_set_shard_geometry(config->dimensions,
-                                config->rank,
-                                min_shard_bytes,
-                                target_concurrent_shards,
-                                min_append_shards,
-                                bytes_per_element)) {
+    // Phase 2: shard geometry (parts budget + concurrency target + byte floor).
+    // Return 1 = MIN_SHARD_TOO_SMALL (retryable by shrinking chunks);
+    // return 2 = PARTS_LIMIT infeasible even with inner fully split — halving
+    // chunks only grows inner_cps_prod, so bail immediately.
+    int sg = dims_set_shard_geometry(config->dimensions,
+                                     config->rank,
+                                     min_shard_bytes,
+                                     target_concurrent_shards,
+                                     min_append_shards,
+                                     bytes_per_element);
+    if (sg == 1) {
       last_reason = ADVISE_MIN_SHARD_TOO_SMALL;
       last_cps_total = 0;
       continue;
     }
-
-    // Cross-phase (5): chunks_per_shard_total <= MAX_PARTS_PER_SHARD.
-    uint64_t cps_total = 1;
-    for (uint8_t d = 0; d < config->rank; ++d) {
-      uint64_t cps = config->dimensions[d].chunks_per_shard;
-      if (cps == 0)
-        cps = 1;
-      cps_total *= cps;
-    }
-    if (cps_total > MAX_PARTS_PER_SHARD) {
+    if (sg == 2) {
       last_reason = ADVISE_PARTS_LIMIT_EXCEEDED;
+      uint64_t cps_total = 1;
+      for (uint8_t d = 0; d < config->rank; ++d) {
+        uint64_t cps = config->dimensions[d].chunks_per_shard;
+        if (cps == 0)
+          cps = 1;
+        cps_total *= cps;
+      }
       last_cps_total = cps_total;
-      continue;
+      break;
+    }
+    if (sg != 0) {
+      last_reason = ADVISE_INVALID_CONFIG;
+      break;
     }
 
     return 0;

--- a/src/stream.cpu.h
+++ b/src/stream.cpu.h
@@ -62,4 +62,5 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,
-                              size_t shard_alignment);
+                              size_t shard_alignment,
+                              struct advise_layout_diagnostic* diag);

--- a/src/stream.cpu.h
+++ b/src/stream.cpu.h
@@ -62,5 +62,6 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,
+                              uint32_t min_append_shards,
                               size_t shard_alignment,
                               struct advise_layout_diagnostic* diag);

--- a/src/stream.cpu.h
+++ b/src/stream.cpu.h
@@ -52,13 +52,14 @@ tile_stream_cpu_memory_estimate(const struct tile_stream_configuration* config,
                                 size_t shard_alignment,
                                 struct tile_stream_cpu_memory_info* info);
 
-// Find the largest power-of-2 chunk size (starting from target_chunk_bytes)
-// that fits within budget_bytes of CPU heap memory.
-// shard_alignment: 0 = no alignment constraint.
-// Modifies config->dimensions in place. Returns 0 on success.
+// Solve chunk + shard layout for the CPU backend.
+// See tile_stream_gpu_advise_layout for semantics.
 int
-tile_stream_cpu_advise_chunk_sizes(struct tile_stream_configuration* config,
-                                   size_t target_chunk_bytes,
-                                   const uint8_t* ratios,
-                                   size_t budget_bytes,
-                                   size_t shard_alignment);
+tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
+                              size_t target_chunk_bytes,
+                              size_t min_chunk_bytes,
+                              const uint8_t* ratios,
+                              size_t budget_bytes,
+                              size_t min_shard_bytes,
+                              uint32_t max_concurrent_shards,
+                              size_t shard_alignment);

--- a/src/stream.cpu.h
+++ b/src/stream.cpu.h
@@ -58,7 +58,7 @@ int
 tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                               size_t target_chunk_bytes,
                               size_t min_chunk_bytes,
-                              const uint8_t* ratios,
+                              const int* ratios,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,

--- a/src/stream.cpu.h
+++ b/src/stream.cpu.h
@@ -61,7 +61,7 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
                               const int* ratios,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
-                              uint32_t max_concurrent_shards,
+                              uint32_t target_concurrent_shards,
                               uint32_t min_append_shards,
                               size_t shard_alignment,
                               struct advise_layout_diagnostic* diag);

--- a/src/stream.gpu.h
+++ b/src/stream.gpu.h
@@ -74,6 +74,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,
+                              uint32_t min_append_shards,
                               size_t shard_alignment,
                               struct advise_layout_diagnostic* diag);
 

--- a/src/stream.gpu.h
+++ b/src/stream.gpu.h
@@ -47,9 +47,12 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
 
 // Solve chunk + shard layout for the GPU backend.
 //
-// Phase 1: starting from target_chunk_bytes, halves until the device memory
-//   estimate fits within budget_bytes or target falls below
-//   max(min_chunk_bytes, bpe).
+// Phase 1: starting from target_chunk_bytes, halves chunk bytes until the
+//   device memory estimate fits within budget_bytes or target falls below
+//   max(min_chunk_bytes, bpe). At each chunk size, if the auto-derived
+//   epochs_per_batch (K) overshoots the budget, K is halved (down to 1)
+//   before shrinking chunks further. A non-zero config->epochs_per_batch
+//   on entry is treated as user-authoritative and is not reduced.
 // Phase 2: with chunks set, computes shard geometry from min_shard_bytes and
 //   max_concurrent_shards (see dims_set_shard_geometry).
 // Cross-phase: checks that chunks_per_shard_total <= MAX_PARTS_PER_SHARD.
@@ -58,7 +61,10 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
 //
 // shard_alignment: 0 = no alignment constraint.
 // min_chunk_bytes: floor on per-chunk bytes; 0 = no floor (clamped to bpe).
-// Modifies config->dimensions in place (chunk_size and chunks_per_shard).
+// diag: optional out-param describing the failure reason and relevant context
+//   when the solver returns non-zero; caller may pass NULL.
+// Modifies config->dimensions in place (chunk_size and chunks_per_shard) and
+// config->epochs_per_batch (set to the chosen K on success).
 // Returns 0 on success.
 int
 tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
@@ -68,7 +74,8 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,
-                              size_t shard_alignment);
+                              size_t shard_alignment,
+                              struct advise_layout_diagnostic* diag);
 
 // Allocate and initialize a tile_stream_gpu. Returns pointer on success,
 // NULL on failure. Caller must free with tile_stream_gpu_destroy.

--- a/src/stream.gpu.h
+++ b/src/stream.gpu.h
@@ -70,7 +70,7 @@ int
 tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                               size_t target_chunk_bytes,
                               size_t min_chunk_bytes,
-                              const uint8_t* ratios,
+                              const int* ratios,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
                               uint32_t max_concurrent_shards,

--- a/src/stream.gpu.h
+++ b/src/stream.gpu.h
@@ -45,16 +45,30 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
                                 size_t shard_alignment,
                                 struct tile_stream_memory_info* info);
 
-// Find the largest power-of-2 chunk size (starting from target_chunk_bytes)
-// that fits within budget_bytes of GPU device memory.
+// Solve chunk + shard layout for the GPU backend.
+//
+// Phase 1: starting from target_chunk_bytes, halves until the device memory
+//   estimate fits within budget_bytes or target falls below
+//   max(min_chunk_bytes, bpe).
+// Phase 2: with chunks set, computes shard geometry from min_shard_bytes and
+//   max_concurrent_shards (see dims_set_shard_geometry).
+// Cross-phase: checks that chunks_per_shard_total <= MAX_PARTS_PER_SHARD.
+//   If violated, halves the chunk target and retries. Bails when the target
+//   would drop below min_chunk_bytes.
+//
 // shard_alignment: 0 = no alignment constraint.
-// Modifies config->dimensions in place. Returns 0 on success.
+// min_chunk_bytes: floor on per-chunk bytes; 0 = no floor (clamped to bpe).
+// Modifies config->dimensions in place (chunk_size and chunks_per_shard).
+// Returns 0 on success.
 int
-tile_stream_gpu_advise_chunk_sizes(struct tile_stream_configuration* config,
-                                   size_t target_chunk_bytes,
-                                   const uint8_t* ratios,
-                                   size_t budget_bytes,
-                                   size_t shard_alignment);
+tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
+                              size_t target_chunk_bytes,
+                              size_t min_chunk_bytes,
+                              const uint8_t* ratios,
+                              size_t budget_bytes,
+                              size_t min_shard_bytes,
+                              uint32_t max_concurrent_shards,
+                              size_t shard_alignment);
 
 // Allocate and initialize a tile_stream_gpu. Returns pointer on success,
 // NULL on failure. Caller must free with tile_stream_gpu_destroy.

--- a/src/stream.gpu.h
+++ b/src/stream.gpu.h
@@ -54,7 +54,7 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
 //   before shrinking chunks further. A non-zero config->epochs_per_batch
 //   on entry is treated as user-authoritative and is not reduced.
 // Phase 2: with chunks set, computes shard geometry from min_shard_bytes and
-//   max_concurrent_shards (see dims_set_shard_geometry).
+//   target_concurrent_shards (see dims_set_shard_geometry).
 // Cross-phase: checks that chunks_per_shard_total <= MAX_PARTS_PER_SHARD.
 //   If violated, halves the chunk target and retries. Bails when the target
 //   would drop below min_chunk_bytes.
@@ -73,7 +73,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
                               const int* ratios,
                               size_t budget_bytes,
                               size_t min_shard_bytes,
-                              uint32_t max_concurrent_shards,
+                              uint32_t target_concurrent_shards,
                               uint32_t min_append_shards,
                               size_t shard_alignment,
                               struct advise_layout_diagnostic* diag);

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -99,6 +99,7 @@ struct advise_layout_diagnostic
   size_t chunk_bytes;              // per-chunk bytes at the failing iteration
   uint32_t epochs_per_batch;       // K at failure
   size_t device_bytes;             // BUDGET_EXCEEDED: memory needed at failure
+                                   // (device_bytes on GPU, heap_bytes on CPU)
   size_t budget_bytes;             // caller's budget (echoed)
   uint64_t chunks_per_shard_total; // PARTS_LIMIT_EXCEEDED: observed total
   uint64_t parts_limit;            // PARTS_LIMIT_EXCEEDED: MAX_PARTS_PER_SHARD

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -78,3 +78,28 @@ struct tile_stream_status
   int pool_current;
   int flush_pending;
 };
+
+// Why tile_stream_{gpu,cpu}_advise_layout returned non-zero.
+enum advise_layout_reason
+{
+  ADVISE_OK = 0,
+  ADVISE_INVALID_CONFIG,       // memory_estimate rejected the configuration
+  ADVISE_MIN_SHARD_TOO_SMALL,  // min_shard_bytes < chunk_bytes (phase 2)
+  ADVISE_BUDGET_EXCEEDED,      // no (chunk, K) combination fits budget
+  ADVISE_PARTS_LIMIT_EXCEEDED, // chunks_per_shard_total > MAX_PARTS_PER_SHARD
+};
+
+// Optional diagnostic out-param for advise_layout. Caller may pass NULL.
+// On failure, reason is set and the other fields describe the last iteration
+// the solver tried (closest to min_chunk_bytes). Units: bytes unless noted.
+struct advise_layout_diagnostic
+{
+  enum advise_layout_reason reason;
+  size_t floor_chunk_bytes;        // effective floor: max(min_chunk_bytes, bpe)
+  size_t chunk_bytes;              // per-chunk bytes at the failing iteration
+  uint32_t epochs_per_batch;       // K at failure
+  size_t device_bytes;             // BUDGET_EXCEEDED: memory needed at failure
+  size_t budget_bytes;             // caller's budget (echoed)
+  uint64_t chunks_per_shard_total; // PARTS_LIMIT_EXCEEDED: observed total
+  uint64_t parts_limit;            // PARTS_LIMIT_EXCEEDED: MAX_PARTS_PER_SHARD
+};

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -83,10 +83,13 @@ struct tile_stream_status
 enum advise_layout_reason
 {
   ADVISE_OK = 0,
-  ADVISE_INVALID_CONFIG,       // memory_estimate rejected the configuration
+  ADVISE_INVALID_CONFIG,       // memory_estimate or shard-geometry rejected
+                               // the configuration as malformed
   ADVISE_MIN_SHARD_TOO_SMALL,  // min_shard_bytes < chunk_bytes (phase 2)
   ADVISE_BUDGET_EXCEEDED,      // no (chunk, K) combination fits budget
   ADVISE_PARTS_LIMIT_EXCEEDED, // chunks_per_shard_total > MAX_PARTS_PER_SHARD
+  ADVISE_CHUNK_BUDGET_INFEASIBLE, // dims_budget_chunk_bytes rejected input
+                                  // (pinned dims > budget, or target < bpe)
 };
 
 // Optional diagnostic out-param for advise_layout. Caller may pass NULL.
@@ -110,4 +113,8 @@ struct advise_layout_diagnostic
                                      // target_concurrent_shards — soft)
   size_t actual_shard_bytes;         // chunk_bytes · chunks_per_shard_total
                                      // (may be < min_shard_bytes — soft)
+  uint8_t min_append_shards_overrode_min_shard_bytes; // 1 if both knobs were
+                                                      // set (min_append_shards
+                                                      // > 1 wins, floor may be
+                                                      // unmet), else 0
 };

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -103,4 +103,11 @@ struct advise_layout_diagnostic
   size_t budget_bytes;             // caller's budget (echoed)
   uint64_t chunks_per_shard_total; // PARTS_LIMIT_EXCEEDED: observed total
   uint64_t parts_limit;            // PARTS_LIMIT_EXCEEDED: MAX_PARTS_PER_SHARD
+
+  // Soft-constraint status (populated on success; ADVISE_OK). Caller compares
+  // against their requested target/floor to detect when the solver compromised.
+  uint64_t actual_concurrent_shards; // Π shards[d] for inner dims (may exceed
+                                     // target_concurrent_shards — soft)
+  size_t actual_shard_bytes;         // chunk_bytes · chunks_per_shard_total
+                                     // (may be < min_shard_bytes — soft)
 };

--- a/src/util/format_bytes.c
+++ b/src/util/format_bytes.c
@@ -1,0 +1,23 @@
+#include "util/format_bytes.h"
+
+#include <stdio.h>
+
+void
+format_bytes(char* buf, size_t bufsz, uint64_t bytes)
+{
+  if (!buf || bufsz == 0)
+    return;
+
+  const double KIB = 1024.0;
+  const double MIB = 1024.0 * 1024.0;
+  const double GIB = 1024.0 * 1024.0 * 1024.0;
+
+  if (bytes >= (uint64_t)GIB)
+    snprintf(buf, bufsz, "%.2f GiB", (double)bytes / GIB);
+  else if (bytes >= (uint64_t)MIB)
+    snprintf(buf, bufsz, "%.2f MiB", (double)bytes / MIB);
+  else if (bytes >= (uint64_t)KIB)
+    snprintf(buf, bufsz, "%.2f KiB", (double)bytes / KIB);
+  else
+    snprintf(buf, bufsz, "%llu B", (unsigned long long)bytes);
+}

--- a/src/util/format_bytes.h
+++ b/src/util/format_bytes.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  // Format a byte count into a human-readable string with a power-of-two
+  // suffix (B, KiB, MiB, GiB). Writes up to bufsz-1 chars plus a NUL into
+  // buf. The unit is chosen by magnitude: >= 1 GiB -> GiB, >= 1 MiB -> MiB,
+  // >= 1 KiB -> KiB, else bytes. Thread-safe: caller owns the buffer.
+  //
+  // A 32-byte buffer is always enough.
+  void format_bytes(char* buf, size_t bufsz, uint64_t bytes);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -283,6 +283,172 @@ test_dims_print(void)
   return !ok;
 }
 
+// --- dims_set_shard_geometry tests ---
+
+static int
+test_shard_geom_no_inner_sharding(void)
+{
+  // 3D, na=1, M=1: inner dims stay at cps=n_chunks, cps_0 from byte floor.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 100, 16, 16 };
+  dims_create(dims, "tyx", sizes);
+  uint64_t cs[] = { 5, 16, 16 };
+  dims_set_chunk_sizes(dims, 3, cs);
+
+  // chunk_bytes = 5*16*16*1 = 1280. row_bytes = 1280 (inner cps=1).
+  // cps_0 = ceildiv(4096, 1280) = 4.
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 4096, 1, 1) == 0);
+  CHECK(Error, dims[0].chunks_per_shard == 4);
+  CHECK(Error, dims[1].chunks_per_shard == 1);
+  CHECK(Error, dims[2].chunks_per_shard == 1);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_shard_geom_errors(void)
+{
+  int ok = 0;
+  struct dimension dims[2];
+  uint64_t sizes[] = { 10, 10 };
+  dims_create(dims, "xy", sizes);
+  uint64_t cs[] = { 10, 10 }; // chunk_bytes = 10*10*8 = 800
+  dims_set_chunk_sizes(dims, 2, cs);
+
+  // NULL dims
+  CHECK(Error, dims_set_shard_geometry(NULL, 2, 4096, 1, 8) != 0);
+  // rank=0
+  CHECK(Error, dims_set_shard_geometry(dims, 0, 4096, 1, 8) != 0);
+  // bpe=0
+  CHECK(Error, dims_set_shard_geometry(dims, 2, 4096, 1, 0) != 0);
+  // min_shard_bytes < chunk_bytes (but > 0)
+  CHECK(Error, dims_set_shard_geometry(dims, 2, 100, 1, 8) != 0);
+  // min_shard_bytes = 0 is allowed (no byte floor; cps_0 clamps to 1)
+  CHECK(Error, dims_set_shard_geometry(dims, 2, 0, 1, 8) == 0);
+  CHECK(Error, dims[0].chunks_per_shard == 1);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_shard_geom_splits_inner_greedy(void)
+{
+  // Unbalanced inner n_chunks=(8,4) with M=8. Greedy prefers the larger
+  // n_chunks/shards ratio; ties favor the earlier-visited (lower-index) dim.
+  // Dim 0 uses chunk_size=5 so dims_n_append yields na=1.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 100, 8, 4 };
+  dims_create(dims, "tyx", sizes);
+  uint64_t cs[] = { 5, 1, 1 };
+  dims_set_chunk_sizes(dims, 3, cs);
+
+  // chunk_bytes = 5. n_chunks = (20, 8, 4). M=8.
+  // Greedy: shards (1,1,1) -> (1,2,1) -> (1,3,1) -> (1,3,2) -> (1,4,2).
+  // cps[1]=ceil(8/4)=2, cps[2]=ceil(4/2)=2. row_bytes = 5*2*2 = 20.
+  // cps_0 = ceildiv(80, 20) = 4.
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 80, 8, 1) == 0);
+  CHECK(Error, dims[0].chunks_per_shard == 4);
+  CHECK(Error, dims[1].chunks_per_shard == 2);
+  CHECK(Error, dims[2].chunks_per_shard == 2);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_shard_geom_caps_at_n_chunks(void)
+{
+  // M exceeds achievable Π n_chunks: greedy stops at actual ceiling.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 100, 2, 2 };
+  dims_create(dims, "tyx", sizes);
+  uint64_t cs[] = { 5, 1, 1 };
+  dims_set_chunk_sizes(dims, 3, cs);
+
+  // chunk_bytes = 5. n_chunks = (20, 2, 2). M=16.
+  // Greedy: d=1 first (tie, lower index wins) -> (_,2,1). Then d=1 can't grow
+  // (shards+1=3 > n_chunks[1]=2), d=2 grows -> (_,2,2). Then neither grows.
+  // cps[1]=1, cps[2]=1; row_bytes=5. cps_0 = ceildiv(40, 5) = 8.
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 40, 16, 1) == 0);
+  CHECK(Error, dims[0].chunks_per_shard == 8);
+  CHECK(Error, dims[1].chunks_per_shard == 1);
+  CHECK(Error, dims[2].chunks_per_shard == 1);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_shard_geom_max_concurrent_zero_is_one(void)
+{
+  // max_concurrent_shards=0 is treated as 1 (no inner splitting).
+  int ok = 0;
+  struct dimension dims_a[3], dims_b[3];
+  uint64_t sizes[] = { 100, 8, 4 };
+  dims_create(dims_a, "tyx", sizes);
+  dims_create(dims_b, "tyx", sizes);
+  uint64_t cs[] = { 5, 1, 1 };
+  dims_set_chunk_sizes(dims_a, 3, cs);
+  dims_set_chunk_sizes(dims_b, 3, cs);
+
+  CHECK(Error, dims_set_shard_geometry(dims_a, 3, 256, 0, 1) == 0);
+  CHECK(Error, dims_set_shard_geometry(dims_b, 3, 256, 1, 1) == 0);
+  for (int d = 0; d < 3; ++d)
+    CHECK(Error, dims_a[d].chunks_per_shard == dims_b[d].chunks_per_shard);
+  // M=1 means no inner splitting: inner cps = n_chunks.
+  CHECK(Error, dims_a[1].chunks_per_shard == 8);
+  CHECK(Error, dims_a[2].chunks_per_shard == 4);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_shard_geom_multi_append(void)
+{
+  // na=2: inner append dim (z) passes through at full span (cps = n_chunks[1]),
+  // inner non-append dims get greedy allocation as usual, cps_0 uses the
+  // row_bytes that includes both factors.
+  int ok = 0;
+  struct dimension dims[4];
+  uint64_t sizes[] = { 0, 10, 128, 128 };
+  dims_create(dims, "tzyx", sizes);
+  uint64_t cs[] = { 1, 1, 64, 64 };
+  dims_set_chunk_sizes(dims, 4, cs);
+
+  // bpe=2, chunk_bytes = 1*1*64*64*2 = 8192.
+  // n_chunks = (0, 10, 2, 2). M=1 -> shards stay at 1.
+  // inner_cps: y=2, x=2 -> inner_cps_prod = 4.
+  // others_prod: dims[1].cps = 10 (n_chunks[1]).
+  // row_bytes = 8192 * 4 * 10 = 327680.
+  // cps_0 = ceildiv(2 MiB, 327680) = ceildiv(2097152, 327680) = 7.
+  CHECK(Error, dims_set_shard_geometry(dims, 4, 2 << 20, 1, 2) == 0);
+  CHECK(Error, dims[0].chunks_per_shard == 7);
+  CHECK(Error, dims[1].chunks_per_shard == 10);
+  CHECK(Error, dims[2].chunks_per_shard == 2);
+  CHECK(Error, dims[3].chunks_per_shard == 2);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
 // --- dim_info tests ---
 
 static int
@@ -707,6 +873,13 @@ main(void)
 
     { "dims_set_shard_counts", test_dims_set_shard_counts },
     { "dims_set_shard_counts_skip_zero", test_dims_set_shard_counts_skip_zero },
+    { "shard_geom_no_inner_sharding", test_shard_geom_no_inner_sharding },
+    { "shard_geom_errors", test_shard_geom_errors },
+    { "shard_geom_splits_inner_greedy", test_shard_geom_splits_inner_greedy },
+    { "shard_geom_caps_at_n_chunks", test_shard_geom_caps_at_n_chunks },
+    { "shard_geom_max_concurrent_zero_is_one",
+      test_shard_geom_max_concurrent_zero_is_one },
+    { "shard_geom_multi_append", test_shard_geom_multi_append },
     { "dims_set_storage_order", test_dims_set_storage_order },
     { "dims_set_downsample_by_name", test_dims_set_downsample_by_name },
     { "dims_print", test_dims_print },

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -349,7 +349,7 @@ test_shard_geom_no_inner_sharding(void)
   // chunk_bytes = 5*16*16*1 = 1280. row_bytes = 1280 (inner cps=1).
   // cps_floor = ceildiv(4096, 1280) = 4. cps_cap = min(MAX_PARTS/1,
   // n_chunks[0]=20) = 20. Maximize policy -> cps_0 = 20.
-  CHECK(Error, dims_set_shard_geometry(dims, 3, 4096, 1, 1) == 0);
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 4096, 1, 0, 1) == 0);
   CHECK(Error, dims[0].chunks_per_shard == 20);
   CHECK(Error, dims[1].chunks_per_shard == 1);
   CHECK(Error, dims[2].chunks_per_shard == 1);
@@ -371,23 +371,23 @@ test_shard_geom_errors(void)
   dims_set_chunk_sizes(dims, 2, cs);
 
   // NULL dims
-  CHECK(Error, dims_set_shard_geometry(NULL, 2, 4096, 1, 8) != 0);
+  CHECK(Error, dims_set_shard_geometry(NULL, 2, 4096, 1, 0, 8) != 0);
   // rank=0
-  CHECK(Error, dims_set_shard_geometry(dims, 0, 4096, 1, 8) != 0);
+  CHECK(Error, dims_set_shard_geometry(dims, 0, 4096, 1, 0, 8) != 0);
   // bpe=0
-  CHECK(Error, dims_set_shard_geometry(dims, 2, 4096, 1, 0) != 0);
+  CHECK(Error, dims_set_shard_geometry(dims, 2, 4096, 1, 0, 0) != 0);
   // min_shard_bytes < chunk_bytes (but > 0)
-  CHECK(Error, dims_set_shard_geometry(dims, 2, 100, 1, 8) != 0);
+  CHECK(Error, dims_set_shard_geometry(dims, 2, 100, 1, 0, 8) != 0);
   // min_shard_bytes = 0 is allowed (no byte floor): dims[0].chunks_per_shard
   // is not modified. Pre-set 0 (from dims_create) stays 0, meaning full span.
   CHECK(Error, dims[0].chunks_per_shard == 0);
-  CHECK(Error, dims_set_shard_geometry(dims, 2, 0, 1, 8) == 0);
+  CHECK(Error, dims_set_shard_geometry(dims, 2, 0, 1, 0, 8) == 0);
   CHECK(Error, dims[0].chunks_per_shard == 0);
 
   // chunk_size == 0 is rejected (undefined ceildiv).
   dims_create(dims, "xy", sizes);
   dims[0].chunk_size = 0;
-  CHECK(Error, dims_set_shard_geometry(dims, 2, 4096, 1, 8) != 0);
+  CHECK(Error, dims_set_shard_geometry(dims, 2, 4096, 1, 0, 8) != 0);
 
   ok = 1;
 Error:
@@ -412,7 +412,7 @@ test_shard_geom_splits_inner_greedy(void)
   // Greedy: shards (1,1,1) -> (1,2,1) -> (1,3,1) -> (1,3,2) -> (1,4,2).
   // cps[1]=ceil(8/4)=2, cps[2]=ceil(4/2)=2. row_bytes = 5*2*2 = 20.
   // cps_floor = ceildiv(80, 20) = 4. cps_cap = min(MAX_PARTS/4, 20) = 20.
-  CHECK(Error, dims_set_shard_geometry(dims, 3, 80, 8, 1) == 0);
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 80, 8, 0, 1) == 0);
   CHECK(Error, dims[0].chunks_per_shard == 20);
   CHECK(Error, dims[1].chunks_per_shard == 2);
   CHECK(Error, dims[2].chunks_per_shard == 2);
@@ -439,7 +439,7 @@ test_shard_geom_caps_at_n_chunks(void)
   // (shards+1=3 > n_chunks[1]=2), d=2 grows -> (_,2,2). Then neither grows.
   // cps[1]=1, cps[2]=1; row_bytes=5. cps_floor=ceildiv(40,5)=8. cps_cap =
   // min(MAX_PARTS/1, n_chunks[0]=20) = 20.
-  CHECK(Error, dims_set_shard_geometry(dims, 3, 40, 16, 1) == 0);
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 40, 16, 0, 1) == 0);
   CHECK(Error, dims[0].chunks_per_shard == 20);
   CHECK(Error, dims[1].chunks_per_shard == 1);
   CHECK(Error, dims[2].chunks_per_shard == 1);
@@ -463,8 +463,8 @@ test_shard_geom_max_concurrent_zero_is_one(void)
   dims_set_chunk_sizes(dims_a, 3, cs);
   dims_set_chunk_sizes(dims_b, 3, cs);
 
-  CHECK(Error, dims_set_shard_geometry(dims_a, 3, 256, 0, 1) == 0);
-  CHECK(Error, dims_set_shard_geometry(dims_b, 3, 256, 1, 1) == 0);
+  CHECK(Error, dims_set_shard_geometry(dims_a, 3, 256, 0, 0, 1) == 0);
+  CHECK(Error, dims_set_shard_geometry(dims_b, 3, 256, 1, 0, 1) == 0);
   for (int d = 0; d < 3; ++d)
     CHECK(Error, dims_a[d].chunks_per_shard == dims_b[d].chunks_per_shard);
   // M=1 means no inner splitting: inner cps = n_chunks. row_bytes = 5*8*4=160.
@@ -499,11 +499,56 @@ test_shard_geom_multi_append(void)
   // row_bytes = 8192 * 4 * 10 = 327680.
   // cps_floor = ceildiv(2 MiB, 327680) = 7. n_chunks[0]=0 (unbounded) so the
   // cap is MAX_PARTS/(4*10) = 10000/40 = 250. cps_0 = max(7, 250) = 250.
-  CHECK(Error, dims_set_shard_geometry(dims, 4, 2 << 20, 1, 2) == 0);
+  CHECK(Error, dims_set_shard_geometry(dims, 4, 2 << 20, 1, 0, 2) == 0);
   CHECK(Error, dims[0].chunks_per_shard == 250);
   CHECK(Error, dims[1].chunks_per_shard == 10);
   CHECK(Error, dims[2].chunks_per_shard == 2);
   CHECK(Error, dims[3].chunks_per_shard == 2);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_shard_geom_min_append_shards(void)
+{
+  // min_append_shards > 1 clamps cps_append down so that ceildiv(n_chunks[0],
+  // cps) >= min. Forces shard-switching even when the parts cap would allow
+  // packing everything into one outer shard.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 100, 16, 16 };
+  dims_create(dims, "tyx", sizes);
+  uint64_t cs[] = { 5, 16, 16 };
+  dims_set_chunk_sizes(dims, 3, cs);
+
+  // n_chunks[0] = 20. Without min_append_shards, cps_cap would pick 20
+  // (one shard). With min=4 the cap becomes floor(20/4)=5.
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 4096, 1, 4, 1) == 0);
+  CHECK(Error, dims[0].chunks_per_shard == 5);
+  // ceildiv(20, 5) = 4 append shards exactly.
+
+  // min=3 → floor(20/3)=6.
+  dims_create(dims, "tyx", sizes);
+  dims_set_chunk_sizes(dims, 3, cs);
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 4096, 1, 3, 1) == 0);
+  CHECK(Error, dims[0].chunks_per_shard == 6);
+
+  // min > n_chunks[0]: cap falls to cps=1 (best we can do). The byte floor
+  // still wins if it's higher, so use min_shard_bytes=chunk_bytes (=1280) to
+  // get cps_floor=1 and observe the cap in isolation.
+  dims_create(dims, "tyx", sizes);
+  dims_set_chunk_sizes(dims, 3, cs);
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 1280, 1, 999, 1) == 0);
+  CHECK(Error, dims[0].chunks_per_shard == 1);
+
+  // min_append_shards = 0 is "no minimum" (same as the baseline test).
+  dims_create(dims, "tyx", sizes);
+  dims_set_chunk_sizes(dims, 3, cs);
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 4096, 1, 0, 1) == 0);
+  CHECK(Error, dims[0].chunks_per_shard == 20);
 
   ok = 1;
 Error:
@@ -945,6 +990,7 @@ main(void)
     { "shard_geom_max_concurrent_zero_is_one",
       test_shard_geom_max_concurrent_zero_is_one },
     { "shard_geom_multi_append", test_shard_geom_multi_append },
+    { "shard_geom_min_append_shards", test_shard_geom_min_append_shards },
     { "dims_set_storage_order", test_dims_set_storage_order },
     { "dims_set_downsample_by_name", test_dims_set_downsample_by_name },
     { "dims_print", test_dims_print },

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -536,13 +536,20 @@ test_shard_geom_min_append_shards(void)
   CHECK(Error, dims_set_shard_geometry(dims, 3, 4096, 1, 3, 1) == 0);
   CHECK(Error, dims[0].chunks_per_shard == 6);
 
-  // min > n_chunks[0]: cap falls to cps=1 (best we can do). The byte floor
-  // still wins if it's higher, so use min_shard_bytes=chunk_bytes (=1280) to
-  // get cps_floor=1 and observe the cap in isolation.
+  // min > n_chunks[0]: cap falls to cps=1 (best we can do). min_append_shards
+  // is authoritative, so cps stays at 1 even if the byte floor would pick
+  // higher.
   dims_create(dims, "tyx", sizes);
   dims_set_chunk_sizes(dims, 3, cs);
-  CHECK(Error, dims_set_shard_geometry(dims, 3, 1280, 1, 999, 1) == 0);
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 4096, 1, 999, 1) == 0);
   CHECK(Error, dims[0].chunks_per_shard == 1);
+
+  // min_append_shards dominates the byte floor. With min=4, cps=5 (4 shards)
+  // even though the 1 GiB floor would want cps much larger.
+  dims_create(dims, "tyx", sizes);
+  dims_set_chunk_sizes(dims, 3, cs);
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 1ull << 30, 1, 4, 1) == 0);
+  CHECK(Error, dims[0].chunks_per_shard == 5);
 
   // min_append_shards = 0 is "no minimum" (same as the baseline test).
   dims_create(dims, "tyx", sizes);

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -347,9 +347,10 @@ test_shard_geom_no_inner_sharding(void)
   dims_set_chunk_sizes(dims, 3, cs);
 
   // chunk_bytes = 5*16*16*1 = 1280. row_bytes = 1280 (inner cps=1).
-  // cps_0 = ceildiv(4096, 1280) = 4.
+  // cps_floor = ceildiv(4096, 1280) = 4. cps_cap = min(MAX_PARTS/1,
+  // n_chunks[0]=20) = 20. Maximize policy -> cps_0 = 20.
   CHECK(Error, dims_set_shard_geometry(dims, 3, 4096, 1, 1) == 0);
-  CHECK(Error, dims[0].chunks_per_shard == 4);
+  CHECK(Error, dims[0].chunks_per_shard == 20);
   CHECK(Error, dims[1].chunks_per_shard == 1);
   CHECK(Error, dims[2].chunks_per_shard == 1);
 
@@ -410,9 +411,9 @@ test_shard_geom_splits_inner_greedy(void)
   // chunk_bytes = 5. n_chunks = (20, 8, 4). M=8.
   // Greedy: shards (1,1,1) -> (1,2,1) -> (1,3,1) -> (1,3,2) -> (1,4,2).
   // cps[1]=ceil(8/4)=2, cps[2]=ceil(4/2)=2. row_bytes = 5*2*2 = 20.
-  // cps_0 = ceildiv(80, 20) = 4.
+  // cps_floor = ceildiv(80, 20) = 4. cps_cap = min(MAX_PARTS/4, 20) = 20.
   CHECK(Error, dims_set_shard_geometry(dims, 3, 80, 8, 1) == 0);
-  CHECK(Error, dims[0].chunks_per_shard == 4);
+  CHECK(Error, dims[0].chunks_per_shard == 20);
   CHECK(Error, dims[1].chunks_per_shard == 2);
   CHECK(Error, dims[2].chunks_per_shard == 2);
 
@@ -436,9 +437,10 @@ test_shard_geom_caps_at_n_chunks(void)
   // chunk_bytes = 5. n_chunks = (20, 2, 2). M=16.
   // Greedy: d=1 first (tie, lower index wins) -> (_,2,1). Then d=1 can't grow
   // (shards+1=3 > n_chunks[1]=2), d=2 grows -> (_,2,2). Then neither grows.
-  // cps[1]=1, cps[2]=1; row_bytes=5. cps_0 = ceildiv(40, 5) = 8.
+  // cps[1]=1, cps[2]=1; row_bytes=5. cps_floor=ceildiv(40,5)=8. cps_cap =
+  // min(MAX_PARTS/1, n_chunks[0]=20) = 20.
   CHECK(Error, dims_set_shard_geometry(dims, 3, 40, 16, 1) == 0);
-  CHECK(Error, dims[0].chunks_per_shard == 8);
+  CHECK(Error, dims[0].chunks_per_shard == 20);
   CHECK(Error, dims[1].chunks_per_shard == 1);
   CHECK(Error, dims[2].chunks_per_shard == 1);
 
@@ -466,8 +468,8 @@ test_shard_geom_max_concurrent_zero_is_one(void)
   for (int d = 0; d < 3; ++d)
     CHECK(Error, dims_a[d].chunks_per_shard == dims_b[d].chunks_per_shard);
   // M=1 means no inner splitting: inner cps = n_chunks. row_bytes = 5*8*4=160.
-  // cps_0 = ceildiv(256, 160) = 2.
-  CHECK(Error, dims_a[0].chunks_per_shard == 2);
+  // cps_floor=ceildiv(256,160)=2. cps_cap = min(MAX_PARTS/32, 20) = 20.
+  CHECK(Error, dims_a[0].chunks_per_shard == 20);
   CHECK(Error, dims_a[1].chunks_per_shard == 8);
   CHECK(Error, dims_a[2].chunks_per_shard == 4);
 
@@ -495,9 +497,10 @@ test_shard_geom_multi_append(void)
   // inner_cps: y=2, x=2 -> inner_cps_prod = 4.
   // others_prod: dims[1].cps = 10 (n_chunks[1]).
   // row_bytes = 8192 * 4 * 10 = 327680.
-  // cps_0 = ceildiv(2 MiB, 327680) = ceildiv(2097152, 327680) = 7.
+  // cps_floor = ceildiv(2 MiB, 327680) = 7. n_chunks[0]=0 (unbounded) so the
+  // cap is MAX_PARTS/(4*10) = 10000/40 = 250. cps_0 = max(7, 250) = 250.
   CHECK(Error, dims_set_shard_geometry(dims, 4, 2 << 20, 1, 2) == 0);
-  CHECK(Error, dims[0].chunks_per_shard == 7);
+  CHECK(Error, dims[0].chunks_per_shard == 250);
   CHECK(Error, dims[1].chunks_per_shard == 10);
   CHECK(Error, dims[2].chunks_per_shard == 2);
   CHECK(Error, dims[3].chunks_per_shard == 2);

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -81,7 +81,7 @@ test_dims_budget_chunk_size(void)
   // dim 1 (ratio 0): 0 bits -> 1
   // dim 2 (ratio 2): 7 bits -> 128
   // dim 3 (ratio 2): 8 bits -> 256
-  uint8_t ratios[] = { 1, 0, 2, 2 };
+  int ratios[] = { 1, 0, 2, 2 };
   dims_budget_chunk_size(dims, 4, 1ULL << 19, ratios);
 
   CHECK(Error, dims[0].chunk_size == 16);
@@ -112,10 +112,60 @@ test_dims_budget_chunk_size_uniform(void)
   // nelem=1<<12, ratios=[1,1,1], sum=3
   // bits_per_part = ceil(12/3) = 4, remainder = 0
   // each dim: 1<<4 = 16
-  uint8_t ratios[] = { 1, 1, 1 };
+  int ratios[] = { 1, 1, 1 };
   dims_budget_chunk_size(dims, 3, 1ULL << 12, ratios);
 
   CHECK(Error, dims[0].chunk_size == 16);
+  CHECK(Error, dims[1].chunk_size == 16);
+  CHECK(Error, dims[2].chunk_size == 16);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_dims_budget_chunk_size_pin(void)
+{
+  // ratios[i] == -1 pins chunk_size to dims[i].size. Remaining participants
+  // share the bit budget after accounting for pinned dims' element footprint.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 1000, 16, 16 };
+  dims_create(dims, "tyx", sizes);
+
+  // nelem = 2^20. Pinned y*x = 256 (2^8), so t gets 2^12 = 4096.
+  int ratios[] = { 1, -1, -1 };
+  dims_budget_chunk_size(dims, 3, 1ULL << 20, ratios);
+
+  CHECK(Error, dims[0].chunk_size == 4096);
+  CHECK(Error, dims[1].chunk_size == 16);
+  CHECK(Error, dims[2].chunk_size == 16);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_dims_budget_chunk_size_pin_unbounded(void)
+{
+  // -1 on an unbounded dim (size=0) is a graceful fallback: that dim becomes
+  // a weight=1 budget participant instead of pinning (which would be zero).
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 0, 16, 16 }; // t unbounded
+  dims_create(dims, "tyx", sizes);
+  // dims_create sets chunk_size = size, so t starts at 0. We fix it.
+  dims[0].chunk_size = 1;
+
+  // nelem = 2^20. y,x pin at 16 (prod=256). Remaining 2^12 all to t.
+  int ratios[] = { -1, -1, -1 };
+  dims_budget_chunk_size(dims, 3, 1ULL << 20, ratios);
+
+  CHECK(Error, dims[0].chunk_size == 4096);
   CHECK(Error, dims[1].chunk_size == 16);
   CHECK(Error, dims[2].chunk_size == 16);
 
@@ -133,7 +183,7 @@ test_dims_set_shard_counts(void)
   uint64_t sizes[] = { 1000, 2, 2048, 2304 };
   dims_create(dims, "tcyx", sizes);
 
-  uint8_t ratios[] = { 1, 0, 2, 2 };
+  int ratios[] = { 1, 0, 2, 2 };
   dims_budget_chunk_size(dims, 4, 1ULL << 19, ratios);
   // chunk_sizes: 16, 1, 128, 256
   // chunk_counts: ceil(1000/16)=63, ceil(2/1)=2, ceil(2048/128)=16,
@@ -189,7 +239,7 @@ test_dims_budget_chunk_bytes(void)
   dims_create(dims_a, "tcyx", sizes);
   dims_create(dims_b, "tcyx", sizes);
 
-  uint8_t ratios[] = { 1, 0, 2, 2 };
+  int ratios[] = { 1, 0, 2, 2 };
   // 1MB / 2 bytes_per_element = 2^19 elements
   dims_budget_chunk_bytes(dims_a, 4, 1 << 20, 2, ratios);
   dims_budget_chunk_size(dims_b, 4, 1ULL << 19, ratios);
@@ -267,7 +317,7 @@ test_dims_print(void)
   uint64_t sizes[] = { 1000, 2, 2048, 2304 };
   dims_create(dims, "tcyx", sizes);
 
-  uint8_t ratios[] = { 1, 0, 2, 2 };
+  int ratios[] = { 1, 0, 2, 2 };
   dims_budget_chunk_size(dims, 4, 1ULL << 19, ratios);
 
   uint64_t shard_counts[] = { 1, 1, 4, 4 };
@@ -878,6 +928,9 @@ main(void)
     { "dims_create_errors", test_dims_create_errors },
     { "dims_budget_chunk_size", test_dims_budget_chunk_size },
     { "dims_budget_chunk_size_uniform", test_dims_budget_chunk_size_uniform },
+    { "dims_budget_chunk_size_pin", test_dims_budget_chunk_size_pin },
+    { "dims_budget_chunk_size_pin_unbounded",
+      test_dims_budget_chunk_size_pin_unbounded },
     { "dims_budget_chunk_bytes", test_dims_budget_chunk_bytes },
 
     { "dims_set_shard_counts", test_dims_set_shard_counts },

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -327,9 +327,16 @@ test_shard_geom_errors(void)
   CHECK(Error, dims_set_shard_geometry(dims, 2, 4096, 1, 0) != 0);
   // min_shard_bytes < chunk_bytes (but > 0)
   CHECK(Error, dims_set_shard_geometry(dims, 2, 100, 1, 8) != 0);
-  // min_shard_bytes = 0 is allowed (no byte floor; cps_0 clamps to 1)
+  // min_shard_bytes = 0 is allowed (no byte floor): dims[0].chunks_per_shard
+  // is not modified. Pre-set 0 (from dims_create) stays 0, meaning full span.
+  CHECK(Error, dims[0].chunks_per_shard == 0);
   CHECK(Error, dims_set_shard_geometry(dims, 2, 0, 1, 8) == 0);
-  CHECK(Error, dims[0].chunks_per_shard == 1);
+  CHECK(Error, dims[0].chunks_per_shard == 0);
+
+  // chunk_size == 0 is rejected (undefined ceildiv).
+  dims_create(dims, "xy", sizes);
+  dims[0].chunk_size = 0;
+  CHECK(Error, dims_set_shard_geometry(dims, 2, 4096, 1, 8) != 0);
 
   ok = 1;
 Error:
@@ -408,7 +415,9 @@ test_shard_geom_max_concurrent_zero_is_one(void)
   CHECK(Error, dims_set_shard_geometry(dims_b, 3, 256, 1, 1) == 0);
   for (int d = 0; d < 3; ++d)
     CHECK(Error, dims_a[d].chunks_per_shard == dims_b[d].chunks_per_shard);
-  // M=1 means no inner splitting: inner cps = n_chunks.
+  // M=1 means no inner splitting: inner cps = n_chunks. row_bytes = 5*8*4=160.
+  // cps_0 = ceildiv(256, 160) = 2.
+  CHECK(Error, dims_a[0].chunks_per_shard == 2);
   CHECK(Error, dims_a[1].chunks_per_shard == 8);
   CHECK(Error, dims_a[2].chunks_per_shard == 4);
 

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -82,7 +82,7 @@ test_dims_budget_chunk_size(void)
   // dim 2 (ratio 2): 7 bits -> 128
   // dim 3 (ratio 2): 8 bits -> 256
   int ratios[] = { 1, 0, 2, 2 };
-  dims_budget_chunk_size(dims, 4, 1ULL << 19, ratios);
+  CHECK(Error, dims_budget_chunk_bytes(dims, 4, 1ULL << 19, 1, ratios) == 0);
 
   CHECK(Error, dims[0].chunk_size == 16);
   CHECK(Error, dims[1].chunk_size == 1);
@@ -113,7 +113,7 @@ test_dims_budget_chunk_size_uniform(void)
   // bits_per_part = ceil(12/3) = 4, remainder = 0
   // each dim: 1<<4 = 16
   int ratios[] = { 1, 1, 1 };
-  dims_budget_chunk_size(dims, 3, 1ULL << 12, ratios);
+  CHECK(Error, dims_budget_chunk_bytes(dims, 3, 1ULL << 12, 1, ratios) == 0);
 
   CHECK(Error, dims[0].chunk_size == 16);
   CHECK(Error, dims[1].chunk_size == 16);
@@ -132,16 +132,78 @@ test_dims_budget_chunk_size_pin(void)
   // share the bit budget after accounting for pinned dims' element footprint.
   int ok = 0;
   struct dimension dims[3];
-  uint64_t sizes[] = { 1000, 16, 16 };
+  uint64_t sizes[] = { 8192, 16, 16 };
   dims_create(dims, "tyx", sizes);
 
   // nelem = 2^20. Pinned y*x = 256 (2^8), so t gets 2^12 = 4096.
   int ratios[] = { 1, -1, -1 };
-  dims_budget_chunk_size(dims, 3, 1ULL << 20, ratios);
+  CHECK(Error, dims_budget_chunk_bytes(dims, 3, 1ULL << 20, 1, ratios) == 0);
 
   CHECK(Error, dims[0].chunk_size == 4096);
   CHECK(Error, dims[1].chunk_size == 16);
   CHECK(Error, dims[2].chunk_size == 16);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_dims_budget_chunk_size_clamp_to_size(void)
+{
+  // Participants are clamped to dim extent so chunks never exceed size.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 1000, 16, 16 };
+  dims_create(dims, "tyx", sizes);
+
+  // Pinned y*x = 256, remaining for t = 2^12 = 4096. But size[t]=1000.
+  int ratios[] = { 1, -1, -1 };
+  CHECK(Error, dims_budget_chunk_bytes(dims, 3, 1ULL << 20, 1, ratios) == 0);
+
+  // Clamped to dim extent, not 4096.
+  CHECK(Error, dims[0].chunk_size == 1000);
+  CHECK(Error, dims[1].chunk_size == 16);
+  CHECK(Error, dims[2].chunk_size == 16);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_dims_budget_chunk_size_pinned_over_budget(void)
+{
+  // Pinned dims' product alone exceeds the budget → error, not silent.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 100, 1024, 1024 };
+  dims_create(dims, "tyx", sizes);
+
+  // Pinned y*x = 1M elements. Budget = 2^10 = 1024 elements. Infeasible.
+  int ratios[] = { 1, -1, -1 };
+  CHECK(Error, dims_budget_chunk_bytes(dims, 3, 1ULL << 10, 1, ratios) != 0);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_dims_budget_chunk_size_target_under_bpe(void)
+{
+  // target_chunk_bytes < bytes_per_element → error, not silent.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 100, 16, 16 };
+  dims_create(dims, "tyx", sizes);
+
+  int ratios[] = { 1, 1, 1 };
+  // 4 byte target with 8-byte elements.
+  CHECK(Error, dims_budget_chunk_bytes(dims, 3, 4, 8, ratios) != 0);
 
   ok = 1;
 Error:
@@ -163,7 +225,7 @@ test_dims_budget_chunk_size_pin_unbounded(void)
 
   // nelem = 2^20. y,x pin at 16 (prod=256). Remaining 2^12 all to t.
   int ratios[] = { -1, -1, -1 };
-  dims_budget_chunk_size(dims, 3, 1ULL << 20, ratios);
+  CHECK(Error, dims_budget_chunk_bytes(dims, 3, 1ULL << 20, 1, ratios) == 0);
 
   CHECK(Error, dims[0].chunk_size == 4096);
   CHECK(Error, dims[1].chunk_size == 16);
@@ -184,7 +246,7 @@ test_dims_set_shard_counts(void)
   dims_create(dims, "tcyx", sizes);
 
   int ratios[] = { 1, 0, 2, 2 };
-  dims_budget_chunk_size(dims, 4, 1ULL << 19, ratios);
+  CHECK(Error, dims_budget_chunk_bytes(dims, 4, 1ULL << 19, 1, ratios) == 0);
   // chunk_sizes: 16, 1, 128, 256
   // chunk_counts: ceil(1000/16)=63, ceil(2/1)=2, ceil(2048/128)=16,
   // ceil(2304/256)=9
@@ -233,6 +295,8 @@ Error:
 static int
 test_dims_budget_chunk_bytes(void)
 {
+  // Byte target with bpe scales the effective element budget: 1 MiB at bpe=2
+  // should match 512 KiB at bpe=1.
   int ok = 0;
   struct dimension dims_a[4], dims_b[4];
   uint64_t sizes[] = { 1000, 2, 2048, 2304 };
@@ -240,9 +304,8 @@ test_dims_budget_chunk_bytes(void)
   dims_create(dims_b, "tcyx", sizes);
 
   int ratios[] = { 1, 0, 2, 2 };
-  // 1MB / 2 bytes_per_element = 2^19 elements
-  dims_budget_chunk_bytes(dims_a, 4, 1 << 20, 2, ratios);
-  dims_budget_chunk_size(dims_b, 4, 1ULL << 19, ratios);
+  CHECK(Error, dims_budget_chunk_bytes(dims_a, 4, 1 << 20, 2, ratios) == 0);
+  CHECK(Error, dims_budget_chunk_bytes(dims_b, 4, 1 << 19, 1, ratios) == 0);
 
   for (int i = 0; i < 4; ++i)
     CHECK(Error, dims_a[i].chunk_size == dims_b[i].chunk_size);
@@ -318,7 +381,7 @@ test_dims_print(void)
   dims_create(dims, "tcyx", sizes);
 
   int ratios[] = { 1, 0, 2, 2 };
-  dims_budget_chunk_size(dims, 4, 1ULL << 19, ratios);
+  (void)dims_budget_chunk_bytes(dims, 4, 1ULL << 19, 1, ratios);
 
   uint64_t shard_counts[] = { 1, 1, 4, 4 };
   dims_set_shard_counts(dims, 4, shard_counts);
@@ -1038,6 +1101,12 @@ main(void)
     { "dims_budget_chunk_size_pin", test_dims_budget_chunk_size_pin },
     { "dims_budget_chunk_size_pin_unbounded",
       test_dims_budget_chunk_size_pin_unbounded },
+    { "dims_budget_chunk_size_clamp_to_size",
+      test_dims_budget_chunk_size_clamp_to_size },
+    { "dims_budget_chunk_size_pinned_over_budget",
+      test_dims_budget_chunk_size_pinned_over_budget },
+    { "dims_budget_chunk_size_target_under_bpe",
+      test_dims_budget_chunk_size_target_under_bpe },
     { "dims_budget_chunk_bytes", test_dims_budget_chunk_bytes },
 
     { "dims_set_shard_counts", test_dims_set_shard_counts },

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -453,7 +453,7 @@ Error:
 static int
 test_shard_geom_max_concurrent_zero_is_one(void)
 {
-  // max_concurrent_shards=0 is treated as 1 (no inner splitting).
+  // target_concurrent_shards=0 is treated as 1 (no inner splitting).
   int ok = 0;
   struct dimension dims_a[3], dims_b[3];
   uint64_t sizes[] = { 100, 8, 4 };

--- a/tests/test_dimension.c
+++ b/tests/test_dimension.c
@@ -563,6 +563,58 @@ Error:
   return !ok;
 }
 
+static int
+test_shard_geom_phase_b_splits_past_target(void)
+{
+  // target=2 but inner dims too big: Phase A fills target (y:2 shards), then
+  // Phase B splits y further to fit MAX_PARTS_PER_SHARD, exceeding the target.
+  // target_concurrent_shards is a soft preference, not a hard cap.
+  int ok = 0;
+  struct dimension dims[3];
+  uint64_t sizes[] = { 100, 500, 100 };
+  dims_create(dims, "tyx", sizes);
+  uint64_t cs[] = { 5, 1, 1 };
+  dims_set_chunk_sizes(dims, 3, cs);
+
+  // chunk_bytes=5. n_chunks=(20,500,100). target=2. min_shard_bytes=5 (≥1
+  // chunk). Phase A: shards=(_,2,1), inner_cps_prod=250*100=25000 >
+  // MAX_PARTS=10000. Phase B: split y to 3 (167*100=16700), 4 (125*100=12500),
+  // 5 (100*100=10000). Π shards = 5 exceeds target=2 — that's the soft
+  // semantics.
+  CHECK(Error, dims_set_shard_geometry(dims, 3, 5, 2, 0, 1) == 0);
+  CHECK(Error, dims[1].chunks_per_shard == 100);
+  CHECK(Error, dims[2].chunks_per_shard == 100);
+  // inner_prod=10000; cps_cap=MAX/10000=1; clamped to n_chunks[0]=20 → 1.
+  CHECK(Error, dims[0].chunks_per_shard == 1);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
+static int
+test_shard_geom_parts_limit_infeasible(void)
+{
+  // Multi-append where the inner-append dim's n_chunks alone exceeds
+  // MAX_PARTS_PER_SHARD — no amount of inner splitting can help. Returns 2.
+  int ok = 0;
+  struct dimension dims[4];
+  uint64_t sizes[] = { 100, 15000, 8, 8 };
+  dims_create(dims, "tzyx", sizes);
+  uint64_t cs[] = { 1, 1, 8, 8 };
+  dims_set_chunk_sizes(dims, 4, cs);
+
+  // na=2 (t,z have chunk_size=1). others_prod = n_chunks[z] = 15000 alone
+  // exceeds MAX_PARTS=10000 — infeasible regardless of inner (y,x) geometry.
+  CHECK(Error, dims_set_shard_geometry(dims, 4, 0, 1, 0, 1) == 2);
+
+  ok = 1;
+Error:
+  REPORT_TEST(ok);
+  return !ok;
+}
+
 // --- dim_info tests ---
 
 static int
@@ -998,6 +1050,10 @@ main(void)
       test_shard_geom_max_concurrent_zero_is_one },
     { "shard_geom_multi_append", test_shard_geom_multi_append },
     { "shard_geom_min_append_shards", test_shard_geom_min_append_shards },
+    { "shard_geom_phase_b_splits_past_target",
+      test_shard_geom_phase_b_splits_past_target },
+    { "shard_geom_parts_limit_infeasible",
+      test_shard_geom_parts_limit_infeasible },
     { "dims_set_storage_order", test_dims_set_storage_order },
     { "dims_set_downsample_by_name", test_dims_set_downsample_by_name },
     { "dims_print", test_dims_print },

--- a/tests/test_stream_cpu.c
+++ b/tests/test_stream_cpu.c
@@ -218,6 +218,249 @@ Fail:
   return 1;
 }
 
+// --- tile_stream_cpu_advise_layout tests ---
+
+static int
+test_advise_basic_fit(void)
+{
+  log_info("=== test_advise_basic_fit ===");
+  struct dimension dims[3];
+  uint64_t sizes[] = { 256, 128, 128 };
+  dims_create(dims, "tyx", sizes);
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .target_batch_chunks = 64,
+  };
+
+  uint8_t ratios[] = { 1, 1, 1 };
+  struct advise_layout_diagnostic diag = { 0 };
+  CHECK(Fail,
+        tile_stream_cpu_advise_layout(
+          &config, 1 << 15, 1024, ratios, 1ull << 30, 1 << 20, 1, 0, &diag) ==
+          0);
+  CHECK(Fail, diag.reason == ADVISE_OK);
+  CHECK(Fail, config.epochs_per_batch >= 1);
+  for (int d = 0; d < 3; ++d) {
+    CHECK(Fail, dims[d].chunk_size >= 1);
+    CHECK(Fail, dims[d].chunks_per_shard >= 1);
+  }
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+static int
+test_advise_invalid_config(void)
+{
+  log_info("=== test_advise_invalid_config ===");
+  struct dimension dims[2];
+  uint64_t sizes[] = { 100, 64 };
+  dims_create(dims, "yx", sizes);
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+
+  uint8_t ratios[] = { 1, 1 };
+  struct advise_layout_diagnostic diag = { 0 };
+
+  // budget=0 -> INVALID_CONFIG.
+  CHECK(Fail,
+        tile_stream_cpu_advise_layout(
+          &config, 1 << 14, 1024, ratios, 0, 1 << 20, 1, 0, &diag) != 0);
+  CHECK(Fail, diag.reason == ADVISE_INVALID_CONFIG);
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+static int
+test_advise_min_shard_too_small(void)
+{
+  log_info("=== test_advise_min_shard_too_small ===");
+  struct dimension dims[3];
+  uint64_t sizes[] = { 100, 64, 64 };
+  dims_create(dims, "tyx", sizes);
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .target_batch_chunks = 64,
+  };
+
+  uint8_t ratios[] = { 1, 1, 1 };
+  struct advise_layout_diagnostic diag = { 0 };
+
+  // target=1 MiB chunks but min_shard=512 B < chunk_bytes ->
+  // MIN_SHARD_TOO_SMALL
+  CHECK(Fail,
+        tile_stream_cpu_advise_layout(
+          &config, 1 << 20, 1 << 20, ratios, 1ull << 30, 512, 1, 0, &diag) !=
+          0);
+  CHECK(Fail, diag.reason == ADVISE_MIN_SHARD_TOO_SMALL);
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+static int
+test_advise_parts_limit(void)
+{
+  log_info("=== test_advise_parts_limit ===");
+  // Mimics the smallepoch case: ratio={1,0,0} forces inner chunk_size=1, so
+  // every inner row is a chunk. Combined with a big min_shard_bytes, the
+  // resulting chunks_per_shard_total exceeds MAX_PARTS_PER_SHARD.
+  struct dimension dims[3];
+  uint64_t sizes[] = { 1 << 20, 16, 16 };
+  dims_create(dims, "tyx", sizes);
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .target_batch_chunks = 64,
+  };
+
+  uint8_t ratios[] = { 1, 0, 0 };
+  struct advise_layout_diagnostic diag = { 0 };
+
+  CHECK(
+    Fail,
+    tile_stream_cpu_advise_layout(
+      &config, 1 << 16, 1 << 16, ratios, 1ull << 30, 1ull << 30, 1, 0, &diag) !=
+      0);
+  CHECK(Fail, diag.reason == ADVISE_PARTS_LIMIT_EXCEEDED);
+  CHECK(Fail, diag.chunks_per_shard_total > diag.parts_limit);
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+static int
+test_advise_halves_k(void)
+{
+  log_info("=== test_advise_halves_k ===");
+  // Pin min_chunk_bytes == target_chunk_bytes so the outer chunk-size loop
+  // has exactly one iteration; K halving is the only adaptation path. Under
+  // a tight budget, advise must choose a K strictly below the auto K.
+  struct dimension dims[3];
+  uint64_t sizes[] = { 1024, 64, 64 };
+  dims_create(dims, "tyx", sizes);
+
+  const size_t target = 1 << 16; // 64 KiB chunk
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .target_batch_chunks = 128,
+  };
+
+  uint8_t ratios[] = { 1, 1, 1 };
+  struct advise_layout_diagnostic diag = { 0 };
+
+  // Step 1: huge budget -> auto K. Preserves the advised chunk geometry.
+  CHECK(Fail,
+        tile_stream_cpu_advise_layout(
+          &config, target, target, ratios, 1ull << 40, 1 << 20, 1, 0, &diag) ==
+          0);
+  const uint32_t auto_k = config.epochs_per_batch;
+  CHECK(Fail, auto_k > 1);
+
+  // Step 2: probe heap for the just-advised geometry at auto K.
+  struct tile_stream_cpu_memory_info mi;
+  CHECK(Fail, tile_stream_cpu_memory_estimate(&config, 0, &mi) == 0);
+  const size_t heap_at_auto_k = mi.heap_bytes;
+
+  // Step 3: reset dims and advise again with a tight budget. With
+  // min_chunk==target, the outer loop runs only once — K halving is the only
+  // way to fit.
+  dims_create(dims, "tyx", sizes);
+  config.epochs_per_batch = 0;
+  const size_t tight_budget = heap_at_auto_k / 4;
+  CHECK(
+    Fail,
+    tile_stream_cpu_advise_layout(
+      &config, target, target, ratios, tight_budget, 1 << 20, 1, 0, &diag) ==
+      0);
+  CHECK(Fail, diag.reason == ADVISE_OK);
+  CHECK(Fail, config.epochs_per_batch < auto_k);
+  CHECK(Fail, config.epochs_per_batch >= 1);
+
+  // Verify the chosen configuration actually fits within the tight budget.
+  CHECK(Fail, tile_stream_cpu_memory_estimate(&config, 0, &mi) == 0);
+  CHECK(Fail, mi.heap_bytes <= tight_budget);
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+static int
+test_advise_user_k_respected(void)
+{
+  log_info("=== test_advise_user_k_respected ===");
+  // Non-zero config.epochs_per_batch on entry is authoritative and isn't
+  // reduced by advise even when the budget is tight.
+  struct dimension dims[3];
+  uint64_t sizes[] = { 256, 128, 128 };
+  dims_create(dims, "tyx", sizes);
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .target_batch_chunks = 4096,
+    .epochs_per_batch = 4, // user-pinned
+  };
+
+  uint8_t ratios[] = { 1, 1, 1 };
+  struct advise_layout_diagnostic diag = { 0 };
+  CHECK(Fail,
+        tile_stream_cpu_advise_layout(
+          &config, 1 << 15, 1024, ratios, 1ull << 30, 1 << 20, 1, 0, &diag) ==
+          0);
+  CHECK(Fail, config.epochs_per_batch == 4);
+  CHECK(Fail, diag.reason == ADVISE_OK);
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
 int
 main(int ac, char* av[])
 {
@@ -228,5 +471,11 @@ main(int ac, char* av[])
   rc |= test_basic_pipeline();
   rc |= test_f16_rejected();
   rc |= test_append_after_flush();
+  rc |= test_advise_basic_fit();
+  rc |= test_advise_invalid_config();
+  rc |= test_advise_min_shard_too_small();
+  rc |= test_advise_parts_limit();
+  rc |= test_advise_halves_k();
+  rc |= test_advise_user_k_respected();
   return rc;
 }

--- a/tests/test_stream_cpu.c
+++ b/tests/test_stream_cpu.c
@@ -239,10 +239,11 @@ test_advise_basic_fit(void)
 
   int ratios[] = { 1, 1, 1 };
   struct advise_layout_diagnostic diag = { 0 };
-  CHECK(Fail,
-        tile_stream_cpu_advise_layout(
-          &config, 1 << 15, 1024, ratios, 1ull << 30, 1 << 20, 1, 0, &diag) ==
-          0);
+  CHECK(
+    Fail,
+    tile_stream_cpu_advise_layout(
+      &config, 1 << 15, 1024, ratios, 1ull << 30, 1 << 20, 1, 0, 0, &diag) ==
+      0);
   CHECK(Fail, diag.reason == ADVISE_OK);
   CHECK(Fail, config.epochs_per_batch >= 1);
   for (int d = 0; d < 3; ++d) {
@@ -279,7 +280,7 @@ test_advise_invalid_config(void)
   // budget=0 -> INVALID_CONFIG.
   CHECK(Fail,
         tile_stream_cpu_advise_layout(
-          &config, 1 << 14, 1024, ratios, 0, 1 << 20, 1, 0, &diag) != 0);
+          &config, 1 << 14, 1024, ratios, 0, 1 << 20, 1, 0, 0, &diag) != 0);
   CHECK(Fail, diag.reason == ADVISE_INVALID_CONFIG);
 
   log_info("  PASS");
@@ -313,7 +314,7 @@ test_advise_min_shard_too_small(void)
   // MIN_SHARD_TOO_SMALL
   CHECK(Fail,
         tile_stream_cpu_advise_layout(
-          &config, 1 << 20, 1 << 20, ratios, 1ull << 30, 512, 1, 0, &diag) !=
+          &config, 1 << 20, 1 << 20, ratios, 1ull << 30, 512, 1, 0, 0, &diag) !=
           0);
   CHECK(Fail, diag.reason == ADVISE_MIN_SHARD_TOO_SMALL);
 
@@ -347,11 +348,17 @@ test_advise_parts_limit(void)
   int ratios[] = { 1, 0, 0 };
   struct advise_layout_diagnostic diag = { 0 };
 
-  CHECK(
-    Fail,
-    tile_stream_cpu_advise_layout(
-      &config, 1 << 16, 1 << 16, ratios, 1ull << 30, 1ull << 30, 1, 0, &diag) !=
-      0);
+  CHECK(Fail,
+        tile_stream_cpu_advise_layout(&config,
+                                      1 << 16,
+                                      1 << 16,
+                                      ratios,
+                                      1ull << 30,
+                                      1ull << 30,
+                                      1,
+                                      0,
+                                      0,
+                                      &diag) != 0);
   CHECK(Fail, diag.reason == ADVISE_PARTS_LIMIT_EXCEEDED);
   CHECK(Fail, diag.chunks_per_shard_total > diag.parts_limit);
 
@@ -387,10 +394,11 @@ test_advise_halves_k(void)
   struct advise_layout_diagnostic diag = { 0 };
 
   // Step 1: huge budget -> auto K. Preserves the advised chunk geometry.
-  CHECK(Fail,
-        tile_stream_cpu_advise_layout(
-          &config, target, target, ratios, 1ull << 40, 1 << 20, 1, 0, &diag) ==
-          0);
+  CHECK(
+    Fail,
+    tile_stream_cpu_advise_layout(
+      &config, target, target, ratios, 1ull << 40, 1 << 20, 1, 0, 0, &diag) ==
+      0);
   const uint32_t auto_k = config.epochs_per_batch;
   CHECK(Fail, auto_k > 1);
 
@@ -408,7 +416,7 @@ test_advise_halves_k(void)
   CHECK(
     Fail,
     tile_stream_cpu_advise_layout(
-      &config, target, target, ratios, tight_budget, 1 << 20, 1, 0, &diag) ==
+      &config, target, target, ratios, tight_budget, 1 << 20, 1, 0, 0, &diag) ==
       0);
   CHECK(Fail, diag.reason == ADVISE_OK);
   CHECK(Fail, config.epochs_per_batch < auto_k);
@@ -447,10 +455,11 @@ test_advise_user_k_respected(void)
 
   int ratios[] = { 1, 1, 1 };
   struct advise_layout_diagnostic diag = { 0 };
-  CHECK(Fail,
-        tile_stream_cpu_advise_layout(
-          &config, 1 << 15, 1024, ratios, 1ull << 30, 1 << 20, 1, 0, &diag) ==
-          0);
+  CHECK(
+    Fail,
+    tile_stream_cpu_advise_layout(
+      &config, 1 << 15, 1024, ratios, 1ull << 30, 1 << 20, 1, 0, 0, &diag) ==
+      0);
   CHECK(Fail, config.epochs_per_batch == 4);
   CHECK(Fail, diag.reason == ADVISE_OK);
 

--- a/tests/test_stream_cpu.c
+++ b/tests/test_stream_cpu.c
@@ -237,7 +237,7 @@ test_advise_basic_fit(void)
     .target_batch_chunks = 64,
   };
 
-  uint8_t ratios[] = { 1, 1, 1 };
+  int ratios[] = { 1, 1, 1 };
   struct advise_layout_diagnostic diag = { 0 };
   CHECK(Fail,
         tile_stream_cpu_advise_layout(
@@ -273,7 +273,7 @@ test_advise_invalid_config(void)
     .codec = { .id = CODEC_NONE },
   };
 
-  uint8_t ratios[] = { 1, 1 };
+  int ratios[] = { 1, 1 };
   struct advise_layout_diagnostic diag = { 0 };
 
   // budget=0 -> INVALID_CONFIG.
@@ -306,7 +306,7 @@ test_advise_min_shard_too_small(void)
     .target_batch_chunks = 64,
   };
 
-  uint8_t ratios[] = { 1, 1, 1 };
+  int ratios[] = { 1, 1, 1 };
   struct advise_layout_diagnostic diag = { 0 };
 
   // target=1 MiB chunks but min_shard=512 B < chunk_bytes ->
@@ -344,7 +344,7 @@ test_advise_parts_limit(void)
     .target_batch_chunks = 64,
   };
 
-  uint8_t ratios[] = { 1, 0, 0 };
+  int ratios[] = { 1, 0, 0 };
   struct advise_layout_diagnostic diag = { 0 };
 
   CHECK(
@@ -383,7 +383,7 @@ test_advise_halves_k(void)
     .target_batch_chunks = 128,
   };
 
-  uint8_t ratios[] = { 1, 1, 1 };
+  int ratios[] = { 1, 1, 1 };
   struct advise_layout_diagnostic diag = { 0 };
 
   // Step 1: huge budget -> auto K. Preserves the advised chunk geometry.
@@ -445,7 +445,7 @@ test_advise_user_k_respected(void)
     .epochs_per_batch = 4, // user-pinned
   };
 
-  uint8_t ratios[] = { 1, 1, 1 };
+  int ratios[] = { 1, 1, 1 };
   struct advise_layout_diagnostic diag = { 0 };
   CHECK(Fail,
         tile_stream_cpu_advise_layout(

--- a/tests/test_stream_cpu.c
+++ b/tests/test_stream_cpu.c
@@ -329,9 +329,11 @@ static int
 test_advise_parts_limit(void)
 {
   log_info("=== test_advise_parts_limit ===");
-  // Mimics the smallepoch case: ratio={1,0,0} forces inner chunk_size=1, so
-  // every inner row is a chunk. Combined with a big min_shard_bytes, the
-  // resulting chunks_per_shard_total exceeds MAX_PARTS_PER_SHARD.
+  // Same config as the old smallepoch-style case that used to fail with
+  // PARTS_LIMIT_EXCEEDED. Phase B in dims_set_shard_geometry now splits inner
+  // dims past target_concurrent_shards to keep chunks_per_shard_total within
+  // MAX_PARTS_PER_SHARD. Solver should succeed; min_shard_bytes may be met
+  // less than fully (it's soft).
   struct dimension dims[3];
   uint64_t sizes[] = { 1 << 20, 16, 16 };
   dims_create(dims, "tyx", sizes);
@@ -358,9 +360,15 @@ test_advise_parts_limit(void)
                                       1,
                                       0,
                                       0,
-                                      &diag) != 0);
-  CHECK(Fail, diag.reason == ADVISE_PARTS_LIMIT_EXCEEDED);
-  CHECK(Fail, diag.chunks_per_shard_total > diag.parts_limit);
+                                      &diag) == 0);
+  uint64_t cps_total = 1;
+  for (uint8_t d = 0; d < config.rank; ++d) {
+    uint64_t cps = config.dimensions[d].chunks_per_shard;
+    if (cps == 0)
+      cps = 1;
+    cps_total *= cps;
+  }
+  CHECK(Fail, cps_total <= MAX_PARTS_PER_SHARD);
 
   log_info("  PASS");
   return 0;

--- a/tests/test_stream_cpu.c
+++ b/tests/test_stream_cpu.c
@@ -291,6 +291,87 @@ Fail:
 }
 
 static int
+test_advise_chunk_budget_infeasible(void)
+{
+  log_info("=== test_advise_chunk_budget_infeasible ===");
+  // Pinned dims whose element product exceeds the target budget → solver bails
+  // immediately with ADVISE_CHUNK_BUDGET_INFEASIBLE (halving target makes it
+  // worse, not better).
+  struct dimension dims[3];
+  uint64_t sizes[] = { 100, 512, 512 };
+  dims_create(dims, "tyx", sizes);
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+
+  // Pinned y*x = 262144 elements * 2 bytes = 512 KiB. Target = 64 KiB → pinned
+  // dims alone exceed the budget.
+  int ratios[] = { 1, -1, -1 };
+  struct advise_layout_diagnostic diag = { 0 };
+
+  CHECK(Fail,
+        tile_stream_cpu_advise_layout(
+          &config, 1 << 16, 1 << 16, ratios, 1ull << 30, 0, 0, 0, 0, &diag) !=
+          0);
+  CHECK(Fail, diag.reason == ADVISE_CHUNK_BUDGET_INFEASIBLE);
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+static int
+test_advise_min_append_shards_overrides_floor(void)
+{
+  log_info("=== test_advise_min_append_shards_overrides_floor ===");
+  // Both min_append_shards and min_shard_bytes set → diagnostic flag is raised.
+  struct dimension dims[3];
+  uint64_t sizes[] = { 100, 64, 64 };
+  dims_create(dims, "tyx", sizes);
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+
+  int ratios[] = { 0, 1, 1 };
+  struct advise_layout_diagnostic diag = { 0 };
+
+  CHECK(
+    Fail,
+    tile_stream_cpu_advise_layout(
+      &config, 1 << 15, 1024, ratios, 1ull << 30, 1 << 20, 1, 4, 0, &diag) ==
+      0);
+  CHECK(Fail, diag.reason == ADVISE_OK);
+  CHECK(Fail, diag.min_append_shards_overrode_min_shard_bytes == 1);
+
+  // Sanity: min_append_shards not set → flag stays 0.
+  struct advise_layout_diagnostic diag2 = { 0 };
+  CHECK(
+    Fail,
+    tile_stream_cpu_advise_layout(
+      &config, 1 << 15, 1024, ratios, 1ull << 30, 1 << 20, 1, 0, 0, &diag2) ==
+      0);
+  CHECK(Fail, diag2.min_append_shards_overrode_min_shard_bytes == 0);
+
+  log_info("  PASS");
+  return 0;
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+static int
 test_advise_min_shard_too_small(void)
 {
   log_info("=== test_advise_min_shard_too_small ===");
@@ -498,6 +579,8 @@ main(int ac, char* av[])
   rc |= test_append_after_flush();
   rc |= test_advise_basic_fit();
   rc |= test_advise_invalid_config();
+  rc |= test_advise_chunk_budget_infeasible();
+  rc |= test_advise_min_append_shards_overrides_floor();
   rc |= test_advise_min_shard_too_small();
   rc |= test_advise_parts_limit();
   rc |= test_advise_halves_k();

--- a/tests/test_stream_cpu.c
+++ b/tests/test_stream_cpu.c
@@ -370,6 +370,14 @@ test_advise_parts_limit(void)
   }
   CHECK(Fail, cps_total <= MAX_PARTS_PER_SHARD);
 
+  // Diagnostic populated on success.
+  CHECK(Fail, diag.reason == ADVISE_OK);
+  CHECK(Fail, diag.actual_concurrent_shards >= 1);
+  CHECK(Fail, diag.actual_shard_bytes == diag.chunk_bytes * cps_total);
+  // The bounded dim 0 (1M rows) caps cps_append below cps_floor — actual shard
+  // is smaller than the 1 GiB min_shard_bytes floor (soft loss).
+  CHECK(Fail, diag.actual_shard_bytes < (1ull << 30));
+
   log_info("  PASS");
   return 0;
 Fail:


### PR DESCRIPTION
## Summary
- New chunk/shard sizing policy 
- `dims_set_shard_geometry` rewritten 
- `bench_spec` struct replaces positional args to `bench_stream_main` / `bench_two_streams_main` — call sites are self-documenting via designated initializers, passed by value.
- `docs/bench-layout-policy.md` documents the policy, constraints, lex objective, and procedure with a worked example.

## Test plan
- [x] `bench_stream_256cube_single` runs to completion at 128 KiB chunks / 3.4 GiB device on a 7.4 GiB-free GPU.
- [x] `bench_stream_medfmt_multiscale_dim0 --codec none` fails with a clear error message on auk (`min_shard_bytes=1.00 GiB`).