### PR TITLE
Double-buffer CPU aggregate slots

### DIFF
--- a/src/cpu/pipeline.c
+++ b/src/cpu/pipeline.c
@@ -40,15 +40,17 @@ compute_batch_luts(const struct computed_stream_layouts* cl,
 // ---- flush_batch helpers ----
 
 static struct aggregate_cpu_workspace
-make_agg_workspace(const struct flush_level_view* lvl, size_t* permuted_sizes)
+make_agg_workspace(const struct flush_level_view* lvl,
+                   const struct cpu_agg_slot* slot,
+                   size_t* permuted_sizes)
 {
   return (struct aggregate_cpu_workspace){
     .perm = lvl->batch_chunk_to_shard_map,
     .permuted_sizes = permuted_sizes,
-    .data = lvl->agg_slot->data,
-    .data_capacity = lvl->agg_slot->data_capacity_bytes,
-    .offsets = lvl->agg_slot->offsets,
-    .chunk_sizes = lvl->agg_slot->chunk_sizes,
+    .data = slot->data,
+    .data_capacity = slot->data_capacity_bytes,
+    .offsets = slot->offsets,
+    .chunk_sizes = slot->chunk_sizes,
   };
 }
 
@@ -86,6 +88,7 @@ static int
 aggregate_and_deliver_batch(int lv,
                             const struct flush_batch_params* p,
                             const struct flush_level_view* lvl,
+                            const struct cpu_agg_slot* slot,
                             uint32_t active_count)
 {
   struct platform_clock clk = { 0 };
@@ -93,7 +96,7 @@ aggregate_and_deliver_batch(int lv,
     platform_toc(&clk);
 
   struct aggregate_cpu_workspace ws =
-    make_agg_workspace(lvl, p->shard_order_sizes_bytes);
+    make_agg_workspace(lvl, slot, p->shard_order_sizes_bytes);
   struct aggregate_result ar;
   if (aggregate_cpu_batch_into(p->compressed,
                                p->comp_sizes,
@@ -169,12 +172,14 @@ cpu_pipeline_flush_batch(const struct flush_batch_params* p,
     if (active_count > lut_cap)
       return 1;
 
-    // Wait for pending async IO before overwriting aggregate buffer.
+    const uint8_t cur = *lvl->agg_current;
+
+    // Wait on the slot we're about to reuse (oldest pending IO on this level).
     if (p->sink->wait_fence) {
       struct platform_clock fence_clk = { 0 };
       if (p->metrics)
         platform_toc(&fence_clk);
-      p->sink->wait_fence(p->sink, (uint8_t)lv, *lvl->io_done);
+      p->sink->wait_fence(p->sink, (uint8_t)lv, lvl->io_done[cur]);
       if (p->metrics) {
         float fence_ms = (float)(platform_toc(&fence_clk) * 1000.0);
         accumulate_metric_ms(&p->metrics->io_fence_stall, fence_ms, 0, 0);
@@ -193,12 +198,15 @@ cpu_pipeline_flush_batch(const struct flush_batch_params* p,
                          lvl->batch_gather,
                          lvl->batch_chunk_to_shard_map);
 
-    if (aggregate_and_deliver_batch(lv, p, lvl, active_count))
+    if (aggregate_and_deliver_batch(lv, p, lvl, &lvl->agg_slot[cur], active_count))
       return 1;
 
-    // Record fence so next batch waits for this delivery's IO.
+    // Record fence on the just-delivered slot so the next reuse waits for it.
     if (p->sink->record_fence)
-      *lvl->io_done = p->sink->record_fence(p->sink, (uint8_t)lv);
+      lvl->io_done[cur] = p->sink->record_fence(p->sink, (uint8_t)lv);
+
+    // Next delivery on this level uses the other slot.
+    *lvl->agg_current = cur ^ 1;
   }
 
   return 0;

--- a/src/cpu/pipeline.c
+++ b/src/cpu/pipeline.c
@@ -174,7 +174,7 @@ cpu_pipeline_flush_batch(const struct flush_batch_params* p,
 
     const uint8_t cur = *lvl->agg_current;
 
-    // Wait on the slot we're about to reuse (oldest pending IO on this level).
+    // Wait on the slot we're about to overwrite.
     if (p->sink->wait_fence) {
       struct platform_clock fence_clk = { 0 };
       if (p->metrics)

--- a/src/cpu/pipeline.h
+++ b/src/cpu/pipeline.h
@@ -24,10 +24,11 @@ struct flush_level_view
   uint64_t chunk_offset;
   uint32_t* batch_chunk_to_shard_map; // [K_l * M_lv] perm LUT (mutable)
   uint32_t* batch_gather;             // [K_l * M_lv] gather LUT (mutable)
-  struct cpu_agg_slot* agg_slot;
+  struct cpu_agg_slot* agg_slot;      // [2] double-buffered agg slots
   struct shard_state* shard;
-  struct io_event*
-    io_done; // tracks pending async IO for this level's agg buffer
+  struct io_event* io_done;  // [2] per-slot pending-IO fences
+  uint8_t* agg_current;      // points to the level's slot-alternator byte
+                             // (0 or 1); value is the slot to use next
 };
 
 struct flush_batch_params

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -41,9 +41,10 @@ make_flush_params(struct cpu_stream_view* v)
       .chunk_offset = v->levels->level[lv].chunk_offset,
       .batch_chunk_to_shard_map = v->batch_chunk_to_shard_map[lv],
       .batch_gather = v->batch_gather[lv],
-      .agg_slot = &v->agg_slots[lv],
+      .agg_slot = v->agg_slots[lv],     // &v->agg_slots[lv][0], array of 2
       .shard = &v->shard[lv],
-      .io_done = &v->io_done[lv],
+      .io_done = v->io_done[lv],        // &v->io_done[lv][0], array of 2
+      .agg_current = &v->agg_current[lv],
     };
   }
   return p;
@@ -307,8 +308,11 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
     platform_toc(&emit_clk);
 
     for (int lv = 0; lv < v->levels->nlod; ++lv) {
-      if (v->sink->wait_fence)
-        v->sink->wait_fence(v->sink, (uint8_t)lv, v->io_done[lv]);
+      // Both slots may hold in-flight IO; wait on both before finalize.
+      if (v->sink->wait_fence) {
+        v->sink->wait_fence(v->sink, (uint8_t)lv, v->io_done[lv][0]);
+        v->sink->wait_fence(v->sink, (uint8_t)lv, v->io_done[lv][1]);
+      }
 
       if (v->sink->has_error && v->sink->has_error(v->sink))
         return writer_error();

--- a/src/cpu/stream.body.h
+++ b/src/cpu/stream.body.h
@@ -33,15 +33,16 @@ struct cpu_stream_view
   uint32_t* batch_active_count;        // [LOD_MAX_LEVELS] array
   struct reduce_csr* csrs;             // [nlod-1] CSR LUTs
   void* append_accum;
-  uint32_t* append_counts;  // [LOD_MAX_LEVELS]
-  struct io_event* io_done; // [LOD_MAX_LEVELS]
+  uint32_t* append_counts;        // [LOD_MAX_LEVELS]
+  struct io_event (*io_done)[2];  // [LOD_MAX_LEVELS][2] per-slot fences
+  uint8_t* agg_current;           // [LOD_MAX_LEVELS] per-level slot index
 
   // Shared buffers
   void* chunk_pool;
   size_t chunk_pool_bytes;
   void* compressed;
   size_t* comp_sizes;
-  struct cpu_agg_slot* agg_slots; // [LOD_MAX_LEVELS]
+  struct cpu_agg_slot (*agg_slots)[2]; // [LOD_MAX_LEVELS][2] double-buffered
   size_t* shard_order_sizes;
   void* linear;
   void* lod_values;

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -98,14 +98,14 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
       if (batch_C > max_batch_C)
         max_batch_C = batch_C;
 
-      // Per-level aggregate output buffers (batch-scaled).
+      // Per-level aggregate output buffers (batch-scaled), double-buffered.
       size_t data_lv = agg_pool_bytes((uint64_t)slot_count * M_lv,
                                       agg->max_comp_chunk_bytes,
                                       C_lv,
                                       agg->cps_inner,
                                       agg->page_size);
-      {
-        struct cpu_agg_slot* as = &s->agg_slots[lv];
+      for (int fc = 0; fc < 2; ++fc) {
+        struct cpu_agg_slot* as = &s->agg_slots[lv][fc];
         if (batch_C > 0) {
           as->offsets = (size_t*)malloc((batch_C + 1) * sizeof(size_t));
           as->chunk_sizes = (size_t*)calloc(batch_C, sizeof(size_t));
@@ -299,10 +299,12 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
     free(s->morton_lut[lv]);
     free(s->lod_fixed_dims_offsets[lv]);
 
-    struct cpu_agg_slot* as = &s->agg_slots[lv];
-    free(as->data);
-    free(as->offsets);
-    free(as->chunk_sizes);
+    for (int fc = 0; fc < 2; ++fc) {
+      struct cpu_agg_slot* as = &s->agg_slots[lv][fc];
+      free(as->data);
+      free(as->offsets);
+      free(as->chunk_sizes);
+    }
   }
   free(s->shard_order_sizes);
 
@@ -395,9 +397,10 @@ compute_memory_info(const struct computed_stream_layouts* cl,
                                       al->cps_inner,
                                       al->page_size);
 
-      agg += data_lv +
-             (batch_C + 1) * sizeof(size_t) + // offsets (batch-scaled)
-             batch_C * sizeof(size_t);        // chunk_sizes (batch-scaled)
+      // Double-buffered: 2 slots per level.
+      agg += 2 * (data_lv +
+                  (batch_C + 1) * sizeof(size_t) + // offsets (batch-scaled)
+                  batch_C * sizeof(size_t));       // chunk_sizes (batch-scaled)
 
       // Batch LUTs (gather + perm).
       {
@@ -684,6 +687,7 @@ make_view(struct tile_stream_cpu* s)
     .append_accum = s->append_accum,
     .append_counts = s->append_counts,
     .io_done = s->io_done,
+    .agg_current = s->agg_current,
     .chunk_pool = s->chunk_pool,
     .chunk_pool_bytes = 0,
     .compressed = s->compressed,

--- a/src/cpu/stream.internal.h
+++ b/src/cpu/stream.internal.h
@@ -30,9 +30,11 @@ struct tile_stream_cpu
   struct shard_state shard[LOD_MAX_LEVELS];
   struct aggregate_layout agg_layout[LOD_MAX_LEVELS];
 
-  // Per-level aggregate output (batch-scaled).
-  struct cpu_agg_slot agg_slots[LOD_MAX_LEVELS]; // [level] sized for batch
-  size_t* shard_order_sizes;                     // [max_batch_C] shared scratch
+  // Per-level aggregate output (batch-scaled), double-buffered so aggregate
+  // of batch N+1 overlaps prior pwrites on batch N's slot.
+  struct cpu_agg_slot agg_slots[LOD_MAX_LEVELS][2];
+  uint8_t agg_current[LOD_MAX_LEVELS]; // next slot to use per level (0 or 1)
+  size_t* shard_order_sizes;           // [max_batch_C] shared scratch
 
   // Batch aggregate LUTs (per level).
   uint32_t* batch_gather[LOD_MAX_LEVELS];             // [K_l * M_l]
@@ -68,9 +70,9 @@ struct tile_stream_cpu
   uint32_t* batch_active_masks;  // [K] per-epoch active level mask
   uint32_t* pool_epochs_scratch; // [K] scratch for kick-time mask scans
 
-  // IO fence state: tracks pending async IO per level so we don't
+  // IO fence state: tracks pending async IO per level per slot so we don't
   // overwrite aggregate buffers before write_direct completes.
-  struct io_event io_done[LOD_MAX_LEVELS];
+  struct io_event io_done[LOD_MAX_LEVELS][2];
 
   int nthreads;           // resolved at init: always > 0
   size_t shard_alignment; // from sink; 0 = no alignment

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -36,7 +36,8 @@ struct array_descriptor
   uint32_t append_counts[LOD_MAX_LEVELS];
   void* append_accum;
   struct reduce_csr* csrs; // [nlod-1] CSR reduce LUTs (multiscale only), owned
-  struct io_event io_done[LOD_MAX_LEVELS];
+  struct io_event io_done[LOD_MAX_LEVELS][2]; // per-slot fences
+  uint8_t agg_current[LOD_MAX_LEVELS];        // next slot to use per level
   size_t shard_alignment; // from sink; 0 = no alignment
   int pool_fully_covered; // 1 if scatter overwrites every pool position
   int flushed;            // 1 once flush body has run for this array
@@ -61,8 +62,8 @@ struct multiarray_tile_stream_cpu
   void* compressed;
   size_t* comp_sizes;
 
-  // Shared aggregate workspace.
-  struct cpu_agg_slot agg_slots[LOD_MAX_LEVELS];
+  // Shared aggregate workspace (double-buffered per level).
+  struct cpu_agg_slot agg_slots[LOD_MAX_LEVELS][2];
   size_t* shard_order_sizes;
 
   // Shared LUT storage (recomputed on switch).
@@ -297,19 +298,22 @@ alloc_shared_buffers(struct multiarray_tile_stream_cpu* ms,
     CHECK(Fail, ms->comp_sizes);
   }
 
-  // Per-level aggregate slots + LUT storage.
+  // Per-level aggregate slots + LUT storage. Double-buffered so a batch's
+  // aggregate overlaps the prior batch's pwrites on the other slot.
   for (int lv = 0; lv < LOD_MAX_LEVELS; ++lv) {
-    struct cpu_agg_slot* as = &ms->agg_slots[lv];
     uint64_t batch_C = mx->agg_batch_C_count[lv];
-    if (batch_C > 0) {
-      as->offsets = (size_t*)malloc((batch_C + 1) * sizeof(size_t));
-      as->chunk_sizes = (size_t*)calloc(batch_C, sizeof(size_t));
-      CHECK(Fail, as->offsets && as->chunk_sizes);
-    }
-    if (mx->agg_data_bytes[lv] > 0) {
-      as->data = malloc(mx->agg_data_bytes[lv]);
-      as->data_capacity_bytes = mx->agg_data_bytes[lv];
-      CHECK(Fail, as->data);
+    for (int fc = 0; fc < 2; ++fc) {
+      struct cpu_agg_slot* as = &ms->agg_slots[lv][fc];
+      if (batch_C > 0) {
+        as->offsets = (size_t*)malloc((batch_C + 1) * sizeof(size_t));
+        as->chunk_sizes = (size_t*)calloc(batch_C, sizeof(size_t));
+        CHECK(Fail, as->offsets && as->chunk_sizes);
+      }
+      if (mx->agg_data_bytes[lv] > 0) {
+        as->data = malloc(mx->agg_data_bytes[lv]);
+        as->data_capacity_bytes = mx->agg_data_bytes[lv];
+        CHECK(Fail, as->data);
+      }
     }
     if (mx->batch_gather_count[lv] > 0) {
       ms->batch_gather[lv] =
@@ -465,9 +469,11 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
   free(ms->comp_sizes);
 
   for (int lv = 0; lv < LOD_MAX_LEVELS; ++lv) {
-    free(ms->agg_slots[lv].data);
-    free(ms->agg_slots[lv].offsets);
-    free(ms->agg_slots[lv].chunk_sizes);
+    for (int fc = 0; fc < 2; ++fc) {
+      free(ms->agg_slots[lv][fc].data);
+      free(ms->agg_slots[lv][fc].offsets);
+      free(ms->agg_slots[lv][fc].chunk_sizes);
+    }
     free(ms->batch_gather[lv]);
     free(ms->batch_chunk_to_shard_map[lv]);
     free(ms->morton_lut[lv]);
@@ -590,6 +596,7 @@ make_multiarray_view(struct multiarray_tile_stream_cpu* ms,
     .append_accum = desc->append_accum,
     .append_counts = desc->append_counts,
     .io_done = desc->io_done,
+    .agg_current = desc->agg_current,
     .chunk_pool = ms->chunk_pool,
     .chunk_pool_bytes = ms->chunk_pool_bytes,
     .compressed = ms->compressed,


### PR DESCRIPTION
## Summary
Double-buffers the per-level CPU aggregate slots so the aggregate for batch N+1 can start while batch N's zero-copy pwrites are still draining.

- Terminal flush waits on both slots per level before `finalize_shards`.
- Memory estimate in `compute_memory_info` doubles the per-level `data_lv + offsets + chunk_sizes` contribution.

