### PR TITLE
Improve batching

### DIFF
--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -96,7 +96,7 @@ resolve_chunk_sizing(const struct bench_config* cfg,
                      enum dtype dtype,
                      double budget_fraction,
                      const char* auto_detect_suffix,
-                     uint8_t* out_epb)
+                     uint32_t* out_epb)
 {
   *out_epb = 0;
   if (!cfg->chunk_ratios)
@@ -140,7 +140,7 @@ resolve_chunk_sizing(const struct bench_config* cfg,
       .codec = cfg->codec,
       .reduce_method = cfg->reduce_method,
       .append_reduce_method = cfg->append_reduce_method,
-      .target_batch_chunks = 2048,
+      .target_batch_bytes = 512u << 20,
     };
     struct advise_layout_diagnostic diag = { 0 };
     int advise_ok;
@@ -338,7 +338,7 @@ run_bench(const struct bench_config* cfg)
   }
 
   const enum dtype dtype = cfg->dtype ? cfg->dtype : dtype_u16;
-  uint8_t chosen_epochs_per_batch = 0; // 0 = auto; set by advise_layout on fit
+  uint32_t chosen_epochs_per_batch = 0; // 0 = auto; set by advise_layout on fit
 
   if (resolve_chunk_sizing(
         cfg, dtype, 0.8, "(restrict to <80%)", &chosen_epochs_per_batch))
@@ -409,7 +409,7 @@ run_bench(const struct bench_config* cfg)
     .reduce_method = cfg->reduce_method,
     .append_reduce_method = cfg->append_reduce_method,
     .epochs_per_batch = chosen_epochs_per_batch,
-    .target_batch_chunks = 2048,
+    .target_batch_bytes = 512u << 20,
     .backpressure_bytes = cfg->backpressure_bytes,
   };
 
@@ -835,7 +835,7 @@ run_bench_two_streams(const struct bench_config* cfg)
 
   const enum dtype dtype = cfg->dtype ? cfg->dtype : dtype_u16;
   const size_t bpe = dtype_bpe(dtype);
-  uint8_t chosen_epochs_per_batch = 0; // 0 = auto; set by advise_layout on fit
+  uint32_t chosen_epochs_per_batch = 0; // 0 = auto; set by advise_layout on fit
 
   if (resolve_chunk_sizing(
         cfg, dtype, 0.4, "(2 streams, ~40% each)", &chosen_epochs_per_batch))
@@ -905,7 +905,7 @@ run_bench_two_streams(const struct bench_config* cfg)
     .reduce_method = cfg->reduce_method,
     .append_reduce_method = cfg->append_reduce_method,
     .epochs_per_batch = chosen_epochs_per_batch,
-    .target_batch_chunks = 2048,
+    .target_batch_bytes = 512u << 20,
     .backpressure_bytes = cfg->backpressure_bytes,
   };
 

--- a/docs/bench-layout-policy.md
+++ b/docs/bench-layout-policy.md
@@ -109,12 +109,13 @@ loop:
 
     if chunk_bytes > max_bytes_per_part:   halve target, continue
 
-    # K sub-loop: start with auto-derived K (ceildiv(target_batch_chunks,
-    # chunks_per_epoch), pow2, clamped to MAX_BATCH_EPOCHS). If device_bytes
-    # exceeds memory_max_bytes, halve K (down to 1) and re-estimate. Pools
-    # scale linearly in K, so this is the cheapest relief before shrinking
-    # chunks. A user-supplied K is authoritative and is not reduced.
-    K = auto_K(target_batch_chunks, chunks_per_epoch)
+    # K sub-loop: start with auto-derived K = ceildiv(target_batch_bytes,
+    # bytes_per_epoch) where bytes_per_epoch sums chunks_per_epoch *
+    # chunk_stride * bpe across LOD levels. No pow2 rounding, no hard cap.
+    # If device_bytes exceeds memory_max_bytes, halve K (down to 1) and
+    # re-estimate. Pools scale linearly in K, so this is the cheapest relief
+    # before shrinking chunks. A user-supplied K is authoritative.
+    K = auto_K(target_batch_bytes, bytes_per_epoch)
     while device_bytes(K) > memory_max_bytes:
         if K == 1: break    # K-alone can't fit, shrink chunks instead
         K /= 2

--- a/docs/design.md
+++ b/docs/design.md
@@ -495,7 +495,7 @@ before touching the same buffer.
 |---|---|---|---|
 | H2D stream | `t_h2d_end` | compute stream | Staging data is on device before scatter |
 | compute stream | `t_scatter_end` | H2D stream | Scatter is done before next H2D overwrites staging |
-| compute stream | `pool_events[k]` | compress stream | All $K$ epochs are scattered before compress starts |
+| compute stream | `pool_ready` | compress stream | All $K$ epochs are scattered before compress starts |
 | compress stream | `t_aggregate_end` | D2H stream | Aggregated data is ready before transfer |
 | D2H stream | `ready` | host | Host can read pinned buffer for shard delivery |
 
@@ -561,8 +561,8 @@ A stream is configured by filling a `tile_stream_configuration`:
 | `dtype` | `enum dtype` | Element type (11 types, 1–8 bytes; see `src/dtype.h`) |
 | `buffer_capacity_bytes` | > 0 | H2D staging buffer size (doubled internally) |
 | `codec` | none / lz4 / zstd | Compression codec |
-| `epochs_per_batch` | 0 or power of 2 | Epochs per batch ($K$); 0 = auto |
-| `target_batch_chunks` | > 0 | Target chunk count for auto-$K$ (default 1024) |
+| `epochs_per_batch` | ≥ 0 | Epochs per batch ($K$); 0 = auto (from `target_batch_bytes`) |
+| `target_batch_bytes` | > 0 | Target uncompressed bytes per batch for auto-$K$ (default 512 MiB) |
 | `reduce_method` | mean / median / min / max / max_suppressed / min_suppressed | Inner LOD reduction |
 | `dim0_reduce_method` | (same) | Dim0 LOD reduction |
 | `metadata_update_interval_s` | ≥ 0 | Seconds between metadata refreshes |

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -55,8 +55,10 @@ SCENARIOS = {
     "smallepoch_single": 65536,
     "orca2_multiscale": 200,
     "256cube_multiscale": 40,
+    "medfmt_multiscale": 10,
     "orca2_multiscale_dim0": 200,
     "256cube_multiscale_dim0": 40,
+    "medfmt_multiscale_dim0": 10,
 }
 
 # Chunk-byte labels -> values (ordered small to large)
@@ -169,8 +171,8 @@ def lod_runs() -> list[RunSpec]:
     """Multiscale / LOD sweeps."""
     runs = []
     chunk_labels = ["64K", "256K", "1M"]
-    scenarios = ["orca2_multiscale", "256cube_multiscale",
-                 "orca2_multiscale_dim0", "256cube_multiscale_dim0"]
+    scenarios = ["orca2_multiscale", "256cube_multiscale", "medfmt_multiscale",
+                 "orca2_multiscale_dim0", "256cube_multiscale_dim0", "medfmt_multiscale_dim0"]
     for sc in scenarios:
         for cl in chunk_labels:
             for codec in ["none", "zstd"]:

--- a/src/cpu/pipeline.c
+++ b/src/cpu/pipeline.c
@@ -3,16 +3,18 @@
 #include "cpu/aggregate.h"
 #include "cpu/compress.h"
 #include "cpu/lod.h"
-#include "defs.limits.h"
 #include "platform/platform.h"
 #include "util/metric.h"
 #include "util/prelude.h"
+
+#include <stdlib.h>
 
 // ---- batch LUT computation ----
 
 // Convenience: compute pool_epochs from the standard formula
 // pool_epoch = (a + 1) * period - 1, then delegate to aggregate_batch_luts.
-static void
+// Init-time helper — allocates a small scratch internally.
+static int
 compute_batch_luts(const struct computed_stream_layouts* cl,
                    const struct level_geometry* levels,
                    const struct aggregate_layout* agg,
@@ -21,13 +23,18 @@ compute_batch_luts(const struct computed_stream_layouts* cl,
                    uint32_t* out_gather,
                    uint32_t* out_perm)
 {
-  uint32_t pool_epochs[MAX_BATCH_EPOCHS];
+  uint32_t* pool_epochs =
+    (uint32_t*)malloc((size_t)active_count * sizeof(uint32_t));
+  if (!pool_epochs)
+    return 1;
   for (uint32_t a = 0; a < active_count; ++a) {
     uint32_t period = (cl->dims.append_downsample && lv > 0) ? (1u << lv) : 1;
     pool_epochs[a] = (a + 1) * period - 1;
   }
   aggregate_batch_luts(
     agg, levels, lv, active_count, pool_epochs, out_gather, out_perm);
+  free(pool_epochs);
+  return 0;
 }
 
 // ---- flush_batch helpers ----
@@ -168,7 +175,7 @@ cpu_pipeline_flush_batch(const struct flush_batch_params* p,
       if (active_count > lut_cap)
         return 1;
 
-      uint32_t pool_epochs[MAX_BATCH_EPOCHS];
+      uint32_t* pool_epochs = p->pool_epochs_scratch;
       uint32_t ai = 0;
       for (uint32_t e = 0; e < n_epochs; ++e)
         if (active_masks[e] & (1u << lv))
@@ -359,13 +366,13 @@ cpu_pipeline_compute_luts(
     uint32_t slot_count = K_l > 0 ? K_l : 1;
 
     if (out->batch_gather[lv] && out->batch_chunk_to_shard_map[lv])
-      compute_batch_luts(cl,
-                         levels,
-                         agg,
-                         lv,
-                         slot_count,
-                         out->batch_gather[lv],
-                         out->batch_chunk_to_shard_map[lv]);
+      (void)compute_batch_luts(cl,
+                               levels,
+                               agg,
+                               lv,
+                               slot_count,
+                               out->batch_gather[lv],
+                               out->batch_chunk_to_shard_map[lv]);
   }
 
   // LOD LUTs (multiscale only).

--- a/src/cpu/pipeline.h
+++ b/src/cpu/pipeline.h
@@ -49,6 +49,7 @@ struct flush_batch_params
   struct shard_sink* sink;
   size_t shard_alignment_bytes;
   int nthreads;                   // resolved at init: always > 0
+  uint32_t* pool_epochs_scratch;  // [K] scratch for LUT recompute
   struct stream_metrics* metrics; // NULL to skip timing
 };
 

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -31,6 +31,7 @@ make_flush_params(struct cpu_stream_view* v)
     .sink = v->sink,
     .shard_alignment_bytes = v->shard_alignment,
     .nthreads = v->nthreads,
+    .pool_epochs_scratch = v->pool_epochs_scratch,
     .metrics = v->metrics,
   };
   for (int lv = 0; lv < v->levels->nlod; ++lv) {
@@ -174,7 +175,7 @@ cpu_stream_append_body(struct cpu_stream_view* v, struct slice input)
                 &sp, *v->batch_accumulated, &active_mask) == 0);
       }
 
-      CHECK(Error, *v->batch_accumulated < MAX_BATCH_EPOCHS);
+      CHECK(Error, *v->batch_accumulated < v->cl->epochs_per_batch);
       v->batch_active_masks[*v->batch_accumulated] = active_mask;
       (*v->batch_accumulated)++;
 
@@ -255,7 +256,7 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
       if (cpu_pipeline_scatter_epoch(&sp, *v->batch_accumulated, &active_mask))
         return writer_error();
     }
-    if (*v->batch_accumulated >= MAX_BATCH_EPOCHS)
+    if (*v->batch_accumulated >= v->cl->epochs_per_batch)
       return writer_error();
     v->batch_active_masks[*v->batch_accumulated] = active_mask;
     (*v->batch_accumulated)++;

--- a/src/cpu/stream.body.h
+++ b/src/cpu/stream.body.h
@@ -23,7 +23,8 @@ struct cpu_stream_view
   uint64_t* cursor_elements;
   uint64_t max_cursor_elements;
   uint32_t* batch_accumulated;
-  uint32_t* batch_active_masks; // [MAX_BATCH_EPOCHS]
+  uint32_t* batch_active_masks;  // [K]
+  uint32_t* pool_epochs_scratch; // [K] scratch for LUT recompute
   int pool_fully_covered;
 
   // Per-array shard/LOD state

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -74,6 +74,12 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
   s->comp_sizes = (size_t*)calloc((uint64_t)K * total_chunks, sizeof(size_t));
   CHECK(Fail, s->comp_sizes);
 
+  // Per-epoch mask + scratch buffers, sized to K.
+  s->batch_active_masks = (uint32_t*)calloc(K, sizeof(uint32_t));
+  CHECK(Fail, s->batch_active_masks);
+  s->pool_epochs_scratch = (uint32_t*)malloc((size_t)K * sizeof(uint32_t));
+  CHECK(Fail, s->pool_epochs_scratch);
+
   // Per-level shard + aggregate state.
   {
     uint64_t max_batch_C = 0;
@@ -303,6 +309,8 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
   free(s->chunk_pool);
   free(s->compressed);
   free(s->comp_sizes);
+  free(s->batch_active_masks);
+  free(s->pool_epochs_scratch);
   free(s->scatter_lut);
   free(s->scatter_fixed_dims_offsets);
   free(s->linear);
@@ -516,7 +524,7 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
     return 1;
   }
 
-  const uint8_t user_k = config->epochs_per_batch;
+  const uint32_t user_k = config->epochs_per_batch;
   const size_t floor =
     min_chunk_bytes > bytes_per_element ? min_chunk_bytes : bytes_per_element;
   if (diag)
@@ -564,7 +572,7 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
       last_k = mem.epochs_per_batch;
       last_heap_bytes = mem.heap_bytes;
       if (mem.heap_bytes <= budget_bytes) {
-        config->epochs_per_batch = (uint8_t)mem.epochs_per_batch;
+        config->epochs_per_batch = mem.epochs_per_batch;
         fit = 1;
         break;
       }
@@ -572,7 +580,7 @@ tile_stream_cpu_advise_layout(struct tile_stream_configuration* config,
       last_cps_total = 0;
       if (user_k || mem.epochs_per_batch <= 1)
         break;
-      config->epochs_per_batch = (uint8_t)(mem.epochs_per_batch / 2);
+      config->epochs_per_batch = mem.epochs_per_batch / 2;
     }
     if (!fit)
       continue;
@@ -667,6 +675,7 @@ make_view(struct tile_stream_cpu* s)
     .max_cursor_elements = s->max_cursor_elements,
     .batch_accumulated = &s->batch_accumulated,
     .batch_active_masks = s->batch_active_masks,
+    .pool_epochs_scratch = s->pool_epochs_scratch,
     .pool_fully_covered = s->pool_fully_covered,
     .shard = s->shard,
     .agg_layout = s->agg_layout,

--- a/src/cpu/stream.internal.h
+++ b/src/cpu/stream.internal.h
@@ -64,8 +64,9 @@ struct tile_stream_cpu
   int flushed;            // 1 after flush; append after flush is an error
 
   // Batch accumulation state (K = cl.epochs_per_batch).
-  uint32_t batch_accumulated;                    // 0..K-1
-  uint32_t batch_active_masks[MAX_BATCH_EPOCHS]; // per-epoch active level mask
+  uint32_t batch_accumulated;    // 0..K-1
+  uint32_t* batch_active_masks;  // [K] per-epoch active level mask
+  uint32_t* pool_epochs_scratch; // [K] scratch for kick-time mask scans
 
   // IO fence state: tracks pending async IO per level so we don't
   // overwrite aggregate buffers before write_direct completes.

--- a/src/defs.limits.h
+++ b/src/defs.limits.h
@@ -6,7 +6,6 @@
 #define HALF_MAX_RANK (MAX_RANK / 2)
 #define LOD_MAX_NDIM HALF_MAX_RANK
 #define LOD_MAX_LEVELS 32
-#define MAX_BATCH_EPOCHS 128
 #define MAX_ZARR_RANK (HALF_MAX_RANK)
 
 // Zarr group metadata

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -245,6 +245,12 @@ compress_agg_kick(struct compress_agg_stage* stage,
   if (in->lod_done)
     CU(Error, cuStreamWaitEvent(compress_stream, in->lod_done, 0));
 
+  // Aggregate writes to agg[fc].d_aggregated; ensure the prior D2H at this
+  // fc has finished reading from it before we overwrite. prev_d2h_done is
+  // initialized signaled, so the first kick on each fc no-ops here.
+  if (in->prev_d2h_done)
+    CU(Error, cuStreamWaitEvent(compress_stream, in->prev_d2h_done, 0));
+
   // Compress all epochs as one batch
   {
     CHECK_MUL_OVERFLOW(Error, n_epochs, levels->total_chunks, UINT64_MAX);

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -77,6 +77,10 @@ compress_agg_init(struct compress_agg_stage* stage,
   // Codec
   CHECK(Fail, codec_init(&stage->codec, config->codec.id, chunk_bytes, M) == 0);
 
+  // Per-level scratch for mask-scan results. Sized at K (max active_count).
+  stage->pool_epochs_scratch = (uint32_t*)malloc((size_t)K * sizeof(uint32_t));
+  CHECK(Fail, stage->pool_epochs_scratch);
+
   CHECK_MUL_OVERFLOW(Fail, M, stage->codec.max_output_size, SIZE_MAX);
   // Compressed buffers + events
   for (int fc = 0; fc < 2; ++fc) {
@@ -155,7 +159,7 @@ compress_agg_init(struct compress_agg_stage* stage,
     CHECK(Fail, h_gather && h_perm);
 
     {
-      uint32_t pool_epochs[MAX_BATCH_EPOCHS];
+      uint32_t* pool_epochs = stage->pool_epochs_scratch;
       for (uint32_t a = 0; a < slot_count; ++a) {
         uint32_t period = 1;
         if (cl->dims.append_downsample && lv > 0)
@@ -208,6 +212,8 @@ compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
   if (!stage)
     return;
   codec_free(&stage->codec);
+  free(stage->pool_epochs_scratch);
+  stage->pool_epochs_scratch = NULL;
   for (int fc = 0; fc < 2; ++fc) {
     cu_mem_free(stage->d_compressed[fc]);
     cu_event_destroy(stage->t_compress_start[fc]);
@@ -232,9 +238,10 @@ compress_agg_kick(struct compress_agg_stage* stage,
   const int fc = in->fc;
   const uint32_t n_epochs = in->n_epochs;
 
-  // Wait for all per-epoch pool-ready events
-  for (uint32_t e = 0; e < n_epochs; ++e)
-    CU(Error, cuStreamWaitEvent(compress_stream, in->epoch_events[e], 0));
+  // Pool work is submitted on the compute stream in order; a single batch-level
+  // pool_ready event recorded after the last scatter subsumes all prior ready
+  // signals.
+  CU(Error, cuStreamWaitEvent(compress_stream, in->pool_ready, 0));
   if (in->lod_done)
     CU(Error, cuStreamWaitEvent(compress_stream, in->lod_done, 0));
 
@@ -266,7 +273,7 @@ compress_agg_kick(struct compress_agg_stage* stage,
     // Scan masks to determine active_count and pool epochs.
     // level_active_epochs returns 0 for infrequent append-downsampled levels
     // (period > K); in that case we scan masks directly.
-    uint32_t pool_epochs_buf[MAX_BATCH_EPOCHS];
+    uint32_t* pool_epochs_buf = stage->pool_epochs_scratch;
     if (active_count == 0) {
       for (uint32_t e = 0; e < n_epochs; ++e)
         if (in->batch_active_masks[e] & (1u << lv))
@@ -347,13 +354,12 @@ compress_agg_kick(struct compress_agg_stage* stage,
 
   CU(Error, cuEventRecord(stage->t_aggregate_end[fc], compress_stream));
 
-  // Fill handoff
+  // Fill handoff (masks pointer is borrowed from the flush slot — lifetime is
+  // safe because the slot isn't reset until after d2h_deliver_drain completes).
   out->fc = fc;
   out->n_epochs = n_epochs;
   out->active_levels_mask = in->active_levels_mask;
-  memcpy(out->batch_active_masks,
-         in->batch_active_masks,
-         n_epochs * sizeof(uint32_t));
+  out->batch_active_masks = in->batch_active_masks;
   out->t_aggregate_end = stage->t_aggregate_end[fc];
   out->t_compress_start = stage->t_compress_start[fc];
   out->t_compress_end = stage->t_compress_end[fc];

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -124,32 +124,25 @@ Error:
   return 1;
 }
 
-// Phase 2: sync on offsets, then D2H only the actual compressed bytes.
-// Called from drain after kick has returned. Uses the stashed d2h_stream.
+// Phase 2: queue bulk D2H for each active level using the worst-case
+// (cap) size. Skips the offset sync so the host doesn't block waiting for
+// compress+aggregate to finish. For codec=none cap == actual. For
+// compressed codecs this wastes PCIe bandwidth up to (cap-actual) bytes
+// per level per batch, traded for keeping the main thread unblocked.
+// Delivery still uses the true bytes (from h_offsets, which lands via the
+// parallel offset D2H) to split the buffer into per-shard writes.
 static int
-drain_bulk_d2h(struct d2h_deliver_stage* stage,
+queue_bulk_d2h(struct d2h_deliver_stage* stage,
                const struct flush_handoff* handoff,
                const struct level_geometry* levels,
                const struct batch_state* batch,
-               const struct dim_info* dims)
+               const struct dim_info* dims,
+               CUstream d2h_stream)
 {
   const int fc = handoff->fc;
   const uint32_t n_epochs = handoff->n_epochs;
   const uint32_t level_mask = handoff->active_levels_mask;
-  CUstream d2h_stream = stage->d2h_stream;
 
-  // Wait for offset D2H to land on the host.
-  {
-    struct platform_clock sync_clk = { 0 };
-    platform_toc(&sync_clk);
-    CU(Error, cuEventSynchronize(stage->offsets_ready[fc]));
-    if (stage->metrics) {
-      float ms = (float)(platform_toc(&sync_clk) * 1000.0);
-      accumulate_metric_ms(&stage->metrics->kick_sync_stall, ms, 0, 0);
-    }
-  }
-
-  // D2H only actual compressed bytes per level.
   for (int lv = 0; lv < levels->nlod; ++lv) {
     if (!(level_mask & (1u << lv)))
       continue;
@@ -165,26 +158,20 @@ drain_bulk_d2h(struct d2h_deliver_stage* stage,
     }
 
     struct aggregate_slot* agg = &lvl->agg[fc];
-    uint64_t covering = (uint64_t)active_count * lvl->agg_layout.covering_count;
 
-    size_t actual = agg->h_offsets[covering];
-    // Add one alignment unit of slack: deliver_to_shards_batch rounds each
-    // write up with align_up, so the D2H must cover at least that much.
-    // The aggregate buffer was sized with this slack via agg_pool_bytes.
-    actual += stage->shard_alignment;
+    // Worst-case bytes across the aggregate buffer for this level/batch.
+    // No host sync needed — h_offsets isn't consulted here.
     size_t cap =
       agg_pool_bytes((uint64_t)active_count * levels->level[lv].chunk_count,
                      handoff->max_output_size,
                      lvl->agg_layout.covering_count,
                      lvl->agg_layout.cps_inner,
                      lvl->agg_layout.page_size);
-    if (actual > cap)
-      actual = cap;
 
     CU(
       Error,
       cuMemcpyDtoHAsync(
-        agg->h_aggregated, (CUdeviceptr)agg->d_aggregated, actual, d2h_stream));
+        agg->h_aggregated, (CUdeviceptr)agg->d_aggregated, cap, d2h_stream));
     CU(Error, cuEventRecord(agg->ready, d2h_stream));
   }
 
@@ -283,8 +270,9 @@ record_flush_metrics(const struct d2h_deliver_stage* stage,
   }
 }
 
-// Wait for IO fences, issue bulk D2H (phase 2), synchronize, record metrics,
-// deliver to sinks.
+// Sync on ready[fc] (near-zero in steady state because kick queued the D2H
+// long ago), record metrics, deliver to sinks. No bulk D2H here — that was
+// queued in d2h_deliver_kick.
 static struct writer_result
 sync_and_deliver(struct d2h_deliver_stage* stage,
                  const struct flush_handoff* handoff,
@@ -301,16 +289,10 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
   const int fc = handoff->fc;
   const uint32_t n_epochs = handoff->n_epochs;
 
-  // Wait for IO fences before overwriting h_aggregated with bulk D2H.
-  // Moved from kick so that compress+aggregate can run without blocking.
-  wait_io_fences(stage, fc, handoff->active_levels_mask, sink);
-
   // Fail fast if async IO encountered an error.
   if (sink->has_error && sink->has_error(sink))
     goto Error;
 
-  // Phase 2: sync on offsets, issue bulk D2H, sync on bulk ready.
-  CHECK(Error, drain_bulk_d2h(stage, handoff, levels, batch, dims) == 0);
   CU(Error, cuEventSynchronize(stage->ready[fc]));
   record_flush_metrics(stage,
                        handoff,
@@ -407,17 +389,27 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                  const struct level_geometry* levels,
                  const struct batch_state* batch,
                  const struct dim_info* dims,
+                 struct shard_sink* sink,
                  CUstream d2h_stream)
 {
   const int fc = handoff->fc;
 
+  // Wait on prior sink IO for this fc so we don't overwrite h_aggregated
+  // while the sink is still reading it. Host-blocking if sink is behind;
+  // no-op for async/discard sinks whose fence is already retired.
+  wait_io_fences(stage, fc, handoff->active_levels_mask, sink);
+
   CU(Error, cuStreamWaitEvent(d2h_stream, handoff->t_aggregate_end, 0));
   CU(Error, cuEventRecord(stage->t_d2h_start[fc], d2h_stream));
+
+  // Phase 1: queue offset D2H on d2h stream.
   CHECK(Error,
         kick_offset_d2h(stage, handoff, levels, batch, dims, d2h_stream) == 0);
 
-  // Stash d2h_stream so drain can issue bulk D2H on the same stream.
-  stage->d2h_stream = d2h_stream;
+  // Phase 2: sync on offsets (tiny) and queue bulk D2H on the same stream.
+  // ready[fc] is recorded after bulk completes.
+  CHECK(Error,
+        queue_bulk_d2h(stage, handoff, levels, batch, dims, d2h_stream) == 0);
 
   return 0;
 

--- a/src/gpu/flush.d2h_deliver.h
+++ b/src/gpu/flush.d2h_deliver.h
@@ -16,14 +16,17 @@ d2h_deliver_init(struct d2h_deliver_stage* stage,
 void
 d2h_deliver_destroy(struct d2h_deliver_stage* stage);
 
-// Enqueue D2H transfers (async). Waits on IO fences first.
-// Returns 0 on success.
+// Enqueue the full D2H (offset + bulk) for this batch on the d2h stream,
+// non-blocking. Briefly host-syncs on the offset D2H to size the bulk
+// transfer, and waits on prior sink IO fences for this fc. ready[fc] is
+// recorded after bulk D2H completes. Returns 0 on success.
 int
 d2h_deliver_kick(struct d2h_deliver_stage* stage,
                  const struct flush_handoff* handoff,
                  const struct level_geometry* levels,
                  const struct batch_state* batch,
                  const struct dim_info* dims,
+                 struct shard_sink* sink,
                  CUstream d2h_stream);
 
 // Synchronize D2H, record metrics, deliver to sinks.

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "defs.limits.h"
 #include "gpu/aggregate.h"
 #include "lod/lod_plan.h"
 
@@ -8,12 +7,15 @@
 #include <stdint.h>
 
 // Handoff from compress+aggregate to D2H+deliver.
+// batch_active_masks is borrowed from the flush_slot_gpu that produced this
+// batch. The slot's masks aren't reset until after d2h_deliver_drain completes,
+// so the borrow is safe for the lifetime of the handoff.
 struct flush_handoff
 {
-  int fc;                                        // flush slot index
-  uint32_t n_epochs;                             // epochs in batch
-  uint32_t active_levels_mask;                   // which levels active
-  uint32_t batch_active_masks[MAX_BATCH_EPOCHS]; // per-epoch masks
+  int fc;                             // flush slot index
+  uint32_t n_epochs;                  // epochs in batch
+  uint32_t active_levels_mask;        // which levels active
+  const uint32_t* batch_active_masks; // borrowed [K] per-epoch masks
 
   CUevent t_aggregate_end;  // D2H waits on this
   CUevent t_compress_start; // for metrics

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -231,9 +231,6 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
   if (ctx->cursor_elements % ctx->layout.epoch_elements != 0) {
     if (flush_run_epoch_lod(e, ctx))
       return writer_error();
-    CU(Error,
-       cuEventRecord(e->batch.pool_events[e->batch.accumulated],
-                     e->streams.compute));
     e->batch.accumulated++;
   }
 
@@ -269,9 +266,6 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
   }
 
   return writer_ok();
-
-Error:
-  return writer_error();
 }
 
 // --- Accessor ---

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -38,10 +38,11 @@ struct staging_state
 };
 
 // Per flush-slot: mutable batch state (masks + epoch count).
+// batch_active_masks is heap-allocated to epochs_per_batch entries.
 struct flush_slot_gpu
 {
   uint32_t active_levels_mask; // union of per-epoch active masks
-  uint32_t batch_active_masks[MAX_BATCH_EPOCHS]; // per-epoch active level masks
+  uint32_t* batch_active_masks; // [K] per-epoch active level masks
   int batch_epoch_count; // number of epochs accumulated in this batch
 };
 
@@ -117,12 +118,14 @@ struct gpu_streams
   CUstream h2d, compute, compress, d2h;
 };
 
-// Batch accumulation: config + mutable counter + per-epoch events
+// Batch accumulation: config + mutable counter + single pool-ready event.
+// All K scatter ops run on the compute stream in order, so a single event
+// recorded after the K-th scatter subsumes all per-epoch ready signals.
 struct batch_state
 {
-  uint32_t epochs_per_batch;             // K (immutable after create)
-  uint32_t accumulated;                  // mutable: 0..K-1
-  CUevent pool_events[MAX_BATCH_EPOCHS]; // per-epoch pool-ready signals
+  uint32_t epochs_per_batch; // K (immutable after create)
+  uint32_t accumulated;      // mutable: 0..K-1
+  CUevent pool_ready;        // recorded on compute after last accumulated epoch
 };
 
 // --- Stage types ---
@@ -132,9 +135,9 @@ struct compress_agg_input
   int fc;
   uint32_t n_epochs;
   uint32_t active_levels_mask;
-  uint32_t batch_active_masks[MAX_BATCH_EPOCHS];
+  const uint32_t* batch_active_masks; // borrowed from flush_slot_gpu [K]
   CUdeviceptr pool_buf;
-  CUevent epoch_events[MAX_BATCH_EPOCHS];
+  CUevent pool_ready; // batch-level (from batch_state.pool_ready)
   CUevent lod_done;
   uint32_t epochs_per_batch;
 };
@@ -146,6 +149,8 @@ struct compress_agg_stage
   CUevent t_compress_start[2];
   CUevent t_compress_end[2];
   CUevent t_aggregate_end[2];
+
+  uint32_t* pool_epochs_scratch; // [K] scratch for kick-time mask scans
 
   struct level_flush_state levels[LOD_MAX_LEVELS];
 };

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -137,8 +137,12 @@ struct compress_agg_input
   uint32_t active_levels_mask;
   const uint32_t* batch_active_masks; // borrowed from flush_slot_gpu [K]
   CUdeviceptr pool_buf;
-  CUevent pool_ready; // batch-level (from batch_state.pool_ready)
+  CUevent pool_ready;    // batch-level (from batch_state.pool_ready)
   CUevent lod_done;
+  CUevent prev_d2h_done; // prior D2H on same fc; compress waits on this so
+                         // aggregate doesn't overwrite agg[fc].d_aggregated
+                         // before the prior D2H has read it. Initialized
+                         // signaled.
   uint32_t epochs_per_batch;
 };
 
@@ -166,15 +170,21 @@ struct d2h_deliver_stage
   int nlod;
   size_t shard_alignment;         // from sink; 0 = no alignment
   struct stream_metrics* metrics; // borrowed, for stall-time accumulation
-  CUstream d2h_stream; // set by kick, consumed by drain (always paired)
 };
 
+// Lazy-delivery pipeline: each fc slot can independently hold a kicked-but-
+// not-yet-delivered batch. Delivery of fc=A happens at the start of the
+// drain_kick_and_swap round that is about to reuse fc=A (two rounds after
+// that batch was kicked, in N=2 alternation). Both fcs may hold a pending
+// batch simultaneously; drain order at final flush follows pending_seq.
 struct flush_pipeline
 {
   struct flush_slot_gpu slot[2];
-  int current;
-  int pending;
-  struct flush_handoff pending_handoff;
+  int current;                                 // fc currently being filled
+  int pending[2];                              // per-fc: batch awaiting delivery
+  uint64_t pending_seq[2];                     // monotonic kick seq per pending
+  uint64_t next_seq;                           // next seq to assign on kick
+  struct flush_handoff pending_handoff[2];     // per-fc
 };
 
 _Static_assert(LOD_MAX_LEVELS <= 32,

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -33,6 +33,7 @@ make_compress_input(struct stream_engine* e,
       (ctx->levels.enable_multiscale && e->lod_shared.timing[fc].t_end)
         ? e->lod_shared.timing[fc].t_end
         : NULL,
+    .prev_d2h_done = e->d2h_deliver.ready[fc],
     .epochs_per_batch = e->batch.epochs_per_batch,
   };
 }
@@ -73,11 +74,45 @@ Error:
   return 1;
 }
 
-// Pipeline the batch boundary: launch compress+aggregate for the new batch
-// on the compress stream, drain the previous batch's bulk D2H + delivery on
-// the d2h stream, then queue the new batch's offset D2H.  This ordering
-// keeps the d2h stream free for the previous batch's bulk transfer before
-// the new batch's aggregate-end wait occupies it.
+// Drain one pending fc slot: host-sync on ready[fc] (near-zero in steady
+// state), run delivery, clear pending. Accumulates flush_stall metric.
+static struct writer_result
+drain_fc(struct stream_engine* e, struct stream_context* ctx, int fc)
+{
+  if (!e->flush.pending[fc])
+    return writer_ok();
+
+  struct platform_clock stall_clk = { 0 };
+  platform_toc(&stall_clk);
+  struct writer_result r = d2h_deliver_drain(&e->d2h_deliver,
+                                             &e->flush.pending_handoff[fc],
+                                             &ctx->levels,
+                                             &e->batch,
+                                             &ctx->dims,
+                                             &ctx->layout,
+                                             &ctx->config,
+                                             ctx->sink,
+                                             &e->lod,
+                                             &e->lod_shared,
+                                             &e->metrics,
+                                             &e->metadata_update_clock);
+  float ms = (float)(platform_toc(&stall_clk) * 1000.0);
+  accumulate_metric_ms(&e->metrics.flush_stall, ms, 0, 0);
+
+  e->flush.pending[fc] = 0;
+  return r;
+}
+
+// Pipeline the batch boundary (lazy drain model):
+//   1. Deliver the PRIOR batch at this fc (if any). In steady state that
+//      batch's D2H has long since completed, so the host-sync is near-zero.
+//   2. Kick compress+aggregate for the new batch on this fc.
+//   3. Kick the full D2H (offset + bulk) on the d2h stream — non-blocking.
+//   4. Record the new handoff as pending for this fc; the drain of this
+//      batch will happen when fc is reused (typically 2 rounds later).
+//   5. Swap pools, zero the fresh one, reset batch accumulation.
+// Shard writes stay in batch order because we always deliver the fc we're
+// about to reuse, which holds the oldest undelivered batch.
 static struct writer_result
 drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
 {
@@ -85,14 +120,14 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
   const int completed_pool = e->pools.current;
   struct flush_slot_gpu* fs = &e->flush.slot[completed_pool];
 
-  // Save the previous pending state so we can drain it after the
-  // compress+aggregate kick but before the d2h kick.
-  struct flush_handoff prev_handoff = e->flush.pending_handoff;
-  int had_pending = e->flush.pending;
-  e->flush.pending = 0;
+  // Phase 1: deliver the PRIOR batch at fc=completed_pool (if any).
+  {
+    struct writer_result r = drain_fc(e, ctx, completed_pool);
+    if (r.error)
+      return r;
+  }
 
-  // Phase A: kick compress+aggregate for the new batch (compress stream).
-  // This starts GPU work immediately — no host blocking.
+  // Phase 2: kick compress+aggregate for the new batch (compress stream).
   fs->batch_epoch_count = (int)e->batch.accumulated;
   struct compress_agg_input in =
     make_compress_input(e, ctx, completed_pool, e->batch.accumulated);
@@ -106,46 +141,22 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
                           e->streams.compress,
                           &new_handoff) == 0);
 
-  // Phase B: drain the PREVIOUS batch.  This issues bulk D2H on d2h_stream
-  // (unblocked — the new batch's aggregate-end wait hasn't been queued yet).
-  if (had_pending) {
-    struct platform_clock stall_clk = { 0 };
-    platform_toc(&stall_clk);
-    struct writer_result r = d2h_deliver_drain(&e->d2h_deliver,
-                                               &prev_handoff,
-                                               &ctx->levels,
-                                               &e->batch,
-                                               &ctx->dims,
-                                               &ctx->layout,
-                                               &ctx->config,
-                                               ctx->sink,
-                                               &e->lod,
-                                               &e->lod_shared,
-                                               &e->metrics,
-                                               &e->metadata_update_clock);
-    float ms = (float)(platform_toc(&stall_clk) * 1000.0);
-    accumulate_metric_ms(&e->metrics.flush_stall, ms, 0, 0);
-    if (r.error)
-      return r;
-  }
-
-  // Phase C: queue the new batch's offset D2H on d2h_stream (non-blocking).
-  // This goes AFTER the previous drain's bulk D2H on d2h_stream, avoiding
-  // the aggregate-end wait from blocking the prior batch's transfer.
+  // Phase 3: kick the full D2H (offset sync + bulk queue) — non-blocking.
   CHECK(Error,
         d2h_deliver_kick(&e->d2h_deliver,
                          &new_handoff,
                          &ctx->levels,
                          &e->batch,
                          &ctx->dims,
+                         ctx->sink,
                          e->streams.d2h) == 0);
 
-  // Save handoff for the next drain.
-  e->flush.pending_handoff = new_handoff;
-  e->flush.pending = 1;
-  e->flush.current = completed_pool;
+  // Phase 4: mark this fc pending delivery.
+  e->flush.pending_handoff[completed_pool] = new_handoff;
+  e->flush.pending_seq[completed_pool] = e->flush.next_seq++;
+  e->flush.pending[completed_pool] = 1;
 
-  // Swap to fresh pool and zero it for next batch.
+  // Phase 5: swap to fresh pool and zero it for next batch.
   e->pools.current ^= 1;
   size_t pool_bytes = (uint64_t)K * ctx->levels.total_chunks *
                       ctx->layout.chunk_stride * dtype_bpe(ctx->config.dtype);
@@ -211,7 +222,9 @@ Error:
 
 // --- Batch flush pipeline ---
 
-// Kick compress + aggregate + D2H for a batch of n_epochs epochs.
+// Kick compress + aggregate + full D2H for a batch of n_epochs epochs on
+// the given fc. Records the handoff as pending for this fc. Caller must
+// drain pending[fc] before calling again on the same fc.
 int
 flush_kick_batch(struct stream_engine* e,
                  struct stream_context* ctx,
@@ -236,10 +249,13 @@ flush_kick_batch(struct stream_engine* e,
                          &ctx->levels,
                          &e->batch,
                          &ctx->dims,
+                         ctx->sink,
                          e->streams.d2h) == 0);
 
-  // Save handoff for drain
-  e->flush.pending_handoff = handoff;
+  // Save handoff for drain; mark this fc pending.
+  e->flush.pending_handoff[fc] = handoff;
+  e->flush.pending_seq[fc] = e->flush.next_seq++;
+  e->flush.pending[fc] = 1;
 
   return 0;
 
@@ -249,25 +265,27 @@ Error:
 
 // --- Public interface ---
 
+// Drain all pending batches in kick order. Called at stream flush.
 struct writer_result
 flush_drain_pending(struct stream_engine* e, struct stream_context* ctx)
 {
-  if (!e->flush.pending)
-    return writer_ok();
-
-  e->flush.pending = 0;
-  return d2h_deliver_drain(&e->d2h_deliver,
-                           &e->flush.pending_handoff,
-                           &ctx->levels,
-                           &e->batch,
-                           &ctx->dims,
-                           &ctx->layout,
-                           &ctx->config,
-                           ctx->sink,
-                           &e->lod,
-                           &e->lod_shared,
-                           &e->metrics,
-                           &e->metadata_update_clock);
+  // Up to 2 pending fcs (one per slot); drain oldest first.
+  for (int i = 0; i < 2; ++i) {
+    int pick = -1;
+    uint64_t pick_seq = UINT64_MAX;
+    for (int fc = 0; fc < 2; ++fc) {
+      if (e->flush.pending[fc] && e->flush.pending_seq[fc] < pick_seq) {
+        pick = fc;
+        pick_seq = e->flush.pending_seq[fc];
+      }
+    }
+    if (pick < 0)
+      break;
+    struct writer_result r = drain_fc(e, ctx, pick);
+    if (r.error)
+      return r;
+  }
+  return writer_ok();
 }
 
 struct writer_result
@@ -288,18 +306,7 @@ flush_accumulated_sync(struct stream_engine* e, struct stream_context* ctx)
   if (flush_kick_batch(e, ctx, fc, e->batch.accumulated))
     return writer_error();
 
-  struct writer_result r = d2h_deliver_drain(&e->d2h_deliver,
-                                             &e->flush.pending_handoff,
-                                             &ctx->levels,
-                                             &e->batch,
-                                             &ctx->dims,
-                                             &ctx->layout,
-                                             &ctx->config,
-                                             ctx->sink,
-                                             &e->lod,
-                                             &e->lod_shared,
-                                             &e->metrics,
-                                             &e->metadata_update_clock);
+  struct writer_result r = drain_fc(e, ctx, fc);
   if (r.error)
     return r;
 
@@ -394,18 +401,7 @@ flush_partial_append(struct stream_engine* e, struct stream_context* ctx)
   CU(Error, cuEventRecord(e->batch.pool_ready, e->streams.compute));
   if (flush_kick_batch(e, ctx, fc, 1))
     return writer_error();
-  return d2h_deliver_drain(&e->d2h_deliver,
-                           &e->flush.pending_handoff,
-                           &ctx->levels,
-                           &e->batch,
-                           &ctx->dims,
-                           &ctx->layout,
-                           &ctx->config,
-                           ctx->sink,
-                           &e->lod,
-                           &e->lod_shared,
-                           &e->metrics,
-                           &e->metadata_update_clock);
+  return drain_fc(e, ctx, fc);
 
 Error:
   return writer_error();

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -22,21 +22,19 @@ make_compress_input(struct stream_engine* e,
                     uint32_t n_epochs)
 {
   struct flush_slot_gpu* fs = &e->flush.slot[fc];
-  struct compress_agg_input in = {
+  return (struct compress_agg_input){
     .fc = fc,
     .n_epochs = n_epochs,
     .active_levels_mask = fs->active_levels_mask,
-    .epochs_per_batch = e->batch.epochs_per_batch,
+    .batch_active_masks = fs->batch_active_masks,
     .pool_buf = e->pools.buf[fc],
+    .pool_ready = e->batch.pool_ready,
     .lod_done =
       (ctx->levels.enable_multiscale && e->lod_shared.timing[fc].t_end)
         ? e->lod_shared.timing[fc].t_end
         : NULL,
+    .epochs_per_batch = e->batch.epochs_per_batch,
   };
-  memcpy(
-    in.batch_active_masks, fs->batch_active_masks, n_epochs * sizeof(uint32_t));
-  memcpy(in.epoch_events, e->batch.pool_events, n_epochs * sizeof(CUevent));
-  return in;
 }
 
 // --- Epoch accumulation ---
@@ -160,7 +158,7 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
   e->flush.slot[e->pools.current].active_levels_mask = 0;
   memset(e->flush.slot[e->pools.current].batch_active_masks,
          0,
-         sizeof(e->flush.slot[e->pools.current].batch_active_masks));
+         (size_t)K * sizeof(uint32_t));
 
   return writer_ok();
 
@@ -176,13 +174,14 @@ flush_accumulate_epoch(struct stream_engine* e, struct stream_context* ctx)
   if (flush_run_epoch_lod(e, ctx))
     return writer_error();
 
-  CU(Error,
-     cuEventRecord(e->batch.pool_events[e->batch.accumulated],
-                   e->streams.compute));
   e->batch.accumulated++;
 
   if (e->batch.accumulated < e->batch.epochs_per_batch)
     return writer_ok();
+
+  // Record pool_ready once after the last epoch's scatter; compute-stream
+  // ordering means this subsumes per-epoch ready signals.
+  CU(Error, cuEventRecord(e->batch.pool_ready, e->streams.compute));
 
   if (e->sync_flush) {
     // Synchronous path: flush the full batch immediately (no pool swap).
@@ -281,6 +280,11 @@ flush_accumulated_sync(struct stream_engine* e, struct stream_context* ctx)
   struct flush_slot_gpu* fs = &e->flush.slot[fc];
 
   fs->batch_epoch_count = (int)e->batch.accumulated;
+
+  // Record pool_ready after all scatter ops for this (possibly partial) batch.
+  if (cuEventRecord(e->batch.pool_ready, e->streams.compute) != CUDA_SUCCESS)
+    return writer_error();
+
   if (flush_kick_batch(e, ctx, fc, e->batch.accumulated))
     return writer_error();
 
@@ -303,7 +307,7 @@ flush_accumulated_sync(struct stream_engine* e, struct stream_context* ctx)
   e->flush.slot[e->pools.current].active_levels_mask = 0;
   memset(e->flush.slot[e->pools.current].batch_active_masks,
          0,
-         sizeof(e->flush.slot[e->pools.current].batch_active_masks));
+         (size_t)e->batch.epochs_per_batch * sizeof(uint32_t));
   return r;
 }
 
@@ -387,7 +391,7 @@ flush_partial_append(struct stream_engine* e, struct stream_context* ctx)
     CU(Error,
        cuEventRecord(e->lod_shared.timing[fc].t_end, e->streams.compute));
 
-  CU(Error, cuEventRecord(e->batch.pool_events[0], e->streams.compute));
+  CU(Error, cuEventRecord(e->batch.pool_ready, e->streams.compute));
   if (flush_kick_batch(e, ctx, fc, 1))
     return writer_error();
   return d2h_deliver_drain(&e->d2h_deliver,

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -38,9 +38,11 @@ destroy_chunk_pools(struct pool_state* pools)
 static void
 destroy_batch_events(struct batch_state* batch)
 {
-  for (uint32_t i = 0; i < batch->epochs_per_batch; ++i)
-    cu_event_destroy(batch->pool_events[i]);
+  cu_event_destroy(batch->pool_ready);
 }
+
+static void
+destroy_flush_pipeline(struct flush_pipeline* fp);
 
 static void
 sync(CUstream stream)
@@ -70,6 +72,7 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.d2h);
 
   destroy_batch_events(&s->engine.batch);
+  destroy_flush_pipeline(&s->engine.flush);
   d2h_deliver_destroy(&s->engine.d2h_deliver);
   compress_agg_destroy(&s->engine.compress_agg, s->ctx.levels.nlod);
   destroy_chunk_pools(&s->engine.pools);
@@ -121,18 +124,37 @@ Fail:
   return 1;
 }
 
-// Allocate and seed per-epoch batch pool events.
+// Create and seed the batch pool-ready event.
 static int
 init_batch_events(struct batch_state* batch, CUstream compute)
 {
-  const uint32_t K = batch->epochs_per_batch;
-  for (uint32_t i = 0; i < K; ++i) {
-    CU(Fail, cuEventCreate(&batch->pool_events[i], CU_EVENT_DEFAULT));
-    CU(Fail, cuEventRecord(batch->pool_events[i], compute));
-  }
+  CU(Fail, cuEventCreate(&batch->pool_ready, CU_EVENT_DEFAULT));
+  CU(Fail, cuEventRecord(batch->pool_ready, compute));
   return 0;
 Fail:
   return 1;
+}
+
+// Allocate per-slot batch_active_masks for the flush pipeline. K entries each.
+static int
+init_flush_pipeline(struct flush_pipeline* fp, uint32_t K)
+{
+  for (int fc = 0; fc < 2; ++fc) {
+    fp->slot[fc].batch_active_masks =
+      (uint32_t*)calloc(K, sizeof(uint32_t));
+    if (!fp->slot[fc].batch_active_masks)
+      return 1;
+  }
+  return 0;
+}
+
+static void
+destroy_flush_pipeline(struct flush_pipeline* fp)
+{
+  for (int fc = 0; fc < 2; ++fc) {
+    free(fp->slot[fc].batch_active_masks);
+    fp->slot[fc].batch_active_masks = NULL;
+  }
 }
 
 static int
@@ -192,9 +214,13 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
     out->engine.lod.layouts[lv] = cl.layouts[lv];
 
   // Copy batch info.
-  CHECK(FailPhase2, (cl.epochs_per_batch & (cl.epochs_per_batch - 1)) == 0);
+  CHECK(FailPhase2, cl.epochs_per_batch >= 1);
   out->engine.batch.epochs_per_batch = cl.epochs_per_batch;
   out->engine.batch.accumulated = 0;
+
+  // Allocate per-slot batch_active_masks sized to K.
+  CHECK(FailPhase2,
+        init_flush_pipeline(&out->engine.flush, cl.epochs_per_batch) == 0);
 
   // GPU allocation and init.
   CHECK(FailPhase2,
@@ -533,7 +559,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
     return 1;
   }
 
-  const uint8_t user_k = config->epochs_per_batch;
+  const uint32_t user_k = config->epochs_per_batch;
   const size_t floor =
     min_chunk_bytes > bytes_per_element ? min_chunk_bytes : bytes_per_element;
   if (diag)
@@ -583,7 +609,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
       last_k = mem.epochs_per_batch;
       last_device_bytes = mem.device_bytes;
       if (mem.device_bytes <= budget_bytes) {
-        config->epochs_per_batch = (uint8_t)mem.epochs_per_batch;
+        config->epochs_per_batch = mem.epochs_per_batch;
         fit = 1;
         break;
       }
@@ -591,7 +617,7 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
       last_cps_total = 0;
       if (user_k || mem.epochs_per_batch <= 1)
         break;
-      config->epochs_per_batch = (uint8_t)(mem.epochs_per_batch / 2);
+      config->epochs_per_batch = mem.epochs_per_batch / 2;
     }
     if (!fit)
       continue;

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -345,7 +345,7 @@ tile_stream_gpu_status(const struct tile_stream_gpu* s)
     .codec_batch_size = s->engine.compress_agg.codec.batch_size,
     .batch_accumulated = s->engine.batch.accumulated,
     .pool_current = s->engine.pools.current,
-    .flush_pending = s->engine.flush.pending,
+    .flush_pending = s->engine.flush.pending[0] || s->engine.flush.pending[1],
   };
 }
 

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -31,7 +31,8 @@ struct array_descriptor
   uint64_t cursor_elements;
   uint64_t max_cursor_elements;
   uint32_t batch_accumulated;
-  uint32_t batch_active_masks[MAX_BATCH_EPOCHS];
+  uint32_t* batch_active_masks;  // [K], heap-allocated
+  uint32_t* pool_epochs_scratch; // [K], heap-allocated
   uint32_t append_counts[LOD_MAX_LEVELS];
   void* append_accum;
   struct reduce_csr* csrs; // [nlod-1] CSR reduce LUTs (multiscale only), owned
@@ -155,6 +156,13 @@ init_array_descriptor(struct array_descriptor* desc,
   const uint32_t K = desc->cl.epochs_per_batch;
   const size_t bytes_per_element = dtype_bpe(config->dtype);
   const uint64_t total_chunks = desc->levels.total_chunks;
+
+  desc->batch_active_masks = (uint32_t*)calloc(K, sizeof(uint32_t));
+  if (!desc->batch_active_masks)
+    return 1;
+  desc->pool_epochs_scratch = (uint32_t*)malloc((size_t)K * sizeof(uint32_t));
+  if (!desc->pool_epochs_scratch)
+    return 1;
 
   // max_cursor
   {
@@ -439,6 +447,8 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
         }
       }
       free(desc->append_accum);
+      free(desc->batch_active_masks);
+      free(desc->pool_epochs_scratch);
       if (desc->csrs) {
         int ncsr = desc->cl.plan.levels.nlod - 1;
         for (int l = 0; l < ncsr; ++l)
@@ -571,6 +581,7 @@ make_multiarray_view(struct multiarray_tile_stream_cpu* ms,
     .max_cursor_elements = desc->max_cursor_elements,
     .batch_accumulated = &desc->batch_accumulated,
     .batch_active_masks = desc->batch_active_masks,
+    .pool_epochs_scratch = desc->pool_epochs_scratch,
     .pool_fully_covered = desc->pool_fully_covered,
     .shard = desc->shard,
     .agg_layout = desc->agg_layout,

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -32,9 +32,10 @@ struct array_descriptor_gpu
   uint32_t batch_accumulated;
   int pools_current;
   struct flush_slot_gpu flush_slots[2];
-  int flush_pending;
-  int flush_current;
-  struct flush_handoff flush_pending_handoff;
+  int flush_pending[2];
+  uint64_t flush_pending_seq[2];
+  uint64_t flush_next_seq;
+  struct flush_handoff flush_pending_handoff[2];
   struct shard_state shard[LOD_MAX_LEVELS];
   struct aggregate_layout agg_layout[LOD_MAX_LEVELS];
   uint32_t batch_active_count[LOD_MAX_LEVELS];
@@ -117,11 +118,13 @@ bind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
   e->batch.epochs_per_batch = desc->cl.epochs_per_batch;
   e->batch.accumulated = desc->batch_accumulated;
   e->pools.current = desc->pools_current;
-  for (int i = 0; i < 2; ++i)
+  for (int i = 0; i < 2; ++i) {
     e->flush.slot[i] = desc->flush_slots[i];
-  e->flush.pending = desc->flush_pending;
-  e->flush.current = desc->flush_current;
-  e->flush.pending_handoff = desc->flush_pending_handoff;
+    e->flush.pending[i] = desc->flush_pending[i];
+    e->flush.pending_seq[i] = desc->flush_pending_seq[i];
+    e->flush.pending_handoff[i] = desc->flush_pending_handoff[i];
+  }
+  e->flush.next_seq = desc->flush_next_seq;
   for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
     e->compress_agg.levels[lv].shard = desc->shard[lv];
     e->compress_agg.levels[lv].agg_layout = desc->agg_layout[lv];
@@ -142,11 +145,13 @@ unbind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
 {
   desc->batch_accumulated = e->batch.accumulated;
   desc->pools_current = e->pools.current;
-  for (int i = 0; i < 2; ++i)
+  for (int i = 0; i < 2; ++i) {
     desc->flush_slots[i] = e->flush.slot[i];
-  desc->flush_pending = e->flush.pending;
-  desc->flush_current = e->flush.current;
-  desc->flush_pending_handoff = e->flush.pending_handoff;
+    desc->flush_pending[i] = e->flush.pending[i];
+    desc->flush_pending_seq[i] = e->flush.pending_seq[i];
+    desc->flush_pending_handoff[i] = e->flush.pending_handoff[i];
+  }
+  desc->flush_next_seq = e->flush.next_seq;
   for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
     desc->shard[lv] = e->compress_agg.levels[lv].shard;
     desc->agg_layout[lv] = e->compress_agg.levels[lv].agg_layout;

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -215,6 +215,16 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
   const uint64_t total_chunks = desc->ctx.levels.total_chunks;
   const uint64_t chunk_stride = desc->ctx.layout.chunk_stride;
 
+  // Per-array, per-slot batch_active_masks. Bind/unbind copies the pointer
+  // into the engine's flush slots; the storage lives here for the array's
+  // lifetime.
+  for (int fc = 0; fc < 2; ++fc) {
+    desc->flush_slots[fc].batch_active_masks =
+      (uint32_t*)calloc(K, sizeof(uint32_t));
+    if (!desc->flush_slots[fc].batch_active_masks)
+      return 1;
+  }
+
   // max_cursor
   {
     const struct dimension* dims = config->dimensions;
@@ -295,6 +305,10 @@ destroy_array_descriptor(struct array_descriptor_gpu* desc)
 {
   if (!desc)
     return;
+  for (int fc = 0; fc < 2; ++fc) {
+    free(desc->flush_slots[fc].batch_active_masks);
+    desc->flush_slots[fc].batch_active_masks = NULL;
+  }
   for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
     struct shard_state* ss = &desc->shard[lv];
     if (ss->shards) {
@@ -339,10 +353,14 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
   }
 
   e->batch.epochs_per_batch = mx->epochs_per_batch;
-  for (uint32_t i = 0; i < mx->epochs_per_batch; ++i) {
-    CU(Fail, cuEventCreate(&e->batch.pool_events[i], CU_EVENT_DEFAULT));
-    CU(Fail, cuEventRecord(e->batch.pool_events[i], e->streams.compute));
-  }
+  CU(Fail, cuEventCreate(&e->batch.pool_ready, CU_EVENT_DEFAULT));
+  CU(Fail, cuEventRecord(e->batch.pool_ready, e->streams.compute));
+
+  // Per-slot batch_active_masks live on each array descriptor (bind/unbind
+  // copies them in). Stage scratch is shared and sized to the max K.
+  e->compress_agg.pool_epochs_scratch =
+    (uint32_t*)malloc((size_t)mx->epochs_per_batch * sizeof(uint32_t));
+  CHECK(Fail, e->compress_agg.pool_epochs_scratch);
 
   CHECK(Fail,
         codec_init(&e->compress_agg.codec,
@@ -591,12 +609,13 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
 
   struct stream_engine* e = &ms->engine;
 
-  for (uint32_t i = 0; i < e->batch.epochs_per_batch; ++i)
-    cu_event_destroy(e->batch.pool_events[i]);
+  cu_event_destroy(e->batch.pool_ready);
 
   d2h_deliver_destroy(&e->d2h_deliver);
 
   codec_free(&e->compress_agg.codec);
+  free(e->compress_agg.pool_epochs_scratch);
+  e->compress_agg.pool_epochs_scratch = NULL;
   for (int fc = 0; fc < 2; ++fc) {
     cu_mem_free(e->compress_agg.d_compressed[fc]);
     cu_event_destroy(e->compress_agg.t_compress_start[fc]);

--- a/src/stream/config.c
+++ b/src/stream/config.c
@@ -11,37 +11,33 @@
 #include <stdlib.h>
 #include <string.h>
 
-static inline uint32_t
-next_pow2_u32(uint32_t v)
-{
-  if (v == 0)
-    return 1;
-  v--;
-  v |= v >> 1;
-  v |= v >> 2;
-  v |= v >> 4;
-  v |= v >> 8;
-  v |= v >> 16;
-  return v + 1;
-}
+// Compute epochs_per_batch (K) from config and uncompressed bytes per epoch.
+// bytes_per_epoch sums chunks_per_epoch * chunk_stride * bpe across LOD levels.
+// User-supplied K is authoritative; otherwise auto-K = ceildiv(target, bpe).
+// Auto-K is clamped to AUTO_K_MAX as a safety backstop against configs with
+// pathologically small bytes_per_epoch (e.g., unit tests with tiny chunks);
+// callers who need more can set epochs_per_batch explicitly.
+// Floors at 1.
+#define AUTO_K_MAX (1u << 16)
 
-// Compute epochs_per_batch (K) from config and total chunks per epoch.
-// Returns K as a power of 2, clamped to MAX_BATCH_EPOCHS.
 static uint32_t
 compute_epochs_per_batch(const struct tile_stream_configuration* config,
-                         uint64_t total_chunks_per_epoch)
+                         size_t bytes_per_epoch)
 {
-  uint32_t K = config->epochs_per_batch;
-  if (K == 0) {
-    uint32_t target = config->target_batch_chunks;
-    if (target == 0)
-      target = 1024;
-    K = (uint32_t)ceildiv(target, total_chunks_per_epoch);
-    K = next_pow2_u32(K);
-  }
-  if (K > MAX_BATCH_EPOCHS)
-    K = MAX_BATCH_EPOCHS;
-  return K;
+  if (config->epochs_per_batch > 0)
+    return config->epochs_per_batch;
+
+  size_t target = config->target_batch_bytes;
+  if (target == 0)
+    target = (size_t)512 << 20; // 512 MiB default
+  if (bytes_per_epoch == 0)
+    return 1;
+  uint64_t K = ceildiv(target, bytes_per_epoch);
+  if (K < 1)
+    K = 1;
+  if (K > AUTO_K_MAX)
+    K = AUTO_K_MAX;
+  return (uint32_t)K;
 }
 
 // Extract forward permutation from dims[d].storage_position.
@@ -280,15 +276,17 @@ compute_stream_layouts(const struct tile_stream_configuration* config,
 
   // --- Level geometry (single loop) ---
   out->levels.total_chunks = 0;
+  size_t bytes_per_epoch = 0;
   for (int lv = 0; lv < out->levels.nlod; ++lv) {
     out->levels.level[lv].chunk_count = out->layouts[lv].chunks_per_epoch;
     out->levels.level[lv].chunk_offset = out->levels.total_chunks;
     out->levels.total_chunks += out->levels.level[lv].chunk_count;
+    bytes_per_epoch += (size_t)out->layouts[lv].chunks_per_epoch *
+                       out->layouts[lv].chunk_stride * bytes_per_element;
   }
 
   // --- Epochs per batch (K) ---
-  out->epochs_per_batch =
-    compute_epochs_per_batch(config, out->levels.total_chunks);
+  out->epochs_per_batch = compute_epochs_per_batch(config, bytes_per_epoch);
 
   // --- Codec-derived max_output_size ---
   {

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -56,9 +56,9 @@ struct tile_stream_configuration
   int max_nlod; // 0 = auto, N>0 = max N total levels (1 = base only)
   int preserve_aspect_ratio; // 0 = drop dims independently (default),
                              // 1 = stop when any dim reaches chunk_size
-  uint8_t epochs_per_batch;  // K: 0 = auto (target_batch_chunks), must be pow2
+  uint32_t epochs_per_batch; // K: 0 = auto (from target_batch_bytes)
   uint32_t
-    target_batch_chunks; // minimum chunks per compress batch (default 1024)
+    target_batch_bytes; // target uncompressed bytes per batch (default 512 MiB)
   float metadata_update_interval_s;
   size_t backpressure_bytes; // 0 = disabled; >0 = stall at epoch boundaries
                              // when sink->pending_bytes exceeds this watermark

--- a/tests/test_batch.c
+++ b/tests/test_batch.c
@@ -175,7 +175,9 @@ test_batch_multi_cycle(void)
   struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
   CHECK(Fail2, r.error == 0);
 
-  // After 2 batches: swapped twice → back to pool 0, batch 2 pending
+  // After 2 batches: swapped twice → back to pool 0, both pending (lazy
+  // delivery: pending[0] = batch 1, pending[1] = batch 2, until either
+  // a 3rd batch reuses fc=0 or the stream is flushed).
   {
     struct tile_stream_status st = tile_stream_gpu_status(s);
     CHECK(Fail2, st.pool_current == 0);
@@ -183,14 +185,11 @@ test_batch_multi_cycle(void)
     CHECK(Fail2, st.flush_pending == 1);
   }
 
-  // Batch 1 drained when batch 2 started; batch 2 still pending
+  // Flush drains both pending batches, finalizing their shards.
   int pre_flush_finalize = css.finalize_count;
-  CHECK(Fail2, pre_flush_finalize >= 1);
-
-  // Flush drains batch 2
   r = writer_flush(tile_stream_gpu_writer(s));
   CHECK(Fail2, r.error == 0);
-  CHECK(Fail2, css.finalize_count > pre_flush_finalize);
+  CHECK(Fail2, css.finalize_count >= pre_flush_finalize + 2);
 
   free(src);
   tile_stream_gpu_destroy(s);

--- a/tests/test_compress_agg.c
+++ b/tests/test_compress_agg.c
@@ -25,7 +25,8 @@ struct ca_test_ctx
   struct compress_agg_stage stage;
   CUstream compute;
   CUdeviceptr d_pool;
-  CUevent epoch_events[2];
+  CUevent pool_ready; // recorded after last fill_epoch call
+  uint32_t* batch_active_masks; // [K] owned scratch for tests
   struct batch_state batch;
   int stage_inited;
 };
@@ -43,8 +44,8 @@ ca_ctx_destroy(struct ca_test_ctx* c)
     compress_agg_destroy(&c->stage, c->cl.levels.nlod);
   computed_stream_layouts_free(&c->cl);
   cu_mem_free(c->d_pool);
-  for (int i = 0; i < 2; ++i)
-    cu_event_destroy(c->epoch_events[i]);
+  cu_event_destroy(c->pool_ready);
+  free(c->batch_active_masks);
   cu_stream_destroy(c->compute);
 }
 
@@ -52,7 +53,7 @@ ca_ctx_destroy(struct ca_test_ctx* c)
 static int
 ca_ctx_setup(struct ca_test_ctx* c,
              struct codec_config codec,
-             uint8_t epochs_per_batch,
+             uint32_t epochs_per_batch,
              int n_pool_epochs)
 {
   make_test_config(&c->config, c->dims, codec, epochs_per_batch);
@@ -73,9 +74,16 @@ ca_ctx_setup(struct ca_test_ctx* c,
                       dtype_bpe(c->config.dtype);
   CU(Fail, cuMemAlloc(&c->d_pool, pool_bytes));
 
+  CU(Fail, cuEventCreate(&c->pool_ready, CU_EVENT_DEFAULT));
+
+  c->batch_active_masks =
+    (uint32_t*)calloc(c->cl.epochs_per_batch, sizeof(uint32_t));
+  CHECK(Fail, c->batch_active_masks);
+
   c->batch = (struct batch_state){
     .epochs_per_batch = c->cl.epochs_per_batch,
     .accumulated = 0,
+    .pool_ready = c->pool_ready,
   };
   return 0;
 
@@ -99,8 +107,9 @@ ca_ctx_fill_epoch(struct ca_test_ctx* c,
           epoch_ptr, total_chunks, chunk_stride, bytes_per_element, fill_fn) ==
           0);
 
-  CU(Fail, cuEventCreate(&c->epoch_events[epoch_idx], CU_EVENT_DEFAULT));
-  CU(Fail, cuEventRecord(c->epoch_events[epoch_idx], c->compute));
+  // Re-record pool_ready on the compute stream after every fill so the test
+  // can rely on the latest event signaling batch-level readiness.
+  CU(Fail, cuEventRecord(c->pool_ready, c->compute));
   return 0;
 
 Fail:
@@ -113,18 +122,19 @@ ca_ctx_kick(struct ca_test_ctx* c,
             uint32_t n_epochs,
             struct flush_handoff* handoff)
 {
+  for (uint32_t i = 0; i < n_epochs; ++i)
+    c->batch_active_masks[i] = 0x1;
+
   struct compress_agg_input in = {
     .fc = 0,
     .n_epochs = n_epochs,
     .active_levels_mask = 0x1,
+    .batch_active_masks = c->batch_active_masks,
     .pool_buf = c->d_pool,
-    .epochs_per_batch = c->cl.epochs_per_batch,
+    .pool_ready = c->pool_ready,
     .lod_done = 0,
+    .epochs_per_batch = c->cl.epochs_per_batch,
   };
-  for (uint32_t i = 0; i < n_epochs; ++i) {
-    in.batch_active_masks[i] = 0x1;
-    in.epoch_events[i] = c->epoch_events[i];
-  }
 
   memset(handoff, 0, sizeof(*handoff));
 

--- a/tests/test_cpu_zarr_fs.c
+++ b/tests/test_cpu_zarr_fs.c
@@ -415,7 +415,7 @@ test_batch_readback_impl(const char* tmpdir, int epochs_per_batch)
     .rank = 3,
     .dimensions = dims,
     .codec = { .id = CODEC_ZSTD },
-    .epochs_per_batch = (uint8_t)epochs_per_batch,
+    .epochs_per_batch = epochs_per_batch,
   };
 
   struct tile_stream_cpu* s =

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -157,11 +157,14 @@ test_ctx_kick_and_drain(struct test_ctx* c,
                           c->compute,
                           handoff) == 0);
 
-  CHECK(
-    Fail,
-    d2h_deliver_kick(
-      &c->d2h, handoff, &c->cl.levels, &c->batch, &c->cl.dims, c->d2h_stream) ==
-      0);
+  CHECK(Fail,
+        d2h_deliver_kick(&c->d2h,
+                         handoff,
+                         &c->cl.levels,
+                         &c->batch,
+                         &c->cl.dims,
+                         sink,
+                         c->d2h_stream) == 0);
 
   struct writer_result r = d2h_deliver_drain(&c->d2h,
                                              handoff,

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -28,7 +28,8 @@ struct test_ctx
   CUstream compute;
   CUstream d2h_stream;
   CUdeviceptr d_pool;
-  CUevent epoch_events[2];
+  CUevent pool_ready;
+  uint32_t* batch_active_masks;
   struct batch_state batch;
   struct stream_metrics metrics;
   struct lod_state lod;
@@ -53,8 +54,8 @@ test_ctx_destroy(struct test_ctx* c)
     compress_agg_destroy(&c->ca, c->cl.levels.nlod);
   computed_stream_layouts_free(&c->cl);
   cu_mem_free(c->d_pool);
-  for (int i = 0; i < 2; ++i)
-    cu_event_destroy(c->epoch_events[i]);
+  cu_event_destroy(c->pool_ready);
+  free(c->batch_active_masks);
   cu_stream_destroy(c->compute);
   cu_stream_destroy(c->d2h_stream);
 }
@@ -91,9 +92,16 @@ test_ctx_setup(struct test_ctx* c,
                       c->cl.layouts[0].chunk_stride * dtype_bpe(config->dtype);
   CU(Fail, cuMemAlloc(&c->d_pool, pool_bytes));
 
+  CU(Fail, cuEventCreate(&c->pool_ready, CU_EVENT_DEFAULT));
+
+  c->batch_active_masks =
+    (uint32_t*)calloc(c->cl.epochs_per_batch, sizeof(uint32_t));
+  CHECK(Fail, c->batch_active_masks);
+
   c->batch = (struct batch_state){
     .epochs_per_batch = c->cl.epochs_per_batch,
     .accumulated = 0,
+    .pool_ready = c->pool_ready,
   };
 
   memset(&c->metrics, 0, sizeof(c->metrics));
@@ -121,21 +129,22 @@ test_ctx_kick_and_drain(struct test_ctx* c,
                         int fc,
                         uint32_t n_epochs,
                         CUdeviceptr pool_buf,
-                        const CUevent* epoch_events,
+                        CUevent pool_ready,
                         struct flush_handoff* handoff)
 {
+  for (uint32_t i = 0; i < n_epochs; ++i)
+    c->batch_active_masks[i] = 0x1;
+
   struct compress_agg_input in = {
     .fc = fc,
     .n_epochs = n_epochs,
     .active_levels_mask = 0x1,
+    .batch_active_masks = c->batch_active_masks,
     .pool_buf = pool_buf,
-    .epochs_per_batch = c->cl.epochs_per_batch,
+    .pool_ready = pool_ready,
     .lod_done = 0,
+    .epochs_per_batch = c->cl.epochs_per_batch,
   };
-  for (uint32_t i = 0; i < n_epochs; ++i) {
-    in.batch_active_masks[i] = 0x1;
-    in.epoch_events[i] = epoch_events[i];
-  }
 
   memset(handoff, 0, sizeof(*handoff));
 
@@ -212,15 +221,14 @@ test_d2h_single_epoch_none(void)
       c.d_pool, total_chunks, chunk_stride, bytes_per_element, fill_epoch0) ==
       0);
 
-  // Create and record epoch event
-  CU(Fail, cuEventCreate(&c.epoch_events[0], CU_EVENT_DEFAULT));
-  CU(Fail, cuEventRecord(c.epoch_events[0], c.compute));
+  // Record pool_ready after the fill
+  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
 
   // Kick compress_agg + D2H + drain
   struct flush_handoff handoff;
   CHECK(Fail,
         test_ctx_kick_and_drain(
-          &c, &config, &sink.base, 0, 1, c.d_pool, c.epoch_events, &handoff) ==
+          &c, &config, &sink.base, 0, 1, c.d_pool, c.pool_ready, &handoff) ==
           0);
 
   // Verify sink state
@@ -284,16 +292,13 @@ test_d2h_batch_none(void)
                         bytes_per_element,
                         fill_epoch1) == 0);
 
-  for (int i = 0; i < 2; ++i) {
-    CU(Fail, cuEventCreate(&c.epoch_events[i], CU_EVENT_DEFAULT));
-    CU(Fail, cuEventRecord(c.epoch_events[i], c.compute));
-  }
+  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
 
   // Kick with 2 epochs
   struct flush_handoff handoff;
   CHECK(Fail,
         test_ctx_kick_and_drain(
-          &c, &config, &sink.base, 0, 2, c.d_pool, c.epoch_events, &handoff) ==
+          &c, &config, &sink.base, 0, 2, c.d_pool, c.pool_ready, &handoff) ==
           0);
 
   // tps_0=2, 2 epochs → shard complete
@@ -422,13 +427,12 @@ test_d2h_zstd_single_epoch(void)
       c.d_pool, total_chunks, chunk_stride, bytes_per_element, fill_epoch0) ==
       0);
 
-  CU(Fail, cuEventCreate(&c.epoch_events[0], CU_EVENT_DEFAULT));
-  CU(Fail, cuEventRecord(c.epoch_events[0], c.compute));
+  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
 
   struct flush_handoff handoff;
   CHECK(Fail,
         test_ctx_kick_and_drain(
-          &c, &config, &sink.base, 0, 1, c.d_pool, c.epoch_events, &handoff) ==
+          &c, &config, &sink.base, 0, 1, c.d_pool, c.pool_ready, &handoff) ==
           0);
 
   CHECK(Fail, sink.writers[0][0].size > 0);
@@ -523,15 +527,14 @@ test_d2h_double_buffer(void)
     fill_pool_epoch(
       c.d_pool, total_chunks, chunk_stride, bytes_per_element, fill_epoch0) ==
       0);
-  CU(Fail, cuEventCreate(&c.epoch_events[0], CU_EVENT_DEFAULT));
-  CU(Fail, cuEventRecord(c.epoch_events[0], c.compute));
+  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
 
   {
     struct flush_handoff handoff;
     CHECK(
       Fail,
       test_ctx_kick_and_drain(
-        &c, &config, &sink.base, 0, 1, c.d_pool, c.epoch_events, &handoff) ==
+        &c, &config, &sink.base, 0, 1, c.d_pool, c.pool_ready, &handoff) ==
         0);
   }
 
@@ -544,8 +547,7 @@ test_d2h_double_buffer(void)
                         chunk_stride,
                         bytes_per_element,
                         fill_epoch1) == 0);
-  CU(Fail, cuEventCreate(&c.epoch_events[1], CU_EVENT_DEFAULT));
-  CU(Fail, cuEventRecord(c.epoch_events[1], c.compute));
+  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
 
   {
     struct flush_handoff handoff;
@@ -556,7 +558,7 @@ test_d2h_double_buffer(void)
                                   1,
                                   1,
                                   c.d_pool + epoch_pool_bytes,
-                                  &c.epoch_events[1],
+                                  c.pool_ready,
                                   &handoff) == 0);
   }
 

--- a/tests/test_flush_orchestration.c
+++ b/tests/test_flush_orchestration.c
@@ -220,7 +220,8 @@ test_accumulate_one_epoch(void)
   // Verify: mid-batch, no flush triggered
   CHECK(Fail, c.s->engine.batch.accumulated == 1);
   CHECK(Fail, c.s->engine.pools.current == 0);
-  CHECK(Fail, c.s->engine.flush.pending == 0);
+  CHECK(Fail, c.s->engine.flush.pending[0] == 0);
+  CHECK(Fail, c.s->engine.flush.pending[1] == 0);
 
   // Epoch mask recorded
   CHECK(Fail, c.s->engine.flush.slot[0].batch_active_masks[0] == 0x1);
@@ -271,8 +272,8 @@ test_full_batch_auto_flush(void)
   // After full batch: drain_kick_and_swap fired
   CHECK(Fail, c.s->engine.batch.accumulated == 0);
   CHECK(Fail, c.s->engine.pools.current == 1); // swapped to pool 1
-  CHECK(Fail, c.s->engine.flush.pending == 1); // batch 1 pending delivery
-  CHECK(Fail, c.s->engine.flush.current == 0); // batch 1 was on pool 0
+  CHECK(Fail, c.s->engine.flush.pending[0] == 1); // batch 1 pending at fc=0
+  CHECK(Fail, c.s->engine.flush.pending[1] == 0);
 
   // Fresh pool slot is reset
   CHECK(Fail, c.s->engine.flush.slot[1].active_levels_mask == 0);
@@ -316,12 +317,13 @@ test_drain_delivers_data(void)
 
   CHECK(Fail, orch_ctx_fill_epoch(&c, 1, &config, fill_epoch1) == 0);
   CHECK(Fail, flush_accumulate_epoch(&c.s->engine, &c.s->ctx).error == 0);
-  CHECK(Fail, c.s->engine.flush.pending == 1);
+  CHECK(Fail, c.s->engine.flush.pending[0] == 1);
 
   // Drain the pending batch
   struct writer_result r = flush_drain_pending(&c.s->engine, &c.s->ctx);
   CHECK(Fail, r.error == 0);
-  CHECK(Fail, c.s->engine.flush.pending == 0);
+  CHECK(Fail, c.s->engine.flush.pending[0] == 0);
+  CHECK(Fail, c.s->engine.flush.pending[1] == 0);
 
   // Data delivered: shard opened and finalized (tps_0=2, 2 epochs → complete)
   CHECK(Fail, sink.open_count >= 1);
@@ -416,10 +418,10 @@ test_two_batch_cycle(void)
   CHECK(Fail, orch_ctx_fill_epoch(&c, 1, &config, fill_epoch1) == 0);
   CHECK(Fail, flush_accumulate_epoch(&c.s->engine, &c.s->ctx).error == 0);
 
-  // Batch 1 kicked, pool swapped to 1
+  // Batch 1 kicked, pool swapped to 1, batch 1 pending at fc=0
   CHECK(Fail, c.s->engine.pools.current == 1);
-  CHECK(Fail, c.s->engine.flush.pending == 1);
-  CHECK(Fail, c.s->engine.flush.current == 0);
+  CHECK(Fail, c.s->engine.flush.pending[0] == 1);
+  CHECK(Fail, c.s->engine.flush.pending[1] == 0);
   CHECK(Fail, c.s->engine.batch.accumulated == 0);
 
   // --- Batch 2: epochs 2,3 on pool 1 ---
@@ -428,22 +430,20 @@ test_two_batch_cycle(void)
   CHECK(Fail, orch_ctx_fill_epoch(&c, 1, &config, fill_epoch3) == 0);
   CHECK(Fail, flush_accumulate_epoch(&c.s->engine, &c.s->ctx).error == 0);
 
-  // Batch 2 auto-drained batch 1 (pending was set), then kicked batch 2
+  // Batch 2 kicked on fc=1. Lazy delivery: batch 1 stays pending at fc=0
+  // until fc=0 is reused (batch 3) or the final flush drains it.
   CHECK(Fail, c.s->engine.pools.current == 0); // swapped back to pool 0
-  CHECK(Fail, c.s->engine.flush.pending == 1); // batch 2 now pending
-  CHECK(Fail, c.s->engine.flush.current == 1); // batch 2 was on pool 1
+  CHECK(Fail, c.s->engine.flush.pending[0] == 1); // batch 1 still pending
+  CHECK(Fail, c.s->engine.flush.pending[1] == 1); // batch 2 pending
   CHECK(Fail, c.s->engine.batch.accumulated == 0);
 
-  // Batch 1 was already drained (by drain_kick_and_swap during batch 2)
-  // tps_0=2, so batch 1 (2 epochs) finalized one shard
-  CHECK(Fail, sink.finalize_count >= 1);
-
-  // Drain batch 2
+  // Drain both pending batches (in kick order: batch 1 then batch 2)
   struct writer_result r = flush_drain_pending(&c.s->engine, &c.s->ctx);
   CHECK(Fail, r.error == 0);
-  CHECK(Fail, c.s->engine.flush.pending == 0);
+  CHECK(Fail, c.s->engine.flush.pending[0] == 0);
+  CHECK(Fail, c.s->engine.flush.pending[1] == 0);
 
-  // Second shard finalized
+  // Both shards finalized (tps_0=2, 2 epochs each → 2 shards)
   CHECK(Fail, sink.finalize_count >= 2);
 
   // Sink metric: 2 batch drains

--- a/tests/test_flush_orchestration.c
+++ b/tests/test_flush_orchestration.c
@@ -35,9 +35,12 @@ static void
 orch_ctx_destroy(struct orch_ctx* c)
 {
   if (c->s) {
-    // Batch events
-    for (uint32_t i = 0; i < c->s->engine.batch.epochs_per_batch; ++i)
-      cu_event_destroy(c->s->engine.batch.pool_events[i]);
+    cu_event_destroy(c->s->engine.batch.pool_ready);
+
+    for (int fc = 0; fc < 2; ++fc) {
+      free(c->s->engine.flush.slot[fc].batch_active_masks);
+      c->s->engine.flush.slot[fc].batch_active_masks = NULL;
+    }
 
     d2h_deliver_destroy(&c->s->engine.d2h_deliver);
     compress_agg_destroy(&c->s->engine.compress_agg, c->cl.levels.nlod);
@@ -124,19 +127,22 @@ orch_ctx_setup(struct orch_ctx* c,
   }
   c->s->engine.pools.current = 0;
 
-  // Batch state + pool events
+  // Batch state + pool_ready event
   c->s->engine.batch.epochs_per_batch = K;
   c->s->engine.batch.accumulated = 0;
-  for (uint32_t i = 0; i < K; ++i) {
-    CU(Fail,
-       cuEventCreate(&c->s->engine.batch.pool_events[i], CU_EVENT_DEFAULT));
-    CU(Fail,
-       cuEventRecord(c->s->engine.batch.pool_events[i],
-                     c->s->engine.streams.compute));
-  }
+  CU(Fail,
+     cuEventCreate(&c->s->engine.batch.pool_ready, CU_EVENT_DEFAULT));
+  CU(Fail,
+     cuEventRecord(c->s->engine.batch.pool_ready,
+                   c->s->engine.streams.compute));
 
   // Flush pipeline state
   memset(&c->s->engine.flush, 0, sizeof(c->s->engine.flush));
+  for (int fc = 0; fc < 2; ++fc) {
+    c->s->engine.flush.slot[fc].batch_active_masks =
+      (uint32_t*)calloc(K, sizeof(uint32_t));
+    CHECK(Fail, c->s->engine.flush.slot[fc].batch_active_masks);
+  }
 
   // Non-multiscale: zeroed lod
   memset(&c->s->engine.lod, 0, sizeof(c->s->engine.lod));

--- a/tests/test_gpu_helpers.c
+++ b/tests/test_gpu_helpers.c
@@ -30,7 +30,7 @@ int
 make_test_config(struct tile_stream_configuration* config,
                  struct dimension* dims,
                  struct codec_config codec,
-                 uint8_t epochs_per_batch)
+                 uint32_t epochs_per_batch)
 {
   make_test_dims_3d(dims);
 

--- a/tests/test_gpu_helpers.h
+++ b/tests/test_gpu_helpers.h
@@ -23,7 +23,7 @@ int
 make_test_config(struct tile_stream_configuration* config,
                  struct dimension* dims,
                  struct codec_config codec,
-                 uint8_t epochs_per_batch);
+                 uint32_t epochs_per_batch);
 
 // Fill one epoch of chunk pool on device.
 // Each chunk t gets all elements set to fill_fn(t).

--- a/tests/test_stream_cpu.c
+++ b/tests/test_stream_cpu.c
@@ -234,7 +234,7 @@ test_advise_basic_fit(void)
     .rank = 3,
     .dimensions = dims,
     .codec = { .id = CODEC_NONE },
-    .target_batch_chunks = 64,
+    .target_batch_bytes = 8u << 20,
   };
 
   int ratios[] = { 1, 1, 1 };
@@ -385,7 +385,7 @@ test_advise_min_shard_too_small(void)
     .rank = 3,
     .dimensions = dims,
     .codec = { .id = CODEC_NONE },
-    .target_batch_chunks = 64,
+    .target_batch_bytes = 8u << 20,
   };
 
   int ratios[] = { 1, 1, 1 };
@@ -425,7 +425,7 @@ test_advise_parts_limit(void)
     .rank = 3,
     .dimensions = dims,
     .codec = { .id = CODEC_NONE },
-    .target_batch_chunks = 64,
+    .target_batch_bytes = 8u << 20,
   };
 
   int ratios[] = { 1, 0, 0 };
@@ -484,7 +484,7 @@ test_advise_halves_k(void)
     .rank = 3,
     .dimensions = dims,
     .codec = { .id = CODEC_NONE },
-    .target_batch_chunks = 128,
+    .target_batch_bytes = 8u << 20,
   };
 
   int ratios[] = { 1, 1, 1 };
@@ -546,7 +546,7 @@ test_advise_user_k_respected(void)
     .rank = 3,
     .dimensions = dims,
     .codec = { .id = CODEC_NONE },
-    .target_batch_chunks = 4096,
+    .target_batch_bytes = 16u << 20,
     .epochs_per_batch = 4, // user-pinned
   };
 

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -1000,8 +1000,9 @@ test_midstream_metadata_update(const char* tmpdir)
     log_info("  midstream metadata: %s", (char*)data);
 
     int not_zero = strstr((char*)data, "\"shape\":[0,") == NULL;
-    // 5 epochs delivered (epoch 5 still pending), dim0_extent = 5 * 2 = 10
-    int has_shape = strstr((char*)data, "\"shape\":[10,8,12]") != NULL;
+    // Lazy delivery: of 6 epochs kicked, epochs 0-3 delivered (pending[0],
+    // pending[1] hold epochs 4,5). dim0_extent = 4 * chunk_size = 4 * 2 = 8.
+    int has_shape = strstr((char*)data, "\"shape\":[8,8,12]") != NULL;
     int is_array = strstr((char*)data, "\"node_type\":\"array\"") != NULL;
     free(data);
 


### PR DESCRIPTION
## Summary

The old formula derived epochs-per-batch from `target_batch_chunks` and clamped K to `MAX_BATCH_EPOCHS=128`. For benches with small chunks and a single chunk per epoch (e.g. `smallepoch_single`), the clamp pinned batch payloads at ~2 MiB, leaving D2H latency-bound.

Expressing the intent in bytes and lifting the ceiling lets compress/D2H see enough work to amortize per-batch sync overhead.

## Perf, vs `main`

Built both branches from clean trees and ran benches back-to-back (3–5 runs each).

| Bench                                     | `main`       | `target-batch-bytes` |
|-------------------------------------------|--------------|----------------------|
| `medfmt_single --codec none`              | ~8.0 GiB/s   | ~9.2 GiB/s (+15%)    |
| `smallepoch_single --codec none` (default)| ~3.9 GiB/s   | ~4.3 GiB/s (+12%)    |
| `smallepoch_single` (sweep tuning: `ratios={1,1,1}`, `target_concurrent_shards=16`) | 1.22 GiB/s (what motivated this PR) | 4.21 GiB/s (3.5×)    |

`smallepoch_single` is bound by the scatter now which is strange, but a problem for another day.
