### PR TITLE
tests: use unbuffered IO

### DIFF
--- a/tests/test_destroy_drain.c
+++ b/tests/test_destroy_drain.c
@@ -83,7 +83,7 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
   _Atomic int gate;
   atomic_store(&gate, 0);
 
-  store = store_fs_create(tmpdir, 0);
+  store = store_fs_create(tmpdir, 1);
   CHECK(Cleanup, store);
   CHECK(Cleanup, store->mkdirs(store, ".") == 0);
   CHECK(Cleanup, store->mkdirs(store, "0") == 0);

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -86,7 +86,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
   _Atomic int gate;
   atomic_store(&gate, 0);
 
-  store = store_fs_create(tmpdir, 0);
+  store = store_fs_create(tmpdir, 1);
   CHECK(Cleanup, store);
   CHECK(Cleanup, store->mkdirs(store, ".") == 0);
   CHECK(Cleanup, store->mkdirs(store, "0") == 0);

--- a/tests/test_ngff_flush_cascade.c
+++ b/tests/test_ngff_flush_cascade.c
@@ -109,7 +109,7 @@ test_cascade_to_multiscale_group(void)
   CHECK(Fail, mk_subdir("caseA") == 0);
   char root[4096];
   snprintf(root, sizeof(root), "%s/caseA", tmpdir);
-  struct store* s = store_fs_create(root, 0);
+  struct store* s = store_fs_create(root, 1);
   CHECK(Fail, s);
 
   // Parent must seed the root group before the multiscale subgroup.
@@ -166,7 +166,7 @@ test_cascade_to_child_array(void)
   CHECK(Fail, mk_subdir("caseB") == 0);
   char root[4096];
   snprintf(root, sizeof(root), "%s/caseB", tmpdir);
-  struct store* s = store_fs_create(root, 0);
+  struct store* s = store_fs_create(root, 1);
   CHECK(Fail, s);
 
   {

--- a/tests/test_ngff_multiscale.c
+++ b/tests/test_ngff_multiscale.c
@@ -1,5 +1,6 @@
 #include "dimension.h"
 #include "ngff.h"
+#include "platform/platform.h"
 #include "store.h"
 #include "test_platform.h"
 #include "util/prelude.h"
@@ -129,7 +130,7 @@ test_multiscale_shard_sink(void)
 {
   log_info("=== test_multiscale_shard_sink ===");
 
-  struct store* store = store_fs_create(tmpdir, 0);
+  struct store* store = store_fs_create(tmpdir, 1);
   CHECK(Fail, store);
   store->mkdirs(store, ".");
 
@@ -166,39 +167,46 @@ test_multiscale_shard_sink(void)
   struct shard_sink* sink = ngff_multiscale_as_shard_sink(ms);
   CHECK(Fail3, sink);
 
+  // O_DIRECT requires page-aligned source pointer and write size.
+  size_t pa = platform_page_alignment();
+  uint8_t* data = (uint8_t*)platform_aligned_alloc(pa, pa);
+  CHECK(Fail3, data);
+  memset(data, 0xAA, pa);
+
   // Open a shard on level 0, write some data, finalize
   struct shard_writer* w = sink->open(sink, 0, 0);
-  CHECK(Fail3, w);
-  uint8_t data[32];
-  memset(data, 0xAA, sizeof(data));
-  CHECK(Fail3, w->write(w, 0, data, data + sizeof(data)) == 0);
-  CHECK(Fail3, w->finalize(w) == 0);
+  CHECK(Fail4, w);
+  CHECK(Fail4, w->write(w, 0, data, data + pa) == 0);
+  CHECK(Fail4, w->finalize(w) == 0);
 
   // update_append: extend dim 0 from 0 to 4
   uint64_t new_sizes[1] = { 4 };
-  CHECK(Fail3, sink->update_append(sink, 0, 1, new_sizes) == 0);
+  CHECK(Fail4, sink->update_append(sink, 0, 1, new_sizes) == 0);
 
   // Verify L0 array zarr.json was updated
   char path[4096];
   snprintf(path, sizeof(path), "%s/ms/0/zarr.json", tmpdir);
   char buf[4096];
   size_t len;
-  CHECK(Fail3, read_file(path, buf, sizeof(buf), &len) == 0);
-  CHECK(Fail3, strstr(buf, "\"shape\":[4,32]"));
+  CHECK(Fail4, read_file(path, buf, sizeof(buf), &len) == 0);
+  CHECK(Fail4, strstr(buf, "\"shape\":[4,32]"));
 
   // Verify group zarr.json was updated (multiscales metadata)
   snprintf(path, sizeof(path), "%s/ms/zarr.json", tmpdir);
-  CHECK(Fail3, read_file(path, buf, sizeof(buf), &len) == 0);
-  CHECK(Fail3, strstr(buf, "\"multiscales\""));
+  CHECK(Fail4, read_file(path, buf, sizeof(buf), &len) == 0);
+  CHECK(Fail4, strstr(buf, "\"multiscales\""));
 
   // Flush pending I/O
-  CHECK(Fail3, ngff_multiscale_flush(ms) == 0);
+  CHECK(Fail4, ngff_multiscale_flush(ms) == 0);
 
+  platform_aligned_free(data);
   ngff_multiscale_destroy(ms);
   store_destroy(store);
   log_info("  PASS");
   return 0;
 
+Fail4:
+  platform_aligned_free(data);
 Fail3:
   ngff_multiscale_destroy(ms);
 Fail2:

--- a/tests/test_zarr_array.c
+++ b/tests/test_zarr_array.c
@@ -1,4 +1,5 @@
 #include "dimension.h"
+#include "platform/platform.h"
 #include "store.h"
 #include "test_platform.h"
 #include "util/prelude.h"
@@ -87,7 +88,7 @@ test_zarr_array_shard_write(void)
 {
   log_info("=== test_zarr_array_shard_write ===");
 
-  struct store* store = store_fs_create(tmpdir, 0);
+  struct store* store = store_fs_create(tmpdir, 1);
   CHECK(Fail, store);
 
   CHECK(Fail2, store->mkdirs(store, "arr1d") == 0);
@@ -109,40 +110,56 @@ test_zarr_array_shard_write(void)
 
   struct shard_sink* sink = zarr_array_as_shard_sink(a);
 
+  // O_DIRECT requires page-aligned source pointer and write size.
+  size_t pa = platform_page_alignment();
+  uint8_t* buf = (uint8_t*)platform_aligned_alloc(pa, pa);
+  CHECK(Fail3, buf);
+
   // Write shard 0
   struct shard_writer* w = sink->open(sink, 0, 0);
-  CHECK(Fail3, w);
-  uint8_t data0[4] = { 1, 2, 3, 4 };
-  CHECK(Fail3, w->write(w, 0, data0, data0 + 4) == 0);
-  CHECK(Fail3, w->finalize(w) == 0);
+  CHECK(Fail4, w);
+  memset(buf, 0, pa);
+  buf[0] = 1;
+  buf[1] = 2;
+  buf[2] = 3;
+  buf[3] = 4;
+  CHECK(Fail4, w->write(w, 0, buf, buf + pa) == 0);
+  CHECK(Fail4, w->finalize(w) == 0);
 
   // Write shard 1
   w = sink->open(sink, 0, 1);
-  CHECK(Fail3, w);
-  uint8_t data1[4] = { 5, 6, 7, 8 };
-  CHECK(Fail3, w->write(w, 0, data1, data1 + 4) == 0);
-  CHECK(Fail3, w->finalize(w) == 0);
+  CHECK(Fail4, w);
+  memset(buf, 0, pa);
+  buf[0] = 5;
+  buf[1] = 6;
+  buf[2] = 7;
+  buf[3] = 8;
+  CHECK(Fail4, w->write(w, 0, buf, buf + pa) == 0);
+  CHECK(Fail4, w->finalize(w) == 0);
 
-  CHECK(Fail3, zarr_array_flush(a) == 0);
-  CHECK(Fail3, zarr_array_has_error(a) == 0);
+  CHECK(Fail4, zarr_array_flush(a) == 0);
+  CHECK(Fail4, zarr_array_has_error(a) == 0);
 
   // Verify shard files exist
   char path[4096];
   snprintf(path, sizeof(path), "%s/arr1d/c/0", tmpdir);
   FILE* f = fopen(path, "rb");
-  CHECK(Fail3, f);
+  CHECK(Fail4, f);
   fclose(f);
 
   snprintf(path, sizeof(path), "%s/arr1d/c/1", tmpdir);
   f = fopen(path, "rb");
-  CHECK(Fail3, f);
+  CHECK(Fail4, f);
   fclose(f);
 
+  platform_aligned_free(buf);
   zarr_array_destroy(a);
   store_destroy(store);
   log_info("  PASS");
   return 0;
 
+Fail4:
+  platform_aligned_free(buf);
 Fail3:
   zarr_array_destroy(a);
 Fail2:
@@ -303,7 +320,7 @@ test_zarr_array_root(void)
   char root[4096];
   snprintf(root, sizeof(root), "%s/rootarr", tmpdir);
 
-  struct store* store = store_fs_create(root, 0);
+  struct store* store = store_fs_create(root, 1);
   CHECK(Fail, store);
   CHECK(Fail2, store->mkdirs(store, ".") == 0);
 
@@ -323,25 +340,34 @@ test_zarr_array_root(void)
 
   char path[4096];
   snprintf(path, sizeof(path), "%s/rootarr/zarr.json", tmpdir);
-  char buf[4096];
+  char rbuf[4096];
   size_t len;
-  CHECK(Fail3, read_file(path, buf, sizeof(buf), &len) == 0);
-  CHECK(Fail3, strstr(buf, "\"node_type\":\"array\""));
+  CHECK(Fail3, read_file(path, rbuf, sizeof(rbuf), &len) == 0);
+  CHECK(Fail3, strstr(rbuf, "\"node_type\":\"array\""));
+
+  // O_DIRECT requires page-aligned source pointer and write size.
+  size_t pa = platform_page_alignment();
+  uint8_t* dbuf = (uint8_t*)platform_aligned_alloc(pa, pa);
+  CHECK(Fail3, dbuf);
+  memset(dbuf, 0, pa);
+  dbuf[0] = 0x42;
 
   // Open a shard with empty prefix — exercises the no-prefix key path
   struct shard_sink* sink = zarr_array_as_shard_sink(a);
   struct shard_writer* w = sink->open(sink, 0, 0);
-  CHECK(Fail3, w);
-  uint8_t byte = 0x42;
-  CHECK(Fail3, w->write(w, 0, &byte, &byte + 1) == 0);
-  CHECK(Fail3, w->finalize(w) == 0);
-  CHECK(Fail3, zarr_array_flush(a) == 0);
+  CHECK(Fail4, w);
+  CHECK(Fail4, w->write(w, 0, dbuf, dbuf + pa) == 0);
+  CHECK(Fail4, w->finalize(w) == 0);
+  CHECK(Fail4, zarr_array_flush(a) == 0);
 
+  platform_aligned_free(dbuf);
   zarr_array_destroy(a);
   store_destroy(store);
   log_info("  PASS");
   return 0;
 
+Fail4:
+  platform_aligned_free(dbuf);
 Fail3:
   zarr_array_destroy(a);
 Fail2:

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -98,7 +98,7 @@ test_metadata(const char* tmpdir)
   struct test_zarr_sink z = { 0 };
   struct codec_config codec = { 0 };
   CHECK(Fail,
-        test_zarr_sink_open(&z, tmpdir, "0", dims, 3, dtype_u32, 0, codec, 0) ==
+        test_zarr_sink_open(&z, tmpdir, "0", dims, 3, dtype_u32, 0, codec, 1) ==
           0);
 
   {
@@ -194,7 +194,7 @@ test_pipeline(const char* tmpdir)
   struct test_zarr_sink z = { 0 };
   struct codec_config codec = { 0 };
   CHECK(Fail2,
-        test_zarr_sink_open(&z, tmpdir, "0", dims, 3, dtype_u32, 0, codec, 0) ==
+        test_zarr_sink_open(&z, tmpdir, "0", dims, 3, dtype_u32, 0, codec, 1) ==
           0);
 
   // Configure stream
@@ -383,7 +383,7 @@ test_multiscale_metadata(const char* tmpdir)
   struct codec_config codec = { 0 };
   CHECK(Fail,
         test_zarr_multiscale_open(
-          &z, tmpdir, "", dims, 3, dtype_u16, 0, 0, codec, NULL, 0) == 0);
+          &z, tmpdir, "", dims, 3, dtype_u16, 0, 0, codec, NULL, 1) == 0);
 
   // Check root zarr.json has multiscales attribute
   {
@@ -472,7 +472,7 @@ test_multiscale_scale_non_pow2(const char* tmpdir)
   struct codec_config codec = { 0 };
   CHECK(Fail,
         test_zarr_multiscale_open(
-          &z, tmpdir, "", dims, 3, dtype_u16, 0, 0, codec, NULL, 0) == 0);
+          &z, tmpdir, "", dims, 3, dtype_u16, 0, 0, codec, NULL, 1) == 0);
 
   {
     char* data;
@@ -533,7 +533,7 @@ test_multiscale_scale_size1(const char* tmpdir)
   struct codec_config codec = { 0 };
   CHECK(Fail,
         test_zarr_multiscale_open(
-          &z, tmpdir, "", dims, 3, dtype_u16, 0, 0, codec, NULL, 0) == 0);
+          &z, tmpdir, "", dims, 3, dtype_u16, 0, 0, codec, NULL, 1) == 0);
 
   {
     char* data;
@@ -597,7 +597,7 @@ test_multiscale_unit_scale(const char* tmpdir)
   struct codec_config codec = { 0 };
   CHECK(Fail,
         test_zarr_multiscale_open(
-          &z, tmpdir, "", dims, 3, dtype_u16, 0, 0, codec, axes, 0) == 0);
+          &z, tmpdir, "", dims, 3, dtype_u16, 0, 0, codec, axes, 1) == 0);
 
   {
     char* data;
@@ -655,7 +655,7 @@ test_metadata_two_append(const char* tmpdir)
   struct test_zarr_sink z = { 0 };
   struct codec_config codec = { 0 };
   CHECK(Fail,
-        test_zarr_sink_open(&z, tmpdir, "0", dims, 4, dtype_u16, 0, codec, 0) ==
+        test_zarr_sink_open(&z, tmpdir, "0", dims, 4, dtype_u16, 0, codec, 1) ==
           0);
 
   {
@@ -735,7 +735,7 @@ test_unbounded_metadata_update(const char* tmpdir)
   struct test_zarr_sink z = { 0 };
   struct codec_config codec = { 0 };
   CHECK(Fail,
-        test_zarr_sink_open(&z, tmpdir, "0", dims, 3, dtype_u16, 0, codec, 0) ==
+        test_zarr_sink_open(&z, tmpdir, "0", dims, 3, dtype_u16, 0, codec, 1) ==
           0);
 
   // Initial zarr.json should have shape[0] = 0
@@ -859,7 +859,7 @@ test_multiscale_unbounded(const char* tmpdir)
   struct codec_config codec = { 0 };
   CHECK(Fail,
         test_zarr_multiscale_open(
-          &z, tmpdir, "", dims, 3, dtype_u16, 0, 0, codec, NULL, 0) == 0);
+          &z, tmpdir, "", dims, 3, dtype_u16, 0, 0, codec, NULL, 1) == 0);
 
   // Check root zarr.json exists with multiscales
   {
@@ -945,7 +945,7 @@ test_midstream_metadata_update(const char* tmpdir)
   struct test_zarr_sink z = { 0 };
   struct codec_config codec = { 0 };
   CHECK(Fail,
-        test_zarr_sink_open(&z, tmpdir, "0", dims, 3, dtype_u16, 0, codec, 0) ==
+        test_zarr_sink_open(&z, tmpdir, "0", dims, 3, dtype_u16, 0, codec, 1) ==
           0);
 
   // Enable periodic metadata updates with a tiny interval.
@@ -1730,7 +1730,7 @@ test_pipeline_storage_order(const char* tmpdir)
   struct codec_config zcodec = { 0 };
   CHECK(Fail2,
         test_zarr_sink_open(
-          &z, tmpdir, "0", sto_dims, 3, dtype_u32, 0, zcodec, 0) == 0);
+          &z, tmpdir, "0", sto_dims, 3, dtype_u32, 0, zcodec, 1) == 0);
 
   // tile_stream uses acquisition-order dims (same array, with storage_position)
   const struct tile_stream_configuration config = {
@@ -1993,7 +1993,7 @@ test_nested_array_name(const char* tmpdir)
   struct codec_config codec = { 0 };
   CHECK(Fail,
         test_zarr_sink_open(
-          &z, tmpdir, "path/to/data", dims, 2, dtype_u16, 0, codec, 0) == 0);
+          &z, tmpdir, "path/to/data", dims, 2, dtype_u16, 0, codec, 1) == 0);
 
   // Check root group zarr.json
   {
@@ -2072,7 +2072,7 @@ test_nested_multiscale_array_name(const char* tmpdir)
   CHECK(
     Fail,
     test_zarr_multiscale_open(
-      &z, tmpdir, "path/to/group", dims, 2, dtype_u16, 0, 0, codec, NULL, 0) ==
+      &z, tmpdir, "path/to/group", dims, 2, dtype_u16, 0, 0, codec, NULL, 1) ==
       0);
 
   // Check root group zarr.json
@@ -2153,7 +2153,7 @@ test_multiscale_chunk_clamp_metadata(const char* tmpdir)
   struct codec_config codec = { 0 };
   CHECK(Fail,
         test_zarr_multiscale_open(
-          &z, tmpdir, "", dims, 2, dtype_u16, 0, 0, codec, NULL, 0) == 0);
+          &z, tmpdir, "", dims, 2, dtype_u16, 0, 0, codec, NULL, 1) == 0);
 
   // L0 zarr.json: shape=[32,10], chunk_size=8 in both dims
   {


### PR DESCRIPTION
Switch tests that exercise real shard writes to `store_fs_create(..., unbuffered=1)` so they match how production runs (matches `bench/bench_zarr.c`).

- Pipeline tests (test_zarr_fs_sink, test_ngff_flush_cascade, test_destroy_drain, test_flush_drain_gpu): just flip the flag — `shard_delivery.c` already pads writes to alignment.
- Raw `shard_writer->write` callers (test_zarr_array, test_ngff_multiscale): replace stack buffers with `platform_aligned_alloc` page-aligned buffers, round write size up to one page.
- Metadata-only tests left buffered.