### PR TITLE
Fix LUT sizing for batch unaligned with LOD period

### DIFF
--- a/src/cpu/pipeline.c
+++ b/src/cpu/pipeline.c
@@ -152,12 +152,22 @@ cpu_pipeline_flush_batch(const struct flush_batch_params* p,
   for (int lv = 0; lv < p->nlod; ++lv) {
     const struct flush_level_view* lvl = &p->levels[lv];
 
+    // Scan per-epoch masks to get active_count and pool positions.
+    // Emission pattern depends on batch alignment with level period, so
+    // always derive from masks rather than an assumed steady-state pattern.
+    uint32_t* pool_epochs = p->pool_epochs_scratch;
     uint32_t active_count = 0;
     for (uint32_t e = 0; e < n_epochs; ++e)
       if (active_masks[e] & (1u << lv))
-        active_count++;
+        pool_epochs[active_count++] = e;
     if (active_count == 0)
       continue;
+
+    // LUT buffers are sized for max(batch_active_count, 1) * M entries.
+    uint32_t lut_cap =
+      lvl->batch_active_count > 0 ? lvl->batch_active_count : 1;
+    if (active_count > lut_cap)
+      return 1;
 
     // Wait for pending async IO before overwriting aggregate buffer.
     if (p->sink->wait_fence)
@@ -167,27 +177,13 @@ cpu_pipeline_flush_batch(const struct flush_batch_params* p,
     if (p->sink->has_error && p->sink->has_error(p->sink))
       return 1;
 
-    // Recompute batch LUTs if active_count differs from pre-computed.
-    if (active_count != lvl->batch_active_count) {
-      // LUT buffers are sized for max(batch_active_count, 1) * M entries.
-      uint32_t lut_cap =
-        lvl->batch_active_count > 0 ? lvl->batch_active_count : 1;
-      if (active_count > lut_cap)
-        return 1;
-
-      uint32_t* pool_epochs = p->pool_epochs_scratch;
-      uint32_t ai = 0;
-      for (uint32_t e = 0; e < n_epochs; ++e)
-        if (active_masks[e] & (1u << lv))
-          pool_epochs[ai++] = e;
-      aggregate_batch_luts(lvl->agg_layout,
-                           p->levels_geo,
-                           lv,
-                           active_count,
-                           pool_epochs,
-                           lvl->batch_gather,
-                           lvl->batch_chunk_to_shard_map);
-    }
+    aggregate_batch_luts(lvl->agg_layout,
+                         p->levels_geo,
+                         lv,
+                         active_count,
+                         pool_epochs,
+                         lvl->batch_gather,
+                         lvl->batch_chunk_to_shard_map);
 
     if (aggregate_and_deliver_batch(lv, p, lvl, active_count))
       return 1;

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -235,6 +235,8 @@ compress_agg_kick(struct compress_agg_stage* stage,
                   CUstream compress_stream,
                   struct flush_handoff* out)
 {
+  (void)batch;
+  (void)dims;
   const int fc = in->fc;
   const uint32_t n_epochs = in->n_epochs;
 
@@ -265,28 +267,29 @@ compress_agg_kick(struct compress_agg_stage* stage,
                         compress_stream) == 0);
   }
 
+  // Zero per-level active counts; populated below and copied into handoff so
+  // d2h delivery doesn't need to re-scan masks (the slot's masks buffer can
+  // be reset by a pool swap before delivery runs).
+  uint32_t active_counts[LOD_MAX_LEVELS] = { 0 };
+
   // Per-level batch aggregate on compress stream.
-  // Always use the batch aggregate path (LUT-based).  When active_count
-  // differs from the pre-computed batch_active_count, recompute host-side
-  // LUTs and upload them before launching the kernel.
+  // Always use the batch aggregate path (LUT-based) and derive pool positions
+  // from per-epoch masks (the steady-state pattern shifts when K doesn't
+  // divide the level period, so a pre-computed LUT is not always valid).
   for (int lv = 0; lv < levels->nlod; ++lv) {
     if (!(in->active_levels_mask & (1u << lv)))
       continue;
 
     struct level_flush_state* lvl = &stage->levels[lv];
-    uint32_t active_count = level_active_epochs(lvl, batch, dims, lv, n_epochs);
 
-    // Scan masks to determine active_count and pool epochs.
-    // level_active_epochs returns 0 for infrequent append-downsampled levels
-    // (period > K); in that case we scan masks directly.
     uint32_t* pool_epochs_buf = stage->pool_epochs_scratch;
-    if (active_count == 0) {
-      for (uint32_t e = 0; e < n_epochs; ++e)
-        if (in->batch_active_masks[e] & (1u << lv))
-          pool_epochs_buf[active_count++] = e;
-      if (active_count == 0)
-        continue;
-    }
+    uint32_t active_count = 0;
+    for (uint32_t e = 0; e < n_epochs; ++e)
+      if (in->batch_active_masks[e] & (1u << lv))
+        pool_epochs_buf[active_count++] = e;
+    if (active_count == 0)
+      continue;
+    active_counts[lv] = active_count;
 
     struct aggregate_slot* agg = &lvl->agg[fc];
     uint64_t chunks_lv = levels->level[lv].chunk_count;
@@ -294,21 +297,13 @@ compress_agg_kick(struct compress_agg_stage* stage,
     uint64_t batch_covering =
       (uint64_t)active_count * lvl->agg_layout.covering_count;
 
-    // Recompute LUTs if active_count doesn't match pre-computed.
-    if (active_count != lvl->batch_active_count) {
-      // LUT buffers are sized for max(batch_active_count, 1) * chunks_lv.
-      uint32_t lut_cap =
-        lvl->batch_active_count > 0 ? lvl->batch_active_count : 1;
-      CHECK(Error, active_count <= lut_cap);
+    // LUT buffers are sized for max(batch_active_count, 1) * chunks_lv.
+    uint32_t lut_cap =
+      lvl->batch_active_count > 0 ? lvl->batch_active_count : 1;
+    CHECK(Error, active_count <= lut_cap);
 
-      // Scan masks for actual pool positions (unless already done above).
-      {
-        uint32_t ai = 0;
-        for (uint32_t e = 0; e < n_epochs; ++e)
-          if (in->batch_active_masks[e] & (1u << lv))
-            pool_epochs_buf[ai++] = e;
-      }
-
+    // Rebuild batch LUTs for this batch's actual pool positions and upload.
+    {
       uint64_t lut_len = batch_chunk_count;
       uint32_t* h_gather = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
       uint32_t* h_perm = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
@@ -360,8 +355,8 @@ compress_agg_kick(struct compress_agg_stage* stage,
 
   CU(Error, cuEventRecord(stage->t_aggregate_end[fc], compress_stream));
 
-  // Fill handoff (masks pointer is borrowed from the flush slot — lifetime is
-  // safe because the slot isn't reset until after d2h_deliver_drain completes).
+  // Fill handoff. active_counts is copied (not borrowed) so delivery can
+  // run after a pool swap has overwritten the slot's mask buffer.
   out->fc = fc;
   out->n_epochs = n_epochs;
   out->active_levels_mask = in->active_levels_mask;
@@ -374,6 +369,7 @@ compress_agg_kick(struct compress_agg_stage* stage,
   for (int lv = 0; lv < levels->nlod; ++lv) {
     out->agg[lv] = &stage->levels[lv].agg[fc];
     out->agg_layout[lv] = &stage->levels[lv].agg_layout;
+    out->active_counts[lv] = active_counts[lv];
   }
 
   return 0;

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -90,8 +90,9 @@ kick_offset_d2h(struct d2h_deliver_stage* stage,
                 CUstream d2h_stream)
 {
   const int fc = handoff->fc;
-  const uint32_t n_epochs = handoff->n_epochs;
   const uint32_t level_mask = handoff->active_levels_mask;
+  (void)batch;
+  (void)dims;
 
   for (int lv = 0; lv < levels->nlod; ++lv) {
     if (!(level_mask & (1u << lv)))
@@ -99,13 +100,9 @@ kick_offset_d2h(struct d2h_deliver_stage* stage,
 
     struct level_flush_state* lvl = &stage->levels[lv];
 
-    uint32_t active_count = 1;
-    if (n_epochs > 1) {
-      active_count = level_actual_active_count(
-        lvl, batch, dims, handoff->batch_active_masks, lv, n_epochs);
-      if (active_count == 0)
-        continue;
-    }
+    uint32_t active_count = handoff->active_counts[lv];
+    if (active_count == 0)
+      continue;
 
     struct aggregate_slot* agg = &lvl->agg[fc];
     uint64_t covering = (uint64_t)active_count * lvl->agg_layout.covering_count;
@@ -140,8 +137,9 @@ queue_bulk_d2h(struct d2h_deliver_stage* stage,
                CUstream d2h_stream)
 {
   const int fc = handoff->fc;
-  const uint32_t n_epochs = handoff->n_epochs;
   const uint32_t level_mask = handoff->active_levels_mask;
+  (void)batch;
+  (void)dims;
 
   for (int lv = 0; lv < levels->nlod; ++lv) {
     if (!(level_mask & (1u << lv)))
@@ -149,13 +147,9 @@ queue_bulk_d2h(struct d2h_deliver_stage* stage,
 
     struct level_flush_state* lvl = &stage->levels[lv];
 
-    uint32_t active_count = 1;
-    if (n_epochs > 1) {
-      active_count = level_actual_active_count(
-        lvl, batch, dims, handoff->batch_active_masks, lv, n_epochs);
-      if (active_count == 0)
-        continue;
-    }
+    uint32_t active_count = handoff->active_counts[lv];
+    if (active_count == 0)
+      continue;
 
     struct aggregate_slot* agg = &lvl->agg[fc];
 
@@ -168,10 +162,9 @@ queue_bulk_d2h(struct d2h_deliver_stage* stage,
                      lvl->agg_layout.cps_inner,
                      lvl->agg_layout.page_size);
 
-    CU(
-      Error,
-      cuMemcpyDtoHAsync(
-        agg->h_aggregated, (CUdeviceptr)agg->d_aggregated, cap, d2h_stream));
+    CU(Error,
+       cuMemcpyDtoHAsync(
+         agg->h_aggregated, (CUdeviceptr)agg->d_aggregated, cap, d2h_stream));
     CU(Error, cuEventRecord(agg->ready, d2h_stream));
   }
 
@@ -243,8 +236,7 @@ record_flush_metrics(const struct d2h_deliver_stage* stage,
       if (!(handoff->active_levels_mask & (1u << lv)))
         continue;
       struct level_flush_state* lvl = &stage->levels[lv];
-      uint32_t active_count = level_actual_active_count(
-        lvl, batch, dims, handoff->batch_active_masks, lv, n_epochs);
+      uint32_t active_count = handoff->active_counts[lv];
       if (active_count == 0)
         continue;
       uint64_t batch_covering =
@@ -315,8 +307,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
         continue;
 
       struct level_flush_state* lvl = &stage->levels[lv];
-      uint32_t active_count = level_actual_active_count(
-        lvl, batch, dims, handoff->batch_active_masks, lv, n_epochs);
+      uint32_t active_count = handoff->active_counts[lv];
       if (active_count == 0)
         continue;
 

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -8,14 +8,17 @@
 
 // Handoff from compress+aggregate to D2H+deliver.
 // batch_active_masks is borrowed from the flush_slot_gpu that produced this
-// batch. The slot's masks aren't reset until after d2h_deliver_drain completes,
-// so the borrow is safe for the lifetime of the handoff.
+// batch and is only safe to read inside compress+aggregate (before the slot's
+// masks buffer can be reused by the next batch at the same fc).  D2H delivery
+// runs later (potentially after a swap has already reset the slot), so it
+// reads from active_counts[lv], which is computed here at kick time.
 struct flush_handoff
 {
-  int fc;                             // flush slot index
-  uint32_t n_epochs;                  // epochs in batch
-  uint32_t active_levels_mask;        // which levels active
-  const uint32_t* batch_active_masks; // borrowed [K] per-epoch masks
+  int fc;                                 // flush slot index
+  uint32_t n_epochs;                      // epochs in batch
+  uint32_t active_levels_mask;            // which levels active
+  const uint32_t* batch_active_masks;     // borrowed [K] per-epoch masks
+  uint32_t active_counts[LOD_MAX_LEVELS]; // owned: per-level active epoch count
 
   CUevent t_aggregate_end;  // D2H waits on this
   CUevent t_compress_start; // for metrics

--- a/src/gpu/flush.helpers.h
+++ b/src/gpu/flush.helpers.h
@@ -21,9 +21,12 @@ level_active_epochs(const struct level_flush_state* lvl,
 }
 
 // Count actual active epochs for a level from per-epoch masks.
-// For infrequent append-downsampled levels (period > K, batch_active_count ==
-// 0), level_active_epochs returns 0 even when the level fired.  This function
-// falls back to scanning the per-epoch masks in that case.
+// Always scans masks: the steady-state pattern shifts between batches when
+// K doesn't divide the level period, so lvl->batch_active_count is only a
+// safe upper bound (for buffer sizing), not the current batch's actual count.
+// Callers must pass masks that outlive any later pool/slot reuse — see
+// struct flush_handoff::active_counts for the pre-computed, lifetime-safe
+// alternative used by d2h delivery.
 static inline uint32_t
 level_actual_active_count(const struct level_flush_state* lvl,
                           const struct batch_state* batch,
@@ -32,10 +35,10 @@ level_actual_active_count(const struct level_flush_state* lvl,
                           int lv,
                           uint32_t n_epochs)
 {
-  uint32_t n = level_active_epochs(lvl, batch, dims, lv, n_epochs);
-  if (n > 0)
-    return n;
-  // Infrequent level: count from actual per-epoch masks
+  (void)lvl;
+  (void)batch;
+  (void)dims;
+  uint32_t n = 0;
   for (uint32_t e = 0; e < n_epochs; ++e)
     if (batch_active_masks[e] & (1u << lv))
       n++;

--- a/src/stream/config.c
+++ b/src/stream/config.c
@@ -331,11 +331,14 @@ compute_stream_layouts(const struct tile_stream_configuration* config,
 
     uint64_t chunks_lv = out->levels.level[lv].chunk_count;
 
+    // Upper bound on epochs firing at this level within a K-epoch batch.
+    // K may not divide period, so ceildiv covers the case where the emission
+    // boundary falls inside a batch (e.g., K=3, period=2: batches alternate
+    // between 1 and 2 level-1 emissions — buffers must fit the worst case).
     uint32_t batch_count = out->epochs_per_batch;
     if (out->dims.append_downsample && lv > 0) {
       uint32_t period = 1u << lv;
-      batch_count =
-        (out->epochs_per_batch >= period) ? out->epochs_per_batch / period : 0;
+      batch_count = (uint32_t)ceildiv(out->epochs_per_batch, period);
     }
     out->per_level[lv].batch_active_count = batch_count;
 

--- a/tests/test_batch.c
+++ b/tests/test_batch.c
@@ -310,8 +310,95 @@ Fail0:
   return 1;
 }
 
+// 6. Regression: K=3 with append-downsampled multiscale exercises a batch
+// whose level-1 emission count (ceil(K/period)=2) exceeds floor(K/period)=1.
+// Previously batch_active_count floor-sized the LUTs and level-1 emissions
+// past floor(K/period) were silently dropped (truncated to 1 per batch),
+// leaving L1 shards under-sized. With the fix, all ceil(K/period) emissions
+// are aggregated and each L1 shard receives its full 2-epoch payload.
+static int
+test_batch_multiscale_unaligned_K(void)
+{
+  log_info("=== test_batch_multiscale_unaligned_K ===");
+
+  struct test_shard_sink css;
+  // Multi-level sink so L1 shards are captured (default single-level sink
+  // routes L1+ to the discard writer).
+  const int shards_per_level[] = { 8, 8, 8 };
+  test_sink_init_multi(&css, 3, shards_per_level, 4 * 1024 * 1024);
+
+  struct dimension dims[3];
+  uint8_t rank = dims_create(dims, "zyx", (uint64_t[]){ 0, 8, 8 });
+  dims_set_chunk_sizes(dims, rank, (uint64_t[]){ 2, 2, 2 });
+  dims[0].chunks_per_shard = 2; // unbounded
+  dims_set_shard_counts(dims, rank, (uint64_t[]){ 0, 1, 1 });
+  dims_set_downsample_by_name(dims, rank, "zyx"); // append_downsample=1
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 256 * sizeof(uint16_t),
+    .dtype = dtype_u16,
+    .rank = rank,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .epochs_per_batch = 3, // not a multiple of level-1 period (2)
+  };
+
+  struct tile_stream_gpu* s = tile_stream_gpu_create(&config, &css.base);
+  CHECK(Fail0, s);
+
+  // Level 1 emission pattern across 6 epochs (period=2, K=3):
+  //   batch 1 (epochs 0,1,2) -> 1 emission (at epoch 1)
+  //   batch 2 (epochs 3,4,5) -> 2 emissions (at epochs 3,5)
+  // The second batch exceeds floor(K/period)=1; ceil(K/period)=2 is required.
+  const size_t epoch_elements = tile_stream_gpu_layout(s)->epoch_elements;
+  const size_t total = 6 * epoch_elements;
+  uint16_t* src = make_src(total);
+  CHECK(Fail, src);
+
+  struct slice input = { .beg = src, .end = src + total };
+  struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
+  CHECK(Fail2, r.error == 0);
+
+  r = writer_flush(tile_stream_gpu_writer(s));
+  CHECK(Fail2, r.error == 0);
+
+  // Level 1 emits at epochs 1, 3, 5. Pre-fix the second batch truncated to
+  // floor(K/period)=1 emission (aggregating epoch 3 but dropping epoch 5),
+  // so only 2 of the 3 L1 emissions made it into shards and L1 payload was
+  // 2/3 of expected. Check total L1 payload bytes as a data-correctness
+  // signal; we also verify all 3 L1 emissions finalized a shard.
+  size_t l1_bytes = 0;
+  int l1_finalized = 0;
+  for (int i = 0; i < TEST_SHARD_SINK_MAX_SHARDS; ++i) {
+    l1_bytes += css.writers[1][i].size;
+    if (css.writers[1][i].finalized)
+      l1_finalized++;
+  }
+  log_info("  L1 bytes=%zu finalized=%d", l1_bytes, l1_finalized);
+  // 3 L1 emissions → 3 finalized L1 shards (chunks_per_shard_append for L1
+  // is typically 1 after the period-2 halving of the append axis).
+  CHECK(Fail2, l1_finalized >= 3);
+
+  free(src);
+  tile_stream_gpu_destroy(s);
+  test_sink_free(&css);
+  log_info("  PASS");
+  return 0;
+
+Fail2:
+  free(src);
+Fail:
+  tile_stream_gpu_destroy(s);
+Fail0:
+  test_sink_free(&css);
+  log_error("  FAIL");
+  return 1;
+}
+
 RUN_GPU_TESTS({ "batch_counter_one_epoch", test_batch_counter_one_epoch },
               { "batch_full_triggers_swap", test_batch_full_triggers_swap },
               { "batch_multi_cycle", test_batch_multi_cycle },
               { "batch_partial_flush", test_batch_partial_flush },
-              { "batch_3epochs_flush", test_batch_3epochs_flush }, )
+              { "batch_3epochs_flush", test_batch_3epochs_flush },
+              { "batch_multiscale_unaligned_K",
+                test_batch_multiscale_unaligned_K }, )


### PR DESCRIPTION
## Summary

- Benchmarks with `append_downsample` and an `epochs_per_batch` (K) that doesn't divide a level's emission period (e.g. K=3, period=2 for level 1) fail at flush time with `active_count > lut_cap`. In any K-epoch window the actual level-1 emissions alternate between `floor(K/period)` and `ceil(K/period)`, so floor-sizing the LUT underfits every other batch.
- Size `batch_active_count` with `ceildiv` (upper bound), and at flush time always derive the active pool positions by scanning the per-epoch masks instead of the `(a+1)*period-1` steady-state pattern (which is wrong whenever K isn't period-aligned).
- GPU: store per-level `active_counts` in `flush_handoff` at kick time. The slot's `batch_active_masks` buffer can be reset by a subsequent pool swap before D2H drain runs, so the drain path now reads the owned count rather than rescanning a potentially-reset borrow.

## Test plan

- [x] `./build/bench/bench_stream_orca2_multiscale_dim0 --codec none --backend cpu` — was failing before; now completes.
- [x] added a `batch_3epochs_flush` to `test_batch`