### PR TITLE
bench: match aqz benchmark precisely

### DIFF
--- a/bench/bench_stream_aqz_single.c
+++ b/bench/bench_stream_aqz_single.c
@@ -2,13 +2,6 @@
 //   tyx = 1024 x 2048 x 2048 u16, 64-cube chunks, 1 x 16 x 16 chunks/shard
 //   -> 64 shards of 128 MiB each.
 // Used for thread-scaling and IO-impact studies against tensorstore.
-//
-// Layout is pinned: chunk_size and chunks_per_shard are set directly and
-// chunk_ratios is left NULL so bench_util's resolve_chunk_sizing skips the
-// planner (no dims_budget_chunk_bytes, no dims_set_shard_geometry). This
-// preserves the exact (1, 16, 16) shard layout that benchmark.py uses; the
-// planner's target_concurrent_shards/min_shard_bytes hints would otherwise
-// collapse it to 4 large shards.
 #include "bench_util.h"
 #include "dimension.h"
 

--- a/bench/bench_stream_aqz_single.c
+++ b/bench/bench_stream_aqz_single.c
@@ -1,6 +1,14 @@
 // Mirrors benchmarks/benchmark.py geometry in the parent acquire-zarr repo:
-//   tyx = 1024 x 2048 x 2048 u16, 64-cube chunks, 16x16 xy shards.
+//   tyx = 1024 x 2048 x 2048 u16, 64-cube chunks, 1 x 16 x 16 chunks/shard
+//   -> 64 shards of 128 MiB each.
 // Used for thread-scaling and IO-impact studies against tensorstore.
+//
+// Layout is pinned: chunk_size and chunks_per_shard are set directly and
+// chunk_ratios is left NULL so bench_util's resolve_chunk_sizing skips the
+// planner (no dims_budget_chunk_bytes, no dims_set_shard_geometry). This
+// preserves the exact (1, 16, 16) shard layout that benchmark.py uses; the
+// planner's target_concurrent_shards/min_shard_bytes hints would otherwise
+// collapse it to 4 large shards.
 #include "bench_util.h"
 #include "dimension.h"
 
@@ -11,8 +19,13 @@ main(int ac, char* av[])
   uint64_t sizes[] = { 1024, 2048, 2048 };
   uint8_t rank = dims_create(dims, "tyx", sizes);
 
-  // Equal weights -> 64-cube chunks at target_chunk_bytes = 64^3 * 2 = 512 KiB.
-  int ratios[] = { 1, 1, 1 };
+  uint64_t chunk_sizes[] = { 64, 64, 64 };
+  dims_set_chunk_sizes(dims, rank, chunk_sizes);
+
+  // 1 t-chunk x 16 y-chunks x 16 x-chunks per shard.
+  dims[0].chunks_per_shard = 1;
+  dims[1].chunks_per_shard = 16;
+  dims[2].chunks_per_shard = 16;
 
   return bench_stream_main(ac,
                            av,
@@ -20,12 +33,6 @@ main(int ac, char* av[])
                              .label = "single",
                              .dims = dims,
                              .rank = rank,
-                             .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 19, // 512 KiB
-                             .min_chunk_bytes = 1 << 14,
-                             // 1 x 16 x 16 chunks/shard -> 128 MiB shards.
-                             .min_shard_bytes = 128ull << 20,
-                             .target_concurrent_shards = 4,
-                             .min_append_shards = 1,
+                             .chunk_ratios = NULL,
                            });
 }


### PR DESCRIPTION
## Summary
- `bench_stream_aqz_single` now pins `chunk_size` and `chunks_per_shard` directly so the runtime layout matches the comment ("1 x 16 x 16 chunks/shard -> 128 MiB shards") and mirrors `benchmarks/benchmark.py` in the parent acquire-zarr repo.
- Previously the bench passed `min_shard_bytes = 128 MiB` + `target_concurrent_shards = 4` to the planner, and the planner satisfied the concurrency target by growing shards to 2 GiB (4 shards total, 4096 chunks/shard) — not the 64 × 128 MiB layout the comment claimed.

## Before vs. after on this host (CPU, --codec none, 8 GiB total)

| layout | shards | chunks/shard | shard bytes | wall GiB/s |
|---|---|---|---|---|
| planner-chosen (old) | 4 | 4096 | 2 GiB | ~3.4 |
| pinned 1×16×16 (new) | 64 | 256 | 128 MiB | ~3.7 |
