### PR TITLE
imporve accuracy of cpu timings

### DIFF
--- a/src/cpu/pipeline.c
+++ b/src/cpu/pipeline.c
@@ -170,8 +170,16 @@ cpu_pipeline_flush_batch(const struct flush_batch_params* p,
       return 1;
 
     // Wait for pending async IO before overwriting aggregate buffer.
-    if (p->sink->wait_fence)
+    if (p->sink->wait_fence) {
+      struct platform_clock fence_clk = { 0 };
+      if (p->metrics)
+        platform_toc(&fence_clk);
       p->sink->wait_fence(p->sink, (uint8_t)lv, *lvl->io_done);
+      if (p->metrics) {
+        float fence_ms = (float)(platform_toc(&fence_clk) * 1000.0);
+        accumulate_metric_ms(&p->metrics->io_fence_stall, fence_ms, 0, 0);
+      }
+    }
 
     // Fail fast if async IO encountered an error.
     if (p->sink->has_error && p->sink->has_error(p->sink))

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -285,7 +285,13 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
   if (sink->has_error && sink->has_error(sink))
     goto Error;
 
-  CU(Error, cuEventSynchronize(stage->ready[fc]));
+  {
+    struct platform_clock kick_clk = { 0 };
+    platform_toc(&kick_clk);
+    CU(Error, cuEventSynchronize(stage->ready[fc]));
+    float kick_ms = platform_toc(&kick_clk) * 1000.0f;
+    accumulate_metric_ms(&metrics->kick_sync_stall, kick_ms, 0, 0);
+  }
   record_flush_metrics(stage,
                        handoff,
                        levels,

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -34,18 +34,22 @@ struct stream_metrics
   struct stream_metric sink;
 
   // Stall metrics — wall-clock time the host is blocked at each sync point.
-  // Populated only on the GPU path.
+  // flush_stall, kick_sync_stall, backpressure are GPU-only. io_fence_stall
+  // is populated on both paths.
   //
   // flush_stall is a SUPERSET: it wraps the entire d2h_deliver_drain call,
   // which already times kick_sync_stall and sink internally. Summing
   // flush_stall + kick_sync_stall + sink over-counts wall time. To isolate
   // the drain-side overhead not already attributed elsewhere, compute
-  // flush_stall − kick_sync_stall − (sink portion inside drain).
+  // flush_stall - kick_sync_stall - (sink portion inside drain).
   struct stream_metric flush_stall; // whole d2h_deliver_drain call
                                     // (drain_fc in stream.flush.c)
   struct stream_metric kick_sync_stall; // cuEventSynchronize(ready[fc])
                                         // in sync_and_deliver
-  struct stream_metric io_fence_stall;  // wait_io_fences in d2h_deliver_kick
+  struct stream_metric io_fence_stall;  // GPU: wait_io_fences in
+                                        // d2h_deliver_kick. CPU: wait_fence
+                                        // before aggregate in
+                                        // cpu_pipeline_flush_batch.
   struct stream_metric backpressure; // wait at epoch boundary for IO to drain
   float max_append_ms;               // longest tile_stream_gpu_append body
   size_t peak_pending_bytes;         // max sink->pending_bytes seen

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -35,10 +35,17 @@ struct stream_metrics
 
   // Stall metrics — wall-clock time the host is blocked at each sync point.
   // Populated only on the GPU path.
-  struct stream_metric
-    flush_stall; // d2h_deliver_drain in drain_kick_and_swap (Phase B)
-  struct stream_metric kick_sync_stall; // cuEventSynchronize in drain_bulk_d2h
-  struct stream_metric io_fence_stall;  // wait_io_fences in d2h_deliver_drain
+  //
+  // flush_stall is a SUPERSET: it wraps the entire d2h_deliver_drain call,
+  // which already times kick_sync_stall and sink internally. Summing
+  // flush_stall + kick_sync_stall + sink over-counts wall time. To isolate
+  // the drain-side overhead not already attributed elsewhere, compute
+  // flush_stall − kick_sync_stall − (sink portion inside drain).
+  struct stream_metric flush_stall; // whole d2h_deliver_drain call
+                                    // (drain_fc in stream.flush.c)
+  struct stream_metric kick_sync_stall; // cuEventSynchronize(ready[fc])
+                                        // in sync_and_deliver
+  struct stream_metric io_fence_stall;  // wait_io_fences in d2h_deliver_kick
   struct stream_metric backpressure; // wait at epoch boundary for IO to drain
   float max_append_ms;               // longest tile_stream_gpu_append body
   size_t peak_pending_bytes;         // max sink->pending_bytes seen


### PR DESCRIPTION
## Summary
- Populate `kick_sync_stall` by timing `cuEventSynchronize(ready[fc])` inside `sync_and_deliver`. Previously declared and printed by bench tooling but never accumulated, so the D2H host-sync time was hidden inside `flush_stall`.
- Add CPU-side `io_fence_stall` timing around `sink->wait_fence` at `cpu_pipeline_flush_batch` (pipeline.c:173). CPU aggregate buffers are single-slot per level and must wait for prior zero-copy pwrites to retire before reuse — that wait is now visible.
