### PR TITLE
Remove stray (void)config in drain_bulk_d2h

### DIFF
--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -133,7 +133,6 @@ drain_bulk_d2h(struct d2h_deliver_stage* stage,
                const struct batch_state* batch,
                const struct dim_info* dims)
 {
-  (void)config;
   const int fc = handoff->fc;
   const uint32_t n_epochs = handoff->n_epochs;
   const uint32_t level_mask = handoff->active_levels_mask;


### PR DESCRIPTION
`(void)config;` added in #95 references a parameter that doesn't exist in `drain_bulk_d2h`, breaking the GPU build. Chucky's GPU CI has been down so this slipped through; caught by acquire-zarr's shim GPU CI.