### PR TITLE
Clamp zarr.json write length (#96)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,27 +48,32 @@ jobs:
         with:
           arch: x64
 
-      - name: Set up vcpkg
-        uses: lukka/run-vcpkg@v11
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          vcpkgJsonGlob: 'vcpkg.json'
+          environment-name: ci
+          create-args: >-
+            cmake ninja sccache uv
+            aws-c-s3 blosc lz4-c zstd snappy zlib
+          init-shell: bash
+          cache-environment: true
 
-      - uses: astral-sh/setup-uv@v5
-
-      - name: Configure
-        shell: bash
-        run: >
-          cmake --preset cpu-only
-          -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
-          -DVCPKG_TARGET_TRIPLET=x64-windows-static-md
-          -DCMAKE_BUILD_TYPE=Release
+      - name: Configure sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Build
-        shell: bash
-        run: cmake --build build
+        shell: micromamba-shell {0}
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: sccache
+          CMAKE_CXX_COMPILER_LAUNCHER: sccache
+        run: |
+          cmake --preset cpu-only \
+            -DCMAKE_PREFIX_PATH="$CONDA_PREFIX/Library" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
+          cmake --build build
 
       - name: Test
-        shell: bash
+        shell: micromamba-shell {0}
         run: >
           ctest --test-dir build
           --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,13 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Build
-        shell: micromamba-shell {0}
+        shell: bash
         env:
           CMAKE_C_COMPILER_LAUNCHER: sccache
           CMAKE_CXX_COMPILER_LAUNCHER: sccache
         run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate ci
           cmake --preset cpu-only \
             -DCMAKE_PREFIX_PATH="$CONDA_PREFIX/Library" \
             -DCMAKE_BUILD_TYPE=Release \
@@ -73,11 +75,11 @@ jobs:
           cmake --build build
 
       - name: Test
-        shell: micromamba-shell {0}
-        run: >
-          ctest --test-dir build
-          --output-on-failure
-          -E "(s3)"
+        shell: bash
+        run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate ci
+          ctest --test-dir build --output-on-failure -E "(s3)"
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,41 @@ jobs:
           sleep 1 &&
           ctest --test-dir build --output-on-failure"
 
+  windows-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Set up vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgJsonGlob: 'vcpkg.json'
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Configure
+        shell: bash
+        run: >
+          cmake --preset cpu-only
+          -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+          -DVCPKG_TARGET_TRIPLET=x64-windows-static-md
+          -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        shell: bash
+        run: cmake --build build
+
+      - name: Test
+        shell: bash
+        run: >
+          ctest --test-dir build
+          --output-on-failure
+          -E "(s3)"
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/src/ngff/ngff_multiscale.c
+++ b/src/ngff/ngff_multiscale.c
@@ -34,21 +34,23 @@ write_ngff_group_metadata(struct ngff_multiscale* ms)
   for (int lv = 0; lv < ms->nlod; ++lv)
     level_ptrs[lv] = zarr_array_dimensions(ms->levels[lv]);
 
-  char json[ZARR_GROUP_JSON_MAX_LENGTH];
+  // Zero-init so a trailing-NUL scan can clamp the write length if
+  // jw_length ever overcounts (see zarr_array.c note, #96).
+  char json[ZARR_GROUP_JSON_MAX_LENGTH] = { 0 };
   int len = ngff_multiscale_group_json(
     json, sizeof(json), ms->rank, ms->nlod, level_ptrs, ms->axes, &ms->attrs);
   if (len < 0)
     return 1;
+  size_t write_len = strnlen(json, (size_t)len);
 
   // Write the full group zarr.json (the ngff function generates the complete
   // JSON including zarr_format, node_type, and attributes).
   char key[4096];
-  int n;
   if (ms->prefix[0])
-    n = snprintf(key, sizeof(key), "%s/zarr.json", ms->prefix);
+    snprintf(key, sizeof(key), "%s/zarr.json", ms->prefix);
   else
     snprintf(key, sizeof(key), "zarr.json");
-  int rc = ms->store->put(ms->store, key, json, (size_t)len);
+  int rc = ms->store->put(ms->store, key, json, write_len);
   if (rc == 0)
     ms->attrs.dirty = 0;
   return rc;

--- a/src/zarr/zarr_array.c
+++ b/src/zarr/zarr_array.c
@@ -54,7 +54,10 @@ write_array_metadata(struct zarr_array* a)
     attr_bytes += 16; // quotes, colon, comma, slack
   }
   size_t cap = 4096 + attr_bytes;
-  char* buf = (char*)malloc(cap);
+  // calloc zeroes tail bytes so a NUL-scan can clamp the write length if
+  // the JSON writer's pos ever overcounts (guards against platform-specific
+  // vsnprintf quirks — see #96).
+  char* buf = (char*)calloc(1, cap);
   if (!buf)
     return 1;
   int len = zarr_array_json(buf,
@@ -70,7 +73,8 @@ write_array_metadata(struct zarr_array* a)
     free(buf);
     return 1;
   }
-  int rc = a->store->put(a->store, key, buf, (size_t)len);
+  size_t write_len = strnlen(buf, (size_t)len);
+  int rc = a->store->put(a->store, key, buf, write_len);
   free(buf);
   if (rc == 0)
     a->attrs.dirty = 0;

--- a/src/zarr/zarr_group.c
+++ b/src/zarr/zarr_group.c
@@ -64,7 +64,9 @@ zarr_group_write(struct zarr_group* g)
     attr_bytes += 16;
   }
   size_t cap = 256 + attr_bytes;
-  char* buf = (char*)malloc(cap);
+  // See note in zarr_array.c:write_array_metadata — calloc + strnlen clamp
+  // guards the file against any overcount from jw_length (#96).
+  char* buf = (char*)calloc(1, cap);
   if (!buf)
     return 1;
 
@@ -88,7 +90,8 @@ zarr_group_write(struct zarr_group* g)
     free(buf);
     return 1;
   }
-  int rc = g->store->put(g->store, g->key, buf, jw_length(&jw));
+  size_t write_len = strnlen(buf, jw_length(&jw));
+  int rc = g->store->put(g->store, g->key, buf, write_len);
   free(buf);
   if (rc == 0)
     g->attrs.dirty = 0;

--- a/tests/test_zarr_array.c
+++ b/tests/test_zarr_array.c
@@ -211,6 +211,87 @@ Fail:
   return 1;
 }
 
+// --- Test: zarr.json byte purity across repeated update_append (#96) ---
+//
+// Regression for zarr-python UnicodeDecodeError on Windows: after repeated
+// rewrites, zarr.json must contain only the JSON content — no embedded NULs
+// or non-ASCII tail bytes leaked from an uninitialized heap buffer.
+
+static int
+test_zarr_array_json_bytes(void)
+{
+  log_info("=== test_zarr_array_json_bytes ===");
+
+  struct store* store = store_fs_create(tmpdir, 0);
+  CHECK(Fail, store);
+  CHECK(Fail2, store->mkdirs(store, "bytes") == 0);
+
+  // Mirror the acquire-zarr reproducer: unbounded t, uint16, no codec.
+  struct dimension dims[3] = {
+    { .size = 0, .chunk_size = 1, .chunks_per_shard = 1, .name = "t" },
+    { .size = 2048, .chunk_size = 2048, .chunks_per_shard = 1, .name = "y" },
+    { .size = 2048, .chunk_size = 2048, .chunks_per_shard = 1, .name = "x" },
+  };
+  struct zarr_array_config cfg = {
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+  };
+
+  struct zarr_array* a = zarr_array_create(store, "bytes", &cfg);
+  CHECK(Fail2, a);
+
+  struct shard_sink* sink = zarr_array_as_shard_sink(a);
+
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/bytes/zarr.json", tmpdir);
+
+  // 128 appends, rewrites zarr.json each time the shape grows.
+  for (uint64_t t = 1; t <= 128; ++t) {
+    uint64_t new_sizes[1] = { t };
+    CHECK(Fail3, sink->update_append(sink, 0, 1, new_sizes) == 0);
+
+    char buf[8192];
+    size_t n;
+    CHECK(Fail3, read_file(path, buf, sizeof(buf), &n) == 0);
+    CHECK(Fail3, n > 0);
+
+    // No embedded NULs — file must be exactly the JSON content.
+    if (strlen(buf) != n) {
+      log_error("t=%llu: file_size=%zu but strlen=%zu (embedded NUL)",
+                (unsigned long long)t,
+                n,
+                strlen(buf));
+      goto Fail3;
+    }
+    // No bytes >= 0x80 — this config emits pure ASCII; a high byte indicates
+    // uninitialized tail leaking past the real JSON end.
+    for (size_t i = 0; i < n; ++i) {
+      if ((unsigned char)buf[i] >= 0x80) {
+        log_error("t=%llu: byte 0x%02x at offset %zu (non-ASCII tail)",
+                  (unsigned long long)t,
+                  (unsigned char)buf[i],
+                  i);
+        goto Fail3;
+      }
+    }
+  }
+
+  zarr_array_destroy(a);
+  store_destroy(store);
+  log_info("  PASS");
+  return 0;
+
+Fail3:
+  zarr_array_destroy(a);
+Fail2:
+  store_destroy(store);
+Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
 // --- Test: root array (empty prefix) ---
 
 static int
@@ -281,6 +362,7 @@ main(void)
   err |= test_zarr_array_metadata();
   err |= test_zarr_array_shard_write();
   err |= test_zarr_array_update_append();
+  err |= test_zarr_array_json_bytes();
   err |= test_zarr_array_root();
 
   test_tmpdir_remove(tmpdir);


### PR DESCRIPTION
## Summary

- Fix zarr.json writers so the on-disk length matches the actual JSON content, guarding against any `jw_length` overcount
- Add a regression test that mirrors the acquire-zarr reproducer in #96
- Add a Windows CI job so the write path is exercised on the platform where the bug was first observed

## Fix

`write_array_metadata`, `zarr_group_write`, and `write_ngff_group_metadata` now zero-init their buffer and pass `strnlen(buf, jw_length)` to `store->put`. If anything ever advances `jw->pos` past the real content, the NUL-clamp stops the file at the true JSON boundary instead of leaking uninitialized tail bytes (the hypothesized cause of the \`UnicodeDecodeError: byte 0x80\` in #96).

## Test

`test_zarr_array_json_bytes` creates a `[t=0, y=2048, x=2048]` uint16 array and calls `update_append` 128 times, asserting after each rewrite that \`strlen == file_size\` and that every byte is `< 0x80`. Passes on Windows (locally) and Linux.

Closes #96.