### PR TITLE
GPU writer_flush should block

### DIFF
--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -253,6 +253,9 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
     }
   }
 
+  if (shard_sink_drain(ctx->sink, ctx->levels.nlod))
+    return writer_error();
+
   // Final metadata update using pre-emit chunk counts.
   if (ctx->sink->update_append) {
     const uint8_t na = dim_info_n_append(&ctx->dims);

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -571,6 +571,38 @@ flush_impl(struct multiarray_writer* self)
   }
 
   ms->active = -1;
+
+  // Fan-out drain across all sinks so flush is a commit point: when it
+  // returns, every queued pwrite_ref job is durable and metadata reflects
+  // only durable chunks. stream_flush_body already drained per-array, but
+  // re-drain here to give callers a single barrier across the multiarray.
+  {
+    struct shard_sink** sinks =
+      (struct shard_sink**)calloc((size_t)ms->n_arrays, sizeof(*sinks));
+    int* nlods = (int*)calloc((size_t)ms->n_arrays, sizeof(*nlods));
+    if (sinks && nlods) {
+      for (int a = 0; a < ms->n_arrays; ++a) {
+        sinks[a] = ms->arrays[a].ctx.sink;
+        nlods[a] = ms->arrays[a].ctx.levels.nlod;
+      }
+      int errors = shard_sink_drain_many(sinks, nlods, ms->n_arrays);
+      free(sinks);
+      free(nlods);
+      if (errors)
+        return (struct multiarray_writer_result){ .error =
+                                                    multiarray_writer_fail };
+    } else {
+      free(sinks);
+      free(nlods);
+      for (int a = 0; a < ms->n_arrays; ++a) {
+        struct array_descriptor_gpu* desc = &ms->arrays[a];
+        if (shard_sink_drain(desc->ctx.sink, desc->ctx.levels.nlod))
+          return (struct multiarray_writer_result){ .error =
+                                                      multiarray_writer_fail };
+      }
+    }
+  }
+
   return (struct multiarray_writer_result){ .error = multiarray_writer_ok };
 
 Error:
@@ -609,24 +641,19 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
   sync_all(&ms->engine.streams);
 
   if (ms->arrays) {
-    // Drain sinks before freeing aggregate buffers they reference. Fan
-    // out the record phase across all arrays so wait blocks on the union
-    // of pending IO instead of serializing per-array drains.
-    struct io_event(*evs)[LOD_MAX_LEVELS] =
-      (struct io_event(*)[LOD_MAX_LEVELS])calloc((size_t)ms->n_arrays,
-                                                 sizeof(*evs));
-    if (evs) {
+    // Drain sinks before freeing aggregate buffers they reference.
+    struct shard_sink** sinks =
+      (struct shard_sink**)calloc((size_t)ms->n_arrays, sizeof(*sinks));
+    int* nlods = (int*)calloc((size_t)ms->n_arrays, sizeof(*nlods));
+    if (sinks && nlods) {
       for (int a = 0; a < ms->n_arrays; ++a) {
-        struct array_descriptor_gpu* desc = &ms->arrays[a];
-        shard_sink_drain_record(desc->ctx.sink, desc->ctx.levels.nlod, evs[a]);
+        sinks[a] = ms->arrays[a].ctx.sink;
+        nlods[a] = ms->arrays[a].ctx.levels.nlod;
       }
-      for (int a = 0; a < ms->n_arrays; ++a) {
-        struct array_descriptor_gpu* desc = &ms->arrays[a];
-        if (shard_sink_drain_wait(
-              desc->ctx.sink, desc->ctx.levels.nlod, evs[a]))
-          log_error("array %d sink reported IO errors during teardown", a);
-      }
-      free(evs);
+      int errors = shard_sink_drain_many(sinks, nlods, ms->n_arrays);
+      if (errors)
+        log_error("%d array sink(s) reported IO errors during teardown",
+                  errors);
     } else {
       for (int a = 0; a < ms->n_arrays; ++a) {
         struct array_descriptor_gpu* desc = &ms->arrays[a];
@@ -634,6 +661,8 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
           log_error("array %d sink reported IO errors during teardown", a);
       }
     }
+    free(sinks);
+    free(nlods);
     for (int a = 0; a < ms->n_arrays; ++a)
       destroy_array_descriptor(&ms->arrays[a]);
     free(ms->arrays);

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -572,36 +572,8 @@ flush_impl(struct multiarray_writer* self)
 
   ms->active = -1;
 
-  // Fan-out drain across all sinks so flush is a commit point: when it
-  // returns, every queued pwrite_ref job is durable and metadata reflects
-  // only durable chunks. stream_flush_body already drained per-array, but
-  // re-drain here to give callers a single barrier across the multiarray.
-  {
-    struct shard_sink** sinks =
-      (struct shard_sink**)calloc((size_t)ms->n_arrays, sizeof(*sinks));
-    int* nlods = (int*)calloc((size_t)ms->n_arrays, sizeof(*nlods));
-    if (sinks && nlods) {
-      for (int a = 0; a < ms->n_arrays; ++a) {
-        sinks[a] = ms->arrays[a].ctx.sink;
-        nlods[a] = ms->arrays[a].ctx.levels.nlod;
-      }
-      int errors = shard_sink_drain_many(sinks, nlods, ms->n_arrays);
-      free(sinks);
-      free(nlods);
-      if (errors)
-        return (struct multiarray_writer_result){ .error =
-                                                    multiarray_writer_fail };
-    } else {
-      free(sinks);
-      free(nlods);
-      for (int a = 0; a < ms->n_arrays; ++a) {
-        struct array_descriptor_gpu* desc = &ms->arrays[a];
-        if (shard_sink_drain(desc->ctx.sink, desc->ctx.levels.nlod))
-          return (struct multiarray_writer_result){ .error =
-                                                      multiarray_writer_fail };
-      }
-    }
-  }
+  // Each array's stream_flush_body already drained its sink as a commit
+  // point; no additional drain needed here.
 
   return (struct multiarray_writer_result){ .error = multiarray_writer_ok };
 
@@ -655,11 +627,7 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
         log_error("%d array sink(s) reported IO errors during teardown",
                   errors);
     } else {
-      for (int a = 0; a < ms->n_arrays; ++a) {
-        struct array_descriptor_gpu* desc = &ms->arrays[a];
-        if (shard_sink_drain(desc->ctx.sink, desc->ctx.levels.nlod))
-          log_error("array %d sink reported IO errors during teardown", a);
-      }
+      log_error("Failed to allocate drain arrays during teardown");
     }
     free(sinks);
     free(nlods);

--- a/src/writer.c
+++ b/src/writer.c
@@ -6,6 +6,7 @@
 #include "platform/platform.h"
 
 #include <assert.h>
+#include <stdlib.h>
 
 struct writer_result
 writer_append(struct writer* w, struct slice data)
@@ -127,6 +128,32 @@ shard_sink_drain(struct shard_sink* s, int nlod)
   struct io_event evs[LOD_MAX_LEVELS];
   shard_sink_drain_record(s, nlod, evs);
   return shard_sink_drain_wait(s, nlod, evs);
+}
+
+int
+shard_sink_drain_many(struct shard_sink** sinks, const int* nlods, int n)
+{
+  if (n <= 0)
+    return 0;
+  struct io_event* evs =
+    (struct io_event*)calloc((size_t)n * LOD_MAX_LEVELS, sizeof(*evs));
+  if (!evs) {
+    int errors = 0;
+    for (int i = 0; i < n; ++i) {
+      if (shard_sink_drain(sinks[i], nlods[i]))
+        ++errors;
+    }
+    return errors;
+  }
+  for (int i = 0; i < n; ++i)
+    shard_sink_drain_record(sinks[i], nlods[i], &evs[i * LOD_MAX_LEVELS]);
+  int errors = 0;
+  for (int i = 0; i < n; ++i) {
+    if (shard_sink_drain_wait(sinks[i], nlods[i], &evs[i * LOD_MAX_LEVELS]))
+      ++errors;
+  }
+  free(evs);
+  return errors;
 }
 
 size_t

--- a/src/writer.h
+++ b/src/writer.h
@@ -105,6 +105,12 @@ shard_sink_drain_wait(struct shard_sink* s,
                       int nlod,
                       const struct io_event* evs);
 
+// Drain N sinks together: fan out the record phase across all sinks, then
+// wait. Returns the number of sinks that reported errors after drain (0 = clean).
+// Falls back to per-sink drain on allocation failure.
+int
+shard_sink_drain_many(struct shard_sink** sinks, const int* nlods, int n);
+
 struct writer_result
 writer_ok(void);
 

--- a/src/writer.h
+++ b/src/writer.h
@@ -105,9 +105,7 @@ shard_sink_drain_wait(struct shard_sink* s,
                       int nlod,
                       const struct io_event* evs);
 
-// Drain N sinks together: fan out the record phase across all sinks, then
-// wait. Returns the number of sinks that reported errors after drain (0 = clean).
-// Falls back to per-sink drain on allocation failure.
+// Drain N sinks together. Returns the number of sinks reporting errors.
 int
 shard_sink_drain_many(struct shard_sink** sinks, const int* nlods, int n);
 

--- a/src/zarr/io_queue.h
+++ b/src/zarr/io_queue.h
@@ -28,3 +28,8 @@ io_queue_record(struct io_queue* q);
 // Block until all jobs up to and including ev.seq have completed.
 void
 io_event_wait(const struct io_queue* q, struct io_event ev);
+
+// Returns non-zero once io_queue_destroy has been called on the queue.
+// Long-running jobs can poll this to bail out early on shutdown.
+int
+io_queue_is_shutdown(const struct io_queue* q);

--- a/src/zarr/io_queue.posix.c
+++ b/src/zarr/io_queue.posix.c
@@ -192,3 +192,13 @@ io_event_wait(const struct io_queue* q, struct io_event ev)
     pthread_cond_wait(&mq->cond_retired, &mq->mutex);
   pthread_mutex_unlock(&mq->mutex);
 }
+
+int
+io_queue_is_shutdown(const struct io_queue* q)
+{
+  struct io_queue* mq = (struct io_queue*)q;
+  pthread_mutex_lock(&mq->mutex);
+  int r = mq->shutdown;
+  pthread_mutex_unlock(&mq->mutex);
+  return r;
+}

--- a/src/zarr/io_queue.win32.c
+++ b/src/zarr/io_queue.win32.c
@@ -190,3 +190,13 @@ io_event_wait(const struct io_queue* q, struct io_event ev)
     SleepConditionVariableSRW(&mq->cond_retired, &mq->srw, INFINITE, 0);
   ReleaseSRWLockExclusive(&mq->srw);
 }
+
+int
+io_queue_is_shutdown(const struct io_queue* q)
+{
+  struct io_queue* mq = (struct io_queue*)q;
+  AcquireSRWLockExclusive(&mq->srw);
+  int r = mq->shutdown;
+  ReleaseSRWLockExclusive(&mq->srw);
+  return r;
+}

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -303,12 +303,11 @@ pool_fs_destroy(struct shard_pool* self)
       fs_slot_finalize(&p->slots[i].base);
   }
 
-  // Flush remaining I/O
-  if (p->queue) {
-    struct io_event ev = io_queue_record(p->queue);
-    io_event_wait(p->queue, ev);
+  // Tear down the queue. io_queue_destroy signals shutdown and joins the
+  // worker; the worker drains all queued jobs before exiting, so any
+  // outstanding pwrite/close jobs run before destroy returns.
+  if (p->queue)
     io_queue_destroy(p->queue);
-  }
 
   free(p->slots);
   strbuf_free(&p->root);
@@ -330,19 +329,37 @@ shard_pool_fs_inject_failing_job(struct shard_pool* self)
   return io_queue_post(p->queue, fail_fn, (void*)&p->io_error, NULL);
 }
 
+struct gate_ctx
+{
+  _Atomic int* gate;
+  struct io_queue* queue;
+};
+
 static void
 gate_fn(void* arg)
 {
-  _Atomic int* gate = (_Atomic int*)arg;
-  while (atomic_load(gate) == 0)
+  struct gate_ctx* g = (struct gate_ctx*)arg;
+  while (atomic_load(g->gate) == 0) {
+    if (io_queue_is_shutdown(g->queue))
+      return;
     platform_sleep_ns(1000000LL); // 1ms
+  }
 }
 
 int
 shard_pool_fs_inject_blocking_job(struct shard_pool* self, _Atomic int* gate)
 {
   struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
-  return io_queue_post(p->queue, gate_fn, (void*)gate, NULL);
+  struct gate_ctx* g = (struct gate_ctx*)malloc(sizeof(*g));
+  if (!g)
+    return 1;
+  g->gate = gate;
+  g->queue = p->queue;
+  if (io_queue_post(p->queue, gate_fn, (void*)g, free)) {
+    free(g);
+    return 1;
+  }
+  return 0;
 }
 
 struct shard_pool*

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,6 +164,8 @@ add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_dr
 if(CHUCKY_ENABLE_GPU)
     set_tests_properties(test-test_flush_drain_gpu PROPERTIES TIMEOUT 30)
 endif()
+add_test_exe(test_flush_drain_multiarray_gpu test_flush_drain_multiarray_gpu.c zarr_array store_fs store_api shard_pool_fs platform test_platform writer chucky_log)
+set_tests_properties(test-test_flush_drain_multiarray_gpu PROPERTIES TIMEOUT 30)
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   zarr_array ngff_multiscale zarr_group zarr_metadata store_s3 store_api lod_plan dimension platform_cmd chucky_log)
 add_test_exe(test_store_s3       test_store_s3.c       store_s3 store_api platform_cmd chucky_log)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,6 +160,10 @@ add_gpu_test_exe(test_destroy_drain  test_destroy_drain.c  LINKS CUDA::cuda_driv
 if(CHUCKY_ENABLE_GPU)
     set_tests_properties(test-test_destroy_drain PROPERTIES TIMEOUT 30)
 endif()
+add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
+if(CHUCKY_ENABLE_GPU)
+    set_tests_properties(test-test_flush_drain_gpu PROPERTIES TIMEOUT 30)
+endif()
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   zarr_array ngff_multiscale zarr_group zarr_metadata store_s3 store_api lod_plan dimension platform_cmd chucky_log)
 add_test_exe(test_store_s3       test_store_s3.c       store_s3 store_api platform_cmd chucky_log)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -157,15 +157,8 @@ target_compile_definitions(
 
 add_gpu_test_exe(test_zarr_fs_sink   test_zarr_fs_sink.c   LINKS CUDA::cuda_driver CUDA::cudart_static test_zarr_helpers stream Zstd::Zstd test_platform test_shard_verify test_voxel_encode)
 add_gpu_test_exe(test_destroy_drain  test_destroy_drain.c  LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
-if(CHUCKY_ENABLE_GPU)
-    set_tests_properties(test-test_destroy_drain PROPERTIES TIMEOUT 30)
-endif()
 add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
-if(CHUCKY_ENABLE_GPU)
-    set_tests_properties(test-test_flush_drain_gpu PROPERTIES TIMEOUT 30)
-endif()
 add_test_exe(test_flush_drain_multiarray_gpu test_flush_drain_multiarray_gpu.c zarr_array store_fs store_api shard_pool_fs platform test_platform writer chucky_log)
-set_tests_properties(test-test_flush_drain_multiarray_gpu PROPERTIES TIMEOUT 30)
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   zarr_array ngff_multiscale zarr_group zarr_metadata store_s3 store_api lod_plan dimension platform_cmd chucky_log)
 add_test_exe(test_store_s3       test_store_s3.c       store_s3 store_api platform_cmd chucky_log)
 

--- a/tests/test_destroy_drain.c
+++ b/tests/test_destroy_drain.c
@@ -137,8 +137,6 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
   if (wait_for_done(&da.done, POST_RELEASE_TIMEOUT_MS)) {
     log_error("destroy did not finish within %d ms after gate release",
               POST_RELEASE_TIMEOUT_MS);
-    // Don't join — would hang. Leak the worker.
-    thr = NULL;
     goto Cleanup;
   }
 

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -1,0 +1,209 @@
+// Regression test: writer_flush() on the GPU stream must drain sink IO
+// before returning, so flush is a commit point: when it returns, all
+// queued pwrite_ref jobs are durable.
+
+#include "gpu/prelude.cuda.h"
+#include "platform/platform.h"
+#include "store.h"
+#include "stream.gpu.h"
+#include "test_platform.h"
+#include "util/prelude.h"
+#include "writer.h"
+#include "zarr.h"
+#include "zarr/shard_pool.h"
+#include "zarr/shard_pool_fs.h"
+#include "zarr/zarr_array.h"
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <cuda.h>
+
+#define DRAIN_OBSERVE_MS 200
+#define POST_RELEASE_TIMEOUT_MS 5000
+#define POLL_STEP_MS 10
+
+struct flush_args
+{
+  struct writer* w;
+  _Atomic int done;
+  int error;
+};
+
+static void
+flush_thread_fn(void* arg)
+{
+  struct flush_args* fa = (struct flush_args*)arg;
+  struct writer_result r = writer_flush(fa->w);
+  fa->error = r.error;
+  atomic_store(&fa->done, 1);
+}
+
+static int
+wait_for_done(_Atomic int* done, int timeout_ms)
+{
+  int waited_ms = 0;
+  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
+    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
+    waited_ms += POLL_STEP_MS;
+  }
+  return atomic_load(done) != 0 ? 0 : -1;
+}
+
+static int
+test_flush_waits_for_sink_io(const char* tmpdir)
+{
+  log_info("=== test_flush_waits_for_sink_io ===");
+
+  struct dimension dims[3] = {
+    { .size = 12,
+      .chunk_size = 2,
+      .chunks_per_shard = 3,
+      .name = "z",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 4,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 12,
+      .chunk_size = 3,
+      .chunks_per_shard = 2,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  const size_t total_elements = 12 * 8 * 12;
+
+  struct store* store = NULL;
+  struct shard_pool* pool = NULL;
+  struct zarr_array* arr = NULL;
+  struct tile_stream_gpu* s = NULL;
+  uint32_t* src = NULL;
+  test_thread* thr = NULL;
+  int rc = 1;
+  _Atomic int gate;
+  atomic_store(&gate, 0);
+
+  store = store_fs_create(tmpdir, 0);
+  CHECK(Cleanup, store);
+  CHECK(Cleanup, store->mkdirs(store, ".") == 0);
+  CHECK(Cleanup, store->mkdirs(store, "0") == 0);
+
+  pool = store->create_pool(store, 8);
+  CHECK(Cleanup, pool);
+
+  struct zarr_array_config acfg = {
+    .data_type = dtype_u32,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  arr = zarr_array_create_with_pool(store, pool, 0, "0", &acfg);
+  CHECK(Cleanup, arr);
+
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = total_elements * sizeof(uint32_t),
+    .dtype = dtype_u32,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  s = tile_stream_gpu_create(&cfg, zarr_array_as_shard_sink(arr));
+  CHECK(Cleanup, s);
+
+  src = (uint32_t*)calloc(total_elements, sizeof(uint32_t));
+  CHECK(Cleanup, src);
+
+  {
+    struct slice input = { .beg = src, .end = src + total_elements };
+    struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
+    CHECK(Cleanup, r.error == 0);
+  }
+
+  // Gate sits at seq=1 in the io_queue ahead of any pwrite jobs the
+  // flush will queue behind it.
+  CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+
+  struct flush_args fa = { .w = tile_stream_gpu_writer(s) };
+  atomic_store(&fa.done, 0);
+  CHECK(Cleanup, test_thread_start(&thr, flush_thread_fn, &fa) == 0);
+
+  platform_sleep_ns((int64_t)DRAIN_OBSERVE_MS * 1000000LL);
+  int flush_returned_early = (atomic_load(&fa.done) != 0);
+
+  atomic_store(&gate, 1);
+
+  if (wait_for_done(&fa.done, POST_RELEASE_TIMEOUT_MS)) {
+    log_error("flush did not finish within %d ms after gate release",
+              POST_RELEASE_TIMEOUT_MS);
+    // Don't join — would hang. Leak the worker.
+    thr = NULL;
+    goto Cleanup;
+  }
+
+  test_thread_join(thr);
+  thr = NULL;
+
+  if (flush_returned_early) {
+    log_error("flush returned before sink IO drained — fix is not in place");
+    goto Cleanup;
+  }
+
+  if (fa.error) {
+    log_error("flush returned error %d", fa.error);
+    goto Cleanup;
+  }
+
+  if (zarr_array_has_error(arr)) {
+    log_error("zarr_array reported IO error after drain");
+    goto Cleanup;
+  }
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  free(src);
+  tile_stream_gpu_destroy(s);
+  test_thread_join(thr);
+  zarr_array_destroy(arr);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return rc;
+}
+
+int
+main(int ac, char* av[])
+{
+  (void)ac;
+  (void)av;
+
+  int ecode = 0;
+  char tmpdir[4096];
+  CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  log_info("temp dir: %s", tmpdir);
+
+  CUcontext ctx = 0;
+  CUdevice dev;
+  CU(Cleanup, cuInit(0));
+  CU(Cleanup, cuDeviceGet(&dev, 0));
+  CU(Cleanup, cuCtxCreate(&ctx, 0, dev));
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/flush_drain", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_flush_waits_for_sink_io(sub);
+  }
+
+Cleanup:
+  if (ctx)
+    cuCtxDestroy(ctx);
+  test_tmpdir_remove(tmpdir);
+
+Fail:
+  return ecode;
+}

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -139,8 +139,6 @@ test_flush_waits_for_sink_io(const char* tmpdir)
   if (wait_for_done(&fa.done, POST_RELEASE_TIMEOUT_MS)) {
     log_error("flush did not finish within %d ms after gate release",
               POST_RELEASE_TIMEOUT_MS);
-    // Don't join — would hang. Leak the worker.
-    thr = NULL;
     goto Cleanup;
   }
 

--- a/tests/test_flush_drain_multiarray_gpu.c
+++ b/tests/test_flush_drain_multiarray_gpu.c
@@ -1,0 +1,236 @@
+// Regression test: shard_sink_drain_many's fan-out walks every sink. An
+// indexing or stride bug in the record-all-then-wait-all loop would
+// otherwise wait on only one sink and slip past CI. Exercises the helper
+// directly with N=2 zarr_array sinks backed by independent FS pools.
+
+#include "platform/platform.h"
+#include "store.h"
+#include "test_platform.h"
+#include "util/prelude.h"
+#include "writer.h"
+#include "zarr.h"
+#include "zarr/shard_pool.h"
+#include "zarr/shard_pool_fs.h"
+#include "zarr/zarr_array.h"
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DRAIN_OBSERVE_MS 200
+#define POST_RELEASE_TIMEOUT_MS 5000
+#define POLL_STEP_MS 10
+
+#define N_SINKS 2
+
+struct drain_args
+{
+  struct shard_sink** sinks;
+  int* nlods;
+  int n;
+  _Atomic int done;
+  int errors;
+};
+
+static void
+drain_thread_fn(void* arg)
+{
+  struct drain_args* da = (struct drain_args*)arg;
+  da->errors = shard_sink_drain_many(da->sinks, da->nlods, da->n);
+  atomic_store(&da->done, 1);
+}
+
+static int
+wait_for_done(_Atomic int* done, int timeout_ms)
+{
+  int waited_ms = 0;
+  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
+    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
+    waited_ms += POLL_STEP_MS;
+  }
+  return atomic_load(done) != 0 ? 0 : -1;
+}
+
+static int
+test_drain_many_fans_out(const char* tmpdir)
+{
+  log_info("=== test_drain_many_fans_out ===");
+
+  // Trivial 2D shape per zarr_array. The arrays don't need to receive any
+  // data — we only exercise the sink's record_fence/wait_fence path,
+  // which is what shard_sink_drain_many fans out across.
+  struct dimension dims_proto[2] = {
+    { .size = 2,
+      .chunk_size = 2,
+      .chunks_per_shard = 1,
+      .name = "y",
+      .storage_position = 0 },
+    { .size = 2,
+      .chunk_size = 2,
+      .chunks_per_shard = 1,
+      .name = "x",
+      .storage_position = 1 },
+  };
+
+  struct store* stores[N_SINKS] = { 0 };
+  struct shard_pool* pools[N_SINKS] = { 0 };
+  struct zarr_array* arrs[N_SINKS] = { 0 };
+  // gates[i]=blocking sentinel for sink i. priming_gate retires pool 1's
+  // seq=1 immediately so its retired_seq starts at 1; gates[1] then sits
+  // at seq=2. Pool 0 has only one sentinel at seq=1. The asymmetry lets
+  // the test catch a buggy _many that mixes events across sinks (e.g.
+  // always passes evs[0] to wait_fence): sink 1's wait on sink 0's seq=1
+  // would return early because pool 1 already retired its own seq=1.
+  _Atomic int gates[N_SINKS];
+  _Atomic int priming_gate;
+  atomic_store(&priming_gate, 1); // pre-released
+  for (int i = 0; i < N_SINKS; ++i)
+    atomic_store(&gates[i], 0);
+
+  test_thread* thr = NULL;
+  int rc = 1;
+
+  for (int i = 0; i < N_SINKS; ++i) {
+    char sub[4096];
+    snprintf(sub, sizeof(sub), "%s/sink%d", tmpdir, i);
+    test_mkdir(sub);
+
+    stores[i] = store_fs_create(sub, 0);
+    CHECK(Cleanup, stores[i]);
+    CHECK(Cleanup, stores[i]->mkdirs(stores[i], ".") == 0);
+    CHECK(Cleanup, stores[i]->mkdirs(stores[i], "0") == 0);
+
+    pools[i] = stores[i]->create_pool(stores[i], 8);
+    CHECK(Cleanup, pools[i]);
+
+    struct dimension dims[2];
+    for (int d = 0; d < 2; ++d)
+      dims[d] = dims_proto[d];
+
+    struct zarr_array_config acfg = {
+      .data_type = dtype_u32,
+      .fill_value = 0,
+      .rank = 2,
+      .dimensions = dims,
+      .codec = { .id = CODEC_NONE },
+    };
+    arrs[i] = zarr_array_create_with_pool(stores[i], pools[i], 0, "0", &acfg);
+    CHECK(Cleanup, arrs[i]);
+  }
+
+  struct shard_sink* sinks[N_SINKS];
+  int nlods[N_SINKS];
+  for (int i = 0; i < N_SINKS; ++i) {
+    sinks[i] = zarr_array_as_shard_sink(arrs[i]);
+    nlods[i] = 1;
+  }
+
+  // Pool 1: priming sentinel (already released) at seq=1, then real
+  // sentinel at seq=2. The priming job retires immediately, advancing
+  // pool 1's retired_seq to 1 before drain_many records its fence.
+  CHECK(Cleanup,
+        shard_pool_fs_inject_blocking_job(pools[1], &priming_gate) == 0);
+
+  // Real sentinels: pool 0 seq=1, pool 1 seq=2.  Drain_many will record
+  // fences at these seqs, fanning out across both sinks.
+  for (int i = 0; i < N_SINKS; ++i)
+    CHECK(Cleanup,
+          shard_pool_fs_inject_blocking_job(pools[i], &gates[i]) == 0);
+
+  // Wait for pool 1's priming sentinel to retire so its retired_seq
+  // advances to 1 deterministically before drain_many records.  Without
+  // this, drain_many's record could observe retired_seq=0 and the bug
+  // detection becomes timing-dependent.
+  pools[1]->wait_fence(pools[1], (struct io_event){ .seq = 1 });
+
+  struct drain_args da = {
+    .sinks = sinks,
+    .nlods = nlods,
+    .n = N_SINKS,
+  };
+  atomic_store(&da.done, 0);
+  CHECK(Cleanup, test_thread_start(&thr, drain_thread_fn, &da) == 0);
+
+  // Phase 1: nothing released — drain_many must be blocked.
+  platform_sleep_ns((int64_t)DRAIN_OBSERVE_MS * 1000000LL);
+  if (atomic_load(&da.done) != 0) {
+    log_error("drain_many returned before any sentinel was released");
+    goto Cleanup;
+  }
+
+  // Phase 2: release ONLY the first sentinel.  A buggy _many that only
+  // waits on sinks[0] (e.g., wrong stride or missing loop tail) would
+  // unblock here; the correct implementation must still be waiting on
+  // sinks[1].
+  atomic_store(&gates[0], 1);
+  platform_sleep_ns((int64_t)DRAIN_OBSERVE_MS * 1000000LL);
+  if (atomic_load(&da.done) != 0) {
+    log_error("drain_many returned after only the first sentinel was released "
+              "— fan-out is not waiting on every sink");
+    goto Cleanup;
+  }
+
+  // Phase 3: release the second sentinel; drain_many should now complete.
+  atomic_store(&gates[1], 1);
+
+  if (wait_for_done(&da.done, POST_RELEASE_TIMEOUT_MS)) {
+    log_error("drain_many did not finish within %d ms after second gate "
+              "release",
+              POST_RELEASE_TIMEOUT_MS);
+    // Don't join — would hang. Leak the worker.
+    thr = NULL;
+    goto Cleanup;
+  }
+
+  test_thread_join(thr);
+  thr = NULL;
+
+  if (da.errors) {
+    log_error("drain_many reported %d sink errors", da.errors);
+    goto Cleanup;
+  }
+
+  for (int i = 0; i < N_SINKS; ++i) {
+    if (zarr_array_has_error(arrs[i])) {
+      log_error("array %d sink reported IO error after drain", i);
+      goto Cleanup;
+    }
+  }
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  test_thread_join(thr);
+  for (int i = 0; i < N_SINKS; ++i) {
+    zarr_array_destroy(arrs[i]);
+    shard_pool_destroy(pools[i]);
+    store_destroy(stores[i]);
+  }
+  return rc;
+}
+
+int
+main(int ac, char* av[])
+{
+  (void)ac;
+  (void)av;
+
+  int ecode = 0;
+  char tmpdir[4096];
+  CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  log_info("temp dir: %s", tmpdir);
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/multi_drain", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_drain_many_fans_out(sub);
+  }
+
+  test_tmpdir_remove(tmpdir);
+
+Fail:
+  return ecode;
+}

--- a/tests/test_flush_drain_multiarray_gpu.c
+++ b/tests/test_flush_drain_multiarray_gpu.c
@@ -178,8 +178,6 @@ test_drain_many_fans_out(const char* tmpdir)
     log_error("drain_many did not finish within %d ms after second gate "
               "release",
               POST_RELEASE_TIMEOUT_MS);
-    // Don't join — would hang. Leak the worker.
-    thr = NULL;
     goto Cleanup;
   }
 


### PR DESCRIPTION
## Summary

Makes GPU `writer_flush()` block until all queued `pwrite_ref` jobs are durable, mirroring the CPU contract. Fixes a metadata-ordering bug where `update_append` was advertising chunks before they were on disk.

Background: PR #111 added `shard_sink_drain` to GPU destroy, but `stream_flush_body` itself was still a kick — it called `finalize_shards` and `update_append` then returned without waiting on the sink io_queue. CPU's `cpu_stream_flush_body` already waits on per-slot fences (`src/cpu/stream.body.c:309-312`), so this brings GPU to parity.

## Changes

- `src/writer.{h,c}`: New `shard_sink_drain_many` helper. Two-phase fan-out (record → wait) across N sinks; falls back to per-sink drain on calloc failure.
- `src/gpu/stream.c` (`stream_flush_body`): Drain after `finalize_shards`, before `update_append`. Mirrors CPU's drain → finalize → metadata ordering.
- `src/multiarray/stream.gpu.c` (`flush_impl`): Fan-out drain across all array sinks via the new helper.
- `src/multiarray/stream.gpu.c` (`multiarray_tile_stream_gpu_destroy`): Replaced inline two-phase block with the helper. Behavior preserved.
- `tests/test_flush_drain_gpu.c`: Regression test. Mirrors `test_destroy_drain.c` but spawns a flush thread and verifies it blocks on a sentinel io_queue job.
- `tests/test_flush_drain_multiarray_gpu.c`: Direct multi-sink test of `shard_sink_drain_many` with two `zarr_array` sinks. Catches indexing/iteration bugs in the fan-out (skipped sinks, wrong stride) via an asymmetric pool-seq priming trick.

## Test plan

- [x] revert the `shard_sink_drain` insert in `stream_flush_body` → `test_flush_drain_gpu` fails. Restore.
- [x] Existing `test_destroy_drain` still passes (multiarray destroy refactor preserves behavior).
- [x] Negative regressions for `_many`: skipping the loop tail, or using `&evs[0]` instead of `&evs[i * LOD_MAX_LEVELS]` in the wait loop, both make `test_flush_drain_multiarray_gpu` fail.