### PR TITLE
Own metadata strings 

### DIFF
--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -222,9 +222,9 @@ print_bench_json_pass(const struct stream_metrics* m,
   const double throughput_gib = wall_s > 0 ? input_gib / wall_s : 0.0;
   const double throughput_out_gib = wall_s > 0 ? compressed_gib / wall_s : 0.0;
 
-  char json_buf[8192];
+  struct strbuf json_buf = { 0 };
   struct json_writer jw;
-  jw_init(&jw, json_buf, sizeof(json_buf));
+  jw_init(&jw, &json_buf);
 
   jw_object_begin(&jw);
   jw_key(&jw, "status");
@@ -291,18 +291,20 @@ print_bench_json_pass(const struct stream_metrics* m,
   jw_object_end(&jw);
 
   jw_object_end(&jw);
-  printf("%.*s\n", (int)jw_length(&jw), json_buf);
+  printf("%s\n", strbuf_cstr(&json_buf));
+  strbuf_free(&json_buf);
 }
 
 void
 print_bench_json_error(void)
 {
-  char buf[64];
+  struct strbuf buf = { 0 };
   struct json_writer jw;
-  jw_init(&jw, buf, sizeof(buf));
+  jw_init(&jw, &buf);
   jw_object_begin(&jw);
   jw_key(&jw, "status");
   jw_string(&jw, "error");
   jw_object_end(&jw);
-  printf("%.*s\n", (int)jw_length(&jw), buf);
+  printf("%s\n", strbuf_cstr(&buf));
+  strbuf_free(&buf);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ endfunction()
 add_src_lib(chucky_log SOURCES log/log.c log/log.h chucky_log.h)
 add_src_lib(index_ops  SOURCES util/index.ops.c util/index.ops.h)
 add_src_lib(format_bytes SOURCES util/format_bytes.c util/format_bytes.h)
+add_src_lib(strbuf SOURCES util/strbuf.c util/strbuf.h)
 add_src_lib(dtype      SOURCES dtype.c dtype.h)
 add_src_lib(dimension  SOURCES dimension.c dimension.h)
 add_src_lib(lod_plan   SOURCES lod/lod_plan.c lod/lod_plan.h

--- a/src/defs.limits.h
+++ b/src/defs.limits.h
@@ -8,9 +8,6 @@
 #define LOD_MAX_LEVELS 32
 #define MAX_ZARR_RANK (HALF_MAX_RANK)
 
-// Zarr group metadata
-#define ZARR_GROUP_JSON_MAX_LENGTH 8192
-
 // S3
 #define S3_MAX_PARTS 10000
 #define S3_DEFAULT_PART_SIZE (8 * 1024 * 1024)

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -44,6 +44,9 @@ dims_copy(struct dimension* dst, const struct dimension* src, uint8_t rank)
     return 1;
   for (uint8_t d = 0; d < rank; ++d) {
     dst[d] = src[d];
+    // Null out the aliased source name before any allocation so the cleanup
+    // below never sees an un-duplicated pointer from src.
+    dst[d].name = NULL;
     if (src[d].name) {
       char* dup = strdup(src[d].name);
       if (!dup) {

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -5,6 +5,7 @@
 
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef _MSC_VER
@@ -35,6 +36,38 @@ static const char name_table[128][2] = {
   ['2'] = "2", ['3'] = "3", ['4'] = "4", ['5'] = "5", ['6'] = "6", ['7'] = "7",
   ['8'] = "8", ['9'] = "9",
 };
+
+int
+dims_copy(struct dimension* dst, const struct dimension* src, uint8_t rank)
+{
+  if (!dst || !src)
+    return 1;
+  for (uint8_t d = 0; d < rank; ++d) {
+    dst[d] = src[d];
+    if (src[d].name) {
+      char* dup = strdup(src[d].name);
+      if (!dup) {
+        dims_free_names(dst, d);
+        for (uint8_t z = d; z < rank; ++z)
+          dst[z] = (struct dimension){ 0 };
+        return 1;
+      }
+      dst[d].name = dup;
+    }
+  }
+  return 0;
+}
+
+void
+dims_free_names(struct dimension* dims, uint8_t rank)
+{
+  if (!dims)
+    return;
+  for (uint8_t d = 0; d < rank; ++d) {
+    free((char*)dims[d].name);
+    dims[d].name = NULL;
+  }
+}
 
 uint8_t
 dims_create(struct dimension* dims, const char* names, const uint64_t* sizes)

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -26,6 +26,18 @@ struct dimension
 uint8_t
 dims_create(struct dimension* dims, const char* names, const uint64_t* sizes);
 
+// Deep-copy rank dimensions from src to dst, duplicating name strings.
+// After success, dst owns its name strings; free with dims_free_names.
+// Returns 0 on success. On failure, frees any partial name allocations and
+// leaves dst zero-initialized for the affected slots.
+int
+dims_copy(struct dimension* dst, const struct dimension* src, uint8_t rank);
+
+// Free name strings previously allocated by dims_copy. Safe on
+// zero-initialized slots (free(NULL)). Does not free the array itself.
+void
+dims_free_names(struct dimension* dims, uint8_t rank);
+
 // Set storage order from a string of dimension names.
 // Each character in order names a dimension; its position is the storage
 // position assigned to that dimension. strlen(order) must equal rank.

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -188,6 +188,7 @@ record_flush_metrics(const struct d2h_deliver_stage* stage,
                      const struct lod_shared_state* lod_shared,
                      struct stream_metrics* metrics)
 {
+  (void)batch;
   const int fc = handoff->fc;
   const uint32_t n_epochs = handoff->n_epochs;
 
@@ -279,7 +280,6 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
                  struct stream_metrics* metrics)
 {
   const int fc = handoff->fc;
-  const uint32_t n_epochs = handoff->n_epochs;
 
   // Fail fast if async IO encountered an error.
   if (sink->has_error && sink->has_error(sink))

--- a/src/hcs/CMakeLists.txt
+++ b/src/hcs/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_src_lib(hcs_metadata SOURCES hcs_metadata.c hcs_metadata.h
-    LINKS json_writer attr_set chucky_log
+    LINKS json_writer attr_set strbuf chucky_log
 )
 
 add_src_lib(hcs SOURCES hcs.c
-    LINKS hcs_metadata attr_set ngff_multiscale zarr_group lod_plan chucky_log
+    LINKS hcs_metadata attr_set ngff_multiscale zarr_group lod_plan strbuf chucky_log
 )

--- a/src/hcs/hcs.c
+++ b/src/hcs/hcs.c
@@ -4,6 +4,7 @@
 #include "lod/lod_plan.h"
 #include "ngff/ngff_multiscale.h"
 #include "util/prelude.h"
+#include "util/strbuf.h"
 #include "zarr.h"
 #include "zarr/attr_set.h"
 #include "zarr/store.h"
@@ -18,8 +19,8 @@ struct hcs_plate
   struct store* store;
   struct shard_pool* pool; // owned
   int rows, cols, field_count;
-  int* well_mask; // rows*cols, owned
-  char name[4096];
+  int* well_mask;     // rows*cols, owned
+  struct strbuf name; // owned
   char row_names[64];
   int has_row_names;
 
@@ -72,35 +73,29 @@ plate_row_names_ptr(const struct hcs_plate* p)
 static int
 write_plate_group(struct hcs_plate* p)
 {
-  // Built-in OME plate metadata bound: ~80 bytes per well + skeleton.
-  // Custom extras add their own payload.
-  size_t extras_bytes = 0;
-  for (size_t i = 0; i < p->plate_attrs.count; ++i) {
-    extras_bytes += strlen(p->plate_attrs.items[i].key);
-    extras_bytes += strlen(p->plate_attrs.items[i].json_value);
-    extras_bytes += 16;
-  }
-  size_t attr_cap =
-    512 + (size_t)(p->rows * p->cols) * 80 + extras_bytes;
-  char* attrs = (char*)malloc(attr_cap);
-  if (!attrs)
-    return 1;
-  int alen = hcs_plate_attributes_json(attrs,
-                                       attr_cap,
-                                       p->name,
-                                       p->rows,
-                                       p->cols,
-                                       plate_row_names_ptr(p),
-                                       p->field_count,
-                                       p->well_mask,
-                                       &p->plate_attrs);
-  char key[4096];
-  snprintf(key, sizeof(key), "%s/zarr.json", p->name);
-  int rc =
-    alen < 0 ? 1 : zarr_group_write_with_raw_attrs(p->store, key, attrs);
-  free(attrs);
+  struct strbuf attrs = { 0 };
+  struct strbuf key = { 0 };
+  int rc = 1;
+
+  if (hcs_plate_attributes_json(&attrs,
+                                strbuf_cstr(&p->name),
+                                p->rows,
+                                p->cols,
+                                plate_row_names_ptr(p),
+                                p->field_count,
+                                p->well_mask,
+                                &p->plate_attrs))
+    goto done;
+  if (strbuf_appendf(&key, "%s/zarr.json", strbuf_cstr(&p->name)))
+    goto done;
+  rc = zarr_group_write_with_raw_attrs(
+    p->store, strbuf_cstr(&key), strbuf_cstr(&attrs));
   if (rc == 0)
     p->plate_attrs.dirty = 0;
+
+done:
+  strbuf_free(&attrs);
+  strbuf_free(&key);
   return rc;
 }
 
@@ -108,30 +103,24 @@ static int
 write_well_group(struct hcs_plate* p, int r, int c)
 {
   struct attr_set* w = &p->well_attrs[well_idx(p, r, c)];
-  // OME well image list grows ~32 bytes per FOV; custom extras add their own
-  // payload. Heap-allocate to avoid silent truncation on large attrs.
-  size_t extras_bytes = 0;
-  for (size_t i = 0; i < w->count; ++i) {
-    extras_bytes += strlen(w->items[i].key);
-    extras_bytes += strlen(w->items[i].json_value);
-    extras_bytes += 16;
-  }
-  size_t cap = 256 + (size_t)p->field_count * 64 + extras_bytes;
-  char* attrs = (char*)malloc(cap);
-  if (!attrs)
-    return 1;
-  int alen = hcs_well_attributes_json(attrs, cap, p->field_count, w);
-  if (alen < 0) {
-    free(attrs);
-    return 1;
-  }
+  struct strbuf attrs = { 0 };
+  struct strbuf key = { 0 };
+  int rc = 1;
+
+  if (hcs_well_attributes_json(&attrs, p->field_count, w))
+    goto done;
   char rc_ch = plate_row_char(p, r);
-  char key[4096];
-  snprintf(key, sizeof(key), "%s/%c/%d/zarr.json", p->name, rc_ch, c + 1);
-  int rc = zarr_group_write_with_raw_attrs(p->store, key, attrs);
-  free(attrs);
+  if (strbuf_appendf(
+        &key, "%s/%c/%d/zarr.json", strbuf_cstr(&p->name), rc_ch, c + 1))
+    goto done;
+  rc = zarr_group_write_with_raw_attrs(
+    p->store, strbuf_cstr(&key), strbuf_cstr(&attrs));
   if (rc == 0)
     w->dirty = 0;
+
+done:
+  strbuf_free(&attrs);
+  strbuf_free(&key);
   return rc;
 }
 
@@ -184,7 +173,7 @@ hcs_plate_create(struct store* store, const struct hcs_plate_config* cfg)
   p->rows = cfg->rows;
   p->cols = cfg->cols;
   p->field_count = cfg->field_count;
-  snprintf(p->name, sizeof(p->name), "%s", cfg->name);
+  CHECK(Fail_alloc, strbuf_set(&p->name, cfg->name) == 0);
   if (cfg->row_names) {
     p->has_row_names = 1;
     snprintf(p->row_names, sizeof(p->row_names), "%s", cfg->row_names);
@@ -226,39 +215,45 @@ hcs_plate_create(struct store* store, const struct hcs_plate_config* cfg)
     char rc = row_char(cfg, r);
 
     // Row group
-    char row_dir[4096];
-    snprintf(row_dir, sizeof(row_dir), "%s/%c", cfg->name, rc);
-    CHECK(Fail_fovs, store->mkdirs(store, row_dir) == 0);
-    {
-      struct zarr_group* g = zarr_group_create(store, row_dir);
-      CHECK(Fail_fovs, g);
-      zarr_group_destroy(g);
+    struct strbuf path_scratch = { 0 };
+    if (strbuf_appendf(&path_scratch, "%s/%c", cfg->name, rc)) {
+      strbuf_free(&path_scratch);
+      goto Fail_fovs;
     }
+    int mkrc = store->mkdirs(store, strbuf_cstr(&path_scratch));
+    struct zarr_group* g =
+      mkrc == 0 ? zarr_group_create(store, strbuf_cstr(&path_scratch)) : NULL;
+    strbuf_free(&path_scratch);
+    CHECK(Fail_fovs, mkrc == 0 && g);
+    zarr_group_destroy(g);
 
     for (int c = 0; c < cfg->cols; ++c) {
       if (!well_active(p, r, c))
         continue;
 
       // Well group with OME well attributes
-      char well_dir[4096];
-      snprintf(well_dir, sizeof(well_dir), "%s/%c/%d", cfg->name, rc, c + 1);
-      CHECK(Fail_fovs, store->mkdirs(store, well_dir) == 0);
+      struct strbuf well_dir = { 0 };
+      if (strbuf_appendf(&well_dir, "%s/%c/%d", cfg->name, rc, c + 1)) {
+        strbuf_free(&well_dir);
+        goto Fail_fovs;
+      }
+      int wmkrc = store->mkdirs(store, strbuf_cstr(&well_dir));
+      strbuf_free(&well_dir);
+      CHECK(Fail_fovs, wmkrc == 0);
       CHECK(Fail_fovs, write_well_group(p, r, c) == 0);
 
       // FOV multiscale sinks
       for (int f = 0; f < cfg->field_count; ++f) {
-        char fov_prefix[4096];
-        snprintf(fov_prefix,
-                 sizeof(fov_prefix),
-                 "%s/%c/%d/%d",
-                 cfg->name,
-                 rc,
-                 c + 1,
-                 f);
-
+        struct strbuf fov_prefix = { 0 };
+        if (strbuf_appendf(
+              &fov_prefix, "%s/%c/%d/%d", cfg->name, rc, c + 1, f)) {
+          strbuf_free(&fov_prefix);
+          goto Fail_fovs;
+        }
         int idx = fov_index(p, r, c, f);
-        p->fovs[idx] =
-          ngff_multiscale_create_with_pool(store, pool, fov_prefix, &cfg->fov);
+        p->fovs[idx] = ngff_multiscale_create_with_pool(
+          store, pool, strbuf_cstr(&fov_prefix), &cfg->fov);
+        strbuf_free(&fov_prefix);
         CHECK(Fail_fovs, p->fovs[idx]);
       }
     }
@@ -280,6 +275,7 @@ Fail_mask:
   free(p->well_mask);
 Fail_alloc:
   attr_set_destroy(&p->plate_attrs);
+  strbuf_free(&p->name);
   free(p);
 Fail_pool:
   pool->destroy(pool);
@@ -311,6 +307,7 @@ hcs_plate_destroy(struct hcs_plate* p)
   free(p->well_attrs);
   free(p->well_mask);
   attr_set_destroy(&p->plate_attrs);
+  strbuf_free(&p->name);
   struct shard_pool* pool = p->pool;
   free(p);
   if (pool)

--- a/src/hcs/hcs.c
+++ b/src/hcs/hcs.c
@@ -10,6 +10,7 @@
 #include "zarr/store.h"
 #include "zarr/zarr_group.h"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -68,6 +69,28 @@ static const char*
 plate_row_names_ptr(const struct hcs_plate* p)
 {
   return p->has_row_names ? p->row_names : NULL;
+}
+
+// Build a printf-formatted path into a scratch strbuf, mkdir it, and free.
+// Returns 0 on success.
+static int
+mkdirs_fmt(struct store* store, const char* fmt, ...)
+#if defined(__GNUC__) || defined(__clang__)
+  __attribute__((format(printf, 2, 3)))
+#endif
+  ;
+static int
+mkdirs_fmt(struct store* store, const char* fmt, ...)
+{
+  struct strbuf path = { 0 };
+  va_list ap;
+  va_start(ap, fmt);
+  int rc = strbuf_vappendf(&path, fmt, ap);
+  va_end(ap);
+  if (rc == 0)
+    rc = store->mkdirs(store, strbuf_cstr(&path));
+  strbuf_free(&path);
+  return rc;
 }
 
 static int
@@ -215,16 +238,14 @@ hcs_plate_create(struct store* store, const struct hcs_plate_config* cfg)
     char rc = row_char(cfg, r);
 
     // Row group
-    struct strbuf path_scratch = { 0 };
-    if (strbuf_appendf(&path_scratch, "%s/%c", cfg->name, rc)) {
-      strbuf_free(&path_scratch);
-      goto Fail_fovs;
-    }
-    int mkrc = store->mkdirs(store, strbuf_cstr(&path_scratch));
+    struct strbuf row_dir = { 0 };
+    int row_rc = strbuf_appendf(&row_dir, "%s/%c", cfg->name, rc);
+    if (row_rc == 0)
+      row_rc = store->mkdirs(store, strbuf_cstr(&row_dir));
     struct zarr_group* g =
-      mkrc == 0 ? zarr_group_create(store, strbuf_cstr(&path_scratch)) : NULL;
-    strbuf_free(&path_scratch);
-    CHECK(Fail_fovs, mkrc == 0 && g);
+      row_rc == 0 ? zarr_group_create(store, strbuf_cstr(&row_dir)) : NULL;
+    strbuf_free(&row_dir);
+    CHECK(Fail_fovs, row_rc == 0 && g);
     zarr_group_destroy(g);
 
     for (int c = 0; c < cfg->cols; ++c) {
@@ -232,27 +253,20 @@ hcs_plate_create(struct store* store, const struct hcs_plate_config* cfg)
         continue;
 
       // Well group with OME well attributes
-      struct strbuf well_dir = { 0 };
-      if (strbuf_appendf(&well_dir, "%s/%c/%d", cfg->name, rc, c + 1)) {
-        strbuf_free(&well_dir);
-        goto Fail_fovs;
-      }
-      int wmkrc = store->mkdirs(store, strbuf_cstr(&well_dir));
-      strbuf_free(&well_dir);
-      CHECK(Fail_fovs, wmkrc == 0);
+      CHECK(Fail_fovs,
+            mkdirs_fmt(store, "%s/%c/%d", cfg->name, rc, c + 1) == 0);
       CHECK(Fail_fovs, write_well_group(p, r, c) == 0);
 
       // FOV multiscale sinks
       for (int f = 0; f < cfg->field_count; ++f) {
         struct strbuf fov_prefix = { 0 };
-        if (strbuf_appendf(
-              &fov_prefix, "%s/%c/%d/%d", cfg->name, rc, c + 1, f)) {
-          strbuf_free(&fov_prefix);
-          goto Fail_fovs;
-        }
+        int fp_rc =
+          strbuf_appendf(&fov_prefix, "%s/%c/%d/%d", cfg->name, rc, c + 1, f);
         int idx = fov_index(p, r, c, f);
-        p->fovs[idx] = ngff_multiscale_create_with_pool(
-          store, pool, strbuf_cstr(&fov_prefix), &cfg->fov);
+        p->fovs[idx] = fp_rc == 0
+                         ? ngff_multiscale_create_with_pool(
+                             store, pool, strbuf_cstr(&fov_prefix), &cfg->fov)
+                         : NULL;
         strbuf_free(&fov_prefix);
         CHECK(Fail_fovs, p->fovs[idx]);
       }

--- a/src/hcs/hcs_metadata.c
+++ b/src/hcs/hcs_metadata.c
@@ -5,8 +5,7 @@
 #include <stdio.h>
 
 int
-hcs_plate_attributes_json(char* buf,
-                          size_t cap,
+hcs_plate_attributes_json(struct strbuf* sb,
                           const char* plate_name,
                           int rows,
                           int cols,
@@ -16,7 +15,7 @@ hcs_plate_attributes_json(char* buf,
                           const struct attr_set* extras)
 {
   struct json_writer jw;
-  jw_init(&jw, buf, cap);
+  jw_init(&jw, sb);
 
   jw_object_begin(&jw); // attributes root
 
@@ -95,19 +94,16 @@ hcs_plate_attributes_json(char* buf,
   attr_set_emit(extras, &jw);
   jw_object_end(&jw); // attributes root
 
-  if (jw_error(&jw))
-    return -1;
-  return (int)jw_length(&jw);
+  return jw_error(&jw) ? 1 : 0;
 }
 
 int
-hcs_well_attributes_json(char* buf,
-                         size_t cap,
+hcs_well_attributes_json(struct strbuf* sb,
                          int field_count,
                          const struct attr_set* extras)
 {
   struct json_writer jw;
-  jw_init(&jw, buf, cap);
+  jw_init(&jw, sb);
 
   jw_object_begin(&jw); // attributes root
 
@@ -137,7 +133,5 @@ hcs_well_attributes_json(char* buf,
   attr_set_emit(extras, &jw);
   jw_object_end(&jw); // attributes root
 
-  if (jw_error(&jw))
-    return -1;
-  return (int)jw_length(&jw);
+  return jw_error(&jw) ? 1 : 0;
 }

--- a/src/hcs/hcs_metadata.h
+++ b/src/hcs/hcs_metadata.h
@@ -1,18 +1,19 @@
 // OME-NGFF v0.5 HCS (High-Content Screening) metadata generation.
 #pragma once
 
+#include "util/strbuf.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
 struct attr_set;
 
-// Generate plate-level OME attributes JSON into buf.
+// Append plate-level OME attributes JSON to sb.
 // This is the "attributes" value for the plate group zarr.json.
 // extras: optional custom attributes spliced alongside the ome block.
-// Returns JSON length on success, -1 on error.
+// Returns 0 on success.
 int
-hcs_plate_attributes_json(char* buf,
-                          size_t cap,
+hcs_plate_attributes_json(struct strbuf* sb,
                           const char* plate_name,
                           int rows,
                           int cols,
@@ -21,11 +22,10 @@ hcs_plate_attributes_json(char* buf,
                           const int* well_mask,
                           const struct attr_set* extras);
 
-// Generate well-level OME attributes JSON into buf.
+// Append well-level OME attributes JSON to sb.
 // extras: optional custom attributes spliced alongside the ome block.
-// Returns JSON length on success, -1 on error.
+// Returns 0 on success.
 int
-hcs_well_attributes_json(char* buf,
-                         size_t cap,
+hcs_well_attributes_json(struct strbuf* sb,
                          int field_count,
                          const struct attr_set* extras);

--- a/src/ngff.h
+++ b/src/ngff.h
@@ -40,6 +40,8 @@ ngff_axes_copy(struct ngff_axis* dst,
 
 // Free unit strings previously allocated by ngff_axes_copy. Safe on
 // zero-initialized slots (free(NULL)). Does not free the array itself.
+// Only the unit pointer is owned; scale and type are plain scalars and are
+// left untouched.
 void
 ngff_axes_free_units(struct ngff_axis* axes, uint8_t rank);
 

--- a/src/ngff.h
+++ b/src/ngff.h
@@ -22,11 +22,26 @@ enum ngff_axis_type
 struct ngff_axis
 {
   const char* unit; // axis unit (e.g. "micrometer"),
-                    // NULL defaults to "index" in metadata
+                    // NULL defaults to "index" in metadata.
+                    // Copied at ngff_multiscale_create; caller may free after.
   double scale;     // physical pixel scale for coordinateTransformations
                     // (must be non-negative; 0 treated as 1.0)
   enum ngff_axis_type type; // space, time, or channel
 };
+
+// Deep-copy rank axes from src to dst, duplicating unit strings.
+// After success, dst owns its unit strings; free with ngff_axes_free_units.
+// Returns 0 on success. On failure, frees any partial unit allocations and
+// leaves dst zero-initialized for the affected slots.
+int
+ngff_axes_copy(struct ngff_axis* dst,
+               const struct ngff_axis* src,
+               uint8_t rank);
+
+// Free unit strings previously allocated by ngff_axes_copy. Safe on
+// zero-initialized slots (free(NULL)). Does not free the array itself.
+void
+ngff_axes_free_units(struct ngff_axis* axes, uint8_t rank);
 
 struct ngff_multiscale_config
 {

--- a/src/ngff/CMakeLists.txt
+++ b/src/ngff/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_src_lib(ngff_metadata SOURCES ngff_metadata.c ngff_metadata.h
-    LINKS json_writer attr_set dimension chucky_log
+    LINKS json_writer attr_set dimension strbuf chucky_log
 )
 
 add_src_lib(ngff_multiscale SOURCES ngff_multiscale.c ngff_multiscale.h
-    LINKS ngff_metadata attr_set zarr_array zarr_group zarr_metadata lod_plan dimension chucky_log
+    LINKS ngff_metadata attr_set zarr_array zarr_group zarr_metadata lod_plan dimension strbuf chucky_log
 )

--- a/src/ngff/ngff_metadata.c
+++ b/src/ngff/ngff_metadata.c
@@ -8,8 +8,7 @@
 #include <stdio.h>
 
 int
-ngff_multiscale_group_json(char* buf,
-                           size_t cap,
+ngff_multiscale_group_json(struct strbuf* sb,
                            uint8_t rank,
                            int nlod,
                            const struct dimension* const* level_dims,
@@ -17,7 +16,7 @@ ngff_multiscale_group_json(char* buf,
                            const struct attr_set* extras)
 {
   struct json_writer jw;
-  jw_init(&jw, buf, cap);
+  jw_init(&jw, sb);
 
   const struct dimension* l0 = level_dims[0];
 
@@ -154,7 +153,5 @@ ngff_multiscale_group_json(char* buf,
   jw_object_end(&jw); // attributes
   jw_object_end(&jw); // root
 
-  if (jw_error(&jw))
-    return -1;
-  return (int)jw_length(&jw);
+  return jw_error(&jw) ? 1 : 0;
 }

--- a/src/ngff/ngff_metadata.h
+++ b/src/ngff/ngff_metadata.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "dimension.h"
+#include "util/strbuf.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -9,14 +10,13 @@
 struct ngff_axis;
 struct attr_set;
 
-// Generate OME-NGFF v0.5 multiscale group JSON into buf.
+// Append OME-NGFF v0.5 multiscale group JSON to sb.
 // level_dims[lv] points to the rank-length dimension array for level lv.
 // axes may be NULL; if so, all axes default to space/no-unit/scale-1.0.
 // extras: optional custom attrs written alongside the OME block. May be NULL.
-// Returns JSON length on success, -1 on error.
+// Returns 0 on success.
 int
-ngff_multiscale_group_json(char* buf,
-                           size_t cap,
+ngff_multiscale_group_json(struct strbuf* sb,
                            uint8_t rank,
                            int nlod,
                            const struct dimension* const* level_dims,

--- a/src/ngff/ngff_multiscale.c
+++ b/src/ngff/ngff_multiscale.c
@@ -19,6 +19,9 @@ ngff_axes_copy(struct ngff_axis* dst, const struct ngff_axis* src, uint8_t rank)
     return 1;
   for (uint8_t d = 0; d < rank; ++d) {
     dst[d] = src[d];
+    // Null the aliased source pointer before any allocation so the cleanup
+    // below never sees an un-duplicated pointer from src.
+    dst[d].unit = NULL;
     if (src[d].unit) {
       char* dup = strdup(src[d].unit);
       if (!dup) {

--- a/src/ngff/ngff_multiscale.c
+++ b/src/ngff/ngff_multiscale.c
@@ -2,6 +2,7 @@
 #include "defs.limits.h"
 #include "dimension.h"
 #include "lod/lod_plan.h"
+#include "ngff.h"
 #include "ngff/ngff_metadata.h"
 #include "util/prelude.h"
 #include "zarr/attr_set.h"
@@ -10,6 +11,38 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+int
+ngff_axes_copy(struct ngff_axis* dst, const struct ngff_axis* src, uint8_t rank)
+{
+  if (!dst || !src)
+    return 1;
+  for (uint8_t d = 0; d < rank; ++d) {
+    dst[d] = src[d];
+    if (src[d].unit) {
+      char* dup = strdup(src[d].unit);
+      if (!dup) {
+        ngff_axes_free_units(dst, d);
+        for (uint8_t z = d; z < rank; ++z)
+          dst[z] = (struct ngff_axis){ 0 };
+        return 1;
+      }
+      dst[d].unit = dup;
+    }
+  }
+  return 0;
+}
+
+void
+ngff_axes_free_units(struct ngff_axis* axes, uint8_t rank)
+{
+  if (!axes)
+    return;
+  for (uint8_t d = 0; d < rank; ++d) {
+    free((char*)axes[d].unit);
+    axes[d].unit = NULL;
+  }
+}
 
 struct ngff_multiscale
 {
@@ -20,7 +53,7 @@ struct ngff_multiscale
   struct zarr_array** levels;
   int nlod;
   uint8_t rank;
-  char prefix[4096];
+  struct strbuf prefix; // owned
   struct ngff_axis axes[MAX_ZARR_RANK];
   struct attr_set attrs;
 };
@@ -34,25 +67,30 @@ write_ngff_group_metadata(struct ngff_multiscale* ms)
   for (int lv = 0; lv < ms->nlod; ++lv)
     level_ptrs[lv] = zarr_array_dimensions(ms->levels[lv]);
 
-  // Zero-init so a trailing-NUL scan can clamp the write length if
-  // jw_length ever overcounts (see zarr_array.c note, #96).
-  char json[ZARR_GROUP_JSON_MAX_LENGTH] = { 0 };
-  int len = ngff_multiscale_group_json(
-    json, sizeof(json), ms->rank, ms->nlod, level_ptrs, ms->axes, &ms->attrs);
-  if (len < 0)
-    return 1;
-  size_t write_len = strnlen(json, (size_t)len);
+  struct strbuf key = { 0 };
+  struct strbuf json = { 0 };
+  int rc = 1;
 
-  // Write the full group zarr.json (the ngff function generates the complete
-  // JSON including zarr_format, node_type, and attributes).
-  char key[4096];
-  if (ms->prefix[0])
-    snprintf(key, sizeof(key), "%s/zarr.json", ms->prefix);
-  else
-    snprintf(key, sizeof(key), "zarr.json");
-  int rc = ms->store->put(ms->store, key, json, write_len);
+  if (ngff_multiscale_group_json(
+        &json, ms->rank, ms->nlod, level_ptrs, ms->axes, &ms->attrs))
+    goto done;
+
+  if (strbuf_len(&ms->prefix) > 0) {
+    if (strbuf_appendf(&key, "%s/zarr.json", strbuf_cstr(&ms->prefix)))
+      goto done;
+  } else {
+    if (strbuf_append_cstr(&key, "zarr.json"))
+      goto done;
+  }
+
+  rc = ms->store->put(
+    ms->store, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
   if (rc == 0)
     ms->attrs.dirty = 0;
+
+done:
+  strbuf_free(&key);
+  strbuf_free(&json);
   return rc;
 }
 
@@ -93,7 +131,7 @@ ngff_multiscale_update_append(struct shard_sink* self,
 
   if (write_ngff_group_metadata(ms)) {
     log_error("ngff_multiscale: failed to rewrite group zarr.json for %s",
-              ms->prefix);
+              strbuf_cstr(&ms->prefix));
     return 1;
   }
   return 0;
@@ -161,10 +199,10 @@ ngff_multiscale_init(struct store* store,
   ms->nlod = plan->levels.nlod;
   ms->rank = cfg->rank;
   attr_set_init(&ms->attrs);
-  if (prefix)
-    snprintf(ms->prefix, sizeof(ms->prefix), "%s", prefix);
+  if (prefix && prefix[0])
+    CHECK(Fail_ms, strbuf_set(&ms->prefix, prefix) == 0);
   if (cfg->axes)
-    memcpy(ms->axes, cfg->axes, cfg->rank * sizeof(struct ngff_axis));
+    CHECK(Fail_ms, ngff_axes_copy(ms->axes, cfg->axes, cfg->rank) == 0);
 
   ms->base.open = ngff_multiscale_open;
   ms->base.update_append = ngff_multiscale_update_append;
@@ -199,18 +237,16 @@ ngff_multiscale_init(struct store* store,
         plan->levels.level[lv].dim[d].chunks_per_shard;
     }
 
-    char name[16];
-    snprintf(name, sizeof(name), "%d", lv);
+    struct strbuf level_prefix = { 0 };
+    int lp_rc = (prefix && prefix[0])
+                  ? strbuf_appendf(&level_prefix, "%s/%d", prefix, lv)
+                  : strbuf_appendf(&level_prefix, "%d", lv);
+    if (lp_rc) {
+      strbuf_free(&level_prefix);
+      goto Fail_levels;
+    }
 
-    char level_prefix[4096];
-    int lp_n;
-    if (prefix && prefix[0])
-      lp_n = snprintf(level_prefix, sizeof(level_prefix), "%s/%s", prefix, name);
-    else
-      lp_n = snprintf(level_prefix, sizeof(level_prefix), "%s", name);
-    (void)lp_n;
-
-    CHECK(Fail_levels, store->mkdirs(store, level_prefix) == 0);
+    int mkrc = store->mkdirs(store, strbuf_cstr(&level_prefix));
 
     struct zarr_array_config acfg = {
       .data_type = cfg->data_type,
@@ -221,7 +257,10 @@ ngff_multiscale_init(struct store* store,
     };
 
     ms->levels[lv] =
-      zarr_array_create_with_pool(store, pool, slot_base, level_prefix, &acfg);
+      mkrc == 0 ? zarr_array_create_with_pool(
+                    store, pool, slot_base, strbuf_cstr(&level_prefix), &acfg)
+                : NULL;
+    strbuf_free(&level_prefix);
     CHECK(Fail_levels, ms->levels[lv]);
 
     uint64_t sc[MAX_ZARR_RANK], cps[MAX_ZARR_RANK];
@@ -240,6 +279,8 @@ Fail_levels:
   }
   free(ms->levels);
 Fail_ms:
+  ngff_axes_free_units(ms->axes, cfg->rank);
+  strbuf_free(&ms->prefix);
   free(ms);
 Fail_plan:
   lod_plan_free(plan);
@@ -331,6 +372,8 @@ ngff_multiscale_destroy(struct ngff_multiscale* ms)
     zarr_array_destroy(ms->levels[i]);
   free(ms->levels);
   attr_set_destroy(&ms->attrs);
+  ngff_axes_free_units(ms->axes, ms->rank);
+  strbuf_free(&ms->prefix);
   struct shard_pool* pool = ms->owns_pool ? ms->pool : NULL;
   free(ms);
   if (pool)

--- a/src/stream/config.c
+++ b/src/stream/config.c
@@ -134,11 +134,12 @@ Fail:
 }
 
 // Validate a tile_stream_configuration.
-// On success, stores the resolved dim partition in *di.
-// Returns 0 on success, non-zero on invalid config.
+// On success, stores the resolved dim partition in *di (slices point into
+// dims). Returns 0 on success, non-zero on invalid config.
 static int
 validate_config(const struct tile_stream_configuration* config,
-                struct dim_info* di)
+                struct dim_info* di,
+                const struct dimension* dims)
 {
   CHECK(Fail, config);
   CHECK(Fail, dtype_bpe(config->dtype) > 0);
@@ -153,12 +154,12 @@ validate_config(const struct tile_stream_configuration* config,
   }
 
   // dim_info_init validates dims and computes the partition.
-  CHECK(Fail, dim_info_init(di, config->dimensions, config->rank) == 0);
+  CHECK(Fail, dim_info_init(di, dims, config->rank) == 0);
 
   {
     uint64_t chunk_elements = 1;
     for (int d = 0; d < config->rank; ++d)
-      chunk_elements *= config->dimensions[d].chunk_size;
+      chunk_elements *= dims[d].chunk_size;
     if (chunk_elements <= 1)
       log_warn("total chunk elements is %llu (chunk_size=1 in all dims?)",
                (unsigned long long)chunk_elements);
@@ -186,7 +187,7 @@ validate_config(const struct tile_stream_configuration* config,
 
   {
     uint8_t na = dim_info_n_append(di);
-    if (resolve_storage_order(config->rank, na, config->dimensions, NULL)) {
+    if (resolve_storage_order(config->rank, na, dims, NULL)) {
       log_error("invalid storage_order permutation");
       goto Fail;
     }
@@ -221,6 +222,7 @@ computed_stream_layouts_free(struct computed_stream_layouts* cl)
 {
   if (!cl)
     return;
+  dims_free_names(cl->dims_owned, cl->rank);
   lod_plan_free(&cl->plan);
 }
 
@@ -234,11 +236,14 @@ compute_stream_layouts(const struct tile_stream_configuration* config,
 {
   const uint8_t rank = config->rank;
   const size_t bytes_per_element = dtype_bpe(config->dtype);
-  const struct dimension* dims = config->dimensions;
 
   memset(out, 0, sizeof(*out));
 
-  CHECK(Fail, validate_config(config, &out->dims) == 0);
+  CHECK(Fail, dims_copy(out->dims_owned, config->dimensions, rank) == 0);
+  out->rank = rank;
+  const struct dimension* dims = out->dims_owned;
+
+  CHECK(Fail, validate_config(config, &out->dims, dims) == 0);
   const uint8_t na = dim_info_n_append(&out->dims);
 
   uint8_t storage_order[HALF_MAX_RANK];

--- a/src/stream/layouts.h
+++ b/src/stream/layouts.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "defs.limits.h"
+#include "dimension.h"
 #include "lod/lod_plan.h"
 #include "stream/dim_info.h"
 #include "stream/types.aggregate.h"
@@ -34,9 +36,16 @@ struct level_layout_info
 // All pre-computed layout data from CPU-only math.
 // Produced by compute_stream_layouts, consumed by the create path
 // and the memory estimate path.
+//
+// Owns dims_owned[]: a deep copy of the caller's config.dimensions (including
+// duplicated name strings) so dim_info slices and later metadata reads don't
+// depend on the caller keeping its dimensions array alive.
 struct computed_stream_layouts
 {
-  struct dim_info dims; // resolved append/inner partition
+  struct dimension dims_owned[HALF_MAX_RANK]; // owned copy of config dims
+  uint8_t rank;
+  struct dim_info
+    dims; // resolved append/inner partition (points into dims_owned)
   struct lod_plan plan; // owned if enable_multiscale
   struct tile_stream_layout layouts[LOD_MAX_LEVELS]; // [0] = L0
   struct level_geometry levels;

--- a/src/util/strbuf.c
+++ b/src/util/strbuf.c
@@ -1,6 +1,7 @@
 #include "util/strbuf.h"
 
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -51,7 +52,10 @@ strbuf_reserve(struct strbuf* sb, size_t need)
 
   size_t len = (size_t)(sb->end - sb->beg);
   size_t cap = (size_t)(sb->cap_end - sb->beg); // includes NUL slot
-  size_t want = len + need + 1;                 // +1 for NUL
+  // Check len + need + 1 without overflowing size_t.
+  if (need > SIZE_MAX - 1 - len)
+    return 1;
+  size_t want = len + need + 1; // +1 for NUL
   if (want <= cap)
     return 0;
 
@@ -153,4 +157,10 @@ const char*
 strbuf_cstr(const struct strbuf* sb)
 {
   return (sb && sb->beg) ? sb->beg : "";
+}
+
+size_t
+strbuf_len(const struct strbuf* sb)
+{
+  return sb->beg ? (size_t)(sb->end - sb->beg) : 0;
 }

--- a/src/util/strbuf.c
+++ b/src/util/strbuf.c
@@ -1,0 +1,156 @@
+#include "util/strbuf.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int
+is_inline(const struct strbuf* sb)
+{
+  return sb->beg == sb->inline_buf;
+}
+
+static void
+activate_inline(struct strbuf* sb)
+{
+  sb->beg = sb->inline_buf;
+  sb->end = sb->inline_buf;
+  sb->cap_end = sb->inline_buf + STRBUF_INLINE_CAP;
+  sb->inline_buf[0] = 0;
+}
+
+void
+strbuf_free(struct strbuf* sb)
+{
+  if (!sb)
+    return;
+  if (sb->beg && !is_inline(sb))
+    free(sb->beg);
+  sb->beg = NULL;
+  sb->end = NULL;
+  sb->cap_end = NULL;
+}
+
+void
+strbuf_reset(struct strbuf* sb)
+{
+  if (!sb || !sb->beg)
+    return;
+  sb->end = sb->beg;
+  *sb->end = 0;
+}
+
+int
+strbuf_reserve(struct strbuf* sb, size_t need)
+{
+  if (!sb)
+    return 1;
+  if (!sb->beg)
+    activate_inline(sb);
+
+  size_t len = (size_t)(sb->end - sb->beg);
+  size_t cap = (size_t)(sb->cap_end - sb->beg); // includes NUL slot
+  size_t want = len + need + 1;                 // +1 for NUL
+  if (want <= cap)
+    return 0;
+
+  size_t new_cap = cap ? cap : STRBUF_INLINE_CAP;
+  while (new_cap < want) {
+    size_t doubled = new_cap * 2;
+    if (doubled < new_cap)
+      return 1; // overflow
+    new_cap = doubled;
+  }
+
+  char* new_buf;
+  if (is_inline(sb)) {
+    new_buf = (char*)malloc(new_cap);
+    if (!new_buf)
+      return 1;
+    memcpy(new_buf, sb->beg, len + 1);
+  } else {
+    new_buf = (char*)realloc(sb->beg, new_cap);
+    if (!new_buf)
+      return 1;
+  }
+  sb->beg = new_buf;
+  sb->end = new_buf + len;
+  sb->cap_end = new_buf + new_cap;
+  return 0;
+}
+
+int
+strbuf_append(struct strbuf* sb, const char* data, size_t n)
+{
+  if (strbuf_reserve(sb, n))
+    return 1;
+  memcpy(sb->end, data, n);
+  sb->end += n;
+  *sb->end = 0;
+  return 0;
+}
+
+int
+strbuf_append_cstr(struct strbuf* sb, const char* s)
+{
+  return strbuf_append(sb, s, strlen(s));
+}
+
+int
+strbuf_vappendf(struct strbuf* sb, const char* fmt, va_list ap)
+{
+  if (!sb)
+    return 1;
+  if (!sb->beg)
+    activate_inline(sb);
+
+  va_list ap2;
+  va_copy(ap2, ap);
+  size_t avail = (size_t)(sb->cap_end - sb->end);
+  int n = vsnprintf(sb->end, avail, fmt, ap);
+  if (n < 0) {
+    va_end(ap2);
+    return 1;
+  }
+  if ((size_t)n < avail) {
+    sb->end += (size_t)n;
+    va_end(ap2);
+    return 0;
+  }
+
+  if (strbuf_reserve(sb, (size_t)n)) {
+    va_end(ap2);
+    return 1;
+  }
+  avail = (size_t)(sb->cap_end - sb->end);
+  int n2 = vsnprintf(sb->end, avail, fmt, ap2);
+  va_end(ap2);
+  if (n2 < 0 || (size_t)n2 >= avail)
+    return 1;
+  sb->end += (size_t)n2;
+  return 0;
+}
+
+int
+strbuf_appendf(struct strbuf* sb, const char* fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  int rc = strbuf_vappendf(sb, fmt, ap);
+  va_end(ap);
+  return rc;
+}
+
+int
+strbuf_set(struct strbuf* sb, const char* s)
+{
+  strbuf_reset(sb);
+  return strbuf_append_cstr(sb, s);
+}
+
+const char*
+strbuf_cstr(const struct strbuf* sb)
+{
+  return (sb && sb->beg) ? sb->beg : "";
+}

--- a/src/util/strbuf.h
+++ b/src/util/strbuf.h
@@ -53,7 +53,10 @@ strbuf_append_cstr(struct strbuf* sb, const char* s);
 // printf-style append. Returns 0 on success.
 int
 strbuf_appendf(struct strbuf* sb, const char* fmt, ...)
-  __attribute__((format(printf, 2, 3)));
+#if defined(__GNUC__) || defined(__clang__)
+  __attribute__((format(printf, 2, 3)))
+#endif
+  ;
 
 // va_list variant of strbuf_appendf.
 int
@@ -65,11 +68,8 @@ int
 strbuf_set(struct strbuf* sb, const char* s);
 
 // Current content length (bytes, excluding NUL).
-static inline size_t
-strbuf_len(const struct strbuf* sb)
-{
-  return sb->beg ? (size_t)(sb->end - sb->beg) : 0;
-}
+size_t
+strbuf_len(const struct strbuf* sb);
 
 // NUL-terminated pointer to content. Never NULL: returns "" for empty/
 // zero-init bufs.

--- a/src/util/strbuf.h
+++ b/src/util/strbuf.h
@@ -1,0 +1,77 @@
+// Dynamic string buffer with small-string inline storage.
+//
+// Use for path/key construction and other variable-length text where a
+// fixed-size stack buffer would risk silent truncation. Short content
+// (<= STRBUF_INLINE_CAP bytes) stays in the inline buffer — zero heap
+// allocations. Growth spills to heap, then reuses the allocation across
+// subsequent reset/append cycles.
+//
+// Zero-initialization is valid: `struct strbuf sb = {0}` is safe to pass
+// to any function; the inline buffer lazy-activates on first append.
+//
+// All append functions return 0 on success, non-zero on allocation
+// failure. Content and NUL terminator are always kept consistent: after a
+// successful call, `*sb.end == 0` and `strbuf_cstr(&sb)` is a valid C
+// string.
+#pragma once
+
+#include <stdarg.h>
+#include <stddef.h>
+
+#define STRBUF_INLINE_CAP 128
+
+struct strbuf
+{
+  char inline_buf[STRBUF_INLINE_CAP];
+  char* beg;     // NULL until first use; then points at inline_buf or heap
+  char* end;     // *end == 0; len == end - beg
+  char* cap_end; // one past last writable byte (NUL slot)
+};
+
+// Free heap allocation (if any). Safe on zero-init and already-freed bufs.
+// Leaves sb in a re-usable zero-init state.
+void
+strbuf_free(struct strbuf* sb);
+
+// Set length to 0, keep allocation. Safe on zero-init (no-op).
+void
+strbuf_reset(struct strbuf* sb);
+
+// Ensure there is room for `need` more content bytes plus the NUL. Lazily
+// activates inline storage on first call. Returns 0 on success.
+int
+strbuf_reserve(struct strbuf* sb, size_t need);
+
+// Append raw bytes. Returns 0 on success.
+int
+strbuf_append(struct strbuf* sb, const char* data, size_t n);
+
+// Append a NUL-terminated C string. Returns 0 on success.
+int
+strbuf_append_cstr(struct strbuf* sb, const char* s);
+
+// printf-style append. Returns 0 on success.
+int
+strbuf_appendf(struct strbuf* sb, const char* fmt, ...)
+  __attribute__((format(printf, 2, 3)));
+
+// va_list variant of strbuf_appendf.
+int
+strbuf_vappendf(struct strbuf* sb, const char* fmt, va_list ap);
+
+// Reset then append the given C string (convenience for "replace contents").
+// Returns 0 on success.
+int
+strbuf_set(struct strbuf* sb, const char* s);
+
+// Current content length (bytes, excluding NUL).
+static inline size_t
+strbuf_len(const struct strbuf* sb)
+{
+  return sb->beg ? (size_t)(sb->end - sb->beg) : 0;
+}
+
+// NUL-terminated pointer to content. Never NULL: returns "" for empty/
+// zero-init bufs.
+const char*
+strbuf_cstr(const struct strbuf* sb);

--- a/src/zarr/CMakeLists.txt
+++ b/src/zarr/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_src_lib(json_writer SOURCES json_writer.c json_writer.h)
+add_src_lib(json_writer SOURCES json_writer.c json_writer.h LINKS strbuf)
 
 add_src_lib(json_validate SOURCES json_validate.c json_validate.h)
 
@@ -15,29 +15,29 @@ add_src_lib(shard_delivery SOURCES shard_delivery.c shard_delivery.h
 )
 
 add_src_lib(shard_pool_fs SOURCES shard_pool_fs.c shard_pool_fs.h shard_pool.h
-    LINKS io_queue platform platform_io writer chucky_log
+    LINKS io_queue platform platform_io writer strbuf chucky_log
 )
 
 add_src_lib(store_fs SOURCES store_fs.c store_fs.h store.h
-    LINKS shard_pool_fs platform_io chucky_log
+    LINKS shard_pool_fs platform_io strbuf chucky_log
 )
 
 add_src_lib(zarr_group SOURCES zarr_group.c zarr_group.h
-    LINKS zarr_metadata attr_set chucky_log
+    LINKS zarr_metadata attr_set strbuf chucky_log
 )
 
 add_src_lib(zarr_array SOURCES zarr_array.c zarr_array.h
-    LINKS zarr_metadata attr_set lod_plan writer chucky_log
+    LINKS zarr_metadata attr_set lod_plan writer strbuf chucky_log
 )
 
 add_src_lib(s3_client SOURCES s3_client.c s3_client.h
-    LINKS AWS::aws-c-s3 chucky_log
+    LINKS AWS::aws-c-s3 strbuf chucky_log
 )
 
 add_src_lib(shard_pool_s3 SOURCES shard_pool_s3.c shard_pool_s3.h
-    LINKS s3_client writer chucky_log
+    LINKS s3_client writer strbuf chucky_log
 )
 
 add_src_lib(store_s3 SOURCES store_s3.c store_s3.h
-    LINKS shard_pool_s3 s3_client dtype chucky_log
+    LINKS shard_pool_s3 s3_client dtype strbuf chucky_log
 )

--- a/src/zarr/json_writer.c
+++ b/src/zarr/json_writer.c
@@ -1,15 +1,11 @@
 #include "zarr/json_writer.h"
 
 #include <stdarg.h>
-#include <stdio.h>
-#include <string.h>
 
 void
-jw_init(struct json_writer* jw, char* buf, size_t cap)
+jw_init(struct json_writer* jw, struct strbuf* sb)
 {
-  jw->buf = buf;
-  jw->cap = cap;
-  jw->pos = 0;
+  jw->sb = sb;
   jw->needs_comma = 0;
   jw->error = 0;
 }
@@ -21,14 +17,10 @@ jw_put(struct json_writer* jw, const char* fmt, ...)
     return;
   va_list ap;
   va_start(ap, fmt);
-  size_t avail = jw->cap > jw->pos ? jw->cap - jw->pos : 0;
-  int n = vsnprintf(jw->buf + jw->pos, avail, fmt, ap);
+  int rc = strbuf_vappendf(jw->sb, fmt, ap);
   va_end(ap);
-  if (n < 0 || (size_t)n >= avail) {
+  if (rc)
     jw->error = 1;
-    return;
-  }
-  jw->pos += (size_t)n;
 }
 
 static void
@@ -175,7 +167,7 @@ jw_raw(struct json_writer* jw, const char* text)
 size_t
 jw_length(const struct json_writer* jw)
 {
-  return jw->pos;
+  return strbuf_len(jw->sb);
 }
 
 int

--- a/src/zarr/json_writer.h
+++ b/src/zarr/json_writer.h
@@ -1,19 +1,22 @@
 #pragma once
 
+#include "util/strbuf.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
+// JSON writer backed by a caller-owned strbuf. Appends to whatever is
+// already in the buffer; use strbuf_reset beforehand if you want to start
+// fresh. The buffer auto-grows, so there is no truncation mode.
 struct json_writer
 {
-  char* buf;
-  size_t cap;
-  size_t pos;
+  struct strbuf* sb;
   int needs_comma;
   int error;
 };
 
 void
-jw_init(struct json_writer* jw, char* buf, size_t cap);
+jw_init(struct json_writer* jw, struct strbuf* sb);
 void
 jw_object_begin(struct json_writer* jw);
 void

--- a/src/zarr/s3_client.c
+++ b/src/zarr/s3_client.c
@@ -1,5 +1,6 @@
 #include "zarr/s3_client.h"
 #include "util/prelude.h"
+#include "util/strbuf.h"
 
 #include <aws/auth/credentials.h>
 #include <aws/common/byte_buf.h>
@@ -266,11 +267,15 @@ make_request_message(struct aws_allocator* alloc,
   aws_http_message_set_request_method(msg, aws_byte_cursor_from_c_str(method));
 
   // Build path and Host header
-  char path[4096];
+  struct strbuf path = { 0 };
+  struct strbuf host = { 0 };
+  char cl[32];
   if (c->has_endpoint) {
     // Path-style: /{bucket}/{key}
-    snprintf(path, sizeof(path), "/%s/%s", bucket, key);
-    aws_http_message_set_request_path(msg, aws_byte_cursor_from_c_str(path));
+    if (strbuf_appendf(&path, "/%s/%s", bucket, key))
+      goto HeaderFail;
+    aws_http_message_set_request_path(
+      msg, aws_byte_cursor_from_c_str(strbuf_cstr(&path)));
 
     const struct aws_byte_cursor* authority =
       aws_uri_authority(&c->endpoint_uri);
@@ -280,24 +285,23 @@ make_request_message(struct aws_allocator* alloc,
                                 .value = *authority });
   } else {
     // Virtual-hosted style: /{key}, Host: {bucket}.s3.{region}.amazonaws.com
-    snprintf(path, sizeof(path), "/%s", key);
-    aws_http_message_set_request_path(msg, aws_byte_cursor_from_c_str(path));
+    if (strbuf_appendf(&path, "/%s", key))
+      goto HeaderFail;
+    aws_http_message_set_request_path(
+      msg, aws_byte_cursor_from_c_str(strbuf_cstr(&path)));
 
-    char host[512];
-    snprintf(host,
-             sizeof(host),
-             "%s.s3.%s.amazonaws.com",
-             bucket,
-             aws_string_c_str(c->region));
+    if (strbuf_appendf(
+          &host, "%s.s3.%s.amazonaws.com", bucket, aws_string_c_str(c->region)))
+      goto HeaderFail;
     aws_http_message_add_header(
       msg,
-      (struct aws_http_header){ .name = aws_byte_cursor_from_c_str("Host"),
-                                .value = aws_byte_cursor_from_c_str(host) });
+      (struct aws_http_header){
+        .name = aws_byte_cursor_from_c_str("Host"),
+        .value = aws_byte_cursor_from_c_str(strbuf_cstr(&host)) });
   }
 
   // Content-Length (only for small puts where we know the size)
   if (content_length > 0) {
-    char cl[32];
     snprintf(cl, sizeof(cl), "%zu", content_length);
     aws_http_message_add_header(
       msg,
@@ -306,7 +310,17 @@ make_request_message(struct aws_allocator* alloc,
                                 .value = aws_byte_cursor_from_c_str(cl) });
   }
 
+  // Headers copy the byte ranges they reference, so it's safe to free these
+  // strbufs now.
+  strbuf_free(&path);
+  strbuf_free(&host);
   return msg;
+
+HeaderFail:
+  strbuf_free(&path);
+  strbuf_free(&host);
+  aws_http_message_release(msg);
+  return NULL;
 }
 
 // --- s3_client_put (small blocking PUT) ---

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -218,16 +218,16 @@ pool_fs_open(struct shard_pool* self, uint64_t slot, const char* key)
   int flags = p->unbuffered ? PLATFORM_OPEN_UNBUFFERED : 0;
   w->fd = platform_open_write(strbuf_cstr(&path), flags);
   if (w->fd == PLATFORM_FD_INVALID) {
-    // Directory may not exist yet — create parent and retry
-    char* last_slash = strrchr(path.beg, '/');
+    // Directory may not exist yet — create parent and retry.
+    const char* path_cstr = strbuf_cstr(&path);
+    const char* last_slash = strrchr(path_cstr, '/');
     if (last_slash) {
-      *last_slash = '\0';
-      if (platform_mkdirp(strbuf_cstr(&path)) == 0) {
-        *last_slash = '/';
+      struct strbuf dir = { 0 };
+      if (strbuf_append(&dir, path_cstr, (size_t)(last_slash - path_cstr)) ==
+            0 &&
+          platform_mkdirp(strbuf_cstr(&dir)) == 0)
         w->fd = platform_open_write(strbuf_cstr(&path), flags);
-      } else {
-        *last_slash = '/';
-      }
+      strbuf_free(&dir);
     }
     if (w->fd == PLATFORM_FD_INVALID) {
       log_error("shard_pool_fs: open(%s) failed", strbuf_cstr(&path));

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -2,10 +2,10 @@
 #include "platform/platform.h"
 #include "platform/platform_io.h"
 #include "util/prelude.h"
+#include "util/strbuf.h"
 #include "zarr/io_queue.h"
 
 #include <stdatomic.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -193,7 +193,7 @@ struct shard_pool_fs
   struct fs_slot* slots;
   uint64_t nslots;
   int unbuffered;
-  char root[4096];
+  struct strbuf root; // owned
   uint64_t queued_bytes;
   _Atomic uint64_t retired_bytes;
   _Atomic int io_error;
@@ -211,33 +211,35 @@ pool_fs_open(struct shard_pool* self, uint64_t slot, const char* key)
   if (w->fd != PLATFORM_FD_INVALID)
     fs_slot_finalize(&w->base);
 
-  // Build full path
-  char path[4096];
-  int n = snprintf(path, sizeof(path), "%s/%s", p->root, key);
-  (void)n;
+  struct strbuf path = { 0 };
+  if (strbuf_appendf(&path, "%s/%s", strbuf_cstr(&p->root), key))
+    goto Fail;
 
   int flags = p->unbuffered ? PLATFORM_OPEN_UNBUFFERED : 0;
-  w->fd = platform_open_write(path, flags);
+  w->fd = platform_open_write(strbuf_cstr(&path), flags);
   if (w->fd == PLATFORM_FD_INVALID) {
     // Directory may not exist yet — create parent and retry
-    char dir[4096];
-    size_t pathlen = strlen(path);
-    memcpy(dir, path, pathlen + 1);
-    char* last_slash = strrchr(dir, '/');
+    char* last_slash = strrchr(path.beg, '/');
     if (last_slash) {
       *last_slash = '\0';
-      if (platform_mkdirp(dir) == 0)
-        w->fd = platform_open_write(path, flags);
+      if (platform_mkdirp(strbuf_cstr(&path)) == 0) {
+        *last_slash = '/';
+        w->fd = platform_open_write(strbuf_cstr(&path), flags);
+      } else {
+        *last_slash = '/';
+      }
     }
     if (w->fd == PLATFORM_FD_INVALID) {
-      log_error("shard_pool_fs: open(%s) failed", path);
+      log_error("shard_pool_fs: open(%s) failed", strbuf_cstr(&path));
       goto Fail;
     }
   }
 
+  strbuf_free(&path);
   return &w->base;
 
 Fail:
+  strbuf_free(&path);
   return NULL;
 }
 
@@ -307,6 +309,7 @@ pool_fs_destroy(struct shard_pool* self)
   }
 
   free(p->slots);
+  strbuf_free(&p->root);
   free(p);
 }
 
@@ -345,7 +348,7 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
   p->base.destroy = pool_fs_destroy;
   p->nslots = nslots;
   p->unbuffered = unbuffered;
-  snprintf(p->root, sizeof(p->root), "%s", root);
+  CHECK(Fail_alloc, strbuf_set(&p->root, root) == 0);
 
   p->queue = io_queue_create();
   CHECK(Fail_alloc, p->queue);
@@ -372,6 +375,7 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
 Fail_queue:
   io_queue_destroy(p->queue);
 Fail_alloc:
+  strbuf_free(&p->root);
   free(p);
 Fail:
   return NULL;

--- a/src/zarr/shard_pool_s3.c
+++ b/src/zarr/shard_pool_s3.c
@@ -1,10 +1,9 @@
 #include "zarr/shard_pool_s3.h"
 #include "util/prelude.h"
+#include "util/strbuf.h"
 #include "zarr/s3_client.h"
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 // --- Pool struct (defined early so slot functions can access it) ---
 
@@ -14,8 +13,8 @@ struct shard_pool_s3
 {
   struct shard_pool base;
   struct s3_client* client; // borrowed, not owned
-  char bucket[256];
-  char prefix[4096]; // prepended to shard keys
+  struct strbuf bucket;     // owned
+  struct strbuf prefix;     // owned; empty if no prefix
   struct s3_slot* slots;
   uint64_t nslots;
   uint64_t finalize_seq;
@@ -107,21 +106,23 @@ pool_s3_open(struct shard_pool* self, uint64_t slot, const char* key)
   // Wait for previous upload on this slot
   s3_wait_pending(w);
 
-  char full_key[4096];
-  int n;
-  if (p->prefix[0])
-    n = snprintf(full_key, sizeof(full_key), "%s/%s", p->prefix, key);
-  else
-    n = snprintf(full_key, sizeof(full_key), "%s", key);
-  (void)n;
+  struct strbuf full_key = { 0 };
+  int ok = (strbuf_len(&p->prefix) > 0
+              ? strbuf_appendf(&full_key, "%s/%s", strbuf_cstr(&p->prefix), key)
+              : strbuf_append_cstr(&full_key, key)) == 0;
 
-  w->upload = s3_upload_begin(p->client, p->bucket, full_key);
+  w->upload = ok ? s3_upload_begin(
+                     p->client, strbuf_cstr(&p->bucket), strbuf_cstr(&full_key))
+                 : NULL;
   if (!w->upload) {
-    log_error(
-      "shard_pool_s3: failed to begin upload for %s/%s", p->bucket, full_key);
+    log_error("shard_pool_s3: failed to begin upload for %s/%s",
+              strbuf_cstr(&p->bucket),
+              strbuf_cstr(&full_key));
+    strbuf_free(&full_key);
     goto Fail;
   }
 
+  strbuf_free(&full_key);
   return &w->base;
 
 Fail:
@@ -189,6 +190,8 @@ pool_s3_destroy(struct shard_pool* self)
   }
 
   free(p->slots);
+  strbuf_free(&p->bucket);
+  strbuf_free(&p->prefix);
   free(p);
 }
 
@@ -216,10 +219,10 @@ shard_pool_s3_create(struct s3_client* client,
   p->base.pending_bytes = pool_s3_pending_bytes;
   p->base.destroy = pool_s3_destroy;
   p->client = client;
-  if (prefix)
-    snprintf(p->prefix, sizeof(p->prefix), "%s", prefix);
+  if (prefix && prefix[0])
+    CHECK(Fail_alloc, strbuf_set(&p->prefix, prefix) == 0);
   p->nslots = nslots;
-  snprintf(p->bucket, sizeof(p->bucket), "%s", bucket);
+  CHECK(Fail_alloc, strbuf_set(&p->bucket, bucket) == 0);
 
   p->slots = (struct s3_slot*)calloc((size_t)nslots, sizeof(struct s3_slot));
   CHECK(Fail_alloc, p->slots);
@@ -235,6 +238,8 @@ shard_pool_s3_create(struct s3_client* client,
   return &p->base;
 
 Fail_alloc:
+  strbuf_free(&p->bucket);
+  strbuf_free(&p->prefix);
   free(p);
 Fail:
   return NULL;

--- a/src/zarr/store_fs.c
+++ b/src/zarr/store_fs.c
@@ -1,65 +1,84 @@
 #include "zarr/store_fs.h"
 #include "platform/platform_io.h"
 #include "util/prelude.h"
+#include "util/strbuf.h"
 #include "zarr/shard_pool_fs.h"
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 struct store_fs
 {
   struct store base;
-  char root[4096];
+  struct strbuf root; // owned
   int unbuffered;
 };
+
+// Build "<root>/<key>" into a fresh strbuf. Caller frees with strbuf_free.
+// Returns 0 on success.
+static int
+fs_join(const struct store_fs* fs, const char* key, struct strbuf* out)
+{
+  return strbuf_appendf(out, "%s/%s", strbuf_cstr(&fs->root), key);
+}
 
 static int
 fs_put(struct store* self, const char* key, const void* data, size_t len)
 {
   struct store_fs* fs = container_of(self, struct store_fs, base);
-  char path[4096];
-  int n = snprintf(path, sizeof(path), "%s/%s", fs->root, key);
-  (void)n;
+  struct strbuf path = { 0 };
+  int rc = 1;
+  if (fs_join(fs, key, &path))
+    goto done;
 
-  platform_fd fd = platform_open_write(path, 0);
+  platform_fd fd = platform_open_write(strbuf_cstr(&path), 0);
   if (fd == PLATFORM_FD_INVALID)
-    return 1;
-  int rc = platform_write(fd, data, len);
+    goto done;
+  rc = platform_write(fd, data, len) != 0;
   platform_close(fd);
-  return rc != 0;
+done:
+  strbuf_free(&path);
+  return rc;
 }
 
 static int
 fs_mkdirs(struct store* self, const char* key)
 {
   struct store_fs* fs = container_of(self, struct store_fs, base);
-  char path[4096];
-  int n = snprintf(path, sizeof(path), "%s/%s", fs->root, key);
-  (void)n;
-  return platform_mkdirp(path);
+  struct strbuf path = { 0 };
+  int rc = 1;
+  if (fs_join(fs, key, &path))
+    goto done;
+  rc = platform_mkdirp(strbuf_cstr(&path));
+done:
+  strbuf_free(&path);
+  return rc;
 }
 
 static struct shard_pool*
 fs_create_pool(struct store* self, uint64_t nslots)
 {
   struct store_fs* fs = container_of(self, struct store_fs, base);
-  return shard_pool_fs_create(fs->root, nslots, fs->unbuffered);
+  return shard_pool_fs_create(strbuf_cstr(&fs->root), nslots, fs->unbuffered);
 }
 
 static int
 fs_has_existing_data(struct store* self)
 {
   struct store_fs* fs = container_of(self, struct store_fs, base);
-  char path[4096];
-  snprintf(path, sizeof(path), "%s/zarr.json", fs->root);
-  return platform_path_exists(path);
+  struct strbuf path = { 0 };
+  int exists = 0;
+  if (strbuf_appendf(&path, "%s/zarr.json", strbuf_cstr(&fs->root)) == 0)
+    exists = platform_path_exists(strbuf_cstr(&path));
+  strbuf_free(&path);
+  return exists;
 }
 
 static void
 fs_destroy(struct store* self)
 {
-  free(container_of(self, struct store_fs, base));
+  struct store_fs* fs = container_of(self, struct store_fs, base);
+  strbuf_free(&fs->root);
+  free(fs);
 }
 
 struct store*
@@ -76,10 +95,13 @@ store_fs_create(const char* root, int unbuffered)
   fs->base.has_existing_data = fs_has_existing_data;
   fs->base.destroy = fs_destroy;
   fs->unbuffered = unbuffered;
-  snprintf(fs->root, sizeof(fs->root), "%s", root);
+  CHECK(Fail_fs, strbuf_set(&fs->root, root) == 0);
 
   return &fs->base;
 
+Fail_fs:
+  strbuf_free(&fs->root);
+  free(fs);
 Fail:
   return NULL;
 }

--- a/src/zarr/store_fs.c
+++ b/src/zarr/store_fs.c
@@ -66,9 +66,14 @@ fs_has_existing_data(struct store* self)
 {
   struct store_fs* fs = container_of(self, struct store_fs, base);
   struct strbuf path = { 0 };
-  int exists = 0;
-  if (strbuf_appendf(&path, "%s/zarr.json", strbuf_cstr(&fs->root)) == 0)
+  int exists;
+  if (strbuf_appendf(&path, "%s/zarr.json", strbuf_cstr(&fs->root))) {
+    // Fail closed: assume data may exist rather than silently overwrite.
+    log_error("store_fs: failed to build path for existence check");
+    exists = 1;
+  } else {
     exists = platform_path_exists(strbuf_cstr(&path));
+  }
   strbuf_free(&path);
   return exists;
 }

--- a/src/zarr/store_s3.c
+++ b/src/zarr/store_s3.c
@@ -60,8 +60,14 @@ s3_has_existing_data(struct store* self)
   struct store_s3* s = container_of(self, struct store_s3, base);
   struct strbuf full = { 0 };
   int rc = 0;
-  if (s3_full_key(s, "zarr.json", &full) == 0)
+  if (s3_full_key(s, "zarr.json", &full)) {
+    // Fail closed: assume data may exist so the caller doesn't silently
+    // overwrite a live dataset on transient OOM.
+    log_error("store_s3: failed to build key for existence check");
+    rc = 1;
+  } else {
     rc = s3_client_head(s->client, strbuf_cstr(&s->bucket), strbuf_cstr(&full));
+  }
   strbuf_free(&full);
   return rc;
 }

--- a/src/zarr/store_s3.c
+++ b/src/zarr/store_s3.c
@@ -1,38 +1,41 @@
 #include "zarr/store_s3.h"
 #include "defs.limits.h"
 #include "util/prelude.h"
+#include "util/strbuf.h"
 #include "zarr/s3_client.h"
 #include "zarr/shard_pool_s3.h"
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 struct store_s3
 {
   struct store base;
   struct s3_client* client;
-  char bucket[256];
-  char prefix[4096]; // "" if no prefix
+  struct strbuf bucket; // owned
+  struct strbuf prefix; // owned; empty if no prefix
 };
 
-// Build a full S3 key: "prefix/key" or just "key" if no prefix.
-static void
-s3_full_key(const struct store_s3* s, const char* key, char* out, size_t cap)
+// Build a full S3 key ("prefix/key" or just "key") into out. Caller frees.
+// Returns 0 on success.
+static int
+s3_full_key(const struct store_s3* s, const char* key, struct strbuf* out)
 {
-  if (s->prefix[0])
-    snprintf(out, cap, "%s/%s", s->prefix, key);
-  else
-    snprintf(out, cap, "%s", key);
+  if (strbuf_len(&s->prefix) > 0)
+    return strbuf_appendf(out, "%s/%s", strbuf_cstr(&s->prefix), key);
+  return strbuf_append_cstr(out, key);
 }
 
 static int
 s3_put(struct store* self, const char* key, const void* data, size_t len)
 {
   struct store_s3* s = container_of(self, struct store_s3, base);
-  char full[4096];
-  s3_full_key(s, key, full, sizeof(full));
-  return s3_client_put(s->client, s->bucket, full, data, len);
+  struct strbuf full = { 0 };
+  int rc = 1;
+  if (s3_full_key(s, key, &full) == 0)
+    rc = s3_client_put(
+      s->client, strbuf_cstr(&s->bucket), strbuf_cstr(&full), data, len);
+  strbuf_free(&full);
+  return rc;
 }
 
 static int
@@ -47,16 +50,20 @@ static struct shard_pool*
 s3_create_pool(struct store* self, uint64_t nslots)
 {
   struct store_s3* s = container_of(self, struct store_s3, base);
-  return shard_pool_s3_create(s->client, s->bucket, s->prefix, nslots);
+  return shard_pool_s3_create(
+    s->client, strbuf_cstr(&s->bucket), strbuf_cstr(&s->prefix), nslots);
 }
 
 static int
 s3_has_existing_data(struct store* self)
 {
   struct store_s3* s = container_of(self, struct store_s3, base);
-  char full[4096];
-  s3_full_key(s, "zarr.json", full, sizeof(full));
-  return s3_client_head(s->client, s->bucket, full);
+  struct strbuf full = { 0 };
+  int rc = 0;
+  if (s3_full_key(s, "zarr.json", &full) == 0)
+    rc = s3_client_head(s->client, strbuf_cstr(&s->bucket), strbuf_cstr(&full));
+  strbuf_free(&full);
+  return rc;
 }
 
 static void
@@ -64,6 +71,8 @@ s3_destroy(struct store* self)
 {
   struct store_s3* s = container_of(self, struct store_s3, base);
   s3_client_destroy(s->client);
+  strbuf_free(&s->bucket);
+  strbuf_free(&s->prefix);
   free(s);
 }
 
@@ -96,12 +105,16 @@ store_s3_create(const struct store_s3_config* cfg)
   s->base.create_pool = s3_create_pool;
   s->base.has_existing_data = s3_has_existing_data;
   s->base.destroy = s3_destroy;
-  snprintf(s->bucket, sizeof(s->bucket), "%s", cfg->bucket);
-  if (cfg->prefix)
-    snprintf(s->prefix, sizeof(s->prefix), "%s", cfg->prefix);
+  CHECK(Fail_client, strbuf_set(&s->bucket, cfg->bucket) == 0);
+  if (cfg->prefix && cfg->prefix[0])
+    CHECK(Fail_client, strbuf_set(&s->prefix, cfg->prefix) == 0);
 
   return &s->base;
 
+Fail_client:
+  s3_client_destroy(s->client);
+  strbuf_free(&s->bucket);
+  strbuf_free(&s->prefix);
 Fail_alloc:
   free(s);
 Fail:

--- a/src/zarr/zarr_array.c
+++ b/src/zarr/zarr_array.c
@@ -1,13 +1,13 @@
 #include "zarr/zarr_array.h"
 #include "defs.limits.h"
+#include "dimension.h"
 #include "lod/lod_plan.h"
 #include "util/prelude.h"
+#include "util/strbuf.h"
 #include "zarr/attr_set.h"
 #include "zarr/zarr_metadata.h"
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 struct zarr_array
 {
@@ -15,7 +15,7 @@ struct zarr_array
   struct store* store;     // borrowed
   struct shard_pool* pool; // borrowed or owned (see owns_pool)
   int owns_pool;
-  char prefix[4096];
+  struct strbuf prefix; // owned
 
   uint8_t rank;
   uint64_t shard_counts[MAX_ZARR_RANK];
@@ -38,46 +38,36 @@ struct zarr_array
 static int
 write_array_metadata(struct zarr_array* a)
 {
-  char key[4096];
-  int n;
-  if (a->prefix[0])
-    n = snprintf(key, sizeof(key), "%s/zarr.json", a->prefix);
-  else
-    n = snprintf(key, sizeof(key), "zarr.json");
-  (void)n;
+  struct strbuf key = { 0 };
+  struct strbuf json = { 0 };
+  int rc = 1;
 
-  // Size the buffer generously to fit custom attributes of arbitrary size.
-  size_t attr_bytes = 0;
-  for (size_t i = 0; i < a->attrs.count; ++i) {
-    attr_bytes += strlen(a->attrs.items[i].key);
-    attr_bytes += strlen(a->attrs.items[i].json_value);
-    attr_bytes += 16; // quotes, colon, comma, slack
+  if (strbuf_len(&a->prefix) > 0) {
+    if (strbuf_appendf(&key, "%s/zarr.json", strbuf_cstr(&a->prefix)))
+      goto done;
+  } else {
+    if (strbuf_append_cstr(&key, "zarr.json"))
+      goto done;
   }
-  size_t cap = 4096 + attr_bytes;
-  // calloc zeroes tail bytes so a NUL-scan can clamp the write length if
-  // the JSON writer's pos ever overcounts (guards against platform-specific
-  // vsnprintf quirks — see #96).
-  char* buf = (char*)calloc(1, cap);
-  if (!buf)
-    return 1;
-  int len = zarr_array_json(buf,
-                            cap,
-                            a->rank,
-                            a->dimensions,
-                            a->data_type,
-                            a->fill_value,
-                            a->chunks_per_shard,
-                            a->codec,
-                            &a->attrs);
-  if (len < 0) {
-    free(buf);
-    return 1;
-  }
-  size_t write_len = strnlen(buf, (size_t)len);
-  int rc = a->store->put(a->store, key, buf, write_len);
-  free(buf);
+
+  if (zarr_array_json(&json,
+                      a->rank,
+                      a->dimensions,
+                      a->data_type,
+                      a->fill_value,
+                      a->chunks_per_shard,
+                      a->codec,
+                      &a->attrs))
+    goto done;
+
+  rc = a->store->put(
+    a->store, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
   if (rc == 0)
     a->attrs.dirty = 0;
+
+done:
+  strbuf_free(&key);
+  strbuf_free(&json);
   return rc;
 }
 
@@ -99,15 +89,17 @@ zarr_array_open(struct shard_sink* self, uint8_t level, uint64_t shard_index)
     return NULL;
   }
 
-  char key[4096];
-  int n;
-  if (a->prefix[0])
-    n = snprintf(key, sizeof(key), "%s/%s", a->prefix, suffix);
+  struct strbuf key = { 0 };
+  int ok;
+  if (strbuf_len(&a->prefix) > 0)
+    ok = strbuf_appendf(&key, "%s/%s", strbuf_cstr(&a->prefix), suffix) == 0;
   else
-    n = snprintf(key, sizeof(key), "%s", suffix);
-  (void)n;
+    ok = strbuf_append_cstr(&key, suffix) == 0;
 
-  return a->pool->open(a->pool, slot, key);
+  struct shard_writer* w =
+    ok ? a->pool->open(a->pool, slot, strbuf_cstr(&key)) : NULL;
+  strbuf_free(&key);
+  return w;
 }
 
 static int
@@ -135,7 +127,8 @@ zarr_array_update_append(struct shard_sink* self,
     a->dimensions[d].size = append_sizes[d];
 
   if (write_array_metadata(a)) {
-    log_error("zarr_array: failed to rewrite zarr.json for %s", a->prefix);
+    log_error("zarr_array: failed to rewrite zarr.json for %s",
+              strbuf_cstr(&a->prefix));
     return 1;
   }
   return 0;
@@ -206,11 +199,11 @@ zarr_array_init(struct store* store,
   a->codec = cfg->codec;
   attr_set_init(&a->attrs);
 
-  if (prefix)
-    snprintf(a->prefix, sizeof(a->prefix), "%s", prefix);
+  if (prefix && prefix[0])
+    CHECK(Fail_alloc, strbuf_set(&a->prefix, prefix) == 0);
 
+  CHECK(Fail_alloc, dims_copy(a->dimensions, cfg->dimensions, cfg->rank) == 0);
   for (int d = 0; d < cfg->rank; ++d) {
-    a->dimensions[d] = cfg->dimensions[d];
     a->shard_counts[d] = shard_counts[d];
     a->chunks_per_shard[d] = chunks_per_shard[d];
   }
@@ -229,6 +222,8 @@ zarr_array_init(struct store* store,
   return a;
 
 Fail_alloc:
+  dims_free_names(a->dimensions, cfg->rank);
+  strbuf_free(&a->prefix);
   free(a);
 Fail:
   return NULL;
@@ -302,6 +297,8 @@ zarr_array_destroy(struct zarr_array* a)
   if (a->attrs.dirty)
     write_array_metadata(a);
   attr_set_destroy(&a->attrs);
+  dims_free_names(a->dimensions, a->rank);
+  strbuf_free(&a->prefix);
   struct shard_pool* pool = a->owns_pool ? a->pool : NULL;
   free(a);
   if (pool)

--- a/src/zarr/zarr_group.c
+++ b/src/zarr/zarr_group.c
@@ -1,19 +1,12 @@
 #include "zarr/zarr_group.h"
-#include "defs.limits.h"
 #include "util/prelude.h"
+#include "util/strbuf.h"
 #include "zarr.h"
 #include "zarr/attr_set.h"
 #include "zarr/json_writer.h"
 #include "zarr/zarr_metadata.h"
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-
-static const char group_prefix[] =
-  "{\"zarr_format\":3,\"node_type\":\"group\","
-  "\"consolidated_metadata\":null,\"attributes\":";
-static const char group_suffix[] = "}";
 
 int
 zarr_group_write_with_raw_attrs(struct store* store,
@@ -24,20 +17,14 @@ zarr_group_write_with_raw_attrs(struct store* store,
   CHECK(Fail, key);
   CHECK(Fail, attributes_json);
 
-  size_t attr_len = strlen(attributes_json);
-  size_t total = sizeof(group_prefix) - 1 + attr_len + sizeof(group_suffix);
-  char* buf = (char*)malloc(total);
-  CHECK(Fail, buf);
-
-  memcpy(buf, group_prefix, sizeof(group_prefix) - 1);
-  memcpy(buf + sizeof(group_prefix) - 1, attributes_json, attr_len);
-  memcpy(buf + sizeof(group_prefix) - 1 + attr_len,
-         group_suffix,
-         sizeof(group_suffix));
-  size_t len = total - 1; // exclude null terminator from group_suffix
-
-  int rc = store->put(store, key, buf, len);
-  free(buf);
+  struct strbuf buf = { 0 };
+  int rc = strbuf_appendf(&buf,
+                          "{\"zarr_format\":3,\"node_type\":\"group\","
+                          "\"consolidated_metadata\":null,\"attributes\":%s}",
+                          attributes_json);
+  if (rc == 0)
+    rc = store->put(store, key, strbuf_cstr(&buf), strbuf_len(&buf));
+  strbuf_free(&buf);
   return rc;
 
 Fail:
@@ -49,29 +36,18 @@ Fail:
 struct zarr_group
 {
   struct store* store; // borrowed
-  char key[4096];
+  struct strbuf key;   // owned
   struct attr_set attrs;
 };
 
 static int
 zarr_group_write(struct zarr_group* g)
 {
-  // Group skeleton is ~100 bytes; size for actual attrs to avoid truncation.
-  size_t attr_bytes = 0;
-  for (size_t i = 0; i < g->attrs.count; ++i) {
-    attr_bytes += strlen(g->attrs.items[i].key);
-    attr_bytes += strlen(g->attrs.items[i].json_value);
-    attr_bytes += 16;
-  }
-  size_t cap = 256 + attr_bytes;
-  // See note in zarr_array.c:write_array_metadata — calloc + strnlen clamp
-  // guards the file against any overcount from jw_length (#96).
-  char* buf = (char*)calloc(1, cap);
-  if (!buf)
-    return 1;
+  struct strbuf json = { 0 };
+  int rc = 1;
 
   struct json_writer jw;
-  jw_init(&jw, buf, cap);
+  jw_init(&jw, &json);
 
   jw_object_begin(&jw);
   jw_key(&jw, "zarr_format");
@@ -86,15 +62,16 @@ zarr_group_write(struct zarr_group* g)
   jw_object_end(&jw);
   jw_object_end(&jw);
 
-  if (jw_error(&jw)) {
-    free(buf);
-    return 1;
-  }
-  size_t write_len = strnlen(buf, jw_length(&jw));
-  int rc = g->store->put(g->store, g->key, buf, write_len);
-  free(buf);
+  if (jw_error(&jw))
+    goto done;
+
+  rc = g->store->put(
+    g->store, strbuf_cstr(&g->key), strbuf_cstr(&json), strbuf_len(&json));
   if (rc == 0)
     g->attrs.dirty = 0;
+
+done:
+  strbuf_free(&json);
   return rc;
 }
 
@@ -108,13 +85,11 @@ zarr_group_create(struct store* store, const char* key)
   CHECK(Fail, g);
   g->store = store;
   attr_set_init(&g->attrs);
-  if (key[0])
-    snprintf(g->key, sizeof(g->key), "%s/zarr.json", key);
-  else
-    snprintf(g->key, sizeof(g->key), "zarr.json");
-
-  if (zarr_group_write(g) != 0) {
+  int rc = (key[0]) ? strbuf_appendf(&g->key, "%s/zarr.json", key)
+                    : strbuf_append_cstr(&g->key, "zarr.json");
+  if (rc || zarr_group_write(g) != 0) {
     attr_set_destroy(&g->attrs);
+    strbuf_free(&g->key);
     free(g);
     return NULL;
   }
@@ -132,6 +107,7 @@ zarr_group_destroy(struct zarr_group* g)
   if (g->attrs.dirty)
     zarr_group_write(g);
   attr_set_destroy(&g->attrs);
+  strbuf_free(&g->key);
   free(g);
 }
 

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -6,6 +6,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 static const char*
@@ -254,26 +255,24 @@ zarr_for_each_intermediate(const char* array_name,
   if (strstr(array_name, "//"))
     return -1;
 
-  struct strbuf name = { 0 };
-  int rc = 0;
-  if (strbuf_append(&name, array_name, len)) {
-    rc = -1;
-    goto done;
-  }
+  // Mutable scratch copy so we can temporarily NUL-terminate at each slash.
+  char* name = (char*)malloc(len + 1);
+  if (!name)
+    return -1;
+  memcpy(name, array_name, len + 1);
 
-  char* buf = name.beg;
+  int rc = 0;
   for (size_t i = 0; i < len; ++i) {
-    if (buf[i] == '/') {
-      buf[i] = '\0';
-      rc = fn(buf, ctx);
-      buf[i] = '/';
+    if (name[i] == '/') {
+      name[i] = '\0';
+      rc = fn(name, ctx);
+      name[i] = '/';
       if (rc != 0)
-        goto done;
+        break;
     }
   }
 
-done:
-  strbuf_free(&name);
+  free(name);
   return rc;
 }
 

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -33,10 +33,10 @@ dtype_zarr_string(enum dtype dt)
 }
 
 int
-zarr_root_json(char* buf, size_t cap)
+zarr_root_json(struct strbuf* sb)
 {
   struct json_writer jw;
-  jw_init(&jw, buf, cap);
+  jw_init(&jw, sb);
 
   jw_object_begin(&jw);
   jw_key(&jw, "zarr_format");
@@ -50,14 +50,11 @@ zarr_root_json(char* buf, size_t cap)
   jw_object_end(&jw);
   jw_object_end(&jw);
 
-  if (jw_error(&jw))
-    return -1;
-  return (int)jw_length(&jw);
+  return jw_error(&jw) ? 1 : 0;
 }
 
 int
-zarr_array_json(char* buf,
-                size_t cap,
+zarr_array_json(struct strbuf* sb,
                 uint8_t rank,
                 const struct dimension* dimensions,
                 enum dtype data_type,
@@ -67,7 +64,7 @@ zarr_array_json(char* buf,
                 const struct attr_set* extras)
 {
   struct json_writer jw;
-  jw_init(&jw, buf, cap);
+  jw_init(&jw, sb);
 
   jw_object_begin(&jw);
 
@@ -236,9 +233,7 @@ zarr_array_json(char* buf,
 
   jw_object_end(&jw);
 
-  if (jw_error(&jw))
-    return -1;
-  return (int)jw_length(&jw);
+  return jw_error(&jw) ? 1 : 0;
 }
 
 int

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -245,7 +245,7 @@ zarr_for_each_intermediate(const char* array_name,
     return 0;
 
   size_t len = strlen(array_name);
-  if (len == 0 || len >= 4096)
+  if (len == 0)
     return -1;
 
   // Reject leading slash, trailing slash, or empty segments (//)
@@ -254,19 +254,27 @@ zarr_for_each_intermediate(const char* array_name,
   if (strstr(array_name, "//"))
     return -1;
 
-  char name[4096];
-  memcpy(name, array_name, len + 1);
+  struct strbuf name = { 0 };
+  int rc = 0;
+  if (strbuf_append(&name, array_name, len)) {
+    rc = -1;
+    goto done;
+  }
 
+  char* buf = name.beg;
   for (size_t i = 0; i < len; ++i) {
-    if (name[i] == '/') {
-      name[i] = '\0';
-      int rc = fn(name, ctx);
-      name[i] = '/';
+    if (buf[i] == '/') {
+      buf[i] = '\0';
+      rc = fn(buf, ctx);
+      buf[i] = '/';
       if (rc != 0)
-        return rc;
+        goto done;
     }
   }
-  return 0;
+
+done:
+  strbuf_free(&name);
+  return rc;
 }
 
 int

--- a/src/zarr/zarr_metadata.h
+++ b/src/zarr/zarr_metadata.h
@@ -3,24 +3,23 @@
 #include "dimension.h"
 #include "dtype.h"
 #include "types.codec.h"
+#include "util/strbuf.h"
 
 #include <stddef.h>
 #include <stdint.h>
 
 struct attr_set;
 
-// Generate zarr v3 root group JSON into buf.
-// Returns length on success, -1 on error.
+// Append zarr v3 root group JSON to sb. Returns 0 on success.
 int
-zarr_root_json(char* buf, size_t cap);
+zarr_root_json(struct strbuf* sb);
 
-// Generate zarr v3 array JSON into buf.
+// Append zarr v3 array JSON to sb.
 // extras: optional pre-validated custom attributes to splice into the
 // "attributes" object. NULL means emit an empty object.
-// Returns length on success, -1 on error.
+// Returns 0 on success.
 int
-zarr_array_json(char* buf,
-                size_t cap,
+zarr_array_json(struct strbuf* sb,
                 uint8_t rank,
                 const struct dimension* dimensions,
                 enum dtype data_type,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,7 +133,7 @@ add_gpu_test_exe(test_stream          test_stream.c          LINKS CUDA::cuda_dr
 add_gpu_test_exe(test_compress        test_compress.c        LINKS CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd)
 add_gpu_test_exe(test_aggregate       test_aggregate.c       LINKS CUDA::cuda_driver CUDA::cudart_static aggregate index_ops_util)
 
-add_test_exe(test_json_writer test_json_writer.c zarr_metadata ngff_metadata chucky_log)
+add_test_exe(test_json_writer test_json_writer.c zarr_metadata ngff_metadata strbuf chucky_log)
 add_test_exe(test_io_queue    test_io_queue.c    io_queue chucky_log)
 add_test_exe(test_store_fs    test_store_fs.c    store_fs store_api zarr_group test_platform chucky_log)
 add_test_exe(test_zarr_attribute test_zarr_attribute.c zarr_array zarr_group store_fs store_api test_platform chucky_log)
@@ -162,6 +162,7 @@ add_gpu_test_exe(test_flush_orch  test_flush_orchestration.c LINKS CUDA::cuda_dr
 add_test_exe(test_dimension   test_dimension.c   stream_config dimension chucky_log)
 add_test_exe(test_lz4_warning test_lz4_warning.c stream_config dimension platform chucky_log)
 add_test_exe(test_chucky_log  test_chucky_log.c  chucky_log)
+add_test_exe(test_strbuf      test_strbuf.c      strbuf chucky_log)
 add_gpu_test_exe(test_lod         test_lod.c         LINKS CUDA::cuda_driver CUDA::cudart_static lod lod_plan index_ops morton_util)
 add_gpu_test_exe(test_lod_dtypes  test_lod_dtypes.cu LINKS CUDA::cuda_driver CUDA::cudart_static lod lod_plan)
 add_gpu_test_exe(test_multiscale  test_multiscale.c  LINKS CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd test_data test_shard_sink)

--- a/tests/test_hcs.c
+++ b/tests/test_hcs.c
@@ -39,30 +39,31 @@ test_plate_metadata(void)
 {
   log_info("=== test_plate_metadata ===");
 
-  char buf[8192];
-  int len =
-    hcs_plate_attributes_json(
-      buf, sizeof(buf), "myplate", 2, 3, NULL, 2, NULL, NULL);
-  CHECK(Fail, len > 0);
-  buf[len] = '\0';
+  struct strbuf sb = { 0 };
+  CHECK(Fail,
+        hcs_plate_attributes_json(&sb, "myplate", 2, 3, NULL, 2, NULL, NULL) ==
+          0);
 
-  CHECK(Fail, strstr(buf, "\"name\":\"myplate\""));
-  CHECK(Fail, strstr(buf, "\"field_count\":2"));
-  CHECK(Fail, strstr(buf, "\"version\":\"0.5\""));
+  const char* s = strbuf_cstr(&sb);
+  CHECK(Fail, strstr(s, "\"name\":\"myplate\""));
+  CHECK(Fail, strstr(s, "\"field_count\":2"));
+  CHECK(Fail, strstr(s, "\"version\":\"0.5\""));
   // Check rows A, B
-  CHECK(Fail, strstr(buf, "{\"name\":\"A\"}"));
-  CHECK(Fail, strstr(buf, "{\"name\":\"B\"}"));
+  CHECK(Fail, strstr(s, "{\"name\":\"A\"}"));
+  CHECK(Fail, strstr(s, "{\"name\":\"B\"}"));
   // Check columns 1, 2, 3
-  CHECK(Fail, strstr(buf, "{\"name\":\"1\"}"));
-  CHECK(Fail, strstr(buf, "{\"name\":\"3\"}"));
+  CHECK(Fail, strstr(s, "{\"name\":\"1\"}"));
+  CHECK(Fail, strstr(s, "{\"name\":\"3\"}"));
   // Check a well path
-  CHECK(Fail, strstr(buf, "\"path\":\"A/1\""));
-  CHECK(Fail, strstr(buf, "\"path\":\"B/3\""));
+  CHECK(Fail, strstr(s, "\"path\":\"A/1\""));
+  CHECK(Fail, strstr(s, "\"path\":\"B/3\""));
 
+  strbuf_free(&sb);
   log_info("  PASS");
   return 0;
 Fail:
-  log_error("  FAIL: %.*s", len > 0 ? len : 0, buf);
+  log_error("  FAIL: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
@@ -73,20 +74,21 @@ test_well_metadata(void)
 {
   log_info("=== test_well_metadata ===");
 
-  char buf[4096];
-  int len = hcs_well_attributes_json(buf, sizeof(buf), 3, NULL);
-  CHECK(Fail, len > 0);
-  buf[len] = '\0';
+  struct strbuf sb = { 0 };
+  CHECK(Fail, hcs_well_attributes_json(&sb, 3, NULL) == 0);
 
-  CHECK(Fail, strstr(buf, "\"well\""));
-  CHECK(Fail, strstr(buf, "\"images\""));
-  CHECK(Fail, strstr(buf, "{\"path\":\"0\",\"acquisition\":0}"));
-  CHECK(Fail, strstr(buf, "{\"path\":\"2\",\"acquisition\":0}"));
+  const char* s = strbuf_cstr(&sb);
+  CHECK(Fail, strstr(s, "\"well\""));
+  CHECK(Fail, strstr(s, "\"images\""));
+  CHECK(Fail, strstr(s, "{\"path\":\"0\",\"acquisition\":0}"));
+  CHECK(Fail, strstr(s, "{\"path\":\"2\",\"acquisition\":0}"));
 
+  strbuf_free(&sb);
   log_info("  PASS");
   return 0;
 Fail:
-  log_error("  FAIL: %.*s", len > 0 ? len : 0, buf);
+  log_error("  FAIL: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
@@ -284,22 +286,23 @@ test_plate_metadata_with_mask(void)
   log_info("=== test_plate_metadata_with_mask ===");
 
   int mask[] = { 1, 0, 0, 1 };
-  char buf[8192];
-  int len =
-    hcs_plate_attributes_json(buf, sizeof(buf), "p", 2, 2, NULL, 1, mask, NULL);
-  CHECK(Fail, len > 0);
-  buf[len] = '\0';
+  struct strbuf sb = { 0 };
+  CHECK(Fail,
+        hcs_plate_attributes_json(&sb, "p", 2, 2, NULL, 1, mask, NULL) == 0);
 
+  const char* s = strbuf_cstr(&sb);
   // Only wells A/1 and B/2 should be present
-  CHECK(Fail, strstr(buf, "\"path\":\"A/1\""));
-  CHECK(Fail, strstr(buf, "\"path\":\"B/2\""));
+  CHECK(Fail, strstr(s, "\"path\":\"A/1\""));
+  CHECK(Fail, strstr(s, "\"path\":\"B/2\""));
   // Inactive wells should NOT be present
-  CHECK(Fail, !strstr(buf, "\"path\":\"A/2\""));
-  CHECK(Fail, !strstr(buf, "\"path\":\"B/1\""));
+  CHECK(Fail, !strstr(s, "\"path\":\"A/2\""));
+  CHECK(Fail, !strstr(s, "\"path\":\"B/1\""));
 
+  strbuf_free(&sb);
   log_info("  PASS");
   return 0;
 Fail:
+  strbuf_free(&sb);
   log_error("  FAIL");
   return 1;
 }

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -2,6 +2,7 @@
 #include "ngff.h"
 #include "ngff/ngff_metadata.h"
 #include "util/prelude.h"
+#include "util/strbuf.h"
 #include "zarr/json_writer.h"
 #include "zarr/zarr_metadata.h"
 
@@ -11,9 +12,9 @@
 static int
 test_simple_object(void)
 {
-  char buf[256];
+  struct strbuf sb = { 0 };
   struct json_writer jw;
-  jw_init(&jw, buf, sizeof(buf));
+  jw_init(&jw, &sb);
 
   jw_object_begin(&jw);
   jw_key(&jw, "name");
@@ -29,21 +30,23 @@ test_simple_object(void)
   const char* expected =
     "{\"name\":\"hello\",\"count\":42,\"enabled\":true,\"nothing\":null}";
   CHECK(Fail, !jw_error(&jw));
-  CHECK(Fail, jw_length(&jw) == strlen(expected));
-  CHECK(Fail, memcmp(buf, expected, jw_length(&jw)) == 0);
+  CHECK(Fail, strbuf_len(&sb) == strlen(expected));
+  CHECK(Fail, memcmp(strbuf_cstr(&sb), expected, strbuf_len(&sb)) == 0);
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", (int)jw_length(&jw), buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
 static int
 test_nested(void)
 {
-  char buf[256];
+  struct strbuf sb = { 0 };
   struct json_writer jw;
-  jw_init(&jw, buf, sizeof(buf));
+  jw_init(&jw, &sb);
 
   jw_object_begin(&jw);
   jw_key(&jw, "a");
@@ -61,56 +64,72 @@ test_nested(void)
 
   const char* expected = "{\"a\":[1,2,3],\"b\":{\"x\":3.14}}";
   CHECK(Fail, !jw_error(&jw));
-  CHECK(Fail, jw_length(&jw) == strlen(expected));
-  CHECK(Fail, memcmp(buf, expected, jw_length(&jw)) == 0);
+  CHECK(Fail, strbuf_len(&sb) == strlen(expected));
+  CHECK(Fail, memcmp(strbuf_cstr(&sb), expected, strbuf_len(&sb)) == 0);
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", (int)jw_length(&jw), buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
 static int
 test_string_escaping(void)
 {
-  char buf[256];
+  struct strbuf sb = { 0 };
   struct json_writer jw;
-  jw_init(&jw, buf, sizeof(buf));
+  jw_init(&jw, &sb);
 
   jw_string(&jw, "hello \"world\"\nnew\tline\\back\x01");
 
   const char* expected = "\"hello \\\"world\\\"\\nnew\\tline\\\\back\\u0001\"";
   CHECK(Fail, !jw_error(&jw));
-  CHECK(Fail, jw_length(&jw) == strlen(expected));
-  CHECK(Fail, memcmp(buf, expected, jw_length(&jw)) == 0);
+  CHECK(Fail, strbuf_len(&sb) == strlen(expected));
+  CHECK(Fail, memcmp(strbuf_cstr(&sb), expected, strbuf_len(&sb)) == 0);
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", (int)jw_length(&jw), buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
 static int
-test_overflow(void)
+test_grows_past_inline(void)
 {
-  char buf[8];
+  // Many writes into a fresh strbuf should succeed (no fixed cap).
+  struct strbuf sb = { 0 };
   struct json_writer jw;
-  jw_init(&jw, buf, sizeof(buf));
+  jw_init(&jw, &sb);
 
-  jw_string(&jw, "this is way too long for the buffer");
-  CHECK(Fail, jw_error(&jw));
+  jw_array_begin(&jw);
+  for (int i = 0; i < 1000; ++i)
+    jw_int(&jw, i);
+  jw_array_end(&jw);
+
+  CHECK(Fail, !jw_error(&jw));
+  // 1000 integers comma-separated, plus brackets. Easily past
+  // STRBUF_INLINE_CAP.
+  CHECK(Fail, strbuf_len(&sb) > 2000);
+  CHECK(Fail, strbuf_cstr(&sb)[0] == '[');
+  CHECK(Fail, strbuf_cstr(&sb)[strbuf_len(&sb) - 1] == ']');
+  strbuf_free(&sb);
   return 0;
 
 Fail:
+  strbuf_free(&sb);
   return 1;
 }
 
 static int
 test_array_commas(void)
 {
-  char buf[128];
+  struct strbuf sb = { 0 };
   struct json_writer jw;
-  jw_init(&jw, buf, sizeof(buf));
+  jw_init(&jw, &sb);
 
   jw_array_begin(&jw);
   jw_string(&jw, "a");
@@ -120,41 +139,45 @@ test_array_commas(void)
 
   const char* expected = "[\"a\",\"b\",\"c\"]";
   CHECK(Fail, !jw_error(&jw));
-  CHECK(Fail, jw_length(&jw) == strlen(expected));
-  CHECK(Fail, memcmp(buf, expected, jw_length(&jw)) == 0);
+  CHECK(Fail, strbuf_len(&sb) == strlen(expected));
+  CHECK(Fail, memcmp(strbuf_cstr(&sb), expected, strbuf_len(&sb)) == 0);
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", (int)jw_length(&jw), buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
 static int
 test_uint(void)
 {
-  char buf[64];
+  struct strbuf sb = { 0 };
   struct json_writer jw;
-  jw_init(&jw, buf, sizeof(buf));
+  jw_init(&jw, &sb);
 
   jw_uint(&jw, 18446744073709551615ULL);
 
   const char* expected = "18446744073709551615";
   CHECK(Fail, !jw_error(&jw));
-  CHECK(Fail, jw_length(&jw) == strlen(expected));
-  CHECK(Fail, memcmp(buf, expected, jw_length(&jw)) == 0);
+  CHECK(Fail, strbuf_len(&sb) == strlen(expected));
+  CHECK(Fail, memcmp(strbuf_cstr(&sb), expected, strbuf_len(&sb)) == 0);
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", (int)jw_length(&jw), buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
 static int
 test_zarr_metadata(void)
 {
-  char buf[2048];
+  struct strbuf sb = { 0 };
   struct json_writer jw;
-  jw_init(&jw, buf, sizeof(buf));
+  jw_init(&jw, &sb);
 
   jw_object_begin(&jw);
   jw_key(&jw, "zarr_format");
@@ -188,48 +211,49 @@ test_zarr_metadata(void)
   jw_object_end(&jw);
 
   CHECK(Fail, !jw_error(&jw));
-  CHECK(Fail, jw_length(&jw) > 0);
+  CHECK(Fail, strbuf_len(&sb) > 0);
 
-  // Verify it starts and ends correctly
-  CHECK(Fail, buf[0] == '{');
-  CHECK(Fail, buf[jw_length(&jw) - 1] == '}');
+  const char* s = strbuf_cstr(&sb);
+  CHECK(Fail, s[0] == '{');
+  CHECK(Fail, s[strbuf_len(&sb) - 1] == '}');
 
-  // Spot-check some substrings
-  buf[jw_length(&jw)] = '\0';
-  CHECK(Fail, strstr(buf, "\"zarr_format\":3"));
-  CHECK(Fail, strstr(buf, "\"node_type\":\"array\""));
-  CHECK(Fail, strstr(buf, "\"shape\":[100,200,300]"));
-  CHECK(Fail, strstr(buf, "\"chunk_shape\":[10,20,30]"));
+  CHECK(Fail, strstr(s, "\"zarr_format\":3"));
+  CHECK(Fail, strstr(s, "\"node_type\":\"array\""));
+  CHECK(Fail, strstr(s, "\"shape\":[100,200,300]"));
+  CHECK(Fail, strstr(s, "\"chunk_shape\":[10,20,30]"));
 
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", (int)jw_length(&jw), buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
 static int
 test_zarr_root_json(void)
 {
-  char buf[ZARR_GROUP_JSON_MAX_LENGTH];
-  int len = zarr_root_json(buf, sizeof(buf));
-  CHECK(Fail, len > 0);
+  struct strbuf sb = { 0 };
+  CHECK(Fail, zarr_root_json(&sb) == 0);
 
   const char* expected = "{\"zarr_format\":3,\"node_type\":\"group\","
                          "\"consolidated_metadata\":null,\"attributes\":{}}";
-  CHECK(Fail, (size_t)len == strlen(expected));
-  CHECK(Fail, memcmp(buf, expected, (size_t)len) == 0);
+  CHECK(Fail, strbuf_len(&sb) == strlen(expected));
+  CHECK(Fail, memcmp(strbuf_cstr(&sb), expected, strbuf_len(&sb)) == 0);
 
   // Check no duplicate "attributes" key
-  buf[len] = '\0';
-  char* first = strstr(buf, "\"attributes\"");
+  const char* s = strbuf_cstr(&sb);
+  const char* first = strstr(s, "\"attributes\"");
   CHECK(Fail, first);
   CHECK(Fail, !strstr(first + 1, "\"attributes\""));
 
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", len > 0 ? len : 0, buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
@@ -266,22 +290,22 @@ test_zarr_multiscale_group_json(void)
 
   const struct dimension* levels[2] = { l0_dims, l1_dims };
 
-  char buf[4096];
-  int len =
-    ngff_multiscale_group_json(buf, sizeof(buf), 3, 2, levels, NULL, NULL);
-  CHECK(Fail, len > 0);
-  buf[len] = '\0';
+  struct strbuf sb = { 0 };
+  CHECK(Fail, ngff_multiscale_group_json(&sb, 3, 2, levels, NULL, NULL) == 0);
 
-  CHECK(Fail, strstr(buf, "\"version\":\"0.5\""));
-  CHECK(Fail, strstr(buf, "\"axes\""));
-  CHECK(Fail, strstr(buf, "\"datasets\""));
-  CHECK(Fail, strstr(buf, "\"coordinateTransformations\""));
-  CHECK(Fail, strstr(buf, "\"attributes\":{\"ome\""));
+  const char* s = strbuf_cstr(&sb);
+  CHECK(Fail, strstr(s, "\"version\":\"0.5\""));
+  CHECK(Fail, strstr(s, "\"axes\""));
+  CHECK(Fail, strstr(s, "\"datasets\""));
+  CHECK(Fail, strstr(s, "\"coordinateTransformations\""));
+  CHECK(Fail, strstr(s, "\"attributes\":{\"ome\""));
 
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", len > 0 ? len : 0, buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
@@ -309,30 +333,29 @@ test_scale_clamped_dim(void)
 
   const struct dimension* levels[3] = { l0, l1, l2 };
 
-  char buf[8192];
-  int len =
-    ngff_multiscale_group_json(buf, sizeof(buf), 3, 3, levels, NULL, NULL);
-  CHECK(Fail, len > 0);
-  buf[len] = '\0';
+  struct strbuf sb = { 0 };
+  CHECK(Fail, ngff_multiscale_group_json(&sb, 3, 3, levels, NULL, NULL) == 0);
 
+  const char* s = strbuf_cstr(&sb);
   // L0: scale=[1.0, 1.0, 1.0]
-  CHECK(Fail, strstr(buf, "\"scale\":[1.0,1.0,1.0]"));
+  CHECK(Fail, strstr(s, "\"scale\":[1.0,1.0,1.0]"));
   // L1: t=1, y=2 (one downsample), x=2 (one downsample)
-  CHECK(Fail, strstr(buf, "\"scale\":[1.0,2.0,2.0]"));
+  CHECK(Fail, strstr(s, "\"scale\":[1.0,2.0,2.0]"));
   // L2: t=1, y=2 (still one -- y dropped after L0->L1), x=4 (two downsamples)
-  CHECK(Fail, strstr(buf, "\"scale\":[1.0,2.0,4.0]"));
+  CHECK(Fail, strstr(s, "\"scale\":[1.0,2.0,4.0]"));
 
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", len > 0 ? len : 0, buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
 static int
 test_zarr_array_json_lz4(void)
 {
-  char buf[4096];
   struct dimension dims[3] = {
     { .size = 0, .chunk_size = 1, .chunks_per_shard = 2, .name = "t" },
     { .size = 64, .chunk_size = 32, .chunks_per_shard = 1, .name = "y" },
@@ -341,26 +364,25 @@ test_zarr_array_json_lz4(void)
   uint64_t cps[3] = { 2, 1, 1 };
   struct codec_config codec = { .id = CODEC_LZ4_NON_STANDARD, .level = 1 };
 
-  int len =
-    zarr_array_json(
-      buf, sizeof(buf), 3, dims, dtype_u16, 0.0, cps, codec, NULL);
-  CHECK(Fail, len > 0 && (size_t)len < sizeof(buf));
-  buf[len] = '\0';
+  struct strbuf sb = { 0 };
+  CHECK(Fail,
+        zarr_array_json(&sb, 3, dims, dtype_u16, 0.0, cps, codec, NULL) == 0);
 
   // The codec name in zarr metadata must be "lz4" (not "lz4_raw")
-  CHECK(Fail, strstr(buf, "\"name\":\"lz4\""));
+  CHECK(Fail, strstr(strbuf_cstr(&sb), "\"name\":\"lz4\""));
 
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", (int)sizeof(buf), buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
 static int
 test_zarr_array_json_zstd(void)
 {
-  char buf[4096];
   struct dimension dims[3] = {
     { .size = 0, .chunk_size = 1, .chunks_per_shard = 2, .name = "t" },
     { .size = 64, .chunk_size = 32, .chunks_per_shard = 1, .name = "y" },
@@ -369,21 +391,21 @@ test_zarr_array_json_zstd(void)
   uint64_t cps[3] = { 2, 1, 1 };
   struct codec_config codec = { .id = CODEC_ZSTD, .level = 3 };
 
-  int len =
-    zarr_array_json(
-      buf, sizeof(buf), 3, dims, dtype_u16, 0.0, cps, codec, NULL);
-  CHECK(Fail, len > 0 && (size_t)len < sizeof(buf));
-  buf[len] = '\0';
+  struct strbuf sb = { 0 };
+  CHECK(Fail,
+        zarr_array_json(&sb, 3, dims, dtype_u16, 0.0, cps, codec, NULL) == 0);
 
   CHECK(Fail,
-        strstr(buf,
+        strstr(strbuf_cstr(&sb),
                "\"name\":\"zstd\",\"configuration\":"
                "{\"level\":3,\"checksum\":false}"));
 
+  strbuf_free(&sb);
   return 0;
 
 Fail:
-  log_error("  got: %.*s", (int)sizeof(buf), buf);
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
   return 1;
 }
 
@@ -399,7 +421,7 @@ main(void)
     { "simple_object", test_simple_object },
     { "nested", test_nested },
     { "string_escaping", test_string_escaping },
-    { "overflow", test_overflow },
+    { "grows_past_inline", test_grows_past_inline },
     { "array_commas", test_array_commas },
     { "uint", test_uint },
     { "zarr_metadata", test_zarr_metadata },

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -6,6 +6,7 @@
 #include "zarr/json_writer.h"
 #include "zarr/zarr_metadata.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -119,6 +120,33 @@ test_grows_past_inline(void)
   strbuf_free(&sb);
   return 0;
 
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
+// Verify that jw_error is 0 on a fresh writer and that downstream writes
+// succeed cleanly. Note: actually triggering jw_error in a unit test
+// requires either injecting a strbuf OOM or forcing vsnprintf to fail —
+// neither is portable without a mock allocator. The underlying overflow
+// guard is covered by test_strbuf's test_reserve_overflow_guard; this test
+// just confirms the happy-path error flag stays clean.
+static int
+test_jw_error_clean(void)
+{
+  log_info("=== test_jw_error_clean ===");
+  struct strbuf sb = { 0 };
+  struct json_writer jw;
+  jw_init(&jw, &sb);
+  CHECK(Fail, !jw_error(&jw));
+  jw_object_begin(&jw);
+  jw_key(&jw, "k");
+  jw_string(&jw, "v");
+  jw_object_end(&jw);
+  CHECK(Fail, !jw_error(&jw));
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "{\"k\":\"v\"}") == 0);
+  strbuf_free(&sb);
+  return 0;
 Fail:
   strbuf_free(&sb);
   return 1;
@@ -422,6 +450,7 @@ main(void)
     { "nested", test_nested },
     { "string_escaping", test_string_escaping },
     { "grows_past_inline", test_grows_past_inline },
+    { "jw_error_clean", test_jw_error_clean },
     { "array_commas", test_array_commas },
     { "uint", test_uint },
     { "zarr_metadata", test_zarr_metadata },

--- a/tests/test_lod.c
+++ b/tests/test_lod.c
@@ -1045,11 +1045,13 @@ main(void)
   nfail +=
     test_lod_gpu("gpu_lod_4d_d13", 4, (uint64_t[]){ 3, 8, 2, 6 }, 0xA, 1);
 
-  // Larger cases for throughput estimation
+  // Larger correctness cases. 1 iter: lod_compute_gpu allocates/frees all
+  // GPU buffers per call, so extra iters here dominate test time without
+  // improving coverage. Throughput benchmarking belongs in bench/.
   nfail +=
-    test_lod_gpu("gpu_lod_3d_256", 3, (uint64_t[]){ 256, 256, 256 }, 0x7, 10);
+    test_lod_gpu("gpu_lod_3d_256", 3, (uint64_t[]){ 256, 256, 256 }, 0x7, 1);
   nfail += test_lod_gpu(
-    "gpu_lod_3d_mixed_large", 3, (uint64_t[]){ 64, 256, 256 }, 0x6, 10);
+    "gpu_lod_3d_mixed_large", 3, (uint64_t[]){ 64, 256, 256 }, 0x6, 1);
 
   // u16 tests (exact integer match)
   nfail +=

--- a/tests/test_strbuf.c
+++ b/tests/test_strbuf.c
@@ -138,6 +138,84 @@ Fail:
   return 1;
 }
 
+// Set on a heap-backed buffer should reuse the existing allocation if it fits.
+static int
+test_set_reuses_heap_allocation(void)
+{
+  log_info("=== test_set_reuses_heap_allocation ===");
+  struct strbuf sb = { 0 };
+  char big[512];
+  memset(big, 'z', sizeof(big));
+  CHECK(Fail, strbuf_append(&sb, big, sizeof(big)) == 0);
+  char* heap_ptr = sb.beg;
+  CHECK(Fail, heap_ptr != sb.inline_buf);
+
+  CHECK(Fail, strbuf_set(&sb, "short") == 0);
+  // Same heap allocation must be reused (no free+malloc cycle).
+  CHECK(Fail, sb.beg == heap_ptr);
+  CHECK(Fail, strbuf_len(&sb) == 5);
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "short") == 0);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
+// Reset on a zero-init buffer should be a no-op (no crash).
+static int
+test_reset_on_zero_init(void)
+{
+  log_info("=== test_reset_on_zero_init ===");
+  struct strbuf sb = { 0 };
+  strbuf_reset(&sb);
+  CHECK(Fail, strbuf_len(&sb) == 0);
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "") == 0);
+  CHECK(Fail, sb.beg == NULL); // still zero-init
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  return 1;
+}
+
+// Reserve(0) on a zero-init buffer should activate inline storage without
+// touching the heap.
+static int
+test_reserve_zero(void)
+{
+  log_info("=== test_reserve_zero ===");
+  struct strbuf sb = { 0 };
+  CHECK(Fail, strbuf_reserve(&sb, 0) == 0);
+  CHECK(Fail, sb.beg == sb.inline_buf);
+  CHECK(Fail, strbuf_len(&sb) == 0);
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "") == 0);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
+// Appending raw bytes with embedded NULs preserves the bytes; the public
+// C-string view ends at the first NUL but the length is correct.
+static int
+test_binary_with_embedded_nul(void)
+{
+  log_info("=== test_binary_with_embedded_nul ===");
+  struct strbuf sb = { 0 };
+  const char bytes[] = { 'a', 0, 'b', 'c' };
+  CHECK(Fail, strbuf_append(&sb, bytes, sizeof(bytes)) == 0);
+  CHECK(Fail, strbuf_len(&sb) == sizeof(bytes));
+  CHECK(Fail, memcmp(sb.beg, bytes, sizeof(bytes)) == 0);
+  // Trailing sentinel NUL after content.
+  CHECK(Fail, sb.beg[sizeof(bytes)] == 0);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
 int
 main(void)
 {
@@ -149,6 +227,10 @@ main(void)
   failed += test_appendf_grows_past_inline();
   failed += test_reset_keeps_capacity();
   failed += test_set();
+  failed += test_set_reuses_heap_allocation();
+  failed += test_reset_on_zero_init();
+  failed += test_reserve_zero();
+  failed += test_binary_with_embedded_nul();
   if (failed)
     log_error("%d strbuf tests FAILED", failed);
   else

--- a/tests/test_strbuf.c
+++ b/tests/test_strbuf.c
@@ -2,6 +2,7 @@
 #include "util/prelude.h"
 #include "util/strbuf.h"
 
+#include <stdint.h>
 #include <string.h>
 
 static int
@@ -196,6 +197,53 @@ Fail:
   return 1;
 }
 
+// Exercise the boundary between the first vsnprintf fitting and triggering
+// the grow+retry path: fill inline to within 1 byte of its capacity, then
+// appendf one more character. Exits the inline buffer by exactly one byte.
+static int
+test_appendf_at_inline_boundary(void)
+{
+  log_info("=== test_appendf_at_inline_boundary ===");
+  struct strbuf sb = { 0 };
+  // Append STRBUF_INLINE_CAP - 1 bytes — fits exactly (leaving NUL slot).
+  char fill[STRBUF_INLINE_CAP - 1];
+  memset(fill, 'x', sizeof(fill));
+  CHECK(Fail, strbuf_append(&sb, fill, sizeof(fill)) == 0);
+  CHECK(Fail, sb.beg == sb.inline_buf);
+  CHECK(Fail, strbuf_len(&sb) == STRBUF_INLINE_CAP - 1);
+
+  // One more byte would overflow inline (no room for content + NUL); must
+  // grow and retry.
+  CHECK(Fail, strbuf_appendf(&sb, "%c", '!') == 0);
+  CHECK(Fail, sb.beg != sb.inline_buf); // moved to heap
+  CHECK(Fail, strbuf_len(&sb) == STRBUF_INLINE_CAP);
+  CHECK(Fail, sb.beg[STRBUF_INLINE_CAP - 1] == '!');
+  CHECK(Fail, sb.beg[STRBUF_INLINE_CAP] == 0);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
+// Oversized reserve request must fail via the overflow guard, not wrap to
+// an absurdly small allocation and write past it.
+static int
+test_reserve_overflow_guard(void)
+{
+  log_info("=== test_reserve_overflow_guard ===");
+  struct strbuf sb = { 0 };
+  CHECK(Fail, strbuf_reserve(&sb, SIZE_MAX) != 0);
+  // Buffer should remain usable after the failed reserve.
+  CHECK(Fail, strbuf_append_cstr(&sb, "ok") == 0);
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "ok") == 0);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
 // Appending raw bytes with embedded NULs preserves the bytes; the public
 // C-string view ends at the first NUL but the length is correct.
 static int
@@ -230,6 +278,8 @@ main(void)
   failed += test_set_reuses_heap_allocation();
   failed += test_reset_on_zero_init();
   failed += test_reserve_zero();
+  failed += test_appendf_at_inline_boundary();
+  failed += test_reserve_overflow_guard();
   failed += test_binary_with_embedded_nul();
   if (failed)
     log_error("%d strbuf tests FAILED", failed);

--- a/tests/test_strbuf.c
+++ b/tests/test_strbuf.c
@@ -1,0 +1,157 @@
+#include "chucky_log.h"
+#include "util/prelude.h"
+#include "util/strbuf.h"
+
+#include <string.h>
+
+static int
+test_zero_init_is_usable(void)
+{
+  log_info("=== test_zero_init_is_usable ===");
+  struct strbuf sb = { 0 };
+  CHECK(Fail, strbuf_len(&sb) == 0);
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "") == 0);
+  strbuf_free(&sb); // no-op on zero-init
+  return 0;
+Fail:
+  return 1;
+}
+
+static int
+test_inline_append(void)
+{
+  log_info("=== test_inline_append ===");
+  struct strbuf sb = { 0 };
+  CHECK(Fail, strbuf_append_cstr(&sb, "hello") == 0);
+  CHECK(Fail, strbuf_append(&sb, ", ", 2) == 0);
+  CHECK(Fail, strbuf_append_cstr(&sb, "world") == 0);
+  CHECK(Fail, strbuf_len(&sb) == 12);
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "hello, world") == 0);
+  // Content must fit in inline storage.
+  CHECK(Fail, sb.beg == sb.inline_buf);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
+static int
+test_spill_to_heap(void)
+{
+  log_info("=== test_spill_to_heap ===");
+  struct strbuf sb = { 0 };
+  // Write something larger than STRBUF_INLINE_CAP (128) to force heap spill.
+  char big[512];
+  memset(big, 'x', sizeof(big));
+  CHECK(Fail, strbuf_append(&sb, big, sizeof(big)) == 0);
+  CHECK(Fail, strbuf_len(&sb) == sizeof(big));
+  // Must have moved off the inline buffer.
+  CHECK(Fail, sb.beg != sb.inline_buf);
+  // Content preserved.
+  CHECK(Fail, memcmp(sb.beg, big, sizeof(big)) == 0);
+  // NUL terminator at end.
+  CHECK(Fail, sb.beg[sizeof(big)] == 0);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
+static int
+test_appendf(void)
+{
+  log_info("=== test_appendf ===");
+  struct strbuf sb = { 0 };
+  CHECK(Fail, strbuf_appendf(&sb, "%s/%d/%s", "pfx", 42, "suffix") == 0);
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "pfx/42/suffix") == 0);
+  // Append again without reset.
+  CHECK(Fail, strbuf_appendf(&sb, "/more%d", 7) == 0);
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "pfx/42/suffix/more7") == 0);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
+static int
+test_appendf_grows_past_inline(void)
+{
+  log_info("=== test_appendf_grows_past_inline ===");
+  struct strbuf sb = { 0 };
+  // vsnprintf's first attempt will run out of inline space; appendf should
+  // grow and retry.
+  for (int i = 0; i < 50; ++i)
+    CHECK(Fail, strbuf_appendf(&sb, "segment-%02d/", i) == 0);
+  // 50 * 11 = 550 bytes. Definitely past inline.
+  CHECK(Fail, strbuf_len(&sb) == 50 * 11);
+  CHECK(Fail, sb.beg != sb.inline_buf);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
+static int
+test_reset_keeps_capacity(void)
+{
+  log_info("=== test_reset_keeps_capacity ===");
+  struct strbuf sb = { 0 };
+  char big[512];
+  memset(big, 'y', sizeof(big));
+  CHECK(Fail, strbuf_append(&sb, big, sizeof(big)) == 0);
+  char* heap_ptr = sb.beg;
+  size_t heap_cap = (size_t)(sb.cap_end - sb.beg);
+  CHECK(Fail, heap_ptr != sb.inline_buf);
+
+  strbuf_reset(&sb);
+  CHECK(Fail, strbuf_len(&sb) == 0);
+  // Same allocation still in use.
+  CHECK(Fail, sb.beg == heap_ptr);
+  CHECK(Fail, (size_t)(sb.cap_end - sb.beg) == heap_cap);
+  // Re-fill.
+  CHECK(Fail, strbuf_append_cstr(&sb, "short") == 0);
+  CHECK(Fail, sb.beg == heap_ptr); // no realloc needed
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
+static int
+test_set(void)
+{
+  log_info("=== test_set ===");
+  struct strbuf sb = { 0 };
+  CHECK(Fail, strbuf_set(&sb, "first") == 0);
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "first") == 0);
+  CHECK(Fail, strbuf_set(&sb, "second (longer)") == 0);
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), "second (longer)") == 0);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  strbuf_free(&sb);
+  return 1;
+}
+
+int
+main(void)
+{
+  int failed = 0;
+  failed += test_zero_init_is_usable();
+  failed += test_inline_append();
+  failed += test_spill_to_heap();
+  failed += test_appendf();
+  failed += test_appendf_grows_past_inline();
+  failed += test_reset_keeps_capacity();
+  failed += test_set();
+  if (failed)
+    log_error("%d strbuf tests FAILED", failed);
+  else
+    log_info("all strbuf tests PASSED");
+  return failed != 0;
+}

--- a/tests/test_stream.c
+++ b/tests/test_stream.c
@@ -396,6 +396,9 @@ test_stream_lz4_roundtrip(void)
     .rank = 3,
     .dimensions = dims,
     .codec = { .id = CODEC_LZ4_NON_STANDARD, .level = 1 },
+    // Tiny dims — auto-K against the 512 MiB byte target would ask nvcomp
+    // for a multi-GiB temp buffer. K=1 keeps the batch size sane.
+    .epochs_per_batch = 1,
   };
 
   struct tile_stream_gpu* s = NULL;


### PR DESCRIPTION
## Summary

- **Fix #105**: previously aliased caller-owned memory. Any caller-side lifetime issue or internal overrun landing in those strings corrupted the final `zarr.json`. Each handle now deep-copies the strings it needs and frees them on destroy.
- **String builder**: introduce `util/strbuf.[ch]` — zero-init friendly, 128-byte inline SSO, reset-and-reuse, pure standard C.

closes #105 

## Test plan

- [x] New `test_strbuf` 