### PR TITLE
Resumable writer_flush

### DIFF
--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -107,7 +107,7 @@ cpu_stream_append_body(struct cpu_stream_view* v, struct slice input)
 
   while (src < end) {
     // Capacity reached: refuse further writes and report `finished` with the
-    // remaining input unconsumed. The terminal flush is NOT run here — it
+    // remaining input unconsumed. Sink finalization is NOT run here — it
     // happens on explicit `writer_flush` or on stream destroy. Keeping the
     // producer path free of sink finalization means appends never block on
     // IO the stream's owner hasn't asked for.

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -103,7 +103,7 @@ cpu_stream_append_body(struct cpu_stream_view* v, struct slice input)
   const size_t bpe = dtype_bpe(v->config->dtype);
   const uint8_t* src = (const uint8_t*)input.beg;
   const uint8_t* end = (const uint8_t*)input.end;
-  const uint64_t max_cursor = v->max_cursor_elements;
+  const uint64_t total = v->total_elements;
 
   while (src < end) {
     // Capacity reached: refuse further writes and report `finished` with the
@@ -111,7 +111,7 @@ cpu_stream_append_body(struct cpu_stream_view* v, struct slice input)
     // happens on explicit `writer_flush` or on stream destroy. Keeping the
     // producer path free of sink finalization means appends never block on
     // IO the stream's owner hasn't asked for.
-    if (max_cursor > 0 && *v->cursor_elements >= max_cursor)
+    if (total > 0 && *v->cursor_elements >= total)
       return writer_finished_at(src, end);
 
     const uint64_t epoch_remaining =
@@ -121,8 +121,8 @@ cpu_stream_append_body(struct cpu_stream_view* v, struct slice input)
     uint64_t elements =
       epoch_remaining < input_remaining ? epoch_remaining : input_remaining;
 
-    if (max_cursor > 0) {
-      uint64_t cap = max_cursor - *v->cursor_elements;
+    if (total > 0) {
+      uint64_t cap = total - *v->cursor_elements;
       if (elements > cap)
         elements = cap;
     }

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -103,7 +103,7 @@ cpu_stream_append_body(struct cpu_stream_view* v, struct slice input)
   const size_t bpe = dtype_bpe(v->config->dtype);
   const uint8_t* src = (const uint8_t*)input.beg;
   const uint8_t* end = (const uint8_t*)input.end;
-  const uint64_t total = v->total_elements;
+  const uint64_t total_limit = v->total_element_limit;
 
   while (src < end) {
     // Capacity reached: refuse further writes and report `finished` with the
@@ -111,7 +111,7 @@ cpu_stream_append_body(struct cpu_stream_view* v, struct slice input)
     // happens on explicit `writer_flush` or on stream destroy. Keeping the
     // producer path free of sink finalization means appends never block on
     // IO the stream's owner hasn't asked for.
-    if (total > 0 && *v->cursor_elements >= total)
+    if (total_limit > 0 && *v->cursor_elements >= total_limit)
       return writer_finished_at(src, end);
 
     const uint64_t epoch_remaining =
@@ -121,8 +121,8 @@ cpu_stream_append_body(struct cpu_stream_view* v, struct slice input)
     uint64_t elements =
       epoch_remaining < input_remaining ? epoch_remaining : input_remaining;
 
-    if (total > 0) {
-      uint64_t cap = total - *v->cursor_elements;
+    if (total_limit > 0) {
+      uint64_t cap = total_limit - *v->cursor_elements;
       if (elements > cap)
         elements = cap;
     }

--- a/src/cpu/stream.body.h
+++ b/src/cpu/stream.body.h
@@ -21,7 +21,7 @@ struct cpu_stream_view
 
   // Mutable per-array cursor + batch state
   uint64_t* cursor_elements;
-  uint64_t max_cursor_elements;
+  uint64_t total_elements;
   uint32_t* batch_accumulated;
   uint32_t* batch_active_masks;  // [K]
   uint32_t* pool_epochs_scratch; // [K] scratch for LUT recompute

--- a/src/cpu/stream.body.h
+++ b/src/cpu/stream.body.h
@@ -21,7 +21,7 @@ struct cpu_stream_view
 
   // Mutable per-array cursor + batch state
   uint64_t* cursor_elements;
-  uint64_t total_elements;
+  uint64_t total_element_limit;
   uint32_t* batch_accumulated;
   uint32_t* batch_active_masks;  // [K]
   uint32_t* pool_epochs_scratch; // [K] scratch for LUT recompute

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -714,11 +714,11 @@ cpu_append(struct writer* self, struct slice input)
   struct tile_stream_cpu* s =
     container_of(self, struct tile_stream_cpu, writer);
 
-  writer_arm_for_append(
-    &s->flushed, input, s->cursor_elements, s->max_cursor_elements);
-
   struct cpu_stream_view v = make_view(s);
-  return cpu_stream_append_body(&v, input);
+  struct writer_result r = cpu_stream_append_body(&v, input);
+  if (s->flushed && r.rest.beg != input.beg)
+    s->flushed = 0;
+  return r;
 }
 
 static struct writer_result

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -714,10 +714,8 @@ cpu_append(struct writer* self, struct slice input)
   struct tile_stream_cpu* s =
     container_of(self, struct tile_stream_cpu, writer);
 
-  // Re-arm for the next sync: a non-empty append after flush has new work,
-  // so the next flush must run flush_body again.
-  if (s->flushed && input.beg != input.end)
-    s->flushed = 0;
+  writer_arm_for_append(
+    &s->flushed, input, s->cursor_elements, s->max_cursor_elements);
 
   struct cpu_stream_view v = make_view(s);
   return cpu_stream_append_body(&v, input);

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -714,8 +714,10 @@ cpu_append(struct writer* self, struct slice input)
   struct tile_stream_cpu* s =
     container_of(self, struct tile_stream_cpu, writer);
 
-  if (s->flushed)
-    return writer_finished_at(input.beg, input.end);
+  // Re-arm for the next sync: a non-empty append after flush has new work,
+  // so the next flush must run flush_body again.
+  if (s->flushed && input.beg != input.end)
+    s->flushed = 0;
 
   struct cpu_stream_view v = make_view(s);
   return cpu_stream_append_body(&v, input);
@@ -726,9 +728,9 @@ cpu_flush_final(struct writer* self)
 {
   struct tile_stream_cpu* s =
     container_of(self, struct tile_stream_cpu, writer);
-  // Re-entering the flush body on an already-finalized stream would
-  // re-finalize already-closed sinks — a deadlock on Windows and wasted
-  // work elsewhere.
+  // Idempotency: a redundant flush with no intervening appends re-finalizes
+  // already-closed sinks (deadlock on Windows, wasted work elsewhere).
+  // The flag is reset by cpu_append when new data arrives.
   if (s->flushed)
     return writer_ok();
   struct cpu_stream_view v = make_view(s);

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -733,6 +733,7 @@ cpu_flush_final(struct writer* self)
     return writer_ok();
   struct cpu_stream_view v = make_view(s);
   struct writer_result r = cpu_stream_flush_body(&v);
-  s->flushed = 1;
+  if (r.error == 0)
+    s->flushed = 1;
   return r;
 }

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -244,16 +244,17 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
     s->metrics.lod_morton_chunk = mk_stream_metric("lod_morton");
   }
 
-  // Precompute max_cursor so cpu_append doesn't recompute each call.
+  // Precompute total_elements (configured stream length) so the body can
+  // detect the at-capacity case without recomputing each call.
   {
     const struct dimension* dims = config->dimensions;
     const uint8_t na = dim_info_n_append(&s->cl.dims);
     if (dims[0].size > 0) {
-      s->max_cursor_elements = s->layout.epoch_elements;
+      s->total_elements = s->layout.epoch_elements;
       for (int d = 0; d < na; ++d)
-        s->max_cursor_elements *= ceildiv(dims[d].size, dims[d].chunk_size);
+        s->total_elements *= ceildiv(dims[d].size, dims[d].chunk_size);
     } else {
-      s->max_cursor_elements = 0;
+      s->total_elements = 0;
     }
   }
 
@@ -672,7 +673,7 @@ make_view(struct tile_stream_cpu* s)
     .layout = &s->layout,
     .levels = &s->levels,
     .cursor_elements = &s->cursor_elements,
-    .max_cursor_elements = s->max_cursor_elements,
+    .total_elements = s->total_elements,
     .batch_accumulated = &s->batch_accumulated,
     .batch_active_masks = s->batch_active_masks,
     .pool_epochs_scratch = s->pool_epochs_scratch,

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -244,17 +244,17 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
     s->metrics.lod_morton_chunk = mk_stream_metric("lod_morton");
   }
 
-  // Precompute total_elements (configured stream length) so the body can
+  // Precompute total_element_limit (configured stream length) so the body can
   // detect the at-capacity case without recomputing each call.
   {
     const struct dimension* dims = config->dimensions;
     const uint8_t na = dim_info_n_append(&s->cl.dims);
     if (dims[0].size > 0) {
-      s->total_elements = s->layout.epoch_elements;
+      s->total_element_limit = s->layout.epoch_elements;
       for (int d = 0; d < na; ++d)
-        s->total_elements *= ceildiv(dims[d].size, dims[d].chunk_size);
+        s->total_element_limit *= ceildiv(dims[d].size, dims[d].chunk_size);
     } else {
-      s->total_elements = 0;
+      s->total_element_limit = 0;
     }
   }
 
@@ -673,7 +673,7 @@ make_view(struct tile_stream_cpu* s)
     .layout = &s->layout,
     .levels = &s->levels,
     .cursor_elements = &s->cursor_elements,
-    .total_elements = s->total_elements,
+    .total_element_limit = s->total_element_limit,
     .batch_accumulated = &s->batch_accumulated,
     .batch_active_masks = s->batch_active_masks,
     .pool_epochs_scratch = s->pool_epochs_scratch,

--- a/src/cpu/stream.internal.h
+++ b/src/cpu/stream.internal.h
@@ -65,7 +65,7 @@ struct tile_stream_cpu
   uint64_t
     max_cursor_elements; // precomputed: total elements across all append chunks
   int pool_fully_covered; // 1 if scatter overwrites every pool position
-  int flushed;            // 1 after flush; append after flush is an error
+  int flushed;            // 1 after flush; reset by append for idempotency
 
   // Batch accumulation state (K = cl.epochs_per_batch).
   uint32_t batch_accumulated;    // 0..K-1

--- a/src/cpu/stream.internal.h
+++ b/src/cpu/stream.internal.h
@@ -62,8 +62,8 @@ struct tile_stream_cpu
   uint32_t append_counts[LOD_MAX_LEVELS]; // per-level fold count
 
   uint64_t cursor_elements;
-  uint64_t
-    max_cursor_elements; // precomputed: total elements across all append chunks
+  uint64_t total_elements; // configured stream length in elements (across all
+                           // append chunks). 0 = unbounded.
   int pool_fully_covered; // 1 if scatter overwrites every pool position
   int flushed;            // 1 after flush; reset by append for idempotency
 

--- a/src/cpu/stream.internal.h
+++ b/src/cpu/stream.internal.h
@@ -62,8 +62,8 @@ struct tile_stream_cpu
   uint32_t append_counts[LOD_MAX_LEVELS]; // per-level fold count
 
   uint64_t cursor_elements;
-  uint64_t total_elements; // configured stream length in elements (across all
-                           // append chunks). 0 = unbounded.
+  uint64_t total_element_limit; // configured stream length in elements (across
+                                // all append chunks). 0 = unbounded.
   int pool_fully_covered; // 1 if scatter overwrites every pool position
   int flushed;            // 1 after flush; reset by append for idempotency
 

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -213,7 +213,7 @@ record_flush_metrics(const struct d2h_deliver_stage* stage,
                          morton_bytes);
     if (dims->append_downsample) {
       size_t accum_bpe = dtype_bpe(config->dtype);
-      size_t accum_bytes = lod->append_accum.total_elements * accum_bpe;
+      size_t accum_bytes = lod->append_accum.element_capacity * accum_bpe;
       accumulate_metric_cu(&metrics->lod_append_fold,
                            t->t_reduce_end,
                            t->t_append_end,

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -89,13 +89,13 @@ stream_append_body(struct stream_engine* e,
   const uint8_t* src = (const uint8_t*)input.beg;
   const uint8_t* end = (const uint8_t*)input.end;
 
-  const uint64_t total = ctx->total_elements;
+  const uint64_t total_limit = ctx->total_element_limit;
 
   while (src < end) {
     // Capacity reached: refuse further writes and report `finished` with the
     // remaining input unconsumed. Sink finalization is NOT run here — it
     // happens on explicit `writer_flush` or on stream destroy.
-    if (total > 0 && ctx->cursor_elements >= total)
+    if (total_limit > 0 && ctx->cursor_elements >= total_limit)
       return writer_finished_at(src, end);
 
     const uint64_t epoch_remaining =
@@ -106,8 +106,8 @@ stream_append_body(struct stream_engine* e,
       epoch_remaining < input_remaining ? epoch_remaining : input_remaining;
 
     // Bounded append dims: clamp to remaining capacity
-    if (total > 0) {
-      const uint64_t remaining_capacity = total - ctx->cursor_elements;
+    if (total_limit > 0) {
+      const uint64_t remaining_capacity = total_limit - ctx->cursor_elements;
       if (elements_this_pass > remaining_capacity)
         elements_this_pass = remaining_capacity;
     }

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -89,13 +89,13 @@ stream_append_body(struct stream_engine* e,
   const uint8_t* src = (const uint8_t*)input.beg;
   const uint8_t* end = (const uint8_t*)input.end;
 
-  const uint64_t max_cursor_elements = ctx->max_cursor_elements;
+  const uint64_t total = ctx->total_elements;
 
   while (src < end) {
     // Capacity reached: refuse further writes and report `finished` with the
     // remaining input unconsumed. Sink finalization is NOT run here — it
     // happens on explicit `writer_flush` or on stream destroy.
-    if (max_cursor_elements > 0 && ctx->cursor_elements >= max_cursor_elements)
+    if (total > 0 && ctx->cursor_elements >= total)
       return writer_finished_at(src, end);
 
     const uint64_t epoch_remaining =
@@ -106,9 +106,8 @@ stream_append_body(struct stream_engine* e,
       epoch_remaining < input_remaining ? epoch_remaining : input_remaining;
 
     // Bounded append dims: clamp to remaining capacity
-    if (max_cursor_elements > 0) {
-      const uint64_t remaining_capacity =
-        max_cursor_elements - ctx->cursor_elements;
+    if (total > 0) {
+      const uint64_t remaining_capacity = total - ctx->cursor_elements;
       if (elements_this_pass > remaining_capacity)
         elements_this_pass = remaining_capacity;
     }

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -284,15 +284,14 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
   struct tile_stream_gpu* s =
     container_of(self, struct tile_stream_gpu, writer);
 
-  writer_arm_for_append(
-    &s->flushed, input, s->ctx.cursor_elements, s->ctx.max_cursor_elements);
-
   struct platform_clock clk = { 0 };
   platform_toc(&clk);
   struct writer_result r = stream_append_body(&s->engine, &s->ctx, input);
   float ms = (float)(platform_toc(&clk) * 1000.0);
   if (ms > s->engine.metrics.max_append_ms)
     s->engine.metrics.max_append_ms = ms;
+  if (s->flushed && r.rest.beg != input.beg)
+    s->flushed = 0;
   return r;
 }
 

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -93,7 +93,7 @@ stream_append_body(struct stream_engine* e,
 
   while (src < end) {
     // Capacity reached: refuse further writes and report `finished` with the
-    // remaining input unconsumed. The terminal flush is NOT run here — it
+    // remaining input unconsumed. Sink finalization is NOT run here — it
     // happens on explicit `writer_flush` or on stream destroy.
     if (max_cursor_elements > 0 && ctx->cursor_elements >= max_cursor_elements)
       return writer_finished_at(src, end);
@@ -284,8 +284,10 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
   struct tile_stream_gpu* s =
     container_of(self, struct tile_stream_gpu, writer);
 
-  if (s->flushed)
-    return writer_finished_at(input.beg, input.end);
+  // Re-arm for the next sync: a non-empty append after flush has new work,
+  // so the next flush must run flush_body again.
+  if (s->flushed && input.beg != input.end)
+    s->flushed = 0;
 
   struct platform_clock clk = { 0 };
   platform_toc(&clk);
@@ -301,7 +303,8 @@ tile_stream_gpu_flush_final(struct writer* self)
 {
   struct tile_stream_gpu* s =
     container_of(self, struct tile_stream_gpu, writer);
-  // Mirrors the CPU guard: avoid re-finalizing an already-finalized stream.
+  // Idempotency: mirrors the CPU guard. Reset by tile_stream_gpu_append when
+  // new data arrives.
   if (s->flushed)
     return writer_ok();
   struct writer_result r = stream_flush_body(&s->engine, &s->ctx);

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -284,10 +284,8 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
   struct tile_stream_gpu* s =
     container_of(self, struct tile_stream_gpu, writer);
 
-  // Re-arm for the next sync: a non-empty append after flush has new work,
-  // so the next flush must run flush_body again.
-  if (s->flushed && input.beg != input.end)
-    s->flushed = 0;
+  writer_arm_for_append(
+    &s->flushed, input, s->ctx.cursor_elements, s->ctx.max_cursor_elements);
 
   struct platform_clock clk = { 0 };
   platform_toc(&clk);

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -306,7 +306,8 @@ tile_stream_gpu_flush_final(struct writer* self)
   if (s->flushed)
     return writer_ok();
   struct writer_result r = stream_flush_body(&s->engine, &s->ctx);
-  s->flushed = 1;
+  if (r.error == 0)
+    s->flushed = 1;
   return r;
 }
 

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -205,7 +205,7 @@ struct stream_context
   struct level_geometry levels;
   struct dim_info dims;
   uint64_t cursor_elements;
-  uint64_t total_elements;      // configured stream length; 0 = unbounded
+  uint64_t total_element_limit; // configured stream length; 0 = unbounded
   size_t shard_alignment;       // from sink; 0 = no alignment
 };
 

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -107,7 +107,7 @@ struct lod_state
     CUdeviceptr d_level_ids;
     CUdeviceptr d_counts;
     uint32_t counts[LOD_MAX_LEVELS];
-    uint64_t total_elements;
+    uint64_t element_capacity;
     uint64_t morton_offset;
   } append_accum;
 };

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -205,7 +205,7 @@ struct stream_context
   struct level_geometry levels;
   struct dim_info dims;
   uint64_t cursor_elements;
-  uint64_t max_cursor_elements; // 0 = unbounded
+  uint64_t total_elements;      // configured stream length; 0 = unbounded
   size_t shard_alignment;       // from sink; 0 = no alignment
 };
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -285,15 +285,15 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
 
   CU(FailPhase2, cuStreamSynchronize(out->engine.streams.compute));
 
-  // Precompute max_cursor_elements so append doesn't recompute each call.
+  // Precompute total_elements (configured stream length) so the body can
+  // detect the at-capacity case without recomputing each call.
   {
     const struct dimension* dims = config->dimensions;
     const uint8_t na = dim_info_n_append(&out->ctx.dims);
     if (dims[0].size > 0) {
-      out->ctx.max_cursor_elements = out->ctx.layout.epoch_elements;
+      out->ctx.total_elements = out->ctx.layout.epoch_elements;
       for (int d = 0; d < na; ++d)
-        out->ctx.max_cursor_elements *=
-          ceildiv(dims[d].size, dims[d].chunk_size);
+        out->ctx.total_elements *= ceildiv(dims[d].size, dims[d].chunk_size);
     }
   }
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -285,15 +285,16 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
 
   CU(FailPhase2, cuStreamSynchronize(out->engine.streams.compute));
 
-  // Precompute total_elements (configured stream length) so the body can
+  // Precompute total_element_limit (configured stream length) so the body can
   // detect the at-capacity case without recomputing each call.
   {
     const struct dimension* dims = config->dimensions;
     const uint8_t na = dim_info_n_append(&out->ctx.dims);
     if (dims[0].size > 0) {
-      out->ctx.total_elements = out->ctx.layout.epoch_elements;
+      out->ctx.total_element_limit = out->ctx.layout.epoch_elements;
       for (int d = 0; d < na; ++d)
-        out->ctx.total_elements *= ceildiv(dims[d].size, dims[d].chunk_size);
+        out->ctx.total_element_limit *=
+          ceildiv(dims[d].size, dims[d].chunk_size);
     }
   }
 

--- a/src/gpu/stream.internal.h
+++ b/src/gpu/stream.internal.h
@@ -7,7 +7,7 @@ struct tile_stream_gpu
   struct writer writer;
   struct stream_engine engine;
   struct stream_context ctx;
-  int flushed; // 1 after flush; append after flush returns finished
+  int flushed; // 1 after flush; reset by append for idempotency
 };
 
 // Set writer vtable (append/flush).

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -444,20 +444,20 @@ lod_state_init_accumulators(struct lod_state* lod,
 
   lod->append_accum.morton_offset = p->level_spans.ends[0];
 
-  lod->append_accum.total_elements = 0;
+  lod->append_accum.element_capacity = 0;
   for (int lv = 1; lv < p->levels.nlod; ++lv)
-    lod->append_accum.total_elements +=
+    lod->append_accum.element_capacity +=
       p->levels.level[lv].fixed_dims_count * p->levels.level[lv].lod_nelem;
 
-  if (lod->append_accum.total_elements == 0)
+  if (lod->append_accum.element_capacity == 0)
     return 0;
 
   size_t accum_bpe = dtype_bpe(config->dtype);
-  size_t accum_bytes = lod->append_accum.total_elements * accum_bpe;
+  size_t accum_bytes = lod->append_accum.element_capacity * accum_bpe;
   CU(Fail, cuMemAlloc(&lod->append_accum.d_accum, accum_bytes));
 
   {
-    uint8_t* h_level_ids = (uint8_t*)malloc(lod->append_accum.total_elements);
+    uint8_t* h_level_ids = (uint8_t*)malloc(lod->append_accum.element_capacity);
     CHECK(Fail, h_level_ids);
 
     uint64_t offset = 0;
@@ -469,14 +469,14 @@ lod_state_init_accumulators(struct lod_state* lod,
     }
 
     CUresult r = cuMemAlloc(&lod->append_accum.d_level_ids,
-                            lod->append_accum.total_elements);
+                            lod->append_accum.element_capacity);
     if (r != CUDA_SUCCESS) {
       free(h_level_ids);
       goto Fail;
     }
     r = cuMemcpyHtoD(lod->append_accum.d_level_ids,
                      h_level_ids,
-                     lod->append_accum.total_elements);
+                     lod->append_accum.element_capacity);
     free(h_level_ids);
     if (r != CUDA_SUCCESS)
       goto Fail;
@@ -570,7 +570,7 @@ run_append_fold_emit(struct lod_state* lod,
                              lod->append_accum.d_counts,
                              dtype,
                              append_reduce_method,
-                             lod->append_accum.total_elements,
+                             lod->append_accum.element_capacity,
                              compute) == 0);
 
   // Increment counts, emit ready levels back to morton
@@ -716,7 +716,7 @@ lod_run_epoch(struct lod_state* lod,
   // which higher levels fire this epoch.
   uint32_t active_levels_mask =
     dims->append_downsample ? 1u : (uint32_t)((1u << p->levels.nlod) - 1);
-  if (dims->append_downsample && lod->append_accum.total_elements > 0) {
+  if (dims->append_downsample && lod->append_accum.element_capacity > 0) {
     CHECK(
       Error,
       run_append_fold_emit(

--- a/src/multiarray/multiarray.h
+++ b/src/multiarray/multiarray.h
@@ -10,6 +10,15 @@ enum multiarray_writer_error
   multiarray_writer_not_flushable = 3,
 };
 
+// update_impl pass-through assigns writer_result.error directly into a
+// multiarray_writer_result.error field; the enums must agree on shared codes.
+_Static_assert((int)multiarray_writer_ok == (int)writer_error_ok,
+               "writer/multiarray ok codes must match");
+_Static_assert((int)multiarray_writer_fail == (int)writer_error_fail,
+               "writer/multiarray fail codes must match");
+_Static_assert((int)multiarray_writer_finished == (int)writer_error_finished,
+               "writer/multiarray finished codes must match");
+
 struct multiarray_writer_result
 {
   int error;

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -642,14 +642,10 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct array_descriptor* desc = &ms->arrays[array_index];
 
-  // If this array has already been flushed (capacity reached with inline
-  // flush, or explicit flush), further appends are a no-op that report
-  // `finished` with the full input unconsumed.
-  if (desc->flushed)
-    return (struct multiarray_writer_result){
-      .error = multiarray_writer_finished,
-      .rest = data,
-    };
+  // Re-arm for the next sync: a non-empty update after flush has new work,
+  // so the next flush must run flush_body again.
+  if (desc->flushed && data.beg != data.end)
+    desc->flushed = 0;
 
   // Switch arrays if needed.
   if (array_index != ms->active) {
@@ -661,8 +657,8 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
   struct cpu_stream_view v = make_multiarray_view(ms, desc);
   struct writer_result r = cpu_stream_append_body(&v, data);
 
-  // `writer_finished` here means "stream is at capacity"; finalization
-  // happens on explicit `flush()` or on destroy, not here.
+  // `writer_finished` here means "stream is at capacity (max_cursor)";
+  // finalization happens on explicit `flush()` or on destroy, not here.
   return (struct multiarray_writer_result){
     .error = r.error,
     .rest = r.rest,
@@ -679,9 +675,9 @@ flush_impl(struct multiarray_writer* self)
 
   for (int a = 0; a < ms->n_arrays; ++a) {
     struct array_descriptor* desc = &ms->arrays[a];
-    // Already-flushed arrays (either by inline flush on capacity or by a
-    // prior explicit flush) re-entering the body would re-finalize an
-    // already-finalized sink — on Windows that deadlocks.
+    // Idempotency: a redundant flush with no intervening updates re-finalizes
+    // already-closed sinks (deadlock on Windows). The flag is reset by
+    // update_impl when new data arrives.
     if (desc->flushed)
       continue;
     if (desc->cursor_elements == 0 && desc->batch_accumulated == 0) {

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -29,7 +29,7 @@ struct array_descriptor
   struct shard_state shard[LOD_MAX_LEVELS];
   struct shard_sink* sink;
   uint64_t cursor_elements;
-  uint64_t total_elements;
+  uint64_t total_element_limit;
   uint32_t batch_accumulated;
   uint32_t* batch_active_masks;  // [K], heap-allocated
   uint32_t* pool_epochs_scratch; // [LOD_MAX_LEVELS * K], heap-allocated
@@ -171,16 +171,16 @@ init_array_descriptor(struct array_descriptor* desc,
   if (!desc->pool_epochs_scratch)
     return 1;
 
-  // total_elements: configured stream length (0 = unbounded)
+  // total_element_limit: configured stream length (0 = unbounded)
   {
     const struct dimension* dims = config->dimensions;
     const uint8_t na = dim_info_n_append(&desc->cl.dims);
     if (dims[0].size > 0) {
-      desc->total_elements = desc->layout.epoch_elements;
+      desc->total_element_limit = desc->layout.epoch_elements;
       for (int d = 0; d < na; ++d)
-        desc->total_elements *= ceildiv(dims[d].size, dims[d].chunk_size);
+        desc->total_element_limit *= ceildiv(dims[d].size, dims[d].chunk_size);
     } else {
-      desc->total_elements = 0;
+      desc->total_element_limit = 0;
     }
   }
 
@@ -594,7 +594,7 @@ make_multiarray_view(struct multiarray_tile_stream_cpu* ms,
     .layout = &desc->layout,
     .levels = &desc->levels,
     .cursor_elements = &desc->cursor_elements,
-    .total_elements = desc->total_elements,
+    .total_element_limit = desc->total_element_limit,
     .batch_accumulated = &desc->batch_accumulated,
     .batch_active_masks = desc->batch_active_masks,
     .pool_epochs_scratch = desc->pool_epochs_scratch,
@@ -654,7 +654,7 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
   if (desc->flushed && r.rest.beg != data.beg)
     desc->flushed = 0;
 
-  // `writer_finished` here means "stream is at capacity (total_elements)";
+  // `writer_finished` here means "stream is at capacity (total_element_limit)";
   // finalization happens on explicit `flush()` or on destroy, not here.
   return (struct multiarray_writer_result){
     .error = r.error,

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -642,9 +642,6 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct array_descriptor* desc = &ms->arrays[array_index];
 
-  writer_arm_for_append(
-    &desc->flushed, data, desc->cursor_elements, desc->max_cursor_elements);
-
   // Switch arrays if needed.
   if (array_index != ms->active) {
     int err = switch_to_array(ms, array_index);
@@ -654,6 +651,8 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct cpu_stream_view v = make_multiarray_view(ms, desc);
   struct writer_result r = cpu_stream_append_body(&v, data);
+  if (desc->flushed && r.rest.beg != data.beg)
+    desc->flushed = 0;
 
   // `writer_finished` here means "stream is at capacity (max_cursor)";
   // finalization happens on explicit `flush()` or on destroy, not here.

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -29,7 +29,7 @@ struct array_descriptor
   struct shard_state shard[LOD_MAX_LEVELS];
   struct shard_sink* sink;
   uint64_t cursor_elements;
-  uint64_t max_cursor_elements;
+  uint64_t total_elements;
   uint32_t batch_accumulated;
   uint32_t* batch_active_masks;  // [K], heap-allocated
   uint32_t* pool_epochs_scratch; // [LOD_MAX_LEVELS * K], heap-allocated
@@ -171,16 +171,16 @@ init_array_descriptor(struct array_descriptor* desc,
   if (!desc->pool_epochs_scratch)
     return 1;
 
-  // max_cursor
+  // total_elements: configured stream length (0 = unbounded)
   {
     const struct dimension* dims = config->dimensions;
     const uint8_t na = dim_info_n_append(&desc->cl.dims);
     if (dims[0].size > 0) {
-      desc->max_cursor_elements = desc->layout.epoch_elements;
+      desc->total_elements = desc->layout.epoch_elements;
       for (int d = 0; d < na; ++d)
-        desc->max_cursor_elements *= ceildiv(dims[d].size, dims[d].chunk_size);
+        desc->total_elements *= ceildiv(dims[d].size, dims[d].chunk_size);
     } else {
-      desc->max_cursor_elements = 0;
+      desc->total_elements = 0;
     }
   }
 
@@ -594,7 +594,7 @@ make_multiarray_view(struct multiarray_tile_stream_cpu* ms,
     .layout = &desc->layout,
     .levels = &desc->levels,
     .cursor_elements = &desc->cursor_elements,
-    .max_cursor_elements = desc->max_cursor_elements,
+    .total_elements = desc->total_elements,
     .batch_accumulated = &desc->batch_accumulated,
     .batch_active_masks = desc->batch_active_masks,
     .pool_epochs_scratch = desc->pool_epochs_scratch,
@@ -654,7 +654,7 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
   if (desc->flushed && r.rest.beg != data.beg)
     desc->flushed = 0;
 
-  // `writer_finished` here means "stream is at capacity (max_cursor)";
+  // `writer_finished` here means "stream is at capacity (total_elements)";
   // finalization happens on explicit `flush()` or on destroy, not here.
   return (struct multiarray_writer_result){
     .error = r.error,

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -642,10 +642,8 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct array_descriptor* desc = &ms->arrays[array_index];
 
-  // Re-arm for the next sync: a non-empty update after flush has new work,
-  // so the next flush must run flush_body again.
-  if (desc->flushed && data.beg != data.end)
-    desc->flushed = 0;
+  writer_arm_for_append(
+    &desc->flushed, data, desc->cursor_elements, desc->max_cursor_elements);
 
   // Switch arrays if needed.
   if (array_index != ms->active) {

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -232,14 +232,14 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
       return 1;
   }
 
-  // max_cursor
+  // total_elements: configured stream length (0 = unbounded)
   {
     const struct dimension* dims = config->dimensions;
     const uint8_t na = dim_info_n_append(&desc->ctx.dims);
     if (dims[0].size > 0) {
-      desc->ctx.max_cursor_elements = desc->ctx.layout.epoch_elements;
+      desc->ctx.total_elements = desc->ctx.layout.epoch_elements;
       for (int d = 0; d < na; ++d)
-        desc->ctx.max_cursor_elements *=
+        desc->ctx.total_elements *=
           ceildiv(dims[d].size, dims[d].chunk_size);
     }
   }
@@ -519,7 +519,7 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
   if (desc->flushed && r.rest.beg != data.beg)
     desc->flushed = 0;
 
-  // `writer_finished` here means "stream is at capacity (max_cursor)";
+  // `writer_finished` here means "stream is at capacity (total_elements)";
   // finalization happens on explicit `flush()` or on destroy, not here.
   return (struct multiarray_writer_result){
     .error = r.error,

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -508,14 +508,10 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct array_descriptor_gpu* desc = &ms->arrays[array_index];
 
-  // If this array has already been flushed (capacity reached with inline
-  // flush, or explicit flush), further appends are a no-op that report
-  // `finished` with the full input unconsumed.
-  if (desc->flushed)
-    return (struct multiarray_writer_result){
-      .error = multiarray_writer_finished,
-      .rest = data,
-    };
+  // Re-arm for the next sync: a non-empty update after flush has new work,
+  // so the next flush must run flush_body again.
+  if (desc->flushed && data.beg != data.end)
+    desc->flushed = 0;
 
   // Switch arrays if needed
   if (array_index != ms->active) {
@@ -526,8 +522,8 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct writer_result r = stream_append_body(&ms->engine, &desc->ctx, data);
 
-  // `writer_finished` here means "stream is at capacity"; finalization
-  // happens on explicit `flush()` or on destroy, not here.
+  // `writer_finished` here means "stream is at capacity (max_cursor)";
+  // finalization happens on explicit `flush()` or on destroy, not here.
   return (struct multiarray_writer_result){
     .error = r.error,
     .rest = r.rest,
@@ -549,9 +545,9 @@ flush_impl(struct multiarray_writer* self)
   // Flush each array that has data
   for (int a = 0; a < ms->n_arrays; ++a) {
     struct array_descriptor_gpu* desc = &ms->arrays[a];
-    // Already-flushed arrays (either by inline flush on capacity or by a
-    // prior explicit flush) re-entering the body would re-finalize an
-    // already-finalized sink.
+    // Idempotency: a redundant flush with no intervening updates re-finalizes
+    // already-closed sinks. The flag is reset by update_impl when new data
+    // arrives.
     if (desc->flushed)
       continue;
     if (desc->ctx.cursor_elements == 0 && desc->batch_accumulated == 0) {

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -232,14 +232,14 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
       return 1;
   }
 
-  // total_elements: configured stream length (0 = unbounded)
+  // total_element_limit: configured stream length (0 = unbounded)
   {
     const struct dimension* dims = config->dimensions;
     const uint8_t na = dim_info_n_append(&desc->ctx.dims);
     if (dims[0].size > 0) {
-      desc->ctx.total_elements = desc->ctx.layout.epoch_elements;
+      desc->ctx.total_element_limit = desc->ctx.layout.epoch_elements;
       for (int d = 0; d < na; ++d)
-        desc->ctx.total_elements *=
+        desc->ctx.total_element_limit *=
           ceildiv(dims[d].size, dims[d].chunk_size);
     }
   }
@@ -519,7 +519,7 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
   if (desc->flushed && r.rest.beg != data.beg)
     desc->flushed = 0;
 
-  // `writer_finished` here means "stream is at capacity (total_elements)";
+  // `writer_finished` here means "stream is at capacity (total_element_limit)";
   // finalization happens on explicit `flush()` or on destroy, not here.
   return (struct multiarray_writer_result){
     .error = r.error,

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -161,14 +161,15 @@ unbind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
       e->compress_agg.levels[lv].batch_active_count;
   }
 
-  // Save per-array LOD mutable state. counts[] and total_elements track
-  // running append-accumulator state across epochs.
+  // Save per-array LOD state. counts[] tracks running append-accumulator
+  // state across epochs; element_capacity is the fixed accumulator buffer
+  // size set at init.
   if (desc->ctx.levels.enable_multiscale) {
     memcpy(desc->array_lod.append_accum.counts,
            e->lod.append_accum.counts,
            sizeof(desc->array_lod.append_accum.counts));
-    desc->array_lod.append_accum.total_elements =
-      e->lod.append_accum.total_elements;
+    desc->array_lod.append_accum.element_capacity =
+      e->lod.append_accum.element_capacity;
   }
 }
 

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -508,11 +508,6 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct array_descriptor_gpu* desc = &ms->arrays[array_index];
 
-  writer_arm_for_append(&desc->flushed,
-                        data,
-                        desc->ctx.cursor_elements,
-                        desc->ctx.max_cursor_elements);
-
   // Switch arrays if needed
   if (array_index != ms->active) {
     int err = switch_to_array(ms, array_index);
@@ -521,6 +516,8 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
   }
 
   struct writer_result r = stream_append_body(&ms->engine, &desc->ctx, data);
+  if (desc->flushed && r.rest.beg != data.beg)
+    desc->flushed = 0;
 
   // `writer_finished` here means "stream is at capacity (max_cursor)";
   // finalization happens on explicit `flush()` or on destroy, not here.

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -508,10 +508,10 @@ update_impl(struct multiarray_writer* self, int array_index, struct slice data)
 
   struct array_descriptor_gpu* desc = &ms->arrays[array_index];
 
-  // Re-arm for the next sync: a non-empty update after flush has new work,
-  // so the next flush must run flush_body again.
-  if (desc->flushed && data.beg != data.end)
-    desc->flushed = 0;
+  writer_arm_for_append(&desc->flushed,
+                        data,
+                        desc->ctx.cursor_elements,
+                        desc->ctx.max_cursor_elements);
 
   // Switch arrays if needed
   if (array_index != ms->active) {

--- a/src/writer.c
+++ b/src/writer.c
@@ -83,21 +83,6 @@ writer_finished_at(const void* beg, const void* end)
   return r;
 }
 
-void
-writer_arm_for_append(int* flushed,
-                      struct slice input,
-                      uint64_t cursor,
-                      uint64_t max_cursor)
-{
-  if (!*flushed)
-    return;
-  if (input.beg == input.end)
-    return;
-  if (max_cursor > 0 && cursor >= max_cursor)
-    return;
-  *flushed = 0;
-}
-
 size_t
 shard_sink_pending_bytes(const struct shard_sink* s)
 {

--- a/src/writer.c
+++ b/src/writer.c
@@ -83,6 +83,21 @@ writer_finished_at(const void* beg, const void* end)
   return r;
 }
 
+void
+writer_arm_for_append(int* flushed,
+                      struct slice input,
+                      uint64_t cursor,
+                      uint64_t max_cursor)
+{
+  if (!*flushed)
+    return;
+  if (input.beg == input.end)
+    return;
+  if (max_cursor > 0 && cursor >= max_cursor)
+    return;
+  *flushed = 0;
+}
+
 size_t
 shard_sink_pending_bytes(const struct shard_sink* s)
 {

--- a/src/writer.h
+++ b/src/writer.h
@@ -18,7 +18,7 @@ enum writer_error_code
 {
   writer_error_ok = 0,
   writer_error_fail = 1,
-  writer_error_finished = 2, // stream complete: total_elements reached
+  writer_error_finished = 2, // stream complete: total_element_limit reached
 };
 
 struct writer_result

--- a/src/writer.h
+++ b/src/writer.h
@@ -128,14 +128,3 @@ writer_flush(struct writer* w);
 // Append data to a writer, retrying with exponential back-off on stall.
 struct writer_result
 writer_append_wait(struct writer* w, struct slice data);
-
-// Re-arm the flush latch for the next sync. If `*flushed` is set, the input
-// is non-empty, and the cursor is below max_cursor (or unbounded), clears
-// `*flushed` so a subsequent flush will run flush_body again. Stays set when
-// the body would refuse the data (at capacity), keeping flush idempotent.
-// `max_cursor == 0` means unbounded.
-void
-writer_arm_for_append(int* flushed,
-                      struct slice input,
-                      uint64_t cursor,
-                      uint64_t max_cursor);

--- a/src/writer.h
+++ b/src/writer.h
@@ -128,3 +128,14 @@ writer_flush(struct writer* w);
 // Append data to a writer, retrying with exponential back-off on stall.
 struct writer_result
 writer_append_wait(struct writer* w, struct slice data);
+
+// Re-arm the flush latch for the next sync. If `*flushed` is set, the input
+// is non-empty, and the cursor is below max_cursor (or unbounded), clears
+// `*flushed` so a subsequent flush will run flush_body again. Stays set when
+// the body would refuse the data (at capacity), keeping flush idempotent.
+// `max_cursor == 0` means unbounded.
+void
+writer_arm_for_append(int* flushed,
+                      struct slice input,
+                      uint64_t cursor,
+                      uint64_t max_cursor);

--- a/src/writer.h
+++ b/src/writer.h
@@ -18,8 +18,7 @@ enum writer_error_code
 {
   writer_error_ok = 0,
   writer_error_fail = 1,
-  writer_error_finished =
-    2, // stream complete: capacity reached or flush already called
+  writer_error_finished = 2, // stream complete: capacity (max_cursor) reached
 };
 
 struct writer_result
@@ -31,8 +30,9 @@ struct writer_result
 struct writer
 {
   struct writer_result (*append)(struct writer* self, struct slice data);
-  struct writer_result (*flush)(struct writer* self); // terminal: append after
-                                                      // flush returns finished
+  // explicit sync; stream remains appendable. Returns when all writes prior
+  // to the call are durable.
+  struct writer_result (*flush)(struct writer* self);
 };
 
 struct shard_writer

--- a/src/writer.h
+++ b/src/writer.h
@@ -18,7 +18,7 @@ enum writer_error_code
 {
   writer_error_ok = 0,
   writer_error_fail = 1,
-  writer_error_finished = 2, // stream complete: capacity (max_cursor) reached
+  writer_error_finished = 2, // stream complete: total_elements reached
 };
 
 struct writer_result

--- a/tests/test_flush_orchestration.c
+++ b/tests/test_flush_orchestration.c
@@ -3,6 +3,7 @@
 #include "gpu/stream.flush.h"
 #include "platform/platform.h"
 #include "stream/config.h"
+#include "stream/dim_info.h"
 
 #include "test_gpu_helpers.h"
 #include "test_shard_sink.h"
@@ -82,6 +83,8 @@ orch_ctx_setup(struct orch_ctx* c,
   c->s->ctx.sink = sink;
   c->s->ctx.levels = c->cl.levels;
   c->s->ctx.layout = c->cl.layouts[0];
+  CHECK(Fail,
+        dim_info_init(&c->s->ctx.dims, config->dimensions, config->rank) == 0);
 
   const uint32_t K = c->cl.epochs_per_batch;
   const uint64_t total_chunks = c->cl.levels.total_chunks;

--- a/tests/test_multiarray_cpu.c
+++ b/tests/test_multiarray_cpu.c
@@ -830,17 +830,17 @@ Fail:
   return 1;
 }
 
-// ---- Test: write past max_cursor returns finished ----
+// ---- Test: write past total_elements returns finished ----
 
 static int
-test_write_past_max_cursor(void)
+test_write_past_total_elements(void)
 {
-  log_info("=== test_write_past_max_cursor ===");
+  log_info("=== test_write_past_total_elements ===");
 
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // 2D 4x4 u8: epoch_elements=8, 2 epochs, max_cursor=16.
+  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_elements=16.
   struct dimension dims[2];
   struct tile_stream_configuration config = make_2d_config(dims, dtype_u8);
 
@@ -853,7 +853,7 @@ test_write_past_max_cursor(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_cpu_writer(ms);
 
-  // Write exactly max_cursor (16 elements).
+  // Write exactly total_elements (16 elements).
   CHECK(Fail, write_fill(w, 0, 16, 1, 0xAA).error == multiarray_writer_ok);
 
   // Writing more should return finished.
@@ -917,7 +917,7 @@ Fail:
 
 // ---- Test: flush is idempotent after writer reaches `finished` ----
 //
-// Once the writer has reached capacity (max_cursor) and been finalized,
+// Once the writer has reached capacity (total_elements) and been finalized,
 // subsequent `update()` calls report `finished` and produce no sink work,
 // and a redundant `flush()` is a no-op (no re-finalization of already-closed
 // shards). A prior bug caused the destructor's follow-up flush to deadlock
@@ -930,7 +930,7 @@ test_flush_idempotent_after_finished(void)
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // 2D 4x4 u8: epoch_elements=8, 2 epochs, max_cursor=16.
+  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_elements=16.
   struct dimension dims[2];
   struct tile_stream_configuration config = make_2d_config(dims, dtype_u8);
   struct tile_stream_configuration configs[] = { config };
@@ -942,7 +942,8 @@ test_flush_idempotent_after_finished(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_cpu_writer(ms);
 
-  // Fill exactly max_cursor. Cursor reaches the cap; loop exits naturally.
+  // Fill exactly total_elements. Cursor reaches the cap; loop exits
+  // naturally.
   // Batch flushes on epoch boundaries finalize complete shards during the
   // append; partial shards wait for an explicit flush or destroy.
   CHECK(Fail, write_fill(w, 0, 16, 1, 0xAA).error == multiarray_writer_ok);
@@ -1024,7 +1025,7 @@ test_flush_resumable(void)
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // Unbounded dim 0 so max_cursor is 0 (no input-side termination). One
+  // Unbounded dim 0 so total_elements is 0 (no input-side termination). One
   // epoch per shard so each batch produces a fresh shard with fresh content.
   struct dimension dims[] = {
     { .size = 0,
@@ -1170,7 +1171,7 @@ main(int ac, char* av[])
   rc |= test_lod_basic();
   rc |= test_mixed_dtypes();
   rc |= test_mixed_lod();
-  rc |= test_write_past_max_cursor();
+  rc |= test_write_past_total_elements();
   rc |= test_flush_no_data();
   rc |= test_flush_idempotent_after_finished();
   rc |= test_flush_resumable();

--- a/tests/test_multiarray_cpu.c
+++ b/tests/test_multiarray_cpu.c
@@ -917,10 +917,10 @@ Fail:
 
 // ---- Test: flush is idempotent after writer reaches `finished` ----
 //
-// Once the writer has reached capacity and been finalized (either by an
-// explicit `flush()` or by the destructor's auto-flush), subsequent `flush()`
-// and `update()` calls must be no-ops — not re-finalize already-finalized
-// shards. A prior bug caused the destructor's follow-up flush to deadlock
+// Once the writer has reached capacity (max_cursor) and been finalized,
+// subsequent `update()` calls report `finished` and produce no sink work,
+// and a redundant `flush()` is a no-op (no re-finalization of already-closed
+// shards). A prior bug caused the destructor's follow-up flush to deadlock
 // on Windows against an already-finalized sink.
 static int
 test_flush_idempotent_after_finished(void)
@@ -961,8 +961,9 @@ test_flush_idempotent_after_finished(void)
   CHECK(Fail, sink.finalize_count == finalize_after_fill);
   CHECK(Fail, sink.open_count == open_after_fill);
 
-  // Explicit flush runs the terminal flush. For this config all shards
-  // already finalized during the append, so no new opens/finalizes occur.
+  // Explicit flush commits any partial shard state. For this config all
+  // shards already finalized during the append, so no new opens/finalizes
+  // occur.
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
   const int finalize_after_flush = sink.finalize_count;
   const int open_after_flush = sink.open_count;
@@ -988,6 +989,76 @@ test_flush_idempotent_after_finished(void)
   multiarray_tile_stream_cpu_destroy(ms);
   CHECK(Fail, sink.finalize_count == finalize_after_flush);
   CHECK(Fail, sink.open_count == open_after_flush);
+  test_sink_free(&sink);
+  log_info("  PASS");
+  return 0;
+
+Fail:
+  multiarray_tile_stream_cpu_destroy(ms);
+  test_sink_free(&sink);
+  log_error("  FAIL");
+  return 1;
+}
+
+// ---- Test: flush is a resumable explicit sync ----
+//
+// After flush(), an array-stream is still appendable. update() succeeds with
+// new data, and the next flush() commits the new batch.
+static int
+test_flush_resumable(void)
+{
+  log_info("=== test_flush_resumable ===");
+
+  struct test_shard_sink sink;
+  test_sink_init_1(&sink);
+
+  // Unbounded dim 0 so max_cursor is 0 (no input-side termination).
+  struct dimension dims[] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 1,
+      .storage_position = 0 },
+    { .size = 4,
+      .chunk_size = 2,
+      .chunks_per_shard = 2,
+      .storage_position = 1 },
+  };
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  struct tile_stream_configuration configs[] = { config };
+  struct shard_sink* sinks[] = { &sink.base };
+
+  struct multiarray_tile_stream_cpu* ms =
+    multiarray_tile_stream_cpu_create(1, configs, sinks, 0);
+  CHECK(Fail, ms);
+
+  struct multiarray_writer* w = multiarray_tile_stream_cpu_writer(ms);
+
+  // First batch: 1 epoch (4 u16) + flush.
+  CHECK(Fail,
+        write_fill(w, 0, 4, sizeof(uint16_t), 0xAA).error ==
+          multiarray_writer_ok);
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  const int finalize_after_first = sink.finalize_count;
+  CHECK(Fail, finalize_after_first > 0);
+
+  // Second batch: another epoch succeeds — stream is still appendable.
+  {
+    struct multiarray_writer_result r =
+      write_fill(w, 0, 4, sizeof(uint16_t), 0xBB);
+    CHECK(Fail, r.error == multiarray_writer_ok);
+  }
+
+  // Second flush commits the new batch.
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  CHECK(Fail, sink.finalize_count > finalize_after_first);
+
+  multiarray_tile_stream_cpu_destroy(ms);
   test_sink_free(&sink);
   log_info("  PASS");
   return 0;
@@ -1066,6 +1137,7 @@ main(int ac, char* av[])
   rc |= test_write_past_max_cursor();
   rc |= test_flush_no_data();
   rc |= test_flush_idempotent_after_finished();
+  rc |= test_flush_resumable();
   rc |= test_metrics_enabled();
   return rc;
 }

--- a/tests/test_multiarray_cpu.c
+++ b/tests/test_multiarray_cpu.c
@@ -830,17 +830,17 @@ Fail:
   return 1;
 }
 
-// ---- Test: write past total_elements returns finished ----
+// ---- Test: write past total_element_limit returns finished ----
 
 static int
-test_write_past_total_elements(void)
+test_write_past_total_element_limit(void)
 {
-  log_info("=== test_write_past_total_elements ===");
+  log_info("=== test_write_past_total_element_limit ===");
 
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_elements=16.
+  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_element_limit=16.
   struct dimension dims[2];
   struct tile_stream_configuration config = make_2d_config(dims, dtype_u8);
 
@@ -853,7 +853,7 @@ test_write_past_total_elements(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_cpu_writer(ms);
 
-  // Write exactly total_elements (16 elements).
+  // Write exactly total_element_limit (16 elements).
   CHECK(Fail, write_fill(w, 0, 16, 1, 0xAA).error == multiarray_writer_ok);
 
   // Writing more should return finished.
@@ -917,7 +917,7 @@ Fail:
 
 // ---- Test: flush is idempotent after writer reaches `finished` ----
 //
-// Once the writer has reached capacity (total_elements) and been finalized,
+// Once the writer has reached capacity (total_element_limit) and been finalized,
 // subsequent `update()` calls report `finished` and produce no sink work,
 // and a redundant `flush()` is a no-op (no re-finalization of already-closed
 // shards). A prior bug caused the destructor's follow-up flush to deadlock
@@ -930,7 +930,7 @@ test_flush_idempotent_after_finished(void)
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_elements=16.
+  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_element_limit=16.
   struct dimension dims[2];
   struct tile_stream_configuration config = make_2d_config(dims, dtype_u8);
   struct tile_stream_configuration configs[] = { config };
@@ -942,7 +942,7 @@ test_flush_idempotent_after_finished(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_cpu_writer(ms);
 
-  // Fill exactly total_elements. Cursor reaches the cap; loop exits
+  // Fill exactly total_element_limit. Cursor reaches the cap; loop exits
   // naturally.
   // Batch flushes on epoch boundaries finalize complete shards during the
   // append; partial shards wait for an explicit flush or destroy.
@@ -1025,7 +1025,7 @@ test_flush_resumable(void)
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // Unbounded dim 0 so total_elements is 0 (no input-side termination). One
+  // Unbounded dim 0 so total_element_limit is 0 (no input-side termination). One
   // epoch per shard so each batch produces a fresh shard with fresh content.
   struct dimension dims[] = {
     { .size = 0,
@@ -1171,7 +1171,7 @@ main(int ac, char* av[])
   rc |= test_lod_basic();
   rc |= test_mixed_dtypes();
   rc |= test_mixed_lod();
-  rc |= test_write_past_total_elements();
+  rc |= test_write_past_total_element_limit();
   rc |= test_flush_no_data();
   rc |= test_flush_idempotent_after_finished();
   rc |= test_flush_resumable();

--- a/tests/test_multiarray_cpu.c
+++ b/tests/test_multiarray_cpu.c
@@ -967,11 +967,14 @@ test_flush_idempotent_after_finished(void)
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
   const int finalize_after_flush = sink.finalize_count;
   const int open_after_flush = sink.open_count;
+  const int update_append_after_flush = sink.update_append_count;
 
-  // Second flush — idempotent: no new sink calls.
+  // Second flush — idempotent: no new sink calls (including no metadata
+  // re-write via update_append).
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
   CHECK(Fail, sink.finalize_count == finalize_after_flush);
   CHECK(Fail, sink.open_count == open_after_flush);
+  CHECK(Fail, sink.update_append_count == update_append_after_flush);
 
   // Further updates still report finished with full input unconsumed, and
   // do not touch the sink.
@@ -985,10 +988,19 @@ test_flush_idempotent_after_finished(void)
   CHECK(Fail, sink.finalize_count == finalize_after_flush);
   CHECK(Fail, sink.open_count == open_after_flush);
 
+  // Flush after the at-capacity probe must remain idempotent: the probe
+  // must not re-arm the latch. Watching update_append_count catches a
+  // phantom re-arm even when no shards need finalizing.
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  CHECK(Fail, sink.finalize_count == finalize_after_flush);
+  CHECK(Fail, sink.open_count == open_after_flush);
+  CHECK(Fail, sink.update_append_count == update_append_after_flush);
+
   // Destroy runs another auto-flush, also idempotent.
   multiarray_tile_stream_cpu_destroy(ms);
   CHECK(Fail, sink.finalize_count == finalize_after_flush);
   CHECK(Fail, sink.open_count == open_after_flush);
+  CHECK(Fail, sink.update_append_count == update_append_after_flush);
   test_sink_free(&sink);
   log_info("  PASS");
   return 0;
@@ -1003,7 +1015,7 @@ Fail:
 // ---- Test: flush is a resumable explicit sync ----
 //
 // After flush(), an array-stream is still appendable. update() succeeds with
-// new data, and the next flush() commits the new batch.
+// new data, and the next flush() commits the new batch with distinct content.
 static int
 test_flush_resumable(void)
 {
@@ -1012,7 +1024,8 @@ test_flush_resumable(void)
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // Unbounded dim 0 so max_cursor is 0 (no input-side termination).
+  // Unbounded dim 0 so max_cursor is 0 (no input-side termination). One
+  // epoch per shard so each batch produces a fresh shard with fresh content.
   struct dimension dims[] = {
     { .size = 0,
       .chunk_size = 1,
@@ -1039,15 +1052,16 @@ test_flush_resumable(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_cpu_writer(ms);
 
-  // First batch: 1 epoch (4 u16) + flush.
+  // First batch: 1 epoch (4 u16) of 0xAA + flush.
   CHECK(Fail,
         write_fill(w, 0, 4, sizeof(uint16_t), 0xAA).error ==
           multiarray_writer_ok);
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
   const int finalize_after_first = sink.finalize_count;
-  CHECK(Fail, finalize_after_first > 0);
+  const int shards_after_first = test_sink_shard_count(&sink);
+  CHECK(Fail, shards_after_first > 0);
 
-  // Second batch: another epoch succeeds — stream is still appendable.
+  // Second batch: another epoch with distinct fill 0xBB succeeds.
   {
     struct multiarray_writer_result r =
       write_fill(w, 0, 4, sizeof(uint16_t), 0xBB);
@@ -1056,7 +1070,29 @@ test_flush_resumable(void)
 
   // Second flush commits the new batch.
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+
+  // Strict checks: a NEW shard finalized with NEW content. A silent
+  // double-flush of batch 1 would not produce both signals.
   CHECK(Fail, sink.finalize_count > finalize_after_first);
+  const int shards_after_second = test_sink_shard_count(&sink);
+  CHECK(Fail, shards_after_second > shards_after_first);
+
+  // Scan all finalized shards: at least one byte 0xAA (batch 1) and at least
+  // one byte 0xBB (batch 2) must be present in the durable output.
+  int found_aa = 0, found_bb = 0;
+  for (int i = 0; i < TEST_SHARD_SINK_MAX_SHARDS; ++i) {
+    const struct test_shard_writer* sw = &sink.writers[0][i];
+    if (!sw->buf || sw->size == 0)
+      continue;
+    for (size_t k = 0; k < sw->size; ++k) {
+      if (sw->buf[k] == 0xAA)
+        found_aa = 1;
+      if (sw->buf[k] == 0xBB)
+        found_bb = 1;
+    }
+  }
+  CHECK(Fail, found_aa);
+  CHECK(Fail, found_bb);
 
   multiarray_tile_stream_cpu_destroy(ms);
   test_sink_free(&sink);

--- a/tests/test_multiarray_gpu.c
+++ b/tests/test_multiarray_gpu.c
@@ -650,11 +650,14 @@ test_flush_idempotent_after_finished(void)
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
   const int finalize_after_flush = sink.finalize_count;
   const int open_after_flush = sink.open_count;
+  const int update_append_after_flush = sink.update_append_count;
 
-  // Second flush — idempotent: no new sink calls.
+  // Second flush — idempotent: no new sink calls (including no metadata
+  // re-write via update_append).
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
   CHECK(Fail, sink.finalize_count == finalize_after_flush);
   CHECK(Fail, sink.open_count == open_after_flush);
+  CHECK(Fail, sink.update_append_count == update_append_after_flush);
 
   // Further updates still report finished with full input unconsumed, and
   // do not touch the sink.
@@ -668,10 +671,19 @@ test_flush_idempotent_after_finished(void)
   CHECK(Fail, sink.finalize_count == finalize_after_flush);
   CHECK(Fail, sink.open_count == open_after_flush);
 
+  // Flush after the at-capacity probe must remain idempotent: the probe
+  // must not re-arm the latch. Watching update_append_count catches a
+  // phantom re-arm even when no shards need finalizing.
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  CHECK(Fail, sink.finalize_count == finalize_after_flush);
+  CHECK(Fail, sink.open_count == open_after_flush);
+  CHECK(Fail, sink.update_append_count == update_append_after_flush);
+
   // Destroy runs another auto-flush, also idempotent.
   multiarray_tile_stream_gpu_destroy(ms);
   CHECK(Fail, sink.finalize_count == finalize_after_flush);
   CHECK(Fail, sink.open_count == open_after_flush);
+  CHECK(Fail, sink.update_append_count == update_append_after_flush);
   test_sink_free(&sink);
   log_info("  PASS");
   return 0;
@@ -721,7 +733,7 @@ Fail:
 // ---- Test: flush is a resumable explicit sync ----
 //
 // After flush(), an array-stream is still appendable. update() succeeds with
-// new data, and the next flush() commits the new batch.
+// new data, and the next flush() commits the new batch with distinct content.
 static int
 test_flush_resumable(void)
 {
@@ -730,7 +742,8 @@ test_flush_resumable(void)
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // Unbounded dim 0 so max_cursor is 0 (no input-side termination).
+  // Unbounded dim 0 so max_cursor is 0 (no input-side termination). One
+  // epoch per shard so each batch produces a fresh shard with fresh content.
   struct dimension dims[] = {
     { .size = 0,
       .chunk_size = 1,
@@ -757,15 +770,16 @@ test_flush_resumable(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(ms);
 
-  // First batch: 1 epoch (4 u16) + flush.
+  // First batch: 1 epoch (4 u16) of 0xAA + flush.
   CHECK(Fail,
         write_fill(w, 0, 4, sizeof(uint16_t), 0xAA).error ==
           multiarray_writer_ok);
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
   const int finalize_after_first = sink.finalize_count;
-  CHECK(Fail, finalize_after_first > 0);
+  const int shards_after_first = test_sink_shard_count(&sink);
+  CHECK(Fail, shards_after_first > 0);
 
-  // Second batch: another epoch succeeds — stream is still appendable.
+  // Second batch: another epoch with distinct fill 0xBB succeeds.
   {
     struct multiarray_writer_result r =
       write_fill(w, 0, 4, sizeof(uint16_t), 0xBB);
@@ -774,7 +788,29 @@ test_flush_resumable(void)
 
   // Second flush commits the new batch.
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+
+  // Strict checks: a NEW shard finalized with NEW content. A silent
+  // double-flush of batch 1 would not produce both signals.
   CHECK(Fail, sink.finalize_count > finalize_after_first);
+  const int shards_after_second = test_sink_shard_count(&sink);
+  CHECK(Fail, shards_after_second > shards_after_first);
+
+  // Scan all finalized shards: at least one byte 0xAA (batch 1) and at least
+  // one byte 0xBB (batch 2) must be present in the durable output.
+  int found_aa = 0, found_bb = 0;
+  for (int i = 0; i < TEST_SHARD_SINK_MAX_SHARDS; ++i) {
+    const struct test_shard_writer* sw = &sink.writers[0][i];
+    if (!sw->buf || sw->size == 0)
+      continue;
+    for (size_t k = 0; k < sw->size; ++k) {
+      if (sw->buf[k] == 0xAA)
+        found_aa = 1;
+      if (sw->buf[k] == 0xBB)
+        found_bb = 1;
+    }
+  }
+  CHECK(Fail, found_aa);
+  CHECK(Fail, found_bb);
 
   multiarray_tile_stream_gpu_destroy(ms);
   test_sink_free(&sink);

--- a/tests/test_multiarray_gpu.c
+++ b/tests/test_multiarray_gpu.c
@@ -551,17 +551,17 @@ Fail:
   return 1;
 }
 
-// ---- Test: write past max_cursor returns finished ----
+// ---- Test: write past total_elements returns finished ----
 
 static int
-test_write_past_max_cursor(void)
+test_write_past_total_elements(void)
 {
-  log_info("=== test_write_past_max_cursor ===");
+  log_info("=== test_write_past_total_elements ===");
 
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // 2D 4x4 u8: epoch_elements=8, 2 epochs, max_cursor=16.
+  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_elements=16.
   struct dimension dims[2];
   struct tile_stream_configuration config = make_2d_config(dims, dtype_u8);
 
@@ -574,7 +574,7 @@ test_write_past_max_cursor(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(ms);
 
-  // Write exactly max_cursor (16 elements).
+  // Write exactly total_elements (16 elements).
   CHECK(Fail, write_fill(w, 0, 16, 1, 0xAA).error == multiarray_writer_ok);
 
   // Writing more should return finished.
@@ -602,7 +602,7 @@ Fail:
 }
 
 // ---- Test: flush is idempotent after writer reaches `finished` ----
-// Once the writer has reached capacity (max_cursor) and been finalized,
+// Once the writer has reached capacity (total_elements) and been finalized,
 // subsequent `update()` calls report `finished` and produce no sink work,
 // and a redundant `flush()` is a no-op (no re-finalization of already-closed
 // shards). A prior bug caused the destructor's follow-up flush to deadlock
@@ -615,7 +615,7 @@ test_flush_idempotent_after_finished(void)
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // 2D 4x4 u8: epoch_elements=8, 2 epochs, max_cursor=16.
+  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_elements=16.
   struct dimension dims[2];
   struct tile_stream_configuration config = make_2d_config(dims, dtype_u8);
   struct tile_stream_configuration configs[] = { config };
@@ -627,7 +627,8 @@ test_flush_idempotent_after_finished(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(ms);
 
-  // Fill exactly max_cursor. Cursor reaches the cap; loop exits naturally.
+  // Fill exactly total_elements. Cursor reaches the cap; loop exits
+  // naturally.
   // Batch flushes on epoch boundaries finalize complete shards during the
   // append; partial shards wait for an explicit flush or destroy.
   CHECK(Fail, write_fill(w, 0, 16, 1, 0xAA).error == multiarray_writer_ok);
@@ -742,7 +743,7 @@ test_flush_resumable(void)
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // Unbounded dim 0 so max_cursor is 0 (no input-side termination). One
+  // Unbounded dim 0 so total_elements is 0 (no input-side termination). One
   // epoch per shard so each batch produces a fresh shard with fresh content.
   struct dimension dims[] = {
     { .size = 0,
@@ -1107,7 +1108,7 @@ main(int ac, char* av[])
   ret |= test_same_array_repeated();
   ret |= test_content_isolation();
   ret |= test_cross_validate_single_array();
-  ret |= test_write_past_max_cursor();
+  ret |= test_write_past_total_elements();
   ret |= test_flush_idempotent_after_finished();
   ret |= test_flush_resumable();
   ret |= test_flush_no_data();

--- a/tests/test_multiarray_gpu.c
+++ b/tests/test_multiarray_gpu.c
@@ -551,17 +551,17 @@ Fail:
   return 1;
 }
 
-// ---- Test: write past total_elements returns finished ----
+// ---- Test: write past total_element_limit returns finished ----
 
 static int
-test_write_past_total_elements(void)
+test_write_past_total_element_limit(void)
 {
-  log_info("=== test_write_past_total_elements ===");
+  log_info("=== test_write_past_total_element_limit ===");
 
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_elements=16.
+  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_element_limit=16.
   struct dimension dims[2];
   struct tile_stream_configuration config = make_2d_config(dims, dtype_u8);
 
@@ -574,7 +574,7 @@ test_write_past_total_elements(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(ms);
 
-  // Write exactly total_elements (16 elements).
+  // Write exactly total_element_limit (16 elements).
   CHECK(Fail, write_fill(w, 0, 16, 1, 0xAA).error == multiarray_writer_ok);
 
   // Writing more should return finished.
@@ -602,7 +602,7 @@ Fail:
 }
 
 // ---- Test: flush is idempotent after writer reaches `finished` ----
-// Once the writer has reached capacity (total_elements) and been finalized,
+// Once the writer has reached capacity (total_element_limit) and been finalized,
 // subsequent `update()` calls report `finished` and produce no sink work,
 // and a redundant `flush()` is a no-op (no re-finalization of already-closed
 // shards). A prior bug caused the destructor's follow-up flush to deadlock
@@ -615,7 +615,7 @@ test_flush_idempotent_after_finished(void)
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_elements=16.
+  // 2D 4x4 u8: epoch_elements=8, 2 epochs, total_element_limit=16.
   struct dimension dims[2];
   struct tile_stream_configuration config = make_2d_config(dims, dtype_u8);
   struct tile_stream_configuration configs[] = { config };
@@ -627,7 +627,7 @@ test_flush_idempotent_after_finished(void)
 
   struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(ms);
 
-  // Fill exactly total_elements. Cursor reaches the cap; loop exits
+  // Fill exactly total_element_limit. Cursor reaches the cap; loop exits
   // naturally.
   // Batch flushes on epoch boundaries finalize complete shards during the
   // append; partial shards wait for an explicit flush or destroy.
@@ -743,7 +743,7 @@ test_flush_resumable(void)
   struct test_shard_sink sink;
   test_sink_init_1(&sink);
 
-  // Unbounded dim 0 so total_elements is 0 (no input-side termination). One
+  // Unbounded dim 0 so total_element_limit is 0 (no input-side termination). One
   // epoch per shard so each batch produces a fresh shard with fresh content.
   struct dimension dims[] = {
     { .size = 0,
@@ -1108,7 +1108,7 @@ main(int ac, char* av[])
   ret |= test_same_array_repeated();
   ret |= test_content_isolation();
   ret |= test_cross_validate_single_array();
-  ret |= test_write_past_total_elements();
+  ret |= test_write_past_total_element_limit();
   ret |= test_flush_idempotent_after_finished();
   ret |= test_flush_resumable();
   ret |= test_flush_no_data();

--- a/tests/test_multiarray_gpu.c
+++ b/tests/test_multiarray_gpu.c
@@ -602,10 +602,10 @@ Fail:
 }
 
 // ---- Test: flush is idempotent after writer reaches `finished` ----
-// Once the writer has reached capacity and been finalized (either by an
-// explicit `flush()` or by the destructor's auto-flush), subsequent `flush()`
-// and `update()` calls must be no-ops — not re-finalize already-finalized
-// shards. A prior bug caused the destructor's follow-up flush to deadlock
+// Once the writer has reached capacity (max_cursor) and been finalized,
+// subsequent `update()` calls report `finished` and produce no sink work,
+// and a redundant `flush()` is a no-op (no re-finalization of already-closed
+// shards). A prior bug caused the destructor's follow-up flush to deadlock
 // on Windows against an already-finalized sink.
 static int
 test_flush_idempotent_after_finished(void)
@@ -646,8 +646,7 @@ test_flush_idempotent_after_finished(void)
   CHECK(Fail, sink.finalize_count == finalize_after_fill);
   CHECK(Fail, sink.open_count == open_after_fill);
 
-  // Explicit flush runs the terminal flush; any partial shard state is
-  // finalized here.
+  // Explicit flush commits any partial shard state.
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
   const int finalize_after_flush = sink.finalize_count;
   const int open_after_flush = sink.open_count;
@@ -706,6 +705,76 @@ test_flush_no_data(void)
   // Flush immediately — no data written.
   struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(ms);
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+
+  multiarray_tile_stream_gpu_destroy(ms);
+  test_sink_free(&sink);
+  log_info("  PASS");
+  return 0;
+
+Fail:
+  multiarray_tile_stream_gpu_destroy(ms);
+  test_sink_free(&sink);
+  log_error("  FAIL");
+  return 1;
+}
+
+// ---- Test: flush is a resumable explicit sync ----
+//
+// After flush(), an array-stream is still appendable. update() succeeds with
+// new data, and the next flush() commits the new batch.
+static int
+test_flush_resumable(void)
+{
+  log_info("=== test_flush_resumable ===");
+
+  struct test_shard_sink sink;
+  test_sink_init_1(&sink);
+
+  // Unbounded dim 0 so max_cursor is 0 (no input-side termination).
+  struct dimension dims[] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 1,
+      .storage_position = 0 },
+    { .size = 4,
+      .chunk_size = 2,
+      .chunks_per_shard = 2,
+      .storage_position = 1 },
+  };
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  struct tile_stream_configuration configs[] = { config };
+  struct shard_sink* sinks[] = { &sink.base };
+
+  struct multiarray_tile_stream_gpu* ms =
+    multiarray_tile_stream_gpu_create(1, configs, sinks, 0);
+  CHECK(Fail, ms);
+
+  struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(ms);
+
+  // First batch: 1 epoch (4 u16) + flush.
+  CHECK(Fail,
+        write_fill(w, 0, 4, sizeof(uint16_t), 0xAA).error ==
+          multiarray_writer_ok);
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  const int finalize_after_first = sink.finalize_count;
+  CHECK(Fail, finalize_after_first > 0);
+
+  // Second batch: another epoch succeeds — stream is still appendable.
+  {
+    struct multiarray_writer_result r =
+      write_fill(w, 0, 4, sizeof(uint16_t), 0xBB);
+    CHECK(Fail, r.error == multiarray_writer_ok);
+  }
+
+  // Second flush commits the new batch.
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  CHECK(Fail, sink.finalize_count > finalize_after_first);
 
   multiarray_tile_stream_gpu_destroy(ms);
   test_sink_free(&sink);
@@ -1004,6 +1073,7 @@ main(int ac, char* av[])
   ret |= test_cross_validate_single_array();
   ret |= test_write_past_max_cursor();
   ret |= test_flush_idempotent_after_finished();
+  ret |= test_flush_resumable();
   ret |= test_flush_no_data();
   ret |= test_metrics_enabled();
   ret |= test_mixed_dtypes();

--- a/tests/test_shard_sink.c
+++ b/tests/test_shard_sink.c
@@ -48,6 +48,20 @@ discard_finalize(struct shard_writer* self)
   return 0;
 }
 
+static int
+test_sink_update_append(struct shard_sink* self,
+                        uint8_t level,
+                        uint8_t n_append,
+                        const uint64_t* append_sizes)
+{
+  (void)level;
+  (void)n_append;
+  (void)append_sizes;
+  struct test_shard_sink* s = (struct test_shard_sink*)self;
+  s->update_append_count++;
+  return 0;
+}
+
 static struct shard_writer*
 test_sink_open(struct shard_sink* self, uint8_t level, uint64_t shard_index)
 {
@@ -82,6 +96,7 @@ test_sink_init_multi(struct test_shard_sink* s,
 {
   memset(s, 0, sizeof(*s));
   s->base.open = test_sink_open;
+  s->base.update_append = test_sink_update_append;
   s->per_shard_capacity = per_shard_capacity;
   s->num_levels = num_levels;
   s->discard_writer.write = discard_write;

--- a/tests/test_shard_sink.h
+++ b/tests/test_shard_sink.h
@@ -32,6 +32,7 @@ struct test_shard_sink
   size_t per_shard_capacity;
   int open_count;
   int finalize_count;
+  int update_append_count;
 };
 
 // Initialize a multi-level sink.

--- a/tests/test_stream_cpu.c
+++ b/tests/test_stream_cpu.c
@@ -140,7 +140,8 @@ Fail:
   return 1;
 }
 
-// Test that append after flush returns an error.
+// Test that flush is a resumable explicit sync: append after flush succeeds
+// and a subsequent flush commits the new data.
 static int
 test_append_after_flush(void)
 {
@@ -186,7 +187,7 @@ test_append_after_flush(void)
 
   struct writer* w = tile_stream_cpu_writer(s);
 
-  // Write one epoch, then flush.
+  // First batch: append + flush.
   {
     struct slice sl = { .beg = data, .end = (const char*)data + epoch_bytes };
     struct writer_result r = writer_append(w, sl);
@@ -197,12 +198,35 @@ test_append_after_flush(void)
     CHECK(Fail, r.error == 0);
   }
 
-  // Append after flush must return "finished" (not a hard error).
+  int shards_after_first_flush = 0;
+  for (int i = 0; i < TEST_SHARD_SINK_MAX_SHARDS; ++i) {
+    if (sink.writers[0][i].buf && sink.writers[0][i].size > 0)
+      shards_after_first_flush++;
+  }
+  CHECK(Fail, shards_after_first_flush > 0);
+
+  // Second batch: append after flush succeeds — stream is still appendable.
   {
     struct slice sl = { .beg = data, .end = (const char*)data + epoch_bytes };
     struct writer_result r = writer_append(w, sl);
-    CHECK(Fail, r.error == writer_error_finished);
+    CHECK(Fail, r.error == 0);
   }
+  // Second flush commits the new data.
+  {
+    struct writer_result r = writer_flush(w);
+    CHECK(Fail, r.error == 0);
+  }
+
+  // Cursor reflects both batches.
+  CHECK(Fail, tile_stream_cpu_cursor(s) == 2 * epoch_elems);
+
+  // The second flush produced additional shard output.
+  int shards_after_second_flush = 0;
+  for (int i = 0; i < TEST_SHARD_SINK_MAX_SHARDS; ++i) {
+    if (sink.writers[0][i].buf && sink.writers[0][i].size > 0)
+      shards_after_second_flush++;
+  }
+  CHECK(Fail, shards_after_second_flush > shards_after_first_flush);
 
   free(data);
   tile_stream_cpu_destroy(s);


### PR DESCRIPTION
## Summary

Makes `writer_flush()` a resumable explicit sync. After flush returns, the stream remains appendable. Finite-length termination is now exclusively input-side via `max_cursor`.

Background: previously `writer_flush()` was documented as terminal — once called, `append` returned `writer_finished_at(...)` and the stream was effectively closed. The new contract: flush is "explicit sync; stream remains appendable. Returns when all writes prior to the call are durable."

## Changes

### Per-array layer 
- `src/writer.h`: Updated `flush` doc and `writer_error_finished` comment — only max_cursor produces the finished error now.
- `src/cpu/stream.c`, `src/gpu/stream.c`: Removed the `if (s->flushed) return writer_finished_at(...)` gate in `*_append`. Replaced with Option-A re-arm: when `flushed && input.beg != input.end`, reset `flushed = 0` so the next `writer_flush()` runs the body again. Empty-slice appends never reset, so back-to-back flushes remain a cheap no-op.
- `src/cpu/stream.body.c`, `src/gpu/stream.c`: Updated the stale "terminal flush" comment in the max-cursor branch.
- `src/cpu/stream.internal.h`, `src/gpu/stream.internal.h`: Updated the `flushed` field doc to reflect idempotency semantics.
- `tests/test_stream_cpu.c::test_append_after_flush`: Rewrote to verify resumable behavior (write → flush → write → flush, both batches land in shards).

### Multiarray layer 
- `src/multiarray/stream.c::update_impl`, `src/multiarray/stream.gpu.c::update_impl`: Removed `desc->flushed` early return; same Option-A re-arm pattern.
- `flush_impl` doc comments updated.
- `tests/test_multiarray_cpu.c`, `tests/test_multiarray_gpu.c`: Added `test_flush_resumable`; cleaned terminal-flush phrasing in existing tests.

## Notes

- `multiarray_writer_finished` (enum value `2`) is still emitted, but only through pass-through from the per-array body's `writer_error_finished` on max_cursor exhaustion. No source code produces it directly anymore.
- `test_flush_idempotent_after_finished` continues to pass because the per-array body is internally idempotent (each phase guards against re-entry).

## Test plan

- [x] Negative regression (per-array): restored the gate; `test_append_after_flush` fails as expected
- [x] Negative regression (multiarray): restored `desc->flushed` early return; new `test_flush_resumable` fails as expected