### PR TITLE
Drain sink IO on GPU destroy

### DIFF
--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -72,7 +72,7 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.compress);
   sync(s->engine.streams.d2h);
 
-  // Drain sink IO before compress_agg_destroy frees referenced buffers (#110).
+  // Drain sink IO before compress_agg_destroy frees referenced buffers.
   if (shard_sink_drain(s->ctx.sink, s->ctx.levels.nlod))
     log_error("sink reported IO errors during teardown");
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -72,8 +72,7 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.compress);
   sync(s->engine.streams.d2h);
 
-  // Drain pending sink IO that references aggregate slot memory before we
-  // free those buffers below in compress_agg_destroy. See issue #110.
+  // Drain sink IO before compress_agg_destroy frees referenced buffers (#110).
   if (shard_sink_drain(s->ctx.sink, s->ctx.levels.nlod))
     log_error("sink reported IO errors during teardown");
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -10,6 +10,7 @@
 #include "platform/platform.h"
 #include "stream/config.h"
 #include "util/prelude.h"
+#include "writer.h"
 
 #include <cuda.h>
 #include <stdlib.h>
@@ -70,6 +71,11 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.compute);
   sync(s->engine.streams.compress);
   sync(s->engine.streams.d2h);
+
+  // Drain pending sink IO that references aggregate slot memory before we
+  // free those buffers below in compress_agg_destroy. See issue #110.
+  if (shard_sink_drain(s->ctx.sink, s->ctx.levels.nlod))
+    log_error("sink reported IO errors during teardown");
 
   destroy_batch_events(&s->engine.batch);
   destroy_flush_pipeline(&s->engine.flush);
@@ -140,8 +146,7 @@ static int
 init_flush_pipeline(struct flush_pipeline* fp, uint32_t K)
 {
   for (int fc = 0; fc < 2; ++fc) {
-    fp->slot[fc].batch_active_masks =
-      (uint32_t*)calloc(K, sizeof(uint32_t));
+    fp->slot[fc].batch_active_masks = (uint32_t*)calloc(K, sizeof(uint32_t));
     if (!fp->slot[fc].batch_active_masks)
       return 1;
   }

--- a/src/hcs/hcs.c
+++ b/src/hcs/hcs.c
@@ -292,7 +292,7 @@ Fail_alloc:
   strbuf_free(&p->name);
   free(p);
 Fail_pool:
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
 Fail:
   return NULL;
 }
@@ -324,8 +324,7 @@ hcs_plate_destroy(struct hcs_plate* p)
   strbuf_free(&p->name);
   struct shard_pool* pool = p->pool;
   free(p);
-  if (pool)
-    pool->destroy(pool);
+  shard_pool_destroy(pool);
 }
 
 struct shard_sink*

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -9,6 +9,7 @@
 #include "multiarray.gpu.h"
 #include "stream/config.h"
 #include "util/prelude.h"
+#include "writer.h"
 #include "zarr/shard_delivery.h"
 
 #include <stdlib.h>
@@ -607,6 +608,13 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
   sync_all(&ms->engine.streams);
 
   if (ms->arrays) {
+    // Drain each array's sink before freeing the shared aggregate buffers
+    // it references below. See issue #110.
+    for (int a = 0; a < ms->n_arrays; ++a) {
+      struct array_descriptor_gpu* desc = &ms->arrays[a];
+      if (shard_sink_drain(desc->ctx.sink, desc->ctx.levels.nlod))
+        log_error("array %d sink reported IO errors during teardown", a);
+    }
     for (int a = 0; a < ms->n_arrays; ++a)
       destroy_array_descriptor(&ms->arrays[a]);
     free(ms->arrays);

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -608,8 +608,7 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
   sync_all(&ms->engine.streams);
 
   if (ms->arrays) {
-    // Drain each array's sink before freeing the shared aggregate buffers
-    // it references below. See issue #110.
+    // Drain each array's sink before freeing aggregate buffers (#110).
     for (int a = 0; a < ms->n_arrays; ++a) {
       struct array_descriptor_gpu* desc = &ms->arrays[a];
       if (shard_sink_drain(desc->ctx.sink, desc->ctx.levels.nlod))

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -5,6 +5,7 @@
 #include "gpu/stream.ingest.h"
 #include "gpu/stream.lod.h"
 
+#include "defs.limits.h"
 #include "gpu/prelude.cuda.h"
 #include "multiarray.gpu.h"
 #include "stream/config.h"
@@ -608,11 +609,30 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
   sync_all(&ms->engine.streams);
 
   if (ms->arrays) {
-    // Drain each array's sink before freeing aggregate buffers (#110).
-    for (int a = 0; a < ms->n_arrays; ++a) {
-      struct array_descriptor_gpu* desc = &ms->arrays[a];
-      if (shard_sink_drain(desc->ctx.sink, desc->ctx.levels.nlod))
-        log_error("array %d sink reported IO errors during teardown", a);
+    // Drain sinks before freeing aggregate buffers they reference. Fan
+    // out the record phase across all arrays so wait blocks on the union
+    // of pending IO instead of serializing per-array drains.
+    struct io_event(*evs)[LOD_MAX_LEVELS] =
+      (struct io_event(*)[LOD_MAX_LEVELS])calloc((size_t)ms->n_arrays,
+                                                 sizeof(*evs));
+    if (evs) {
+      for (int a = 0; a < ms->n_arrays; ++a) {
+        struct array_descriptor_gpu* desc = &ms->arrays[a];
+        shard_sink_drain_record(desc->ctx.sink, desc->ctx.levels.nlod, evs[a]);
+      }
+      for (int a = 0; a < ms->n_arrays; ++a) {
+        struct array_descriptor_gpu* desc = &ms->arrays[a];
+        if (shard_sink_drain_wait(
+              desc->ctx.sink, desc->ctx.levels.nlod, evs[a]))
+          log_error("array %d sink reported IO errors during teardown", a);
+      }
+      free(evs);
+    } else {
+      for (int a = 0; a < ms->n_arrays; ++a) {
+        struct array_descriptor_gpu* desc = &ms->arrays[a];
+        if (shard_sink_drain(desc->ctx.sink, desc->ctx.levels.nlod))
+          log_error("array %d sink reported IO errors during teardown", a);
+      }
     }
     for (int a = 0; a < ms->n_arrays; ++a)
       destroy_array_descriptor(&ms->arrays[a]);

--- a/src/ngff/ngff_multiscale.c
+++ b/src/ngff/ngff_multiscale.c
@@ -351,7 +351,7 @@ ngff_multiscale_create(struct store* store,
   struct ngff_multiscale* ms =
     ngff_multiscale_init(store, pool, prefix, cfg, &plan);
   if (!ms) {
-    pool->destroy(pool);
+    shard_pool_destroy(pool);
     return NULL;
   }
   ms->owns_pool = 1;
@@ -379,8 +379,7 @@ ngff_multiscale_destroy(struct ngff_multiscale* ms)
   strbuf_free(&ms->prefix);
   struct shard_pool* pool = ms->owns_pool ? ms->pool : NULL;
   free(ms);
-  if (pool)
-    pool->destroy(pool);
+  shard_pool_destroy(pool);
 }
 
 struct shard_sink*

--- a/src/writer.c
+++ b/src/writer.c
@@ -5,6 +5,8 @@
 #include "log/log.h"
 #include "platform/platform.h"
 
+#include <assert.h>
+
 struct writer_result
 writer_append(struct writer* w, struct slice data)
 {
@@ -94,21 +96,37 @@ shard_sink_required_shard_alignment(const struct shard_sink* s)
                                             : 0;
 }
 
+void
+shard_sink_drain_record(struct shard_sink* s, int nlod, struct io_event* evs)
+{
+  if (!s || !s->record_fence || nlod <= 0)
+    return;
+  assert(nlod <= LOD_MAX_LEVELS);
+  for (int lv = 0; lv < nlod; ++lv)
+    evs[lv] = s->record_fence(s, (uint8_t)lv);
+}
+
 int
-shard_sink_drain(struct shard_sink* s, int nlod)
+shard_sink_drain_wait(struct shard_sink* s,
+                      int nlod,
+                      const struct io_event* evs)
 {
   if (!s)
     return 0;
-  if (s->record_fence && s->wait_fence && nlod > 0) {
-    struct io_event evs[LOD_MAX_LEVELS];
-    if (nlod > LOD_MAX_LEVELS)
-      nlod = LOD_MAX_LEVELS;
-    for (int lv = 0; lv < nlod; ++lv)
-      evs[lv] = s->record_fence(s, (uint8_t)lv);
+  if (s->wait_fence && nlod > 0) {
+    assert(nlod <= LOD_MAX_LEVELS);
     for (int lv = 0; lv < nlod; ++lv)
       s->wait_fence(s, (uint8_t)lv, evs[lv]);
   }
   return s->has_error ? s->has_error(s) : 0;
+}
+
+int
+shard_sink_drain(struct shard_sink* s, int nlod)
+{
+  struct io_event evs[LOD_MAX_LEVELS];
+  shard_sink_drain_record(s, nlod, evs);
+  return shard_sink_drain_wait(s, nlod, evs);
 }
 
 size_t

--- a/src/writer.c
+++ b/src/writer.c
@@ -1,4 +1,5 @@
 #include "writer.h"
+#include "defs.limits.h"
 #include "zarr/shard_pool.h"
 
 #include "log/log.h"
@@ -98,11 +99,16 @@ shard_sink_drain(struct shard_sink* s, int nlod)
 {
   if (!s)
     return 0;
-  if (s->record_fence && s->wait_fence) {
-    for (int lv = 0; lv < nlod; ++lv) {
-      struct io_event ev = s->record_fence(s, (uint8_t)lv);
-      s->wait_fence(s, (uint8_t)lv, ev);
-    }
+  if (s->record_fence && s->wait_fence && nlod > 0) {
+    // Record all level fences first, then wait — so per-level pools
+    // drain concurrently rather than serializing.
+    struct io_event evs[LOD_MAX_LEVELS];
+    if (nlod > LOD_MAX_LEVELS)
+      nlod = LOD_MAX_LEVELS;
+    for (int lv = 0; lv < nlod; ++lv)
+      evs[lv] = s->record_fence(s, (uint8_t)lv);
+    for (int lv = 0; lv < nlod; ++lv)
+      s->wait_fence(s, (uint8_t)lv, evs[lv]);
   }
   return s->has_error ? s->has_error(s) : 0;
 }

--- a/src/writer.c
+++ b/src/writer.c
@@ -100,8 +100,6 @@ shard_sink_drain(struct shard_sink* s, int nlod)
   if (!s)
     return 0;
   if (s->record_fence && s->wait_fence && nlod > 0) {
-    // Record all level fences first, then wait — so per-level pools
-    // drain concurrently rather than serializing.
     struct io_event evs[LOD_MAX_LEVELS];
     if (nlod > LOD_MAX_LEVELS)
       nlod = LOD_MAX_LEVELS;

--- a/src/writer.c
+++ b/src/writer.c
@@ -93,6 +93,20 @@ shard_sink_required_shard_alignment(const struct shard_sink* s)
                                             : 0;
 }
 
+int
+shard_sink_drain(struct shard_sink* s, int nlod)
+{
+  if (!s)
+    return 0;
+  if (s->record_fence && s->wait_fence) {
+    for (int lv = 0; lv < nlod; ++lv) {
+      struct io_event ev = s->record_fence(s, (uint8_t)lv);
+      s->wait_fence(s, (uint8_t)lv, ev);
+    }
+  }
+  return s->has_error ? s->has_error(s) : 0;
+}
+
 size_t
 shard_pool_pending_bytes(const struct shard_pool* p)
 {
@@ -104,4 +118,11 @@ shard_pool_required_shard_alignment(const struct shard_pool* p)
 {
   return (p && p->required_shard_alignment) ? p->required_shard_alignment(p)
                                             : 0;
+}
+
+void
+shard_pool_destroy(struct shard_pool* p)
+{
+  if (p)
+    p->destroy(p);
 }

--- a/src/writer.h
+++ b/src/writer.h
@@ -89,6 +89,13 @@ shard_sink_pending_bytes(const struct shard_sink* s);
 size_t
 shard_sink_required_shard_alignment(const struct shard_sink* s);
 
+// Drain pending async IO on this sink across all levels by recording a
+// terminal fence per level and waiting on it. No-op for synchronous sinks
+// (those without record_fence/wait_fence). Returns non-zero if the sink
+// reports an error after drain.
+int
+shard_sink_drain(struct shard_sink* s, int nlod);
+
 struct writer_result
 writer_ok(void);
 

--- a/src/writer.h
+++ b/src/writer.h
@@ -94,6 +94,17 @@ shard_sink_required_shard_alignment(const struct shard_sink* s);
 int
 shard_sink_drain(struct shard_sink* s, int nlod);
 
+// Two-phase drain: record fences for all levels, then wait. Lets callers
+// fan out the record phase across many sinks before blocking on waits.
+// `evs` must point to at least `nlod` io_event slots.
+void
+shard_sink_drain_record(struct shard_sink* s, int nlod, struct io_event* evs);
+
+int
+shard_sink_drain_wait(struct shard_sink* s,
+                      int nlod,
+                      const struct io_event* evs);
+
 struct writer_result
 writer_ok(void);
 

--- a/src/writer.h
+++ b/src/writer.h
@@ -89,10 +89,8 @@ shard_sink_pending_bytes(const struct shard_sink* s);
 size_t
 shard_sink_required_shard_alignment(const struct shard_sink* s);
 
-// Drain pending async IO on this sink across all levels by recording a
-// terminal fence per level and waiting on it. No-op for synchronous sinks
-// (those without record_fence/wait_fence). Returns non-zero if the sink
-// reports an error after drain.
+// Drain pending async IO on this sink across all levels. Returns non-zero
+// if the sink reports an error after drain.
 int
 shard_sink_drain(struct shard_sink* s, int nlod);
 

--- a/src/zarr/shard_pool.h
+++ b/src/zarr/shard_pool.h
@@ -43,3 +43,7 @@ shard_pool_pending_bytes(const struct shard_pool* p);
 
 size_t
 shard_pool_required_shard_alignment(const struct shard_pool* p);
+
+// NULL-safe destroy wrapper. Dispatches to p->destroy(p) when p is non-NULL.
+void
+shard_pool_destroy(struct shard_pool* p);

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -328,6 +328,21 @@ shard_pool_fs_inject_failing_job(struct shard_pool* self)
   return io_queue_post(p->queue, fail_fn, (void*)&p->io_error, NULL);
 }
 
+static void
+gate_fn(void* arg)
+{
+  _Atomic int* gate = (_Atomic int*)arg;
+  while (atomic_load(gate) == 0)
+    platform_sleep_ns(1000000LL); // 1ms
+}
+
+int
+shard_pool_fs_inject_blocking_job(struct shard_pool* self, _Atomic int* gate)
+{
+  struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
+  return io_queue_post(p->queue, gate_fn, (void*)gate, NULL);
+}
+
 struct shard_pool*
 shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
 {

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -20,7 +20,6 @@ int
 shard_pool_fs_inject_failing_job(struct shard_pool* pool);
 
 // Test helper: enqueue a job that spins until *gate becomes non-zero.
-// The caller owns the gate and must keep it alive until after the job
-// observes the release. Returns 0 on successful enqueue.
+// Caller owns gate. Returns 0 on successful enqueue.
 int
 shard_pool_fs_inject_blocking_job(struct shard_pool* pool, _Atomic int* gate);

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -18,3 +18,9 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered);
 // without depending on filesystem behavior. Returns 0 on successful enqueue.
 int
 shard_pool_fs_inject_failing_job(struct shard_pool* pool);
+
+// Test helper: enqueue a job that spins until *gate becomes non-zero.
+// The caller owns the gate and must keep it alive until after the job
+// observes the release. Returns 0 on successful enqueue.
+int
+shard_pool_fs_inject_blocking_job(struct shard_pool* pool, _Atomic int* gate);

--- a/src/zarr/zarr_array.c
+++ b/src/zarr/zarr_array.c
@@ -278,7 +278,7 @@ zarr_array_create(struct store* store,
   struct zarr_array* a =
     zarr_array_init(store, pool, prefix, cfg, sc, cps, sic, 0);
   if (!a) {
-    pool->destroy(pool);
+    shard_pool_destroy(pool);
     return NULL;
   }
   a->owns_pool = 1;
@@ -301,8 +301,7 @@ zarr_array_destroy(struct zarr_array* a)
   strbuf_free(&a->prefix);
   struct shard_pool* pool = a->owns_pool ? a->pool : NULL;
   free(a);
-  if (pool)
-    pool->destroy(pool);
+  shard_pool_destroy(pool);
 }
 
 struct shard_sink*

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,6 +123,7 @@ add_gpu_test_exe(test_cross_validate test_cross_validate.c LINKS CUDA::cuda_driv
 # Test platform utilities
 add_test_lib(test_platform test_platform.h)
 add_platform_sources(test_platform)
+target_link_libraries(test_platform PUBLIC Threads::Threads)
 
 # Shared test data generation library
 add_test_lib(test_data test_data.c test_data.h)
@@ -151,6 +152,10 @@ target_compile_definitions(
 )
 
 add_gpu_test_exe(test_zarr_fs_sink   test_zarr_fs_sink.c   LINKS CUDA::cuda_driver CUDA::cudart_static test_zarr_helpers stream Zstd::Zstd test_platform test_shard_verify test_voxel_encode)
+add_gpu_test_exe(test_destroy_drain  test_destroy_drain.c  LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
+if(CHUCKY_ENABLE_GPU)
+    set_tests_properties(test-test_destroy_drain PROPERTIES TIMEOUT 30)
+endif()
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   zarr_array ngff_multiscale zarr_group zarr_metadata store_s3 store_api lod_plan dimension platform_cmd chucky_log)
 add_test_exe(test_store_s3       test_store_s3.c       store_s3 store_api platform_cmd chucky_log)
 

--- a/tests/test_destroy_drain.c
+++ b/tests/test_destroy_drain.c
@@ -1,5 +1,5 @@
-// Regression test for #110: tile_stream_gpu_destroy must drain sink IO
-// before freeing pinned aggregate buffers it references.
+// Regression test: tile_stream_gpu_destroy must drain sink IO before
+// freeing pinned aggregate buffers it references.
 
 #include "gpu/prelude.cuda.h"
 #include "platform/platform.h"
@@ -17,7 +17,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <cuda.h>
 
@@ -114,8 +113,6 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
 
   src = (uint32_t*)calloc(total_elements, sizeof(uint32_t));
   CHECK(Cleanup, src);
-  for (size_t i = 0; i < total_elements; ++i)
-    src[i] = (uint32_t)i;
 
   {
     struct slice input = { .beg = src, .end = src + total_elements };

--- a/tests/test_destroy_drain.c
+++ b/tests/test_destroy_drain.c
@@ -1,16 +1,5 @@
-// Regression test for issue #110.
-//
-// On GPU stream teardown, h_aggregated (pinned host memory referenced by
-// async pwrite_ref jobs) used to be freed before the sink's IO queue had
-// drained. tile_stream_gpu_destroy now calls shard_sink_drain to record
-// and wait on a terminal fence per level before freeing the aggregate
-// slots.
-//
-// We verify the drain is actually present by injecting a job that blocks
-// on an atomic gate. With the drain in place, destroy runs on a worker
-// thread and blocks until the test releases the gate. Without the drain,
-// destroy returns immediately and the assertion that the worker is still
-// alive fails.
+// Regression test for #110: tile_stream_gpu_destroy must drain sink IO
+// before freeing pinned aggregate buffers it references.
 
 #include "gpu/prelude.cuda.h"
 #include "platform/platform.h"
@@ -32,12 +21,8 @@
 
 #include <cuda.h>
 
-// Timing budgets. We know the sink IO is a single CPU-bound spin and a
-// handful of pwrite jobs against ~512 KiB of compressed data, so we can
-// afford tight bounds: the test does not depend on disk speed because
-// the gate job blocks the io_queue worker until we release it.
-#define DRAIN_OBSERVE_MS 200         // wait this long while gate is closed
-#define POST_RELEASE_TIMEOUT_MS 5000 // generous bound after gate releases
+#define DRAIN_OBSERVE_MS 200
+#define POST_RELEASE_TIMEOUT_MS 5000
 #define POLL_STEP_MS 10
 
 struct destroy_args
@@ -70,10 +55,6 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
 {
   log_info("=== test_destroy_waits_for_sink_io ===");
 
-  // Mirror tests/test_zarr_fs_sink.c::test_pipeline geometry: 12x8x12
-  // elements, 2x4x3 chunks, (3,2,2) chunks/shard => 4 shards. This config
-  // is known-good for the compress pipeline, so writes actually queue
-  // pwrite_ref jobs behind the blocking gate.
   struct dimension dims[3] = {
     { .size = 12,
       .chunk_size = 2,
@@ -108,7 +89,6 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
   CHECK(Cleanup, store->mkdirs(store, ".") == 0);
   CHECK(Cleanup, store->mkdirs(store, "0") == 0);
 
-  // 8 shards => 8 slots so writes don't serialize through one slot.
   pool = store->create_pool(store, 8);
   CHECK(Cleanup, pool);
 
@@ -143,38 +123,24 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
     CHECK(Cleanup, r.error == 0);
   }
 
-  // Inject the blocking job before destroy. It sits at seq=1 in the
-  // io_queue. The destroy auto-flush will queue pwrite jobs behind it,
-  // and shard_sink_drain will record a terminal fence behind everything.
-  // wait_fence then blocks until the gate is released.
+  // Gate sits at seq=1 in the io_queue ahead of any pwrite jobs the
+  // destroy auto-flush will queue behind it.
   CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
 
   struct destroy_args da = { .s = s };
   atomic_store(&da.done, 0);
   CHECK(Cleanup, test_thread_start(&thr, destroy_thread_fn, &da) == 0);
-
-  // Hand ownership of the stream to the worker thread.
   s = NULL;
 
-  // Phase 1: while the gate is closed, destroy MUST be blocked in
-  // shard_sink_drain. If `done` is set within DRAIN_OBSERVE_MS, the
-  // drain isn't waiting — fix is missing.
   platform_sleep_ns((int64_t)DRAIN_OBSERVE_MS * 1000000LL);
   int destroy_returned_early = (atomic_load(&da.done) != 0);
 
-  // Release the gate. The blocking job exits, queued pwrites drain, the
-  // terminal fence retires, destroy unblocks. Always release so the
-  // failure path can still tear down the pool cleanly.
   atomic_store(&gate, 1);
 
-  // Phase 2: bounded wait for destroy to finish. With the fix this is
-  // ~milliseconds; we allow POST_RELEASE_TIMEOUT_MS as a slop budget for
-  // CI noise. If we exceed it, something is genuinely wrong — fail loud
-  // and leak the worker rather than hanging the test.
   if (wait_for_done(&da.done, POST_RELEASE_TIMEOUT_MS)) {
     log_error("destroy did not finish within %d ms after gate release",
               POST_RELEASE_TIMEOUT_MS);
-    // Intentionally do NOT join — would hang. Leak the test_thread.
+    // Don't join — would hang. Leak the worker.
     thr = NULL;
     goto Cleanup;
   }
@@ -197,9 +163,6 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
 
 Cleanup:
   free(src);
-  // If the worker is still pending (e.g. early init failure before
-  // handoff), we never spawned it; if we leaked it on timeout, thr is
-  // already NULL.
   tile_stream_gpu_destroy(s);
   test_thread_join(thr);
   zarr_array_destroy(arr);

--- a/tests/test_destroy_drain.c
+++ b/tests/test_destroy_drain.c
@@ -1,0 +1,242 @@
+// Regression test for issue #110.
+//
+// On GPU stream teardown, h_aggregated (pinned host memory referenced by
+// async pwrite_ref jobs) used to be freed before the sink's IO queue had
+// drained. tile_stream_gpu_destroy now calls shard_sink_drain to record
+// and wait on a terminal fence per level before freeing the aggregate
+// slots.
+//
+// We verify the drain is actually present by injecting a job that blocks
+// on an atomic gate. With the drain in place, destroy runs on a worker
+// thread and blocks until the test releases the gate. Without the drain,
+// destroy returns immediately and the assertion that the worker is still
+// alive fails.
+
+#include "gpu/prelude.cuda.h"
+#include "platform/platform.h"
+#include "store.h"
+#include "stream.gpu.h"
+#include "test_platform.h"
+#include "util/prelude.h"
+#include "writer.h"
+#include "zarr.h"
+#include "zarr/shard_pool.h"
+#include "zarr/shard_pool_fs.h"
+#include "zarr/zarr_array.h"
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <cuda.h>
+
+// Timing budgets. We know the sink IO is a single CPU-bound spin and a
+// handful of pwrite jobs against ~512 KiB of compressed data, so we can
+// afford tight bounds: the test does not depend on disk speed because
+// the gate job blocks the io_queue worker until we release it.
+#define DRAIN_OBSERVE_MS 200         // wait this long while gate is closed
+#define POST_RELEASE_TIMEOUT_MS 5000 // generous bound after gate releases
+#define POLL_STEP_MS 10
+
+struct destroy_args
+{
+  struct tile_stream_gpu* s;
+  _Atomic int done;
+};
+
+static void
+destroy_thread_fn(void* arg)
+{
+  struct destroy_args* da = (struct destroy_args*)arg;
+  tile_stream_gpu_destroy(da->s);
+  atomic_store(&da->done, 1);
+}
+
+static int
+wait_for_done(_Atomic int* done, int timeout_ms)
+{
+  int waited_ms = 0;
+  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
+    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
+    waited_ms += POLL_STEP_MS;
+  }
+  return atomic_load(done) != 0 ? 0 : -1;
+}
+
+static int
+test_destroy_waits_for_sink_io(const char* tmpdir)
+{
+  log_info("=== test_destroy_waits_for_sink_io ===");
+
+  // Mirror tests/test_zarr_fs_sink.c::test_pipeline geometry: 12x8x12
+  // elements, 2x4x3 chunks, (3,2,2) chunks/shard => 4 shards. This config
+  // is known-good for the compress pipeline, so writes actually queue
+  // pwrite_ref jobs behind the blocking gate.
+  struct dimension dims[3] = {
+    { .size = 12,
+      .chunk_size = 2,
+      .chunks_per_shard = 3,
+      .name = "z",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 4,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 12,
+      .chunk_size = 3,
+      .chunks_per_shard = 2,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  const size_t total_elements = 12 * 8 * 12;
+
+  struct store* store = NULL;
+  struct shard_pool* pool = NULL;
+  struct zarr_array* arr = NULL;
+  struct tile_stream_gpu* s = NULL;
+  uint32_t* src = NULL;
+  test_thread* thr = NULL;
+  int rc = 1;
+  _Atomic int gate;
+  atomic_store(&gate, 0);
+
+  store = store_fs_create(tmpdir, 0);
+  CHECK(Cleanup, store);
+  CHECK(Cleanup, store->mkdirs(store, ".") == 0);
+  CHECK(Cleanup, store->mkdirs(store, "0") == 0);
+
+  // 8 shards => 8 slots so writes don't serialize through one slot.
+  pool = store->create_pool(store, 8);
+  CHECK(Cleanup, pool);
+
+  struct zarr_array_config acfg = {
+    .data_type = dtype_u32,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  arr = zarr_array_create_with_pool(store, pool, 0, "0", &acfg);
+  CHECK(Cleanup, arr);
+
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = total_elements * sizeof(uint32_t),
+    .dtype = dtype_u32,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  s = tile_stream_gpu_create(&cfg, zarr_array_as_shard_sink(arr));
+  CHECK(Cleanup, s);
+
+  src = (uint32_t*)calloc(total_elements, sizeof(uint32_t));
+  CHECK(Cleanup, src);
+  for (size_t i = 0; i < total_elements; ++i)
+    src[i] = (uint32_t)i;
+
+  {
+    struct slice input = { .beg = src, .end = src + total_elements };
+    struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
+    CHECK(Cleanup, r.error == 0);
+  }
+
+  // Inject the blocking job before destroy. It sits at seq=1 in the
+  // io_queue. The destroy auto-flush will queue pwrite jobs behind it,
+  // and shard_sink_drain will record a terminal fence behind everything.
+  // wait_fence then blocks until the gate is released.
+  CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+
+  struct destroy_args da = { .s = s };
+  atomic_store(&da.done, 0);
+  CHECK(Cleanup, test_thread_start(&thr, destroy_thread_fn, &da) == 0);
+
+  // Hand ownership of the stream to the worker thread.
+  s = NULL;
+
+  // Phase 1: while the gate is closed, destroy MUST be blocked in
+  // shard_sink_drain. If `done` is set within DRAIN_OBSERVE_MS, the
+  // drain isn't waiting — fix is missing.
+  platform_sleep_ns((int64_t)DRAIN_OBSERVE_MS * 1000000LL);
+  int destroy_returned_early = (atomic_load(&da.done) != 0);
+
+  // Release the gate. The blocking job exits, queued pwrites drain, the
+  // terminal fence retires, destroy unblocks. Always release so the
+  // failure path can still tear down the pool cleanly.
+  atomic_store(&gate, 1);
+
+  // Phase 2: bounded wait for destroy to finish. With the fix this is
+  // ~milliseconds; we allow POST_RELEASE_TIMEOUT_MS as a slop budget for
+  // CI noise. If we exceed it, something is genuinely wrong — fail loud
+  // and leak the worker rather than hanging the test.
+  if (wait_for_done(&da.done, POST_RELEASE_TIMEOUT_MS)) {
+    log_error("destroy did not finish within %d ms after gate release",
+              POST_RELEASE_TIMEOUT_MS);
+    // Intentionally do NOT join — would hang. Leak the test_thread.
+    thr = NULL;
+    goto Cleanup;
+  }
+
+  test_thread_join(thr);
+  thr = NULL;
+
+  if (destroy_returned_early) {
+    log_error("destroy returned before sink IO drained — fix is not in place");
+    goto Cleanup;
+  }
+
+  if (zarr_array_has_error(arr)) {
+    log_error("zarr_array reported IO error after drain");
+    goto Cleanup;
+  }
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  free(src);
+  // If the worker is still pending (e.g. early init failure before
+  // handoff), we never spawned it; if we leaked it on timeout, thr is
+  // already NULL.
+  tile_stream_gpu_destroy(s);
+  test_thread_join(thr);
+  zarr_array_destroy(arr);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return rc;
+}
+
+int
+main(int ac, char* av[])
+{
+  (void)ac;
+  (void)av;
+
+  int ecode = 0;
+  char tmpdir[4096];
+  CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  log_info("temp dir: %s", tmpdir);
+
+  CUcontext ctx = 0;
+  CUdevice dev;
+  CU(Cleanup, cuInit(0));
+  CU(Cleanup, cuDeviceGet(&dev, 0));
+  CU(Cleanup, cuCtxCreate(&ctx, 0, dev));
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/destroy_drain", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_destroy_waits_for_sink_io(sub);
+  }
+
+Cleanup:
+  if (ctx)
+    cuCtxDestroy(ctx);
+  test_tmpdir_remove(tmpdir);
+
+Fail:
+  return ecode;
+}

--- a/tests/test_platform.h
+++ b/tests/test_platform.h
@@ -25,13 +25,9 @@ test_mkdir(const char* path);
 int
 test_file_exists(const char* path);
 
-// --- Threading (for tests that need a side worker, e.g. blocking-sink
-// regression tests). Minimal: start + join. No cancellation; the test
-// must arrange for the worker to return via its own signaling.
-
 typedef struct test_thread test_thread;
 
-// Start fn(arg) on a new thread. Returns 0 on success, -1 on failure.
+// Start fn(arg) on a new thread. Returns 0 on success.
 int
 test_thread_start(test_thread** out, void (*fn)(void*), void* arg);
 

--- a/tests/test_platform.h
+++ b/tests/test_platform.h
@@ -24,3 +24,17 @@ test_mkdir(const char* path);
 // Check whether a file exists. Returns 1 if it exists, 0 otherwise.
 int
 test_file_exists(const char* path);
+
+// --- Threading (for tests that need a side worker, e.g. blocking-sink
+// regression tests). Minimal: start + join. No cancellation; the test
+// must arrange for the worker to return via its own signaling.
+
+typedef struct test_thread test_thread;
+
+// Start fn(arg) on a new thread. Returns 0 on success, -1 on failure.
+int
+test_thread_start(test_thread** out, void (*fn)(void*), void* arg);
+
+// Wait for the thread to finish and free resources. Returns 0 on success.
+int
+test_thread_join(test_thread* t);

--- a/tests/test_platform.posix.c
+++ b/tests/test_platform.posix.c
@@ -1,6 +1,7 @@
 #include "test_platform.h"
 
 #include <errno.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,4 +40,45 @@ test_file_exists(const char* path)
 {
   struct stat st;
   return stat(path, &st) == 0;
+}
+
+struct test_thread
+{
+  pthread_t handle;
+  void (*fn)(void*);
+  void* arg;
+};
+
+static void*
+thread_trampoline(void* p)
+{
+  struct test_thread* t = (struct test_thread*)p;
+  t->fn(t->arg);
+  return NULL;
+}
+
+int
+test_thread_start(struct test_thread** out, void (*fn)(void*), void* arg)
+{
+  struct test_thread* t = (struct test_thread*)malloc(sizeof(*t));
+  if (!t)
+    return -1;
+  t->fn = fn;
+  t->arg = arg;
+  if (pthread_create(&t->handle, NULL, thread_trampoline, t) != 0) {
+    free(t);
+    return -1;
+  }
+  *out = t;
+  return 0;
+}
+
+int
+test_thread_join(struct test_thread* t)
+{
+  if (!t)
+    return -1;
+  int rc = pthread_join(t->handle, NULL);
+  free(t);
+  return rc == 0 ? 0 : -1;
 }

--- a/tests/test_platform.win32.c
+++ b/tests/test_platform.win32.c
@@ -56,3 +56,46 @@ test_file_exists(const char* path)
   DWORD attr = GetFileAttributesA(path);
   return attr != INVALID_FILE_ATTRIBUTES;
 }
+
+struct test_thread
+{
+  HANDLE handle;
+  void (*fn)(void*);
+  void* arg;
+};
+
+static DWORD WINAPI
+thread_trampoline(LPVOID p)
+{
+  struct test_thread* t = (struct test_thread*)p;
+  t->fn(t->arg);
+  return 0;
+}
+
+int
+test_thread_start(struct test_thread** out, void (*fn)(void*), void* arg)
+{
+  struct test_thread* t = (struct test_thread*)malloc(sizeof(*t));
+  if (!t)
+    return -1;
+  t->fn = fn;
+  t->arg = arg;
+  t->handle = CreateThread(NULL, 0, thread_trampoline, t, 0, NULL);
+  if (!t->handle) {
+    free(t);
+    return -1;
+  }
+  *out = t;
+  return 0;
+}
+
+int
+test_thread_join(struct test_thread* t)
+{
+  if (!t)
+    return -1;
+  WaitForSingleObject(t->handle, INFINITE);
+  CloseHandle(t->handle);
+  free(t);
+  return 0;
+}

--- a/tests/test_store_fs.c
+++ b/tests/test_store_fs.c
@@ -2,9 +2,9 @@
 #include "store.h"
 #include "test_platform.h"
 #include "util/prelude.h"
+#include "zarr.h"
 #include "zarr/shard_pool.h"
 #include "zarr/shard_pool_fs.h"
-#include "zarr.h"
 #include "zarr/store.h"
 #include "zarr/store_fs.h"
 
@@ -125,13 +125,13 @@ test_shard_pool_write(void)
   CHECK(Fail3, n == len);
   CHECK(Fail3, memcmp(buf, data, n) == 0);
 
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
   s->destroy(s);
   log_info("  PASS");
   return 0;
 
 Fail3:
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
 Fail2:
   s->destroy(s);
 Fail:
@@ -168,13 +168,13 @@ test_shard_pool_fence(void)
   CHECK(Fail3, pool->has_error(pool) == 0);
   CHECK(Fail3, pool->pending_bytes(pool) == 0);
 
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
   s->destroy(s);
   log_info("  PASS");
   return 0;
 
 Fail3:
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
 Fail2:
   s->destroy(s);
 Fail:
@@ -207,13 +207,13 @@ test_shard_pool_on_demand_mkdir(void)
   CHECK(Fail3, f);
   fclose(f);
 
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
   s->destroy(s);
   log_info("  PASS");
   return 0;
 
 Fail3:
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
 Fail2:
   s->destroy(s);
 Fail:
@@ -261,7 +261,7 @@ test_shard_pool_unbuffered(void)
   CHECK(Fail4, test_file_exists(path));
 
   platform_aligned_free(data);
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
   s->destroy(s);
   log_info("  PASS");
   return 0;
@@ -269,7 +269,7 @@ test_shard_pool_unbuffered(void)
 Fail4:
   platform_aligned_free(data);
 Fail3:
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
 Fail2:
   s->destroy(s);
 Fail:
@@ -296,12 +296,12 @@ test_shard_pool_error_propagation(void)
   CHECK(Fail2, flush_err != 0);
   CHECK(Fail2, pool->has_error(pool) != 0);
 
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
   log_info("  PASS");
   return 0;
 
 Fail2:
-  pool->destroy(pool);
+  shard_pool_destroy(pool);
 Fail:
   log_error("  FAIL");
   return 1;


### PR DESCRIPTION
## Summary
- `tile_stream_gpu_destroy` and `multiarray_tile_stream_gpu_destroy` now record a terminal fence on each sink and wait for it before freeing aggregate slots, so async `pwrite_ref` jobs can no longer reference freed `h_aggregated` (issue #110).
- New `shard_sink_drain` helper (`src/writer.{h,c}`) shared by both destroy paths.
- Deterministic regression test `tests/test_destroy_drain.c` injects a blocking job into the FS pool's `io_queue` and verifies destroy waits on it. New cross-platform `test_thread_*` helpers in `tests/test_platform.{h,posix.c,win32.c}`.

## Test plan
- [x] Add `test_destroy_drain` and confirm it fails with the fix reverted and passes with it in place

Closes #110.