### PR TITLE
Bench: thread-scaling support

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -59,6 +59,7 @@ set(BENCH_STREAM_SOURCES
     bench_stream_medfmt_multiscale_dim0.c
     bench_stream_smallepoch_single.c
     bench_stream_256cube_two_streams.c
+    bench_stream_acq2k_single.c
 )
 
 foreach(src IN LISTS BENCH_STREAM_SOURCES)

--- a/bench/bench_stream_acq2k_single.c
+++ b/bench/bench_stream_acq2k_single.c
@@ -1,0 +1,31 @@
+// Mirrors benchmarks/benchmark.py geometry in the parent acquire-zarr repo:
+//   tyx = 1024 x 2048 x 2048 u16, 64-cube chunks, 16x16 xy shards.
+// Used for thread-scaling and IO-impact studies against tensorstore.
+#include "bench_util.h"
+#include "dimension.h"
+
+int
+main(int ac, char* av[])
+{
+  struct dimension dims[3];
+  uint64_t sizes[] = { 1024, 2048, 2048 };
+  uint8_t rank = dims_create(dims, "tyx", sizes);
+
+  // Equal weights -> 64-cube chunks at target_chunk_bytes = 64^3 * 2 = 512 KiB.
+  int ratios[] = { 1, 1, 1 };
+
+  return bench_stream_main(ac,
+                           av,
+                           (struct bench_spec){
+                             .label = "single",
+                             .dims = dims,
+                             .rank = rank,
+                             .chunk_ratios = ratios,
+                             .target_chunk_bytes = 1 << 19, // 512 KiB
+                             .min_chunk_bytes = 1 << 14,
+                             // 1 x 16 x 16 chunks/shard -> 128 MiB shards.
+                             .min_shard_bytes = 128ull << 20,
+                             .target_concurrent_shards = 4,
+                             .min_append_shards = 1,
+                           });
+}

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -411,6 +411,7 @@ run_bench(const struct bench_config* cfg)
     .epochs_per_batch = chosen_epochs_per_batch,
     .target_batch_bytes = 512u << 20,
     .backpressure_bytes = cfg->backpressure_bytes,
+    .max_threads = cfg->max_threads,
   };
 
   uint64_t est_total_chunks = 0;
@@ -603,13 +604,15 @@ struct bench_cli_args
   uint64_t io_bw_mbps;
   uint64_t io_latency_us;
   size_t backpressure_bytes;
+  int max_threads;
 };
 
 // Parse the shared bench CLI flags into out. Unknown options print a usage
 // string and return 1. Flags accepted:
 //   --fill --codec --reduce --backend --dtype --frames --json --chunk-bytes
 //   --memory-budget -o --s3-bucket --s3-prefix --s3-region --s3-endpoint
-//   --s3-throughput-gbps --io-bw-mbps --io-latency-us --backpressure.
+//   --s3-throughput-gbps --io-bw-mbps --io-latency-us --backpressure
+//   --max-threads.
 // Drivers that don't honor a given flag (e.g. two-streams ignores --backend)
 // just don't read the corresponding field afterward.
 static int
@@ -633,6 +636,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
   out->io_bw_mbps = 0;
   out->io_latency_us = 0;
   out->backpressure_bytes = 0;
+  out->max_threads = 0;
 
   for (int i = 1; i < ac; ++i) {
     if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
@@ -677,6 +681,8 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
       out->io_latency_us = strtoull(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--backpressure") == 0 && i + 1 < ac) {
       out->backpressure_bytes = parse_bytes(av[++i]);
+    } else if (strcmp(av[i], "--max-threads") == 0 && i + 1 < ac) {
+      out->max_threads = (int)strtol(av[++i], NULL, 10);
     } else {
       fprintf(stderr, "Unknown option: %s\n", av[i]);
       fprintf(stderr,
@@ -687,7 +693,8 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
               "[--s3-bucket B --s3-region R --s3-endpoint E [--s3-prefix P] "
               "[--s3-throughput-gbps N]] "
               "[--io-bw-mbps N (MiB/s)] [--io-latency-us N] "
-              "[--backpressure N (bytes, e.g. 256M)]\n",
+              "[--backpressure N (bytes, e.g. 256M)] "
+              "[--max-threads N (0 = OpenMP default)]\n",
               av[0]);
       return 1;
     }
@@ -746,6 +753,7 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
     .io_bw_mbps = a.io_bw_mbps,
     .io_latency_us = a.io_latency_us,
     .backpressure_bytes = a.backpressure_bytes,
+    .max_threads = a.max_threads,
   };
   ecode = run_bench(&cfg);
 
@@ -907,6 +915,7 @@ run_bench_two_streams(const struct bench_config* cfg)
     .epochs_per_batch = chosen_epochs_per_batch,
     .target_batch_bytes = 512u << 20,
     .backpressure_bytes = cfg->backpressure_bytes,
+    .max_threads = cfg->max_threads,
   };
 
   // Memory estimates
@@ -1115,6 +1124,7 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
     .io_bw_mbps = a.io_bw_mbps,
     .io_latency_us = a.io_latency_us,
     .backpressure_bytes = a.backpressure_bytes,
+    .max_threads = a.max_threads,
   };
   int ecode = run_bench_two_streams(&cfg);
 

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -52,6 +52,7 @@ struct bench_config
   uint64_t io_bw_mbps;        // 0 = no bandwidth cap (MiB/s)
   uint64_t io_latency_us;     // 0 = no fixed per-job latency
   size_t backpressure_bytes;  // 0 = disabled; >0 = stall when pending > N
+  int max_threads;            // 0 = OpenMP default (omp_get_max_threads)
 };
 
 int

--- a/src/cpu/aggregate.c
+++ b/src/cpu/aggregate.c
@@ -109,7 +109,7 @@ aggregate_cpu_into(const void* compressed,
   // Pass 3: gather compressed chunks in shard order.
   {
     int i;
-#pragma omp parallel for schedule(static) if (M > 1024) num_threads(nthreads)
+#pragma omp parallel for schedule(static) if (M > 64) num_threads(nthreads)
     for (i = 0; i < (int)M; ++i) {
       size_t nbytes = comp_sizes[i];
       if (nbytes == 0)
@@ -169,7 +169,8 @@ aggregate_cpu_batch_into(const void* compressed_base,
   // Pass 3: gather compressed chunks in shard order.
   {
     int i;
-#pragma omp parallel for schedule(static) if (batch_M > 1024) num_threads(nthreads)
+#pragma omp parallel for schedule(static) if (batch_M > 64)                    \
+  num_threads(nthreads)
     for (i = 0; i < (int)batch_M; ++i) {
       size_t nbytes = comp_sizes_base[gather[i]];
       if (nbytes == 0)

--- a/src/cpu/compress.c
+++ b/src/cpu/compress.c
@@ -42,7 +42,7 @@ compress_cpu(struct codec_config codec,
   int i;
   switch (codec.id) {
     case CODEC_NONE:
-#pragma omp parallel for schedule(static) if (batch_size > 1024)               \
+#pragma omp parallel for schedule(static) if (batch_size > 64)                 \
   num_threads(nthreads)
       for (i = 0; i < (int)batch_size; ++i) {
         memcpy((char*)dst + i * max_output_size,
@@ -55,7 +55,7 @@ compress_cpu(struct codec_config codec,
     case CODEC_LZ4_NON_STANDARD: {
       _Atomic int err = 0;
       int level = codec.level;
-#pragma omp parallel for schedule(dynamic) if (batch_size > 1024)              \
+#pragma omp parallel for schedule(dynamic) if (batch_size > 64)                \
   num_threads(nthreads)
       for (i = 0; i < (int)batch_size; ++i) {
         if (err)
@@ -75,7 +75,7 @@ compress_cpu(struct codec_config codec,
     case CODEC_ZSTD: {
       int level = codec.level;
       _Atomic int err = 0;
-#pragma omp parallel for schedule(dynamic) if (batch_size > 1024)              \
+#pragma omp parallel for schedule(dynamic) if (batch_size > 64)                \
   num_threads(nthreads)
       for (i = 0; i < (int)batch_size; ++i) {
         if (err)

--- a/src/cpu/compress_blosc.c
+++ b/src/cpu/compress_blosc.c
@@ -39,7 +39,8 @@ compress_blosc(struct codec_config codec,
   size_t typesize = bytes_per_element > 0 ? bytes_per_element : 1;
   _Atomic int err = 0;
   int i;
-#pragma omp parallel for schedule(dynamic) if (batch_size > 1024) num_threads(nthreads)
+#pragma omp parallel for schedule(dynamic) if (batch_size > 64)                \
+  num_threads(nthreads)
   for (i = 0; i < (int)batch_size; ++i) {
     if (err)
       continue;


### PR DESCRIPTION
## Summary
- New CLI flag `--max-threads N` on the bench drivers, plumbed through `bench_config` and `tile_stream_configuration.max_threads`. `0` keeps the existing OMP default.
- New `bench_stream_acq2k_single` mirroring the geometry used in acquire-zarr's benchmark.py

## Test plan
- [x] `bench_stream_orca2_single --backend cpu --max-threads N --json` for N in {1,2,4,8,12,16,20} — wall-time curve as expected