### PR TITLE
Bench chunk size bump and sweep --tmpdir

### DIFF
--- a/bench/bench_stream_256cube_multiscale.c
+++ b/bench/bench_stream_256cube_multiscale.c
@@ -19,7 +19,7 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 20,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
                              .target_concurrent_shards = 16,

--- a/bench/bench_stream_256cube_multiscale_dim0.c
+++ b/bench/bench_stream_256cube_multiscale_dim0.c
@@ -20,7 +20,7 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 20,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
                              .target_concurrent_shards = 16,

--- a/bench/bench_stream_256cube_single.c
+++ b/bench/bench_stream_256cube_single.c
@@ -17,7 +17,7 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 20,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
                              .target_concurrent_shards = 16,

--- a/bench/bench_stream_256cube_two_streams.c
+++ b/bench/bench_stream_256cube_two_streams.c
@@ -17,7 +17,7 @@ main(int ac, char* av[])
                                   .dims = dims,
                                   .rank = rank,
                                   .chunk_ratios = ratios,
-                                  .target_chunk_bytes = 1 << 18,
+                                  .target_chunk_bytes = 1 << 20,
                                   .min_chunk_bytes = 1 << 14,
                                   .min_shard_bytes = 1ull << 30,
                                   .target_concurrent_shards = 16,

--- a/bench/bench_stream_medfmt_multiscale.c
+++ b/bench/bench_stream_medfmt_multiscale.c
@@ -19,7 +19,7 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 20,
                              .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1ull << 30,
                              .target_concurrent_shards = 20,

--- a/bench/bench_stream_medfmt_multiscale_dim0.c
+++ b/bench/bench_stream_medfmt_multiscale_dim0.c
@@ -19,7 +19,7 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 20,
                              .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1ull << 30,
                              .target_concurrent_shards = 20,

--- a/bench/bench_stream_medfmt_single.c
+++ b/bench/bench_stream_medfmt_single.c
@@ -17,7 +17,7 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 20,
                              .min_chunk_bytes = 1 << 12,
                              .min_shard_bytes = 1ull << 30,
                              .target_concurrent_shards = 20,

--- a/bench/bench_stream_orca2_multiscale.c
+++ b/bench/bench_stream_orca2_multiscale.c
@@ -19,7 +19,7 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 20,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
                              .target_concurrent_shards = 16,

--- a/bench/bench_stream_orca2_multiscale_dim0.c
+++ b/bench/bench_stream_orca2_multiscale_dim0.c
@@ -19,7 +19,7 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 20,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
                              .target_concurrent_shards = 16,

--- a/bench/bench_stream_orca2_single.c
+++ b/bench/bench_stream_orca2_single.c
@@ -17,7 +17,7 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 18,
+                             .target_chunk_bytes = 1 << 20,
                              .min_chunk_bytes = 1 << 14,
                              .min_shard_bytes = 1ull << 30,
                              .target_concurrent_shards = 16,

--- a/bench/bench_stream_smallepoch_single.c
+++ b/bench/bench_stream_smallepoch_single.c
@@ -17,9 +17,9 @@ main(int ac, char* av[])
                              .dims = dims,
                              .rank = rank,
                              .chunk_ratios = ratios,
-                             .target_chunk_bytes = 1 << 16,
+                             .target_chunk_bytes = 1 << 20,
                              .min_chunk_bytes = 1 << 12,
-                             .min_shard_bytes = 1 << 16,
+                             .min_shard_bytes = 1 << 20,
                              .target_concurrent_shards = 1,
                              .min_append_shards = 4,
                            });

--- a/bench/results/livescreen-kubuntu-a5bc797-20260420.json
+++ b/bench/results/livescreen-kubuntu-a5bc797-20260420.json
@@ -1,0 +1,30015 @@
+{
+  "version": 1,
+  "machine": {
+    "hostname": "livescreen-kubuntu",
+    "gpu": "NVIDIA RTX PRO 6000 Blackwell Workstation Edition",
+    "commit": "a5bc797",
+    "date": "2026-04-20T20:13:21"
+  },
+  "runs": [
+    {
+      "id": "orca2_single__none__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.82,
+      "status": "pass",
+      "throughput_in_gibs": 7.55436,
+      "throughput_out_gibs": 7.56321,
+      "compression_fold": 0.998829,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51975,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.465377,
+      "init_s": 0.0986388,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.43698,
+          "best_ms": 0.803205,
+          "in_gibs": 19.2349,
+          "out_gibs": 19.2349
+        },
+        "h2d": {
+          "avg_ms": 0.915477,
+          "best_ms": 0.297152,
+          "in_gibs": 51.4366,
+          "out_gibs": 51.4366
+        },
+        "scatter": {
+          "avg_ms": 0.199981,
+          "best_ms": 0.0704,
+          "in_gibs": 235.467,
+          "out_gibs": 235.467
+        },
+        "compress": {
+          "avg_ms": 0.176442,
+          "best_ms": 0.165504,
+          "in_gibs": 797.006,
+          "out_gibs": 797.006
+        },
+        "aggregate": {
+          "avg_ms": 1.9388,
+          "best_ms": 0.411648,
+          "in_gibs": 72.5321,
+          "out_gibs": 72.5321
+        },
+        "d2h": {
+          "avg_ms": 16.44,
+          "best_ms": 2.6879,
+          "in_gibs": 8.55383,
+          "out_gibs": 8.55383
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 74.0041,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 0.022306,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.86429,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.56,
+      "status": "pass",
+      "throughput_in_gibs": 7.61921,
+      "throughput_out_gibs": 7.62374,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.461416,
+      "init_s": 0.0854181,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.45579,
+          "best_ms": 0.783976,
+          "in_gibs": 19.0875,
+          "out_gibs": 19.0875
+        },
+        "h2d": {
+          "avg_ms": 0.913139,
+          "best_ms": 0.296224,
+          "in_gibs": 51.5683,
+          "out_gibs": 51.5683
+        },
+        "scatter": {
+          "avg_ms": 0.200149,
+          "best_ms": 0.070624,
+          "in_gibs": 235.27,
+          "out_gibs": 235.27
+        },
+        "compress": {
+          "avg_ms": 0.176435,
+          "best_ms": 0.165536,
+          "in_gibs": 797.035,
+          "out_gibs": 797.035
+        },
+        "aggregate": {
+          "avg_ms": 1.95044,
+          "best_ms": 0.428032,
+          "in_gibs": 72.0992,
+          "out_gibs": 72.0992
+        },
+        "d2h": {
+          "avg_ms": 16.5397,
+          "best_ms": 2.69293,
+          "in_gibs": 8.50226,
+          "out_gibs": 8.50226
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 70.0234,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 0.024738,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.11513,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.57,
+      "status": "pass",
+      "throughput_in_gibs": 7.64745,
+      "throughput_out_gibs": 7.64969,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51666,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.459712,
+      "init_s": 0.0923639,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41179,
+          "best_ms": 0.805598,
+          "in_gibs": 19.4357,
+          "out_gibs": 19.4357
+        },
+        "h2d": {
+          "avg_ms": 0.915919,
+          "best_ms": 0.296032,
+          "in_gibs": 51.4118,
+          "out_gibs": 51.4118
+        },
+        "scatter": {
+          "avg_ms": 0.200312,
+          "best_ms": 0.07056,
+          "in_gibs": 235.078,
+          "out_gibs": 235.078
+        },
+        "compress": {
+          "avg_ms": 0.177371,
+          "best_ms": 0.16912,
+          "in_gibs": 792.83,
+          "out_gibs": 792.83
+        },
+        "aggregate": {
+          "avg_ms": 1.97463,
+          "best_ms": 0.510816,
+          "in_gibs": 71.2157,
+          "out_gibs": 71.2157
+        },
+        "d2h": {
+          "avg_ms": 16.361,
+          "best_ms": 2.69078,
+          "in_gibs": 8.59513,
+          "out_gibs": 8.59513
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 68.7027,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 0.021793,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.59456,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.72,
+      "status": "pass",
+      "throughput_in_gibs": 7.55846,
+      "throughput_out_gibs": 7.55968,
+      "compression_fold": 0.99984,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51619,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.465124,
+      "init_s": 0.139249,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.49346,
+          "best_ms": 0.851547,
+          "in_gibs": 18.7992,
+          "out_gibs": 18.7992
+        },
+        "h2d": {
+          "avg_ms": 0.903689,
+          "best_ms": 0.296064,
+          "in_gibs": 52.1076,
+          "out_gibs": 52.1076
+        },
+        "scatter": {
+          "avg_ms": 0.199379,
+          "best_ms": 0.0688,
+          "in_gibs": 236.179,
+          "out_gibs": 236.179
+        },
+        "compress": {
+          "avg_ms": 0.382969,
+          "best_ms": 0.171968,
+          "in_gibs": 706.148,
+          "out_gibs": 706.148
+        },
+        "aggregate": {
+          "avg_ms": 4.20676,
+          "best_ms": 0.35024,
+          "in_gibs": 64.2852,
+          "out_gibs": 64.2852
+        },
+        "d2h": {
+          "avg_ms": 30.917,
+          "best_ms": 2.68262,
+          "in_gibs": 8.74705,
+          "out_gibs": 8.74705
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 62.0196,
+        "flush_stall_count": 11,
+        "kick_sync_ms": 0.443405,
+        "kick_sync_count": 13,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 9.25596,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.65,
+      "status": "pass",
+      "throughput_in_gibs": 7.61803,
+      "throughput_out_gibs": 7.61865,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.461487,
+      "init_s": 0.218416,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.46936,
+          "best_ms": 0.817136,
+          "in_gibs": 18.9826,
+          "out_gibs": 18.9826
+        },
+        "h2d": {
+          "avg_ms": 0.900622,
+          "best_ms": 0.29584,
+          "in_gibs": 52.285,
+          "out_gibs": 52.285
+        },
+        "scatter": {
+          "avg_ms": 0.199253,
+          "best_ms": 0.0688,
+          "in_gibs": 236.328,
+          "out_gibs": 236.328
+        },
+        "compress": {
+          "avg_ms": 0.724357,
+          "best_ms": 0.175424,
+          "in_gibs": 693.349,
+          "out_gibs": 693.349
+        },
+        "aggregate": {
+          "avg_ms": 7.7797,
+          "best_ms": 0.450528,
+          "in_gibs": 64.5568,
+          "out_gibs": 64.5568
+        },
+        "d2h": {
+          "avg_ms": 52.82,
+          "best_ms": 2.68051,
+          "in_gibs": 9.50837,
+          "out_gibs": 9.50837
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 55.8716,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 0.576284,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.7322,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.07,
+      "status": "pass",
+      "throughput_in_gibs": 7.69422,
+      "throughput_out_gibs": 8.0023,
+      "compression_fold": 0.999961,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65639,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.456918,
+      "init_s": 0.383353,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.8858,
+          "best_ms": 0.796745,
+          "in_gibs": 19.3373,
+          "out_gibs": 19.3373
+        },
+        "h2d": {
+          "avg_ms": 1.07039,
+          "best_ms": 0.58992,
+          "in_gibs": 52.6469,
+          "out_gibs": 52.6469
+        },
+        "scatter": {
+          "avg_ms": 0.235493,
+          "best_ms": 0.133952,
+          "in_gibs": 239.295,
+          "out_gibs": 239.295
+        },
+        "compress": {
+          "avg_ms": 1.33341,
+          "best_ms": 0.389632,
+          "in_gibs": 685.508,
+          "out_gibs": 685.508
+        },
+        "aggregate": {
+          "avg_ms": 12.2687,
+          "best_ms": 0.88576,
+          "in_gibs": 74.5037,
+          "out_gibs": 74.5037
+        },
+        "d2h": {
+          "avg_ms": 76.5794,
+          "best_ms": 5.35238,
+          "in_gibs": 11.9361,
+          "out_gibs": 11.9361
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 44.3388,
+        "flush_stall_count": 2,
+        "kick_sync_ms": 1.19126,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 25.4484,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.67,
+      "status": "pass",
+      "throughput_in_gibs": 7.61524,
+      "throughput_out_gibs": 7.91999,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65631,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.461657,
+      "init_s": 0.843774,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.86193,
+          "best_ms": 0.831638,
+          "in_gibs": 19.4986,
+          "out_gibs": 19.4986
+        },
+        "h2d": {
+          "avg_ms": 1.06487,
+          "best_ms": 0.58992,
+          "in_gibs": 52.9194,
+          "out_gibs": 52.9194
+        },
+        "scatter": {
+          "avg_ms": 0.235816,
+          "best_ms": 0.13408,
+          "in_gibs": 238.968,
+          "out_gibs": 238.968
+        },
+        "compress": {
+          "avg_ms": 2.64992,
+          "best_ms": 2.03366,
+          "in_gibs": 689.879,
+          "out_gibs": 689.879
+        },
+        "aggregate": {
+          "avg_ms": 5.42662,
+          "best_ms": 3.63622,
+          "in_gibs": 336.881,
+          "out_gibs": 336.881
+        },
+        "d2h": {
+          "avg_ms": 96.1564,
+          "best_ms": 26.7292,
+          "in_gibs": 19.012,
+          "out_gibs": 19.012
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 5.57799,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.01826,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 4.52,
+      "status": "pass",
+      "throughput_in_gibs": 7.60205,
+      "throughput_out_gibs": 7.9062,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.462458,
+      "init_s": 1.43827,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.837,
+          "best_ms": 0.809264,
+          "in_gibs": 19.6699,
+          "out_gibs": 19.6699
+        },
+        "h2d": {
+          "avg_ms": 1.06396,
+          "best_ms": 0.58992,
+          "in_gibs": 52.9648,
+          "out_gibs": 52.9648
+        },
+        "scatter": {
+          "avg_ms": 0.235432,
+          "best_ms": 0.133984,
+          "in_gibs": 239.358,
+          "out_gibs": 239.358
+        },
+        "compress": {
+          "avg_ms": 5.31622,
+          "best_ms": 5.31622,
+          "in_gibs": 687.753,
+          "out_gibs": 687.753
+        },
+        "aggregate": {
+          "avg_ms": 7.97901,
+          "best_ms": 7.97901,
+          "in_gibs": 458.234,
+          "out_gibs": 458.234
+        },
+        "d2h": {
+          "avg_ms": 69.4977,
+          "best_ms": 69.4977,
+          "in_gibs": 52.6097,
+          "out_gibs": 52.6097
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 13.4331,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.48932,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.74,
+      "status": "pass",
+      "throughput_in_gibs": 7.84361,
+      "throughput_out_gibs": 3.97018,
+      "compression_fold": 1.97563,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.7795,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.448215,
+      "init_s": 0.106693,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.49909,
+          "best_ms": 0.819879,
+          "in_gibs": 18.7568,
+          "out_gibs": 18.7568
+        },
+        "h2d": {
+          "avg_ms": 0.915726,
+          "best_ms": 0.298528,
+          "in_gibs": 51.4226,
+          "out_gibs": 51.4226
+        },
+        "scatter": {
+          "avg_ms": 0.215639,
+          "best_ms": 0.070688,
+          "in_gibs": 218.37,
+          "out_gibs": 218.37
+        },
+        "compress": {
+          "avg_ms": 6.58471,
+          "best_ms": 6.47834,
+          "in_gibs": 21.3563,
+          "out_gibs": 10.7848
+        },
+        "aggregate": {
+          "avg_ms": 0.173381,
+          "best_ms": 0.165856,
+          "in_gibs": 409.589,
+          "out_gibs": 409.589
+        },
+        "d2h": {
+          "avg_ms": 10.041,
+          "best_ms": 1.36461,
+          "in_gibs": 7.07248,
+          "out_gibs": 7.07248
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 41.7412,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 4.03377,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.64931,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.74,
+      "status": "pass",
+      "throughput_in_gibs": 7.99386,
+      "throughput_out_gibs": 4.00071,
+      "compression_fold": 1.99811,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.75947,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.439791,
+      "init_s": 0.100256,
+      "flush_s": 3.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.46353,
+          "best_ms": 0.862814,
+          "in_gibs": 19.0276,
+          "out_gibs": 19.0276
+        },
+        "h2d": {
+          "avg_ms": 0.913983,
+          "best_ms": 0.295904,
+          "in_gibs": 51.5207,
+          "out_gibs": 51.5207
+        },
+        "scatter": {
+          "avg_ms": 0.244459,
+          "best_ms": 0.070528,
+          "in_gibs": 192.625,
+          "out_gibs": 192.625
+        },
+        "compress": {
+          "avg_ms": 8.3262,
+          "best_ms": 8.24022,
+          "in_gibs": 16.8895,
+          "out_gibs": 8.44266
+        },
+        "aggregate": {
+          "avg_ms": 0.175528,
+          "best_ms": 0.16176,
+          "in_gibs": 400.479,
+          "out_gibs": 400.479
+        },
+        "d2h": {
+          "avg_ms": 8.03523,
+          "best_ms": 1.34486,
+          "in_gibs": 8.74837,
+          "out_gibs": 8.74837
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 37.9443,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 6.57094,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.80988,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.56,
+      "status": "pass",
+      "throughput_in_gibs": 7.84608,
+      "throughput_out_gibs": 3.94086,
+      "compression_fold": 1.99096,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.7658,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.448074,
+      "init_s": 0.0974198,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.46017,
+          "best_ms": 0.804136,
+          "in_gibs": 19.0536,
+          "out_gibs": 19.0536
+        },
+        "h2d": {
+          "avg_ms": 0.91739,
+          "best_ms": 0.296224,
+          "in_gibs": 51.3293,
+          "out_gibs": 51.3293
+        },
+        "scatter": {
+          "avg_ms": 0.215759,
+          "best_ms": 0.070688,
+          "in_gibs": 218.248,
+          "out_gibs": 218.248
+        },
+        "compress": {
+          "avg_ms": 9.29307,
+          "best_ms": 9.11456,
+          "in_gibs": 15.1322,
+          "out_gibs": 7.59605
+        },
+        "aggregate": {
+          "avg_ms": 0.201811,
+          "best_ms": 0.17408,
+          "in_gibs": 349.785,
+          "out_gibs": 349.785
+        },
+        "d2h": {
+          "avg_ms": 7.36964,
+          "best_ms": 1.34947,
+          "in_gibs": 9.57857,
+          "out_gibs": 9.57857
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 36.193,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 8.07787,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 13.7493,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.64,
+      "status": "pass",
+      "throughput_in_gibs": 7.70614,
+      "throughput_out_gibs": 3.45799,
+      "compression_fold": 2.2285,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.57757,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.456211,
+      "init_s": 0.130127,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.51036,
+          "best_ms": 0.819679,
+          "in_gibs": 18.6726,
+          "out_gibs": 18.6726
+        },
+        "h2d": {
+          "avg_ms": 0.906772,
+          "best_ms": 0.295968,
+          "in_gibs": 51.9304,
+          "out_gibs": 51.9304
+        },
+        "scatter": {
+          "avg_ms": 0.225545,
+          "best_ms": 0.068736,
+          "in_gibs": 209.754,
+          "out_gibs": 209.754
+        },
+        "compress": {
+          "avg_ms": 18.3861,
+          "best_ms": 16.7177,
+          "in_gibs": 14.7085,
+          "out_gibs": 6.59783
+        },
+        "aggregate": {
+          "avg_ms": 0.342201,
+          "best_ms": 0.219104,
+          "in_gibs": 354.495,
+          "out_gibs": 354.495
+        },
+        "d2h": {
+          "avg_ms": 13.5547,
+          "best_ms": 1.20467,
+          "in_gibs": 8.94956,
+          "out_gibs": 8.94956
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 28.2932,
+        "flush_stall_count": 11,
+        "kick_sync_ms": 19.8304,
+        "kick_sync_count": 13,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 10.7198,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.96,
+      "status": "pass",
+      "throughput_in_gibs": 7.08995,
+      "throughput_out_gibs": 3.46986,
+      "compression_fold": 2.04329,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.72057,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.495861,
+      "init_s": 0.250491,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41755,
+          "best_ms": 0.740931,
+          "in_gibs": 19.3895,
+          "out_gibs": 19.3895
+        },
+        "h2d": {
+          "avg_ms": 0.903455,
+          "best_ms": 0.297472,
+          "in_gibs": 52.1211,
+          "out_gibs": 52.1211
+        },
+        "scatter": {
+          "avg_ms": 0.217988,
+          "best_ms": 0.066752,
+          "in_gibs": 214.026,
+          "out_gibs": 214.026
+        },
+        "compress": {
+          "avg_ms": 36.9093,
+          "best_ms": 30.5959,
+          "in_gibs": 13.6072,
+          "out_gibs": 6.65834
+        },
+        "aggregate": {
+          "avg_ms": 0.66619,
+          "best_ms": 0.241632,
+          "in_gibs": 368.896,
+          "out_gibs": 368.896
+        },
+        "d2h": {
+          "avg_ms": 24.1389,
+          "best_ms": 1.32253,
+          "in_gibs": 10.1809,
+          "out_gibs": 10.1809
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 27.2475,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 50.5246,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 24.8593,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.38,
+      "status": "pass",
+      "throughput_in_gibs": 6.1414,
+      "throughput_out_gibs": 2.93052,
+      "compression_fold": 2.1795,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.67757,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.572447,
+      "init_s": 0.463419,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.9131,
+          "best_ms": 0.824527,
+          "in_gibs": 19.1561,
+          "out_gibs": 19.1561
+        },
+        "h2d": {
+          "avg_ms": 1.07125,
+          "best_ms": 0.590112,
+          "in_gibs": 52.6043,
+          "out_gibs": 52.6043
+        },
+        "scatter": {
+          "avg_ms": 0.24702,
+          "best_ms": 0.131872,
+          "in_gibs": 227.714,
+          "out_gibs": 227.714
+        },
+        "compress": {
+          "avg_ms": 65.318,
+          "best_ms": 33.8036,
+          "in_gibs": 13.994,
+          "out_gibs": 6.42022
+        },
+        "aggregate": {
+          "avg_ms": 1.20266,
+          "best_ms": 0.227328,
+          "in_gibs": 348.692,
+          "out_gibs": 348.692
+        },
+        "d2h": {
+          "avg_ms": 45.2767,
+          "best_ms": 1.33264,
+          "in_gibs": 9.26207,
+          "out_gibs": 9.26207
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 20.8011,
+        "flush_stall_count": 2,
+        "kick_sync_ms": 87.4054,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 62.6139,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.77,
+      "status": "pass",
+      "throughput_in_gibs": 5.86576,
+      "throughput_out_gibs": 1.67166,
+      "compression_fold": 3.64929,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.00191,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.599347,
+      "init_s": 0.76253,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.94679,
+          "best_ms": 0.841362,
+          "in_gibs": 18.9371,
+          "out_gibs": 18.9371
+        },
+        "h2d": {
+          "avg_ms": 1.06684,
+          "best_ms": 0.590272,
+          "in_gibs": 52.822,
+          "out_gibs": 52.822
+        },
+        "scatter": {
+          "avg_ms": 0.234446,
+          "best_ms": 0.131424,
+          "in_gibs": 239.927,
+          "out_gibs": 239.927
+        },
+        "compress": {
+          "avg_ms": 98.8129,
+          "best_ms": 95.8729,
+          "in_gibs": 18.5009,
+          "out_gibs": 5.06939
+        },
+        "aggregate": {
+          "avg_ms": 2.0719,
+          "best_ms": 1.00352,
+          "in_gibs": 241.768,
+          "out_gibs": 241.768
+        },
+        "d2h": {
+          "avg_ms": 67.4116,
+          "best_ms": 6.94845,
+          "in_gibs": 7.43078,
+          "out_gibs": 7.43078
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 96.753,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 89.4256,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 4.9,
+      "status": "pass",
+      "throughput_in_gibs": 5.97254,
+      "throughput_out_gibs": 1.59795,
+      "compression_fold": 3.88713,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.940604,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.588631,
+      "init_s": 1.60765,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.87844,
+          "best_ms": 0.838508,
+          "in_gibs": 19.3868,
+          "out_gibs": 19.3868
+        },
+        "h2d": {
+          "avg_ms": 1.06615,
+          "best_ms": 0.589952,
+          "in_gibs": 52.8561,
+          "out_gibs": 52.8561
+        },
+        "scatter": {
+          "avg_ms": 0.235658,
+          "best_ms": 0.133984,
+          "in_gibs": 239.128,
+          "out_gibs": 239.128
+        },
+        "compress": {
+          "avg_ms": 184.719,
+          "best_ms": 184.719,
+          "in_gibs": 19.7936,
+          "out_gibs": 5.09191
+        },
+        "aggregate": {
+          "avg_ms": 2.20477,
+          "best_ms": 2.20477,
+          "in_gibs": 426.608,
+          "out_gibs": 426.608
+        },
+        "d2h": {
+          "avg_ms": 17.8828,
+          "best_ms": 17.8828,
+          "in_gibs": 52.5965,
+          "out_gibs": 52.5965
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 2.08324,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.57463,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.5,
+      "status": "pass",
+      "throughput_in_gibs": 8.49335,
+      "throughput_out_gibs": 1.09441,
+      "compression_fold": 7.76066,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.453006,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.413927,
+      "init_s": 0.0850969,
+      "flush_s": 1.041e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.43657,
+          "best_ms": 0.798688,
+          "in_gibs": 19.2381,
+          "out_gibs": 19.2381
+        },
+        "h2d": {
+          "avg_ms": 0.904035,
+          "best_ms": 0.29984,
+          "in_gibs": 52.0877,
+          "out_gibs": 52.0877
+        },
+        "scatter": {
+          "avg_ms": 1.31865,
+          "best_ms": 0.070656,
+          "in_gibs": 35.7124,
+          "out_gibs": 35.7124
+        },
+        "compress": {
+          "avg_ms": 11.5474,
+          "best_ms": 11.224,
+          "in_gibs": 12.1781,
+          "out_gibs": 1.55494
+        },
+        "aggregate": {
+          "avg_ms": 0.0626906,
+          "best_ms": 0.047104,
+          "in_gibs": 286.414,
+          "out_gibs": 286.414
+        },
+        "d2h": {
+          "avg_ms": 2.99085,
+          "best_ms": 0.35056,
+          "in_gibs": 6.00346,
+          "out_gibs": 6.00346
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.7362,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 10.0216,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.2796,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.63,
+      "status": "pass",
+      "throughput_in_gibs": 5.89166,
+      "throughput_out_gibs": 0.762918,
+      "compression_fold": 7.72253,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.455243,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.596712,
+      "init_s": 0.0840269,
+      "flush_s": 2.674e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.45533,
+          "best_ms": 0.877145,
+          "in_gibs": 19.0911,
+          "out_gibs": 19.0911
+        },
+        "h2d": {
+          "avg_ms": 0.893851,
+          "best_ms": 0.296032,
+          "in_gibs": 52.6811,
+          "out_gibs": 52.6811
+        },
+        "scatter": {
+          "avg_ms": 0.366637,
+          "best_ms": 0.070496,
+          "in_gibs": 139.784,
+          "out_gibs": 139.784
+        },
+        "compress": {
+          "avg_ms": 22.255,
+          "best_ms": 21.5374,
+          "in_gibs": 6.31881,
+          "out_gibs": 0.81447
+        },
+        "aggregate": {
+          "avg_ms": 0.0542195,
+          "best_ms": 0.047104,
+          "in_gibs": 334.308,
+          "out_gibs": 334.308
+        },
+        "d2h": {
+          "avg_ms": 0.492567,
+          "best_ms": 0.353248,
+          "in_gibs": 36.7991,
+          "out_gibs": 36.7991
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 176.745,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 184.985,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 13.9631,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.54,
+      "status": "pass",
+      "throughput_in_gibs": 8.57673,
+      "throughput_out_gibs": 1.06728,
+      "compression_fold": 8.03606,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.437481,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.409903,
+      "init_s": 0.0909269,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.43141,
+          "best_ms": 0.797556,
+          "in_gibs": 19.279,
+          "out_gibs": 19.279
+        },
+        "h2d": {
+          "avg_ms": 0.900403,
+          "best_ms": 0.296864,
+          "in_gibs": 52.2978,
+          "out_gibs": 52.2978
+        },
+        "scatter": {
+          "avg_ms": 0.263564,
+          "best_ms": 0.07056,
+          "in_gibs": 178.663,
+          "out_gibs": 178.663
+        },
+        "compress": {
+          "avg_ms": 10.5638,
+          "best_ms": 10.4096,
+          "in_gibs": 13.312,
+          "out_gibs": 1.65263
+        },
+        "aggregate": {
+          "avg_ms": 0.0612211,
+          "best_ms": 0.051168,
+          "in_gibs": 285.164,
+          "out_gibs": 285.164
+        },
+        "d2h": {
+          "avg_ms": 3.78216,
+          "best_ms": 0.342976,
+          "in_gibs": 4.61589,
+          "out_gibs": 4.61589
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 10.985,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 10.1309,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.7093,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.97,
+      "status": "pass",
+      "throughput_in_gibs": 6.02639,
+      "throughput_out_gibs": 0.781209,
+      "compression_fold": 7.71419,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.455735,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.583371,
+      "init_s": 0.16203,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41905,
+          "best_ms": 0.815252,
+          "in_gibs": 19.3774,
+          "out_gibs": 19.3774
+        },
+        "h2d": {
+          "avg_ms": 0.893643,
+          "best_ms": 0.298592,
+          "in_gibs": 52.6934,
+          "out_gibs": 52.6934
+        },
+        "scatter": {
+          "avg_ms": 0.329635,
+          "best_ms": 0.0688,
+          "in_gibs": 143.52,
+          "out_gibs": 143.52
+        },
+        "compress": {
+          "avg_ms": 39.247,
+          "best_ms": 15.9476,
+          "in_gibs": 6.89053,
+          "out_gibs": 0.892123
+        },
+        "aggregate": {
+          "avg_ms": 0.0966523,
+          "best_ms": 0.059392,
+          "in_gibs": 362.259,
+          "out_gibs": 362.259
+        },
+        "d2h": {
+          "avg_ms": 1.97377,
+          "best_ms": 0.358304,
+          "in_gibs": 17.7392,
+          "out_gibs": 17.7392
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 125.172,
+        "flush_stall_count": 11,
+        "kick_sync_ms": 157.442,
+        "kick_sync_count": 13,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 32.3586,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.18,
+      "status": "pass",
+      "throughput_in_gibs": 5.31932,
+      "throughput_out_gibs": 0.676367,
+      "compression_fold": 7.86454,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.447023,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.660917,
+      "init_s": 0.257476,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.47661,
+          "best_ms": 0.800681,
+          "in_gibs": 18.9271,
+          "out_gibs": 18.9271
+        },
+        "h2d": {
+          "avg_ms": 0.897332,
+          "best_ms": 0.29904,
+          "in_gibs": 52.4767,
+          "out_gibs": 52.4767
+        },
+        "scatter": {
+          "avg_ms": 0.320674,
+          "best_ms": 0.0688,
+          "in_gibs": 146.844,
+          "out_gibs": 146.844
+        },
+        "compress": {
+          "avg_ms": 73.2281,
+          "best_ms": 26.3718,
+          "in_gibs": 6.85846,
+          "out_gibs": 0.871515
+        },
+        "aggregate": {
+          "avg_ms": 0.194331,
+          "best_ms": 0.057312,
+          "in_gibs": 328.405,
+          "out_gibs": 328.405
+        },
+        "d2h": {
+          "avg_ms": 9.72447,
+          "best_ms": 0.34912,
+          "in_gibs": 6.56277,
+          "out_gibs": 6.56277
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 91.8004,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 175.138,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 83.2941,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.34,
+      "status": "pass",
+      "throughput_in_gibs": 4.59041,
+      "throughput_out_gibs": 0.575859,
+      "compression_fold": 8.29026,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.44103,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.765864,
+      "init_s": 0.384517,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.89157,
+          "best_ms": 0.869474,
+          "in_gibs": 19.2987,
+          "out_gibs": 19.2987
+        },
+        "h2d": {
+          "avg_ms": 1.0689,
+          "best_ms": 0.589984,
+          "in_gibs": 52.7199,
+          "out_gibs": 52.7199
+        },
+        "scatter": {
+          "avg_ms": 0.29561,
+          "best_ms": 0.13216,
+          "in_gibs": 190.631,
+          "out_gibs": 190.631
+        },
+        "compress": {
+          "avg_ms": 126.561,
+          "best_ms": 30.5476,
+          "in_gibs": 7.22231,
+          "out_gibs": 0.870897
+        },
+        "aggregate": {
+          "avg_ms": 0.472912,
+          "best_ms": 0.057312,
+          "in_gibs": 233.07,
+          "out_gibs": 233.07
+        },
+        "d2h": {
+          "avg_ms": 31.202,
+          "best_ms": 0.34992,
+          "in_gibs": 3.53252,
+          "out_gibs": 3.53252
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 48.726,
+        "flush_stall_count": 2,
+        "kick_sync_ms": 213.44,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 162.379,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 4.21,
+      "status": "pass",
+      "throughput_in_gibs": 3.23546,
+      "throughput_out_gibs": 0.427608,
+      "compression_fold": 7.86908,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.464635,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 1.08659,
+      "init_s": 0.775066,
+      "flush_s": 7.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.9728,
+          "best_ms": 0.835874,
+          "in_gibs": 18.7714,
+          "out_gibs": 18.7714
+        },
+        "h2d": {
+          "avg_ms": 1.06973,
+          "best_ms": 0.591808,
+          "in_gibs": 52.679,
+          "out_gibs": 52.679
+        },
+        "scatter": {
+          "avg_ms": 0.235416,
+          "best_ms": 0.132128,
+          "in_gibs": 239.374,
+          "out_gibs": 239.374
+        },
+        "compress": {
+          "avg_ms": 337.717,
+          "best_ms": 200.811,
+          "in_gibs": 5.41319,
+          "out_gibs": 0.687811
+        },
+        "aggregate": {
+          "avg_ms": 1.38906,
+          "best_ms": 0.495616,
+          "in_gibs": 167.225,
+          "out_gibs": 167.225
+        },
+        "d2h": {
+          "avg_ms": 71.205,
+          "best_ms": 3.20109,
+          "in_gibs": 3.2622,
+          "out_gibs": 3.2622
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 201.173,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 479.708,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 5.35,
+      "status": "pass",
+      "throughput_in_gibs": 3.21777,
+      "throughput_out_gibs": 0.426238,
+      "compression_fold": 7.8512,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.465693,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.09257,
+      "init_s": 1.50353,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.00645,
+          "best_ms": 0.847541,
+          "in_gibs": 18.5613,
+          "out_gibs": 18.5613
+        },
+        "h2d": {
+          "avg_ms": 1.06801,
+          "best_ms": 0.592,
+          "in_gibs": 52.7641,
+          "out_gibs": 52.7641
+        },
+        "scatter": {
+          "avg_ms": 0.235681,
+          "best_ms": 0.134016,
+          "in_gibs": 239.105,
+          "out_gibs": 239.105
+        },
+        "compress": {
+          "avg_ms": 682.318,
+          "best_ms": 682.318,
+          "in_gibs": 5.35857,
+          "out_gibs": 0.682469
+        },
+        "aggregate": {
+          "avg_ms": 1.05677,
+          "best_ms": 1.05677,
+          "in_gibs": 440.646,
+          "out_gibs": 440.646
+        },
+        "d2h": {
+          "avg_ms": 8.88013,
+          "best_ms": 8.88013,
+          "in_gibs": 52.4385,
+          "out_gibs": 52.4385
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 683.095,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.68356,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.94,
+      "status": "pass",
+      "throughput_in_gibs": 7.52744,
+      "throughput_out_gibs": 7.53479,
+      "compression_fold": 0.999024,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75366,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.498177,
+      "init_s": 0.107765,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.26303,
+          "best_ms": 3.1161,
+          "in_gibs": 19.154,
+          "out_gibs": 19.154
+        },
+        "h2d": {
+          "avg_ms": 1.22783,
+          "best_ms": 1.17856,
+          "in_gibs": 50.9029,
+          "out_gibs": 50.9029
+        },
+        "scatter": {
+          "avg_ms": 0.323361,
+          "best_ms": 0.315872,
+          "in_gibs": 193.283,
+          "out_gibs": 193.283
+        },
+        "compress": {
+          "avg_ms": 0.257838,
+          "best_ms": 0.247392,
+          "in_gibs": 727.2,
+          "out_gibs": 727.2
+        },
+        "aggregate": {
+          "avg_ms": 2.2599,
+          "best_ms": 0.51712,
+          "in_gibs": 82.9684,
+          "out_gibs": 82.9684
+        },
+        "d2h": {
+          "avg_ms": 22.254,
+          "best_ms": 3.58483,
+          "in_gibs": 8.42546,
+          "out_gibs": 8.42546
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 78.0682,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 0.445847,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 9.0631,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 12.16,
+      "status": "pass",
+      "throughput_in_gibs": 7.50145,
+      "throughput_out_gibs": 7.50512,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.499903,
+      "init_s": 0.104105,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.32571,
+          "best_ms": 3.25143,
+          "in_gibs": 18.793,
+          "out_gibs": 18.793
+        },
+        "h2d": {
+          "avg_ms": 1.22697,
+          "best_ms": 1.17859,
+          "in_gibs": 50.9386,
+          "out_gibs": 50.9386
+        },
+        "scatter": {
+          "avg_ms": 0.322701,
+          "best_ms": 0.314144,
+          "in_gibs": 193.678,
+          "out_gibs": 193.678
+        },
+        "compress": {
+          "avg_ms": 0.25992,
+          "best_ms": 0.24944,
+          "in_gibs": 721.376,
+          "out_gibs": 721.376
+        },
+        "aggregate": {
+          "avg_ms": 2.2937,
+          "best_ms": 0.605184,
+          "in_gibs": 81.7457,
+          "out_gibs": 81.7457
+        },
+        "d2h": {
+          "avg_ms": 22.5463,
+          "best_ms": 3.57142,
+          "in_gibs": 8.31621,
+          "out_gibs": 8.31621
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 74.1567,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 0.516904,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.969,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.9,
+      "status": "pass",
+      "throughput_in_gibs": 7.97106,
+      "throughput_out_gibs": 7.973,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75092,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.470452,
+      "init_s": 0.100038,
+      "flush_s": 2.333e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.10214,
+          "best_ms": 3.07032,
+          "in_gibs": 20.1474,
+          "out_gibs": 20.1474
+        },
+        "h2d": {
+          "avg_ms": 1.21981,
+          "best_ms": 1.17866,
+          "in_gibs": 51.2373,
+          "out_gibs": 51.2373
+        },
+        "scatter": {
+          "avg_ms": 0.322034,
+          "best_ms": 0.316448,
+          "in_gibs": 194.079,
+          "out_gibs": 194.079
+        },
+        "compress": {
+          "avg_ms": 0.259606,
+          "best_ms": 0.247456,
+          "in_gibs": 722.247,
+          "out_gibs": 722.247
+        },
+        "aggregate": {
+          "avg_ms": 2.31896,
+          "best_ms": 0.623648,
+          "in_gibs": 80.855,
+          "out_gibs": 80.855
+        },
+        "d2h": {
+          "avg_ms": 21.1946,
+          "best_ms": 3.57194,
+          "in_gibs": 8.84658,
+          "out_gibs": 8.84658
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 72.9326,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 0.532468,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.33333,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 12.26,
+      "status": "pass",
+      "throughput_in_gibs": 8.00512,
+      "throughput_out_gibs": 8.00609,
+      "compression_fold": 0.999878,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75046,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.46845,
+      "init_s": 0.157634,
+      "flush_s": 5.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.10594,
+          "best_ms": 3.08086,
+          "in_gibs": 20.1227,
+          "out_gibs": 20.1227
+        },
+        "h2d": {
+          "avg_ms": 1.19863,
+          "best_ms": 1.17891,
+          "in_gibs": 52.143,
+          "out_gibs": 52.143
+        },
+        "scatter": {
+          "avg_ms": 0.320788,
+          "best_ms": 0.313984,
+          "in_gibs": 194.833,
+          "out_gibs": 194.833
+        },
+        "compress": {
+          "avg_ms": 0.539123,
+          "best_ms": 0.52384,
+          "in_gibs": 695.574,
+          "out_gibs": 695.574
+        },
+        "aggregate": {
+          "avg_ms": 5.85925,
+          "best_ms": 1.15712,
+          "in_gibs": 64.0014,
+          "out_gibs": 64.0014
+        },
+        "d2h": {
+          "avg_ms": 40.2971,
+          "best_ms": 7.13418,
+          "in_gibs": 9.30588,
+          "out_gibs": 9.30588
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 67.6619,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 1.05876,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 10.8446,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.34,
+      "status": "pass",
+      "throughput_in_gibs": 8.02172,
+      "throughput_out_gibs": 8.02221,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.467481,
+      "init_s": 0.263207,
+      "flush_s": 6.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.12232,
+          "best_ms": 3.10414,
+          "in_gibs": 20.0172,
+          "out_gibs": 20.0172
+        },
+        "h2d": {
+          "avg_ms": 1.18992,
+          "best_ms": 1.17965,
+          "in_gibs": 52.5247,
+          "out_gibs": 52.5247
+        },
+        "scatter": {
+          "avg_ms": 0.320072,
+          "best_ms": 0.314144,
+          "in_gibs": 195.268,
+          "out_gibs": 195.268
+        },
+        "compress": {
+          "avg_ms": 1.09364,
+          "best_ms": 1.06976,
+          "in_gibs": 685.784,
+          "out_gibs": 685.784
+        },
+        "aggregate": {
+          "avg_ms": 11.7831,
+          "best_ms": 2.0224,
+          "in_gibs": 63.6505,
+          "out_gibs": 63.6505
+        },
+        "d2h": {
+          "avg_ms": 72.8309,
+          "best_ms": 14.2588,
+          "in_gibs": 10.2978,
+          "out_gibs": 10.2978
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 59.4078,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 2.06888,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 18.0773,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.12,
+      "status": "pass",
+      "throughput_in_gibs": 7.9185,
+      "throughput_out_gibs": 7.91875,
+      "compression_fold": 0.999969,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75011,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.473574,
+      "init_s": 0.478774,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.16248,
+          "best_ms": 3.13949,
+          "in_gibs": 19.763,
+          "out_gibs": 19.763
+        },
+        "h2d": {
+          "avg_ms": 1.18406,
+          "best_ms": 1.1783,
+          "in_gibs": 52.7844,
+          "out_gibs": 52.7844
+        },
+        "scatter": {
+          "avg_ms": 0.320715,
+          "best_ms": 0.315744,
+          "in_gibs": 194.877,
+          "out_gibs": 194.877
+        },
+        "compress": {
+          "avg_ms": 1.82364,
+          "best_ms": 1.07098,
+          "in_gibs": 685.443,
+          "out_gibs": 685.443
+        },
+        "aggregate": {
+          "avg_ms": 12.1081,
+          "best_ms": 1.86573,
+          "in_gibs": 103.237,
+          "out_gibs": 103.237
+        },
+        "d2h": {
+          "avg_ms": 97.1231,
+          "best_ms": 14.259,
+          "in_gibs": 12.8703,
+          "out_gibs": 12.8703
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 29.4783,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 2.83941,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 32.7062,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.0,
+      "status": "pass",
+      "throughput_in_gibs": 8.12961,
+      "throughput_out_gibs": 8.12974,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75006,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.461277,
+      "init_s": 1.01275,
+      "flush_s": 2.584e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.06672,
+          "best_ms": 3.04189,
+          "in_gibs": 20.3801,
+          "out_gibs": 20.3801
+        },
+        "h2d": {
+          "avg_ms": 1.1805,
+          "best_ms": 1.1783,
+          "in_gibs": 52.9435,
+          "out_gibs": 52.9435
+        },
+        "scatter": {
+          "avg_ms": 0.423492,
+          "best_ms": 0.307584,
+          "in_gibs": 147.583,
+          "out_gibs": 147.583
+        },
+        "compress": {
+          "avg_ms": 2.71986,
+          "best_ms": 1.07782,
+          "in_gibs": 689.375,
+          "out_gibs": 689.375
+        },
+        "aggregate": {
+          "avg_ms": 4.99816,
+          "best_ms": 1.8985,
+          "in_gibs": 375.138,
+          "out_gibs": 375.138
+        },
+        "d2h": {
+          "avg_ms": 65.8782,
+          "best_ms": 14.2599,
+          "in_gibs": 28.4616,
+          "out_gibs": 28.4616
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 2.90836,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.43668,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 14.07,
+      "status": "pass",
+      "throughput_in_gibs": 7.88695,
+      "throughput_out_gibs": 7.88703,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.475469,
+      "init_s": 1.78249,
+      "flush_s": 2.203e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.12901,
+          "best_ms": 3.08686,
+          "in_gibs": 19.9744,
+          "out_gibs": 19.9744
+        },
+        "h2d": {
+          "avg_ms": 1.1809,
+          "best_ms": 1.17821,
+          "in_gibs": 52.9257,
+          "out_gibs": 52.9257
+        },
+        "scatter": {
+          "avg_ms": 0.319609,
+          "best_ms": 0.315552,
+          "in_gibs": 195.552,
+          "out_gibs": 195.552
+        },
+        "compress": {
+          "avg_ms": 5.46064,
+          "best_ms": 5.46064,
+          "in_gibs": 686.733,
+          "out_gibs": 686.733
+        },
+        "aggregate": {
+          "avg_ms": 8.11011,
+          "best_ms": 8.11011,
+          "in_gibs": 462.386,
+          "out_gibs": 462.386
+        },
+        "d2h": {
+          "avg_ms": 71.2688,
+          "best_ms": 71.2688,
+          "in_gibs": 52.6177,
+          "out_gibs": 52.6177
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 8.00301,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.47715,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 11.65,
+      "status": "pass",
+      "throughput_in_gibs": 8.37391,
+      "throughput_out_gibs": 3.88739,
+      "compression_fold": 2.15412,
+      "input_gib": 3.75,
+      "compressed_gib": 1.74085,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.447819,
+      "init_s": 0.100199,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.13804,
+          "best_ms": 3.08621,
+          "in_gibs": 19.9169,
+          "out_gibs": 19.9169
+        },
+        "h2d": {
+          "avg_ms": 1.21505,
+          "best_ms": 1.17843,
+          "in_gibs": 51.4381,
+          "out_gibs": 51.4381
+        },
+        "scatter": {
+          "avg_ms": 0.32301,
+          "best_ms": 0.317504,
+          "in_gibs": 193.492,
+          "out_gibs": 193.492
+        },
+        "compress": {
+          "avg_ms": 6.5331,
+          "best_ms": 6.46726,
+          "in_gibs": 28.7,
+          "out_gibs": 13.2953
+        },
+        "aggregate": {
+          "avg_ms": 0.209485,
+          "best_ms": 0.190464,
+          "in_gibs": 414.633,
+          "out_gibs": 414.633
+        },
+        "d2h": {
+          "avg_ms": 14.0656,
+          "best_ms": 1.66538,
+          "in_gibs": 6.1753,
+          "out_gibs": 6.1753
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 39.2275,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 6.47655,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.7021,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 11.63,
+      "status": "pass",
+      "throughput_in_gibs": 8.30106,
+      "throughput_out_gibs": 3.70512,
+      "compression_fold": 2.24043,
+      "input_gib": 3.75,
+      "compressed_gib": 1.67379,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.451749,
+      "init_s": 0.0989625,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.18447,
+          "best_ms": 3.1172,
+          "in_gibs": 19.6265,
+          "out_gibs": 19.6265
+        },
+        "h2d": {
+          "avg_ms": 1.22255,
+          "best_ms": 1.17843,
+          "in_gibs": 51.1226,
+          "out_gibs": 51.1226
+        },
+        "scatter": {
+          "avg_ms": 0.336313,
+          "best_ms": 0.318176,
+          "in_gibs": 185.839,
+          "out_gibs": 185.839
+        },
+        "compress": {
+          "avg_ms": 8.446,
+          "best_ms": 8.31043,
+          "in_gibs": 22.1999,
+          "out_gibs": 9.89791
+        },
+        "aggregate": {
+          "avg_ms": 0.222888,
+          "best_ms": 0.18432,
+          "in_gibs": 375.066,
+          "out_gibs": 375.066
+        },
+        "d2h": {
+          "avg_ms": 12.2901,
+          "best_ms": 1.60323,
+          "in_gibs": 6.80205,
+          "out_gibs": 6.80205
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 35.4746,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 8.41136,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 13.6469,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.04,
+      "status": "pass",
+      "throughput_in_gibs": 8.28242,
+      "throughput_out_gibs": 3.90192,
+      "compression_fold": 2.12266,
+      "input_gib": 3.75,
+      "compressed_gib": 1.76666,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.452766,
+      "init_s": 0.107108,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.17594,
+          "best_ms": 3.151,
+          "in_gibs": 19.6792,
+          "out_gibs": 19.6792
+        },
+        "h2d": {
+          "avg_ms": 1.22153,
+          "best_ms": 1.1784,
+          "in_gibs": 51.1655,
+          "out_gibs": 51.1655
+        },
+        "scatter": {
+          "avg_ms": 0.370778,
+          "best_ms": 0.318272,
+          "in_gibs": 168.565,
+          "out_gibs": 168.565
+        },
+        "compress": {
+          "avg_ms": 9.06236,
+          "best_ms": 8.93974,
+          "in_gibs": 20.69,
+          "out_gibs": 9.74216
+        },
+        "aggregate": {
+          "avg_ms": 0.207442,
+          "best_ms": 0.186336,
+          "in_gibs": 425.599,
+          "out_gibs": 425.599
+        },
+        "d2h": {
+          "avg_ms": 11.7514,
+          "best_ms": 1.68995,
+          "in_gibs": 7.51289,
+          "out_gibs": 7.51289
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 36.0619,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 8.92661,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.3364,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 11.87,
+      "status": "pass",
+      "throughput_in_gibs": 8.31061,
+      "throughput_out_gibs": 3.0712,
+      "compression_fold": 2.70598,
+      "input_gib": 3.75,
+      "compressed_gib": 1.38582,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.45123,
+      "init_s": 0.151701,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.09388,
+          "best_ms": 3.03041,
+          "in_gibs": 20.2011,
+          "out_gibs": 20.2011
+        },
+        "h2d": {
+          "avg_ms": 1.20038,
+          "best_ms": 1.18035,
+          "in_gibs": 52.0669,
+          "out_gibs": 52.0669
+        },
+        "scatter": {
+          "avg_ms": 0.344376,
+          "best_ms": 0.316096,
+          "in_gibs": 181.488,
+          "out_gibs": 181.488
+        },
+        "compress": {
+          "avg_ms": 15.5338,
+          "best_ms": 14.5564,
+          "in_gibs": 24.1409,
+          "out_gibs": 8.91837
+        },
+        "aggregate": {
+          "avg_ms": 0.346557,
+          "best_ms": 0.30512,
+          "in_gibs": 399.75,
+          "out_gibs": 399.75
+        },
+        "d2h": {
+          "avg_ms": 24.9186,
+          "best_ms": 2.67526,
+          "in_gibs": 5.55956,
+          "out_gibs": 5.55956
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 25.6085,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 14.8688,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 20.6927,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.76,
+      "status": "pass",
+      "throughput_in_gibs": 8.14643,
+      "throughput_out_gibs": 2.45297,
+      "compression_fold": 3.32105,
+      "input_gib": 3.75,
+      "compressed_gib": 1.12916,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.460324,
+      "init_s": 0.260339,
+      "flush_s": 2.634e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.2272,
+          "best_ms": 3.2075,
+          "in_gibs": 19.3666,
+          "out_gibs": 19.3666
+        },
+        "h2d": {
+          "avg_ms": 1.18995,
+          "best_ms": 1.17846,
+          "in_gibs": 52.5234,
+          "out_gibs": 52.5234
+        },
+        "scatter": {
+          "avg_ms": 0.337858,
+          "best_ms": 0.315616,
+          "in_gibs": 184.989,
+          "out_gibs": 184.989
+        },
+        "compress": {
+          "avg_ms": 27.249,
+          "best_ms": 26.2407,
+          "in_gibs": 27.5239,
+          "out_gibs": 8.28604
+        },
+        "aggregate": {
+          "avg_ms": 0.597811,
+          "best_ms": 0.483328,
+          "in_gibs": 377.688,
+          "out_gibs": 377.688
+        },
+        "d2h": {
+          "avg_ms": 47.9222,
+          "best_ms": 4.31382,
+          "in_gibs": 4.71152,
+          "out_gibs": 4.71152
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 18.0547,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 23.8207,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.1378,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.37,
+      "status": "pass",
+      "throughput_in_gibs": 7.19582,
+      "throughput_out_gibs": 2.15412,
+      "compression_fold": 3.34049,
+      "input_gib": 3.75,
+      "compressed_gib": 1.12259,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.521136,
+      "init_s": 0.486866,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.15388,
+          "best_ms": 3.1257,
+          "in_gibs": 19.8169,
+          "out_gibs": 19.8169
+        },
+        "h2d": {
+          "avg_ms": 1.18353,
+          "best_ms": 1.17811,
+          "in_gibs": 52.808,
+          "out_gibs": 52.808
+        },
+        "scatter": {
+          "avg_ms": 0.334716,
+          "best_ms": 0.315776,
+          "in_gibs": 186.726,
+          "out_gibs": 186.726
+        },
+        "compress": {
+          "avg_ms": 51.851,
+          "best_ms": 48.2046,
+          "in_gibs": 24.1075,
+          "out_gibs": 7.21604
+        },
+        "aggregate": {
+          "avg_ms": 1.21092,
+          "best_ms": 0.5816,
+          "in_gibs": 308.986,
+          "out_gibs": 308.986
+        },
+        "d2h": {
+          "avg_ms": 66.5065,
+          "best_ms": 4.28467,
+          "in_gibs": 5.6259,
+          "out_gibs": 5.6259
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 8.76549,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 48.6913,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 57.8677,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.48,
+      "status": "pass",
+      "throughput_in_gibs": 6.67389,
+      "throughput_out_gibs": 1.55522,
+      "compression_fold": 4.29129,
+      "input_gib": 3.75,
+      "compressed_gib": 0.873863,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.561891,
+      "init_s": 0.919122,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.10595,
+          "best_ms": 3.09106,
+          "in_gibs": 20.1226,
+          "out_gibs": 20.1226
+        },
+        "h2d": {
+          "avg_ms": 1.18101,
+          "best_ms": 1.17824,
+          "in_gibs": 52.9207,
+          "out_gibs": 52.9207
+        },
+        "scatter": {
+          "avg_ms": 0.319972,
+          "best_ms": 0.307808,
+          "in_gibs": 195.33,
+          "out_gibs": 195.33
+        },
+        "compress": {
+          "avg_ms": 83.8804,
+          "best_ms": 77.0443,
+          "in_gibs": 22.3532,
+          "out_gibs": 5.20864
+        },
+        "aggregate": {
+          "avg_ms": 1.99946,
+          "best_ms": 0.50176,
+          "in_gibs": 218.511,
+          "out_gibs": 218.511
+        },
+        "d2h": {
+          "avg_ms": 36.911,
+          "best_ms": 3.33306,
+          "in_gibs": 11.8367,
+          "out_gibs": 11.8367
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 77.4703,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 78.956,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 14.16,
+      "status": "pass",
+      "throughput_in_gibs": 6.82149,
+      "throughput_out_gibs": 1.26541,
+      "compression_fold": 5.39072,
+      "input_gib": 3.75,
+      "compressed_gib": 0.695639,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.549733,
+      "init_s": 1.79228,
+      "flush_s": 5.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.10915,
+          "best_ms": 3.08772,
+          "in_gibs": 20.1019,
+          "out_gibs": 20.1019
+        },
+        "h2d": {
+          "avg_ms": 1.18295,
+          "best_ms": 1.17837,
+          "in_gibs": 52.8342,
+          "out_gibs": 52.8342
+        },
+        "scatter": {
+          "avg_ms": 0.319904,
+          "best_ms": 0.31408,
+          "in_gibs": 195.371,
+          "out_gibs": 195.371
+        },
+        "compress": {
+          "avg_ms": 142.825,
+          "best_ms": 142.825,
+          "in_gibs": 26.2558,
+          "out_gibs": 4.87029
+        },
+        "aggregate": {
+          "avg_ms": 1.5961,
+          "best_ms": 1.5961,
+          "in_gibs": 435.814,
+          "out_gibs": 435.814
+        },
+        "d2h": {
+          "avg_ms": 13.236,
+          "best_ms": 13.236,
+          "in_gibs": 52.5537,
+          "out_gibs": 52.5537
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 1.51427,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.41442,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.22,
+      "status": "pass",
+      "throughput_in_gibs": 8.88854,
+      "throughput_out_gibs": 1.09953,
+      "compression_fold": 8.08391,
+      "input_gib": 3.75,
+      "compressed_gib": 0.463885,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.421892,
+      "init_s": 0.101875,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.1137,
+          "best_ms": 3.09175,
+          "in_gibs": 20.0726,
+          "out_gibs": 20.0726
+        },
+        "h2d": {
+          "avg_ms": 1.19712,
+          "best_ms": 1.17824,
+          "in_gibs": 52.2087,
+          "out_gibs": 52.2087
+        },
+        "scatter": {
+          "avg_ms": 0.602795,
+          "best_ms": 0.314816,
+          "in_gibs": 103.684,
+          "out_gibs": 103.684
+        },
+        "compress": {
+          "avg_ms": 10.6173,
+          "best_ms": 10.4536,
+          "in_gibs": 17.6599,
+          "out_gibs": 2.16733
+        },
+        "aggregate": {
+          "avg_ms": 0.0703616,
+          "best_ms": 0.057376,
+          "in_gibs": 327.041,
+          "out_gibs": 327.041
+        },
+        "d2h": {
+          "avg_ms": 7.6573,
+          "best_ms": 0.44656,
+          "in_gibs": 3.00512,
+          "out_gibs": 3.00512
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 14.932,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 11.5769,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.28475,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 11.63,
+      "status": "pass",
+      "throughput_in_gibs": 8.88612,
+      "throughput_out_gibs": 1.07738,
+      "compression_fold": 8.24786,
+      "input_gib": 3.75,
+      "compressed_gib": 0.454663,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.422006,
+      "init_s": 0.100258,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.11771,
+          "best_ms": 3.09129,
+          "in_gibs": 20.0468,
+          "out_gibs": 20.0468
+        },
+        "h2d": {
+          "avg_ms": 1.1986,
+          "best_ms": 1.17827,
+          "in_gibs": 52.1442,
+          "out_gibs": 52.1442
+        },
+        "scatter": {
+          "avg_ms": 0.744314,
+          "best_ms": 0.31728,
+          "in_gibs": 83.97,
+          "out_gibs": 83.97
+        },
+        "compress": {
+          "avg_ms": 13.5293,
+          "best_ms": 13.2697,
+          "in_gibs": 13.8588,
+          "out_gibs": 1.67352
+        },
+        "aggregate": {
+          "avg_ms": 0.0774656,
+          "best_ms": 0.055328,
+          "in_gibs": 292.279,
+          "out_gibs": 292.279
+        },
+        "d2h": {
+          "avg_ms": 4.78626,
+          "best_ms": 0.439008,
+          "in_gibs": 4.73054,
+          "out_gibs": 4.73054
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.2727,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 14.4508,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.84351,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.53,
+      "status": "pass",
+      "throughput_in_gibs": 9.02924,
+      "throughput_out_gibs": 1.05569,
+      "compression_fold": 8.55294,
+      "input_gib": 3.75,
+      "compressed_gib": 0.438446,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.415317,
+      "init_s": 0.0975381,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.10437,
+          "best_ms": 3.08535,
+          "in_gibs": 20.1329,
+          "out_gibs": 20.1329
+        },
+        "h2d": {
+          "avg_ms": 1.1967,
+          "best_ms": 1.17958,
+          "in_gibs": 52.227,
+          "out_gibs": 52.227
+        },
+        "scatter": {
+          "avg_ms": 0.452214,
+          "best_ms": 0.31632,
+          "in_gibs": 138.209,
+          "out_gibs": 138.209
+        },
+        "compress": {
+          "avg_ms": 10.8622,
+          "best_ms": 10.7059,
+          "in_gibs": 17.2618,
+          "out_gibs": 2.01401
+        },
+        "aggregate": {
+          "avg_ms": 0.0621392,
+          "best_ms": 0.053248,
+          "in_gibs": 352.056,
+          "out_gibs": 352.056
+        },
+        "d2h": {
+          "avg_ms": 7.16251,
+          "best_ms": 0.423552,
+          "in_gibs": 3.0543,
+          "out_gibs": 3.0543
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 10.7387,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 11.7552,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.83049,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 11.64,
+      "status": "pass",
+      "throughput_in_gibs": 8.69979,
+      "throughput_out_gibs": 1.00816,
+      "compression_fold": 8.62941,
+      "input_gib": 3.75,
+      "compressed_gib": 0.434561,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.431045,
+      "init_s": 0.152972,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.11295,
+          "best_ms": 3.08791,
+          "in_gibs": 20.0774,
+          "out_gibs": 20.0774
+        },
+        "h2d": {
+          "avg_ms": 1.1926,
+          "best_ms": 1.17818,
+          "in_gibs": 52.4063,
+          "out_gibs": 52.4063
+        },
+        "scatter": {
+          "avg_ms": 0.495886,
+          "best_ms": 0.315392,
+          "in_gibs": 126.037,
+          "out_gibs": 126.037
+        },
+        "compress": {
+          "avg_ms": 21.0745,
+          "best_ms": 20.8432,
+          "in_gibs": 17.794,
+          "out_gibs": 2.05985
+        },
+        "aggregate": {
+          "avg_ms": 0.115552,
+          "best_ms": 0.083968,
+          "in_gibs": 375.677,
+          "out_gibs": 375.677
+        },
+        "d2h": {
+          "avg_ms": 15.933,
+          "best_ms": 0.832608,
+          "in_gibs": 2.72455,
+          "out_gibs": 2.72455
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 9.22083,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 21.631,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 9.44752,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.2,
+      "status": "pass",
+      "throughput_in_gibs": 7.88252,
+      "throughput_out_gibs": 0.906789,
+      "compression_fold": 8.69277,
+      "input_gib": 3.75,
+      "compressed_gib": 0.431393,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.475736,
+      "init_s": 0.269303,
+      "flush_s": 2.634e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.23712,
+          "best_ms": 3.16271,
+          "in_gibs": 19.3073,
+          "out_gibs": 19.3073
+        },
+        "h2d": {
+          "avg_ms": 1.18852,
+          "best_ms": 1.17875,
+          "in_gibs": 52.5864,
+          "out_gibs": 52.5864
+        },
+        "scatter": {
+          "avg_ms": 0.718904,
+          "best_ms": 0.316032,
+          "in_gibs": 86.9379,
+          "out_gibs": 86.9379
+        },
+        "compress": {
+          "avg_ms": 41.1916,
+          "best_ms": 40.1957,
+          "in_gibs": 18.2076,
+          "out_gibs": 2.09345
+        },
+        "aggregate": {
+          "avg_ms": 0.296774,
+          "best_ms": 0.188416,
+          "in_gibs": 290.567,
+          "out_gibs": 290.567
+        },
+        "d2h": {
+          "avg_ms": 35.4114,
+          "best_ms": 1.64672,
+          "in_gibs": 2.43517,
+          "out_gibs": 2.43517
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 7.5389,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 40.7553,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 28.4637,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.94,
+      "status": "pass",
+      "throughput_in_gibs": 5.72711,
+      "throughput_out_gibs": 0.661501,
+      "compression_fold": 8.65775,
+      "input_gib": 3.75,
+      "compressed_gib": 0.433138,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.654781,
+      "init_s": 0.492801,
+      "flush_s": 2.284e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.16606,
+          "best_ms": 3.11026,
+          "in_gibs": 19.7406,
+          "out_gibs": 19.7406
+        },
+        "h2d": {
+          "avg_ms": 1.18546,
+          "best_ms": 1.17862,
+          "in_gibs": 52.7223,
+          "out_gibs": 52.7223
+        },
+        "scatter": {
+          "avg_ms": 0.89836,
+          "best_ms": 0.316288,
+          "in_gibs": 69.5712,
+          "out_gibs": 69.5712
+        },
+        "compress": {
+          "avg_ms": 114.465,
+          "best_ms": 60.5497,
+          "in_gibs": 10.9203,
+          "out_gibs": 1.261
+        },
+        "aggregate": {
+          "avg_ms": 0.666101,
+          "best_ms": 0.217088,
+          "in_gibs": 216.695,
+          "out_gibs": 216.695
+        },
+        "d2h": {
+          "avg_ms": 47.9007,
+          "best_ms": 1.65466,
+          "in_gibs": 3.01334,
+          "out_gibs": 3.01334
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 3.54653,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 126.975,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 127.438,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.68,
+      "status": "pass",
+      "throughput_in_gibs": 4.49356,
+      "throughput_out_gibs": 0.527193,
+      "compression_fold": 8.52357,
+      "input_gib": 3.75,
+      "compressed_gib": 0.439957,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.834527,
+      "init_s": 0.927853,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.1444,
+          "best_ms": 3.12814,
+          "in_gibs": 19.8766,
+          "out_gibs": 19.8766
+        },
+        "h2d": {
+          "avg_ms": 1.18166,
+          "best_ms": 1.17821,
+          "in_gibs": 52.8918,
+          "out_gibs": 52.8918
+        },
+        "scatter": {
+          "avg_ms": 0.319031,
+          "best_ms": 0.307776,
+          "in_gibs": 195.906,
+          "out_gibs": 195.906
+        },
+        "compress": {
+          "avg_ms": 222.795,
+          "best_ms": 64.0224,
+          "in_gibs": 8.41581,
+          "out_gibs": 0.987228
+        },
+        "aggregate": {
+          "avg_ms": 1.50117,
+          "best_ms": 0.237536,
+          "in_gibs": 146.519,
+          "out_gibs": 146.519
+        },
+        "d2h": {
+          "avg_ms": 33.4384,
+          "best_ms": 1.68032,
+          "in_gibs": 6.57774,
+          "out_gibs": 6.57774
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 64.1617,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 370.352,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 15.29,
+      "status": "pass",
+      "throughput_in_gibs": 4.26778,
+      "throughput_out_gibs": 0.499194,
+      "compression_fold": 8.54936,
+      "input_gib": 3.75,
+      "compressed_gib": 0.43863,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.878676,
+      "init_s": 1.78811,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.09936,
+          "best_ms": 3.08443,
+          "in_gibs": 20.1655,
+          "out_gibs": 20.1655
+        },
+        "h2d": {
+          "avg_ms": 1.18205,
+          "best_ms": 1.17821,
+          "in_gibs": 52.8742,
+          "out_gibs": 52.8742
+        },
+        "scatter": {
+          "avg_ms": 0.320273,
+          "best_ms": 0.316256,
+          "in_gibs": 195.146,
+          "out_gibs": 195.146
+        },
+        "compress": {
+          "avg_ms": 479.053,
+          "best_ms": 479.053,
+          "in_gibs": 7.82794,
+          "out_gibs": 0.915537
+        },
+        "aggregate": {
+          "avg_ms": 1.0199,
+          "best_ms": 1.0199,
+          "in_gibs": 430.032,
+          "out_gibs": 430.032
+        },
+        "d2h": {
+          "avg_ms": 8.35088,
+          "best_ms": 8.35088,
+          "in_gibs": 52.5203,
+          "out_gibs": 52.5203
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.912168,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.40079,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 28.53,
+      "status": "pass",
+      "throughput_in_gibs": 7.75127,
+      "throughput_out_gibs": 7.75884,
+      "compression_fold": 0.999024,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93255,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.377962,
+      "init_s": 0.229634,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.9942,
+          "best_ms": 0.356565,
+          "in_gibs": 19.1854,
+          "out_gibs": 19.1854
+        },
+        "h2d": {
+          "avg_ms": 1.08936,
+          "best_ms": 0.165056,
+          "in_gibs": 52.6899,
+          "out_gibs": 52.6899
+        },
+        "scatter": {
+          "avg_ms": 0.240077,
+          "best_ms": 0.042688,
+          "in_gibs": 239.081,
+          "out_gibs": 239.081
+        },
+        "compress": {
+          "avg_ms": 0.849965,
+          "best_ms": 0.829088,
+          "in_gibs": 689.367,
+          "out_gibs": 689.367
+        },
+        "aggregate": {
+          "avg_ms": 9.14943,
+          "best_ms": 1.54112,
+          "in_gibs": 64.0409,
+          "out_gibs": 64.0409
+        },
+        "d2h": {
+          "avg_ms": 58.794,
+          "best_ms": 11.1667,
+          "in_gibs": 9.96593,
+          "out_gibs": 9.96593
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 50.1176,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 0.251006,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 15.8894,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 30.61,
+      "status": "pass",
+      "throughput_in_gibs": 7.53145,
+      "throughput_out_gibs": 7.53513,
+      "compression_fold": 0.999512,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93112,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.388994,
+      "init_s": 0.244927,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.06696,
+          "best_ms": 0.387512,
+          "in_gibs": 18.7302,
+          "out_gibs": 18.7302
+        },
+        "h2d": {
+          "avg_ms": 1.09118,
+          "best_ms": 0.162176,
+          "in_gibs": 52.6015,
+          "out_gibs": 52.6015
+        },
+        "scatter": {
+          "avg_ms": 0.240365,
+          "best_ms": 0.042208,
+          "in_gibs": 238.795,
+          "out_gibs": 238.795
+        },
+        "compress": {
+          "avg_ms": 0.850893,
+          "best_ms": 0.831104,
+          "in_gibs": 688.615,
+          "out_gibs": 688.615
+        },
+        "aggregate": {
+          "avg_ms": 9.2566,
+          "best_ms": 1.5023,
+          "in_gibs": 63.2995,
+          "out_gibs": 63.2995
+        },
+        "d2h": {
+          "avg_ms": 60.4014,
+          "best_ms": 11.1588,
+          "in_gibs": 9.70072,
+          "out_gibs": 9.70072
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 48.1208,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 0.890495,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 15.5332,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 30.11,
+      "status": "pass",
+      "throughput_in_gibs": 7.40123,
+      "throughput_out_gibs": 7.40304,
+      "compression_fold": 0.999756,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.9304,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.395838,
+      "init_s": 0.251836,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14826,
+          "best_ms": 0.467991,
+          "in_gibs": 18.2465,
+          "out_gibs": 18.2465
+        },
+        "h2d": {
+          "avg_ms": 1.0899,
+          "best_ms": 0.164448,
+          "in_gibs": 52.6633,
+          "out_gibs": 52.6633
+        },
+        "scatter": {
+          "avg_ms": 0.239951,
+          "best_ms": 0.041888,
+          "in_gibs": 239.207,
+          "out_gibs": 239.207
+        },
+        "compress": {
+          "avg_ms": 0.850842,
+          "best_ms": 0.829088,
+          "in_gibs": 688.656,
+          "out_gibs": 688.656
+        },
+        "aggregate": {
+          "avg_ms": 9.39577,
+          "best_ms": 1.56102,
+          "in_gibs": 62.3618,
+          "out_gibs": 62.3618
+        },
+        "d2h": {
+          "avg_ms": 61.18,
+          "best_ms": 11.1443,
+          "in_gibs": 9.57727,
+          "out_gibs": 9.57727
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 47.2754,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 1.23374,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 15.4797,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 30.14,
+      "status": "pass",
+      "throughput_in_gibs": 7.40211,
+      "throughput_out_gibs": 7.40302,
+      "compression_fold": 0.999878,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93005,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.395791,
+      "init_s": 0.232184,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14768,
+          "best_ms": 0.454732,
+          "in_gibs": 18.2499,
+          "out_gibs": 18.2499
+        },
+        "h2d": {
+          "avg_ms": 1.0917,
+          "best_ms": 0.161536,
+          "in_gibs": 52.5765,
+          "out_gibs": 52.5765
+        },
+        "scatter": {
+          "avg_ms": 0.241538,
+          "best_ms": 0.043872,
+          "in_gibs": 237.635,
+          "out_gibs": 237.635
+        },
+        "compress": {
+          "avg_ms": 0.850835,
+          "best_ms": 0.831072,
+          "in_gibs": 688.662,
+          "out_gibs": 688.662
+        },
+        "aggregate": {
+          "avg_ms": 9.48282,
+          "best_ms": 1.69984,
+          "in_gibs": 61.7894,
+          "out_gibs": 61.7894
+        },
+        "d2h": {
+          "avg_ms": 61.4571,
+          "best_ms": 11.1416,
+          "in_gibs": 9.53409,
+          "out_gibs": 9.53409
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 46.6322,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 1.43844,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 15.3204,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 29.66,
+      "status": "pass",
+      "throughput_in_gibs": 7.40086,
+      "throughput_out_gibs": 7.40132,
+      "compression_fold": 0.999939,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92987,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.395858,
+      "init_s": 0.25536,
+      "flush_s": 3.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.17217,
+          "best_ms": 0.45943,
+          "in_gibs": 18.109,
+          "out_gibs": 18.109
+        },
+        "h2d": {
+          "avg_ms": 1.091,
+          "best_ms": 0.16304,
+          "in_gibs": 52.6104,
+          "out_gibs": 52.6104
+        },
+        "scatter": {
+          "avg_ms": 0.241399,
+          "best_ms": 0.042176,
+          "in_gibs": 237.772,
+          "out_gibs": 237.772
+        },
+        "compress": {
+          "avg_ms": 0.849286,
+          "best_ms": 0.829056,
+          "in_gibs": 689.917,
+          "out_gibs": 689.917
+        },
+        "aggregate": {
+          "avg_ms": 9.62904,
+          "best_ms": 1.80739,
+          "in_gibs": 60.8511,
+          "out_gibs": 60.8511
+        },
+        "d2h": {
+          "avg_ms": 61.0295,
+          "best_ms": 11.1421,
+          "in_gibs": 9.60089,
+          "out_gibs": 9.60089
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 46.3635,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 1.66399,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 15.253,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 30.7,
+      "status": "pass",
+      "throughput_in_gibs": 7.50547,
+      "throughput_out_gibs": 7.50572,
+      "compression_fold": 0.999967,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92978,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.39034,
+      "init_s": 0.413385,
+      "flush_s": 5.9e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.08783,
+          "best_ms": 0.443515,
+          "in_gibs": 18.6036,
+          "out_gibs": 18.6036
+        },
+        "h2d": {
+          "avg_ms": 1.08848,
+          "best_ms": 0.149696,
+          "in_gibs": 52.7323,
+          "out_gibs": 52.7323
+        },
+        "scatter": {
+          "avg_ms": 0.241919,
+          "best_ms": 0.038048,
+          "in_gibs": 237.261,
+          "out_gibs": 237.261
+        },
+        "compress": {
+          "avg_ms": 1.41835,
+          "best_ms": 0.835296,
+          "in_gibs": 688.522,
+          "out_gibs": 688.522
+        },
+        "aggregate": {
+          "avg_ms": 9.78401,
+          "best_ms": 1.73261,
+          "in_gibs": 99.8121,
+          "out_gibs": 99.8121
+        },
+        "d2h": {
+          "avg_ms": 79.4104,
+          "best_ms": 11.1417,
+          "in_gibs": 12.2977,
+          "out_gibs": 12.2977
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 23.008,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 2.48451,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 26.5057,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 31.46,
+      "status": "pass",
+      "throughput_in_gibs": 7.4253,
+      "throughput_out_gibs": 7.42541,
+      "compression_fold": 0.999985,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92973,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.394555,
+      "init_s": 0.902937,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.15082,
+          "best_ms": 0.368052,
+          "in_gibs": 18.2317,
+          "out_gibs": 18.2317
+        },
+        "h2d": {
+          "avg_ms": 1.09293,
+          "best_ms": 0.207872,
+          "in_gibs": 52.5173,
+          "out_gibs": 52.5173
+        },
+        "scatter": {
+          "avg_ms": 0.329133,
+          "best_ms": 0.040096,
+          "in_gibs": 174.391,
+          "out_gibs": 174.391
+        },
+        "compress": {
+          "avg_ms": 2.12086,
+          "best_ms": 0.84976,
+          "in_gibs": 690.683,
+          "out_gibs": 690.683
+        },
+        "aggregate": {
+          "avg_ms": 4.46464,
+          "best_ms": 1.77357,
+          "in_gibs": 328.099,
+          "out_gibs": 328.099
+        },
+        "d2h": {
+          "avg_ms": 53.9633,
+          "best_ms": 11.143,
+          "in_gibs": 27.1452,
+          "out_gibs": 27.1452
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 2.50678,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.99141,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 30.68,
+      "status": "pass",
+      "throughput_in_gibs": 7.37407,
+      "throughput_out_gibs": 8.84895,
+      "compression_fold": 0.999992,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.51565,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.397296,
+      "init_s": 1.4277,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.12374,
+          "best_ms": 0.754231,
+          "in_gibs": 19.1404,
+          "out_gibs": 19.1404
+        },
+        "h2d": {
+          "avg_ms": 1.13504,
+          "best_ms": 0.364256,
+          "in_gibs": 52.7211,
+          "out_gibs": 52.7211
+        },
+        "scatter": {
+          "avg_ms": 0.24939,
+          "best_ms": 0.0688,
+          "in_gibs": 239.947,
+          "out_gibs": 239.947
+        },
+        "compress": {
+          "avg_ms": 5.11043,
+          "best_ms": 5.11043,
+          "in_gibs": 687.931,
+          "out_gibs": 687.931
+        },
+        "aggregate": {
+          "avg_ms": 7.9473,
+          "best_ms": 7.9473,
+          "in_gibs": 442.367,
+          "out_gibs": 442.367
+        },
+        "d2h": {
+          "avg_ms": 66.8125,
+          "best_ms": 66.8125,
+          "in_gibs": 52.6193,
+          "out_gibs": 52.6193
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 7.83343,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.58331,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 28.46,
+      "status": "pass",
+      "throughput_in_gibs": 7.69254,
+      "throughput_out_gibs": 4.03107,
+      "compression_fold": 1.90831,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.53523,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.380848,
+      "init_s": 0.230036,
+      "flush_s": 2.294e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.00543,
+          "best_ms": 0.349244,
+          "in_gibs": 19.1137,
+          "out_gibs": 19.1137
+        },
+        "h2d": {
+          "avg_ms": 1.088,
+          "best_ms": 0.15776,
+          "in_gibs": 52.7555,
+          "out_gibs": 52.7555
+        },
+        "scatter": {
+          "avg_ms": 0.261584,
+          "best_ms": 0.042112,
+          "in_gibs": 226.982,
+          "out_gibs": 226.982
+        },
+        "compress": {
+          "avg_ms": 22.6088,
+          "best_ms": 22.4563,
+          "in_gibs": 25.9164,
+          "out_gibs": 13.5555
+        },
+        "aggregate": {
+          "avg_ms": 0.709965,
+          "best_ms": 0.600064,
+          "in_gibs": 431.673,
+          "out_gibs": 431.673
+        },
+        "d2h": {
+          "avg_ms": 41.5071,
+          "best_ms": 5.83645,
+          "in_gibs": 7.38362,
+          "out_gibs": 7.38362
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 27.6881,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 17.5099,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.1215,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 27.92,
+      "status": "pass",
+      "throughput_in_gibs": 7.62595,
+      "throughput_out_gibs": 3.94844,
+      "compression_fold": 1.93138,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.51688,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.384174,
+      "init_s": 0.227141,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.01743,
+          "best_ms": 0.368873,
+          "in_gibs": 19.0377,
+          "out_gibs": 19.0377
+        },
+        "h2d": {
+          "avg_ms": 1.09,
+          "best_ms": 0.161536,
+          "in_gibs": 52.6587,
+          "out_gibs": 52.6587
+        },
+        "scatter": {
+          "avg_ms": 0.259975,
+          "best_ms": 0.043136,
+          "in_gibs": 228.387,
+          "out_gibs": 228.387
+        },
+        "compress": {
+          "avg_ms": 25.01,
+          "best_ms": 24.7388,
+          "in_gibs": 23.4281,
+          "out_gibs": 12.1188
+        },
+        "aggregate": {
+          "avg_ms": 0.686656,
+          "best_ms": 0.585728,
+          "in_gibs": 441.401,
+          "out_gibs": 441.401
+        },
+        "d2h": {
+          "avg_ms": 39.7301,
+          "best_ms": 5.76163,
+          "in_gibs": 7.62874,
+          "out_gibs": 7.62874
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 25.4458,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 20.6384,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 16.2989,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 28.79,
+      "status": "pass",
+      "throughput_in_gibs": 7.47372,
+      "throughput_out_gibs": 3.79516,
+      "compression_fold": 1.96928,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.4877,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.391999,
+      "init_s": 0.222629,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.02301,
+          "best_ms": 0.385578,
+          "in_gibs": 19.0025,
+          "out_gibs": 19.0025
+        },
+        "h2d": {
+          "avg_ms": 1.09337,
+          "best_ms": 0.1648,
+          "in_gibs": 52.4963,
+          "out_gibs": 52.4963
+        },
+        "scatter": {
+          "avg_ms": 0.260736,
+          "best_ms": 0.045376,
+          "in_gibs": 227.721,
+          "out_gibs": 227.721
+        },
+        "compress": {
+          "avg_ms": 28.8515,
+          "best_ms": 28.5275,
+          "in_gibs": 20.3088,
+          "out_gibs": 10.3078
+        },
+        "aggregate": {
+          "avg_ms": 0.679059,
+          "best_ms": 0.585728,
+          "in_gibs": 437.953,
+          "out_gibs": 437.953
+        },
+        "d2h": {
+          "avg_ms": 37.3276,
+          "best_ms": 5.65501,
+          "in_gibs": 7.9672,
+          "out_gibs": 7.9672
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 23.9936,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 24.6354,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 20.0706,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 27.9,
+      "status": "pass",
+      "throughput_in_gibs": 7.15488,
+      "throughput_out_gibs": 3.11919,
+      "compression_fold": 2.29382,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.27721,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.409467,
+      "init_s": 0.224311,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.01479,
+          "best_ms": 0.389395,
+          "in_gibs": 19.0543,
+          "out_gibs": 19.0543
+        },
+        "h2d": {
+          "avg_ms": 1.09126,
+          "best_ms": 0.15728,
+          "in_gibs": 52.5979,
+          "out_gibs": 52.5979
+        },
+        "scatter": {
+          "avg_ms": 0.275995,
+          "best_ms": 0.041984,
+          "in_gibs": 213.531,
+          "out_gibs": 213.531
+        },
+        "compress": {
+          "avg_ms": 33.6199,
+          "best_ms": 32.9609,
+          "in_gibs": 17.4283,
+          "out_gibs": 7.59579
+        },
+        "aggregate": {
+          "avg_ms": 0.657754,
+          "best_ms": 0.546848,
+          "in_gibs": 388.245,
+          "out_gibs": 388.245
+        },
+        "d2h": {
+          "avg_ms": 35.4399,
+          "best_ms": 4.87018,
+          "in_gibs": 7.20571,
+          "out_gibs": 7.20571
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 20.3022,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 29.7421,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 37.7272,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 28.53,
+      "status": "pass",
+      "throughput_in_gibs": 7.23912,
+      "throughput_out_gibs": 2.93117,
+      "compression_fold": 2.46971,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.18625,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.404702,
+      "init_s": 0.230595,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.98505,
+          "best_ms": 0.352188,
+          "in_gibs": 19.2442,
+          "out_gibs": 19.2442
+        },
+        "h2d": {
+          "avg_ms": 1.09321,
+          "best_ms": 0.160928,
+          "in_gibs": 52.504,
+          "out_gibs": 52.504
+        },
+        "scatter": {
+          "avg_ms": 0.261204,
+          "best_ms": 0.04368,
+          "in_gibs": 219.744,
+          "out_gibs": 219.744
+        },
+        "compress": {
+          "avg_ms": 32.7115,
+          "best_ms": 31.7824,
+          "in_gibs": 17.9123,
+          "out_gibs": 7.2517
+        },
+        "aggregate": {
+          "avg_ms": 0.681901,
+          "best_ms": 0.577536,
+          "in_gibs": 347.872,
+          "out_gibs": 347.872
+        },
+        "d2h": {
+          "avg_ms": 35.1434,
+          "best_ms": 4.52445,
+          "in_gibs": 6.74989,
+          "out_gibs": 6.74989
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 18.6354,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 29.6697,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 37.2068,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 28.47,
+      "status": "pass",
+      "throughput_in_gibs": 6.44371,
+      "throughput_out_gibs": 2.62719,
+      "compression_fold": 2.4527,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.19448,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.454659,
+      "init_s": 0.401337,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.01182,
+          "best_ms": 0.407321,
+          "in_gibs": 19.0731,
+          "out_gibs": 19.0731
+        },
+        "h2d": {
+          "avg_ms": 1.08722,
+          "best_ms": 0.156256,
+          "in_gibs": 52.7931,
+          "out_gibs": 52.7931
+        },
+        "scatter": {
+          "avg_ms": 0.256911,
+          "best_ms": 0.036,
+          "in_gibs": 226.803,
+          "out_gibs": 226.803
+        },
+        "compress": {
+          "avg_ms": 62.9789,
+          "best_ms": 58.5752,
+          "in_gibs": 15.5062,
+          "out_gibs": 6.32159
+        },
+        "aggregate": {
+          "avg_ms": 1.27545,
+          "best_ms": 0.71888,
+          "in_gibs": 312.147,
+          "out_gibs": 312.147
+        },
+        "d2h": {
+          "avg_ms": 44.5308,
+          "best_ms": 4.54736,
+          "in_gibs": 8.94048,
+          "out_gibs": 8.94048
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 9.28199,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 59.2102,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 56.5981,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 29.48,
+      "status": "pass",
+      "throughput_in_gibs": 5.19652,
+      "throughput_out_gibs": 1.86463,
+      "compression_fold": 2.78689,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.05124,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.563779,
+      "init_s": 0.778106,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.95481,
+          "best_ms": 0.354622,
+          "in_gibs": 19.4411,
+          "out_gibs": 19.4411
+        },
+        "h2d": {
+          "avg_ms": 1.0905,
+          "best_ms": 0.205408,
+          "in_gibs": 52.6346,
+          "out_gibs": 52.6346
+        },
+        "scatter": {
+          "avg_ms": 0.242034,
+          "best_ms": 0.038016,
+          "in_gibs": 237.149,
+          "out_gibs": 237.149
+        },
+        "compress": {
+          "avg_ms": 113.134,
+          "best_ms": 102.341,
+          "in_gibs": 12.9479,
+          "out_gibs": 4.64579
+        },
+        "aggregate": {
+          "avg_ms": 2.14509,
+          "best_ms": 0.649184,
+          "in_gibs": 245.023,
+          "out_gibs": 245.023
+        },
+        "d2h": {
+          "avg_ms": 37.6838,
+          "best_ms": 3.98582,
+          "in_gibs": 13.9475,
+          "out_gibs": 13.9475
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 102.896,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 128.171,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 30.61,
+      "status": "pass",
+      "throughput_in_gibs": 5.4956,
+      "throughput_out_gibs": 1.77655,
+      "compression_fold": 3.7121,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.947071,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.533097,
+      "init_s": 1.42662,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.11237,
+          "best_ms": 0.831727,
+          "in_gibs": 19.2103,
+          "out_gibs": 19.2103
+        },
+        "h2d": {
+          "avg_ms": 1.13627,
+          "best_ms": 0.422176,
+          "in_gibs": 52.6641,
+          "out_gibs": 52.6641
+        },
+        "scatter": {
+          "avg_ms": 0.248934,
+          "best_ms": 0.0688,
+          "in_gibs": 240.387,
+          "out_gibs": 240.387
+        },
+        "compress": {
+          "avg_ms": 195.629,
+          "best_ms": 195.629,
+          "in_gibs": 17.9709,
+          "out_gibs": 4.84102
+        },
+        "aggregate": {
+          "avg_ms": 2.28934,
+          "best_ms": 2.28934,
+          "in_gibs": 413.675,
+          "out_gibs": 413.675
+        },
+        "d2h": {
+          "avg_ms": 18.0094,
+          "best_ms": 18.0094,
+          "in_gibs": 52.5861,
+          "out_gibs": 52.5861
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 197.202,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.57017,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 28.63,
+      "status": "pass",
+      "throughput_in_gibs": 4.36707,
+      "throughput_out_gibs": 0.623327,
+      "compression_fold": 7.00606,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.418165,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.67086,
+      "init_s": 0.232848,
+      "flush_s": 7.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.01611,
+          "best_ms": 0.352499,
+          "in_gibs": 19.046,
+          "out_gibs": 19.046
+        },
+        "h2d": {
+          "avg_ms": 1.09058,
+          "best_ms": 0.158752,
+          "in_gibs": 52.6306,
+          "out_gibs": 52.6306
+        },
+        "scatter": {
+          "avg_ms": 0.559906,
+          "best_ms": 0.040224,
+          "in_gibs": 104.301,
+          "out_gibs": 104.301
+        },
+        "compress": {
+          "avg_ms": 89.5006,
+          "best_ms": 88.2449,
+          "in_gibs": 6.54674,
+          "out_gibs": 0.928046
+        },
+        "aggregate": {
+          "avg_ms": 0.213395,
+          "best_ms": 0.192512,
+          "in_gibs": 389.234,
+          "out_gibs": 389.234
+        },
+        "d2h": {
+          "avg_ms": 29.7286,
+          "best_ms": 1.59344,
+          "in_gibs": 2.79397,
+          "out_gibs": 2.79397
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 10.7738,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 87.7965,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 92.2038,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 29.71,
+      "status": "pass",
+      "throughput_in_gibs": 3.58135,
+      "throughput_out_gibs": 0.525901,
+      "compression_fold": 6.80994,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.430208,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.818039,
+      "init_s": 0.261788,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.06057,
+          "best_ms": 0.44696,
+          "in_gibs": 18.7693,
+          "out_gibs": 18.7693
+        },
+        "h2d": {
+          "avg_ms": 1.08849,
+          "best_ms": 0.156288,
+          "in_gibs": 52.7319,
+          "out_gibs": 52.7319
+        },
+        "scatter": {
+          "avg_ms": 0.690237,
+          "best_ms": 0.040064,
+          "in_gibs": 85.3247,
+          "out_gibs": 85.3247
+        },
+        "compress": {
+          "avg_ms": 121.6,
+          "best_ms": 120.254,
+          "in_gibs": 4.81856,
+          "out_gibs": 0.705224
+        },
+        "aggregate": {
+          "avg_ms": 0.276723,
+          "best_ms": 0.186368,
+          "in_gibs": 309.896,
+          "out_gibs": 309.896
+        },
+        "d2h": {
+          "avg_ms": 26.6597,
+          "best_ms": 1.64992,
+          "in_gibs": 3.21667,
+          "out_gibs": 3.21667
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 9.3262,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 120.883,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 112.124,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 30.71,
+      "status": "pass",
+      "throughput_in_gibs": 3.55566,
+      "throughput_out_gibs": 0.482249,
+      "compression_fold": 7.37307,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.39735,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.82395,
+      "init_s": 0.247361,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.06917,
+          "best_ms": 0.427521,
+          "in_gibs": 18.7168,
+          "out_gibs": 18.7168
+        },
+        "h2d": {
+          "avg_ms": 1.09892,
+          "best_ms": 0.159424,
+          "in_gibs": 52.2313,
+          "out_gibs": 52.2313
+        },
+        "scatter": {
+          "avg_ms": 0.315394,
+          "best_ms": 0.041952,
+          "in_gibs": 185.16,
+          "out_gibs": 185.16
+        },
+        "compress": {
+          "avg_ms": 122.188,
+          "best_ms": 120.829,
+          "in_gibs": 4.79537,
+          "out_gibs": 0.649219
+        },
+        "aggregate": {
+          "avg_ms": 0.211846,
+          "best_ms": 0.16592,
+          "in_gibs": 374.454,
+          "out_gibs": 374.454
+        },
+        "d2h": {
+          "avg_ms": 27.2041,
+          "best_ms": 1.53555,
+          "in_gibs": 2.91598,
+          "out_gibs": 2.91598
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 7.51231,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 121.59,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 124.905,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 30.32,
+      "status": "pass",
+      "throughput_in_gibs": 3.56284,
+      "throughput_out_gibs": 0.507983,
+      "compression_fold": 7.01371,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.417709,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.822289,
+      "init_s": 0.25282,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.09686,
+          "best_ms": 0.456455,
+          "in_gibs": 18.5494,
+          "out_gibs": 18.5494
+        },
+        "h2d": {
+          "avg_ms": 1.09071,
+          "best_ms": 0.156096,
+          "in_gibs": 52.6246,
+          "out_gibs": 52.6246
+        },
+        "scatter": {
+          "avg_ms": 0.400974,
+          "best_ms": 0.040416,
+          "in_gibs": 146.878,
+          "out_gibs": 146.878
+        },
+        "compress": {
+          "avg_ms": 128.368,
+          "best_ms": 126.749,
+          "in_gibs": 4.56452,
+          "out_gibs": 0.650242
+        },
+        "aggregate": {
+          "avg_ms": 0.268909,
+          "best_ms": 0.176096,
+          "in_gibs": 310.403,
+          "out_gibs": 310.403
+        },
+        "d2h": {
+          "avg_ms": 20.9485,
+          "best_ms": 1.59453,
+          "in_gibs": 3.98455,
+          "out_gibs": 3.98455
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 7.29173,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 127.336,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 118.777,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 29.08,
+      "status": "pass",
+      "throughput_in_gibs": 4.99996,
+      "throughput_out_gibs": 0.684761,
+      "compression_fold": 7.30175,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.401231,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.585943,
+      "init_s": 0.252832,
+      "flush_s": 7.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.1469,
+          "best_ms": 0.475863,
+          "in_gibs": 18.2544,
+          "out_gibs": 18.2544
+        },
+        "h2d": {
+          "avg_ms": 1.09224,
+          "best_ms": 0.154144,
+          "in_gibs": 52.5505,
+          "out_gibs": 52.5505
+        },
+        "scatter": {
+          "avg_ms": 0.368439,
+          "best_ms": 0.086528,
+          "in_gibs": 156.824,
+          "out_gibs": 156.824
+        },
+        "compress": {
+          "avg_ms": 90.2591,
+          "best_ms": 88.2736,
+          "in_gibs": 6.49173,
+          "out_gibs": 0.888668
+        },
+        "aggregate": {
+          "avg_ms": 0.28791,
+          "best_ms": 0.198656,
+          "in_gibs": 278.595,
+          "out_gibs": 278.595
+        },
+        "d2h": {
+          "avg_ms": 11.5908,
+          "best_ms": 1.53888,
+          "in_gibs": 6.92014,
+          "out_gibs": 6.92014
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 83.9141,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 165.197,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 79.975,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 31.51,
+      "status": "pass",
+      "throughput_in_gibs": 4.22303,
+      "throughput_out_gibs": 0.594673,
+      "compression_fold": 7.10144,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.412549,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.693741,
+      "init_s": 0.41122,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.12669,
+          "best_ms": 0.443626,
+          "in_gibs": 18.3724,
+          "out_gibs": 18.3724
+        },
+        "h2d": {
+          "avg_ms": 1.08699,
+          "best_ms": 0.149376,
+          "in_gibs": 52.8045,
+          "out_gibs": 52.8045
+        },
+        "scatter": {
+          "avg_ms": 0.275758,
+          "best_ms": 0.035936,
+          "in_gibs": 211.302,
+          "out_gibs": 211.302
+        },
+        "compress": {
+          "avg_ms": 142.198,
+          "best_ms": 62.7856,
+          "in_gibs": 6.86762,
+          "out_gibs": 0.966851
+        },
+        "aggregate": {
+          "avg_ms": 0.617003,
+          "best_ms": 0.198656,
+          "in_gibs": 222.826,
+          "out_gibs": 222.826
+        },
+        "d2h": {
+          "avg_ms": 41.4753,
+          "best_ms": 1.58179,
+          "in_gibs": 3.31484,
+          "out_gibs": 3.31484
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 3.32508,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 183.271,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 171.73,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 30.85,
+      "status": "pass",
+      "throughput_in_gibs": 3.29153,
+      "throughput_out_gibs": 0.462614,
+      "compression_fold": 7.11507,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.411758,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.890068,
+      "init_s": 0.847892,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.09188,
+          "best_ms": 0.451949,
+          "in_gibs": 18.5793,
+          "out_gibs": 18.5793
+        },
+        "h2d": {
+          "avg_ms": 1.08943,
+          "best_ms": 0.155776,
+          "in_gibs": 52.6864,
+          "out_gibs": 52.6864
+        },
+        "scatter": {
+          "avg_ms": 0.241938,
+          "best_ms": 0.038048,
+          "in_gibs": 239.494,
+          "out_gibs": 239.494
+        },
+        "compress": {
+          "avg_ms": 281.267,
+          "best_ms": 64.8546,
+          "in_gibs": 5.20802,
+          "out_gibs": 0.731891
+        },
+        "aggregate": {
+          "avg_ms": 1.33786,
+          "best_ms": 0.270336,
+          "in_gibs": 153.871,
+          "out_gibs": 153.871
+        },
+        "d2h": {
+          "avg_ms": 28.6668,
+          "best_ms": 1.58109,
+          "in_gibs": 7.18102,
+          "out_gibs": 7.18102
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 65.0108,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 489.021,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 31.56,
+      "status": "pass",
+      "throughput_in_gibs": 3.37219,
+      "throughput_out_gibs": 0.472936,
+      "compression_fold": 8.5564,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.410876,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.868778,
+      "init_s": 1.42146,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.12836,
+          "best_ms": 0.829816,
+          "in_gibs": 19.1121,
+          "out_gibs": 19.1121
+        },
+        "h2d": {
+          "avg_ms": 1.1343,
+          "best_ms": 0.364448,
+          "in_gibs": 52.7552,
+          "out_gibs": 52.7552
+        },
+        "scatter": {
+          "avg_ms": 0.24939,
+          "best_ms": 0.06864,
+          "in_gibs": 239.948,
+          "out_gibs": 239.948
+        },
+        "compress": {
+          "avg_ms": 541.476,
+          "best_ms": 541.476,
+          "in_gibs": 6.49267,
+          "out_gibs": 0.758758
+        },
+        "aggregate": {
+          "avg_ms": 1.11619,
+          "best_ms": 1.11619,
+          "in_gibs": 368.081,
+          "out_gibs": 368.081
+        },
+        "d2h": {
+          "avg_ms": 7.82227,
+          "best_ms": 7.82227,
+          "in_gibs": 52.523,
+          "out_gibs": 52.523
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 1.01061,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.59384,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.32,
+      "status": "pass",
+      "throughput_in_gibs": 0.946268,
+      "throughput_out_gibs": 0.947193,
+      "compression_fold": 0.999024,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312805,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0330245,
+      "init_s": 0.048363,
+      "flush_s": 2.524e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000530879,
+          "best_ms": 0.00036,
+          "in_gibs": 28.7425,
+          "out_gibs": 28.7425
+        },
+        "h2d": {
+          "avg_ms": 0.011456,
+          "best_ms": 0.011456,
+          "in_gibs": 1.33195,
+          "out_gibs": 1.33195
+        },
+        "scatter": {
+          "avg_ms": 0.0118234,
+          "best_ms": 0.010016,
+          "in_gibs": 1.29056,
+          "out_gibs": 1.29056
+        },
+        "aggregate": {
+          "avg_ms": 0.056594,
+          "best_ms": 0.025536,
+          "in_gibs": 34.5112,
+          "out_gibs": 34.5112
+        },
+        "d2h": {
+          "avg_ms": 1.40179,
+          "best_ms": 0.043296,
+          "in_gibs": 1.3933,
+          "out_gibs": 1.3933
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.718195,
+        "flush_stall_count": 15,
+        "kick_sync_ms": 0.002694,
+        "kick_sync_count": 16,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 24.9863,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.28,
+      "status": "pass",
+      "throughput_in_gibs": 1.41145,
+      "throughput_out_gibs": 1.41214,
+      "compression_fold": 0.999511,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312653,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0221403,
+      "init_s": 0.0503323,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000906112,
+          "best_ms": 0.000611,
+          "in_gibs": 33.6797,
+          "out_gibs": 33.6797
+        },
+        "h2d": {
+          "avg_ms": 0.01216,
+          "best_ms": 0.01216,
+          "in_gibs": 2.50967,
+          "out_gibs": 2.50967
+        },
+        "scatter": {
+          "avg_ms": 0.0117405,
+          "best_ms": 0.010016,
+          "in_gibs": 2.59935,
+          "out_gibs": 2.59935
+        },
+        "aggregate": {
+          "avg_ms": 0.096176,
+          "best_ms": 0.03568,
+          "in_gibs": 40.6156,
+          "out_gibs": 40.6156
+        },
+        "d2h": {
+          "avg_ms": 1.40215,
+          "best_ms": 0.081472,
+          "in_gibs": 2.7859,
+          "out_gibs": 2.7859
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.603734,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 0.001542,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 13.7333,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.92792,
+      "throughput_out_gibs": 1.92839,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0162092,
+      "init_s": 0.0483131,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00163728,
+          "best_ms": 0.001292,
+          "in_gibs": 37.2784,
+          "out_gibs": 37.2784
+        },
+        "h2d": {
+          "avg_ms": 0.011424,
+          "best_ms": 0.011424,
+          "in_gibs": 5.34271,
+          "out_gibs": 5.34271
+        },
+        "scatter": {
+          "avg_ms": 0.0115476,
+          "best_ms": 0.010016,
+          "in_gibs": 5.28552,
+          "out_gibs": 5.28552
+        },
+        "compress": {
+          "avg_ms": 0.010944,
+          "best_ms": 0.010944,
+          "in_gibs": 713.861,
+          "out_gibs": 713.861
+        },
+        "aggregate": {
+          "avg_ms": 0.173344,
+          "best_ms": 0.054944,
+          "in_gibs": 45.0693,
+          "out_gibs": 45.0693
+        },
+        "d2h": {
+          "avg_ms": 1.34206,
+          "best_ms": 0.15472,
+          "in_gibs": 5.82126,
+          "out_gibs": 5.82126
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.486009,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 0.00089,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.83423,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.27,
+      "status": "pass",
+      "throughput_in_gibs": 2.00507,
+      "throughput_out_gibs": 2.00556,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0155855,
+      "init_s": 0.0487811,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00160892,
+          "best_ms": 0.001262,
+          "in_gibs": 37.9354,
+          "out_gibs": 37.9354
+        },
+        "h2d": {
+          "avg_ms": 0.012704,
+          "best_ms": 0.012704,
+          "in_gibs": 4.8044,
+          "out_gibs": 4.8044
+        },
+        "scatter": {
+          "avg_ms": 0.0115833,
+          "best_ms": 0.010016,
+          "in_gibs": 5.26924,
+          "out_gibs": 5.26924
+        },
+        "compress": {
+          "avg_ms": 0.010752,
+          "best_ms": 0.010752,
+          "in_gibs": 726.609,
+          "out_gibs": 726.609
+        },
+        "aggregate": {
+          "avg_ms": 0.069816,
+          "best_ms": 0.054816,
+          "in_gibs": 111.901,
+          "out_gibs": 111.901
+        },
+        "d2h": {
+          "avg_ms": 1.33163,
+          "best_ms": 0.155232,
+          "in_gibs": 5.86686,
+          "out_gibs": 5.86686
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.490246,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 0.00098,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.41143,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.99521,
+      "throughput_out_gibs": 1.99569,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0156625,
+      "init_s": 0.0471346,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00163187,
+          "best_ms": 0.001242,
+          "in_gibs": 37.4021,
+          "out_gibs": 37.4021
+        },
+        "h2d": {
+          "avg_ms": 0.011264,
+          "best_ms": 0.011264,
+          "in_gibs": 5.4186,
+          "out_gibs": 5.4186
+        },
+        "scatter": {
+          "avg_ms": 0.011558,
+          "best_ms": 0.010016,
+          "in_gibs": 5.28078,
+          "out_gibs": 5.28078
+        },
+        "compress": {
+          "avg_ms": 0.010784,
+          "best_ms": 0.010784,
+          "in_gibs": 724.453,
+          "out_gibs": 724.453
+        },
+        "aggregate": {
+          "avg_ms": 0.068768,
+          "best_ms": 0.054688,
+          "in_gibs": 113.607,
+          "out_gibs": 113.607
+        },
+        "d2h": {
+          "avg_ms": 1.33922,
+          "best_ms": 0.15488,
+          "in_gibs": 5.8336,
+          "out_gibs": 5.8336
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.48619,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 0.000982,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.44428,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.31,
+      "status": "pass",
+      "throughput_in_gibs": 1.96003,
+      "throughput_out_gibs": 1.9605,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0159437,
+      "init_s": 0.047509,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00160425,
+          "best_ms": 0.001192,
+          "in_gibs": 38.046,
+          "out_gibs": 38.046
+        },
+        "h2d": {
+          "avg_ms": 0.012608,
+          "best_ms": 0.012608,
+          "in_gibs": 4.84099,
+          "out_gibs": 4.84099
+        },
+        "scatter": {
+          "avg_ms": 0.0116258,
+          "best_ms": 0.010016,
+          "in_gibs": 5.24997,
+          "out_gibs": 5.24997
+        },
+        "compress": {
+          "avg_ms": 0.010944,
+          "best_ms": 0.010944,
+          "in_gibs": 713.861,
+          "out_gibs": 713.861
+        },
+        "aggregate": {
+          "avg_ms": 0.168928,
+          "best_ms": 0.053824,
+          "in_gibs": 46.2475,
+          "out_gibs": 46.2475
+        },
+        "d2h": {
+          "avg_ms": 1.33862,
+          "best_ms": 0.155392,
+          "in_gibs": 5.83622,
+          "out_gibs": 5.83622
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.489244,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 0.001222,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.84139,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.97335,
+      "throughput_out_gibs": 1.97384,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.015836,
+      "init_s": 0.0476591,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00161744,
+          "best_ms": 0.001282,
+          "in_gibs": 37.7357,
+          "out_gibs": 37.7357
+        },
+        "h2d": {
+          "avg_ms": 0.011936,
+          "best_ms": 0.011936,
+          "in_gibs": 5.11354,
+          "out_gibs": 5.11354
+        },
+        "scatter": {
+          "avg_ms": 0.0116127,
+          "best_ms": 0.010016,
+          "in_gibs": 5.25591,
+          "out_gibs": 5.25591
+        },
+        "compress": {
+          "avg_ms": 0.010368,
+          "best_ms": 0.010368,
+          "in_gibs": 753.52,
+          "out_gibs": 753.52
+        },
+        "aggregate": {
+          "avg_ms": 0.068888,
+          "best_ms": 0.05424,
+          "in_gibs": 113.409,
+          "out_gibs": 113.409
+        },
+        "d2h": {
+          "avg_ms": 1.34491,
+          "best_ms": 0.154816,
+          "in_gibs": 5.80893,
+          "out_gibs": 5.80893
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.487021,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 0.000932,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.47146,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.31,
+      "status": "pass",
+      "throughput_in_gibs": 1.92665,
+      "throughput_out_gibs": 1.92712,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0162199,
+      "init_s": 0.0494667,
+      "flush_s": 4.6e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00161574,
+          "best_ms": 0.001261,
+          "in_gibs": 37.7753,
+          "out_gibs": 37.7753
+        },
+        "h2d": {
+          "avg_ms": 0.011712,
+          "best_ms": 0.011712,
+          "in_gibs": 5.21134,
+          "out_gibs": 5.21134
+        },
+        "scatter": {
+          "avg_ms": 0.011618,
+          "best_ms": 0.010016,
+          "in_gibs": 5.25348,
+          "out_gibs": 5.25348
+        },
+        "compress": {
+          "avg_ms": 0.011136,
+          "best_ms": 0.011136,
+          "in_gibs": 701.554,
+          "out_gibs": 701.554
+        },
+        "aggregate": {
+          "avg_ms": 0.172488,
+          "best_ms": 0.054848,
+          "in_gibs": 45.293,
+          "out_gibs": 45.293
+        },
+        "d2h": {
+          "avg_ms": 1.34256,
+          "best_ms": 0.155488,
+          "in_gibs": 5.81911,
+          "out_gibs": 5.81911
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.485739,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 0.000991,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.87583,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.32,
+      "status": "pass",
+      "throughput_in_gibs": 0.897819,
+      "throughput_out_gibs": 0.221222,
+      "compression_fold": 4.05845,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00769998,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0348066,
+      "init_s": 0.0453939,
+      "flush_s": 4.7e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000529639,
+          "best_ms": 0.00036,
+          "in_gibs": 28.8098,
+          "out_gibs": 28.8098
+        },
+        "scatter": {
+          "avg_ms": 0.0111745,
+          "best_ms": 0.010016,
+          "in_gibs": 1.3655,
+          "out_gibs": 1.3655
+        },
+        "compress": {
+          "avg_ms": 1.03653,
+          "best_ms": 0.859168,
+          "in_gibs": 1.88429,
+          "out_gibs": 0.462446
+        },
+        "aggregate": {
+          "avg_ms": 0.02571,
+          "best_ms": 0.0184,
+          "in_gibs": 18.6441,
+          "out_gibs": 18.6441
+        },
+        "d2h": {
+          "avg_ms": 0.522126,
+          "best_ms": 0.0152,
+          "in_gibs": 0.918055,
+          "out_gibs": 0.918055
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.288973,
+        "flush_stall_count": 15,
+        "kick_sync_ms": 0.854461,
+        "kick_sync_count": 16,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 26.0025,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.31,
+      "status": "pass",
+      "throughput_in_gibs": 1.32945,
+      "throughput_out_gibs": 0.166385,
+      "compression_fold": 7.99022,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00391103,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0235059,
+      "init_s": 0.0464019,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000885229,
+          "best_ms": 0.000601,
+          "in_gibs": 34.4742,
+          "out_gibs": 34.4742
+        },
+        "h2d": {
+          "avg_ms": 0.010368,
+          "best_ms": 0.010368,
+          "in_gibs": 2.94344,
+          "out_gibs": 2.94344
+        },
+        "scatter": {
+          "avg_ms": 0.0114718,
+          "best_ms": 0.010016,
+          "in_gibs": 2.66022,
+          "out_gibs": 2.66022
+        },
+        "compress": {
+          "avg_ms": 1.18059,
+          "best_ms": 0.950752,
+          "in_gibs": 3.30872,
+          "out_gibs": 0.412479
+        },
+        "aggregate": {
+          "avg_ms": 0.030472,
+          "best_ms": 0.018432,
+          "in_gibs": 15.9809,
+          "out_gibs": 15.9809
+        },
+        "d2h": {
+          "avg_ms": 0.520952,
+          "best_ms": 0.0152,
+          "in_gibs": 0.934769,
+          "out_gibs": 0.934769
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.142905,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 0.940163,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.6855,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.28,
+      "status": "pass",
+      "throughput_in_gibs": 1.74404,
+      "throughput_out_gibs": 0.112543,
+      "compression_fold": 15.4967,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00201656,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0179181,
+      "init_s": 0.0483908,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00163758,
+          "best_ms": 0.001272,
+          "in_gibs": 37.2715,
+          "out_gibs": 37.2715
+        },
+        "h2d": {
+          "avg_ms": 0.012096,
+          "best_ms": 0.012096,
+          "in_gibs": 5.0459,
+          "out_gibs": 5.0459
+        },
+        "scatter": {
+          "avg_ms": 0.0116163,
+          "best_ms": 0.010016,
+          "in_gibs": 5.25426,
+          "out_gibs": 5.25426
+        },
+        "compress": {
+          "avg_ms": 1.36883,
+          "best_ms": 1.13328,
+          "in_gibs": 5.70742,
+          "out_gibs": 0.366903
+        },
+        "aggregate": {
+          "avg_ms": 0.039152,
+          "best_ms": 0.020064,
+          "in_gibs": 12.8277,
+          "out_gibs": 12.8277
+        },
+        "d2h": {
+          "avg_ms": 0.5782,
+          "best_ms": 0.015424,
+          "in_gibs": 0.868607,
+          "out_gibs": 0.868607
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.070897,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 1.12126,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.80681,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.73236,
+      "throughput_out_gibs": 0.111789,
+      "compression_fold": 15.4967,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00201656,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.018039,
+      "init_s": 0.0485709,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00163084,
+          "best_ms": 0.001262,
+          "in_gibs": 37.4255,
+          "out_gibs": 37.4255
+        },
+        "h2d": {
+          "avg_ms": 0.011552,
+          "best_ms": 0.011552,
+          "in_gibs": 5.28351,
+          "out_gibs": 5.28351
+        },
+        "scatter": {
+          "avg_ms": 0.0116011,
+          "best_ms": 0.010048,
+          "in_gibs": 5.26114,
+          "out_gibs": 5.26114
+        },
+        "compress": {
+          "avg_ms": 1.44162,
+          "best_ms": 1.13427,
+          "in_gibs": 5.41927,
+          "out_gibs": 0.348379
+        },
+        "aggregate": {
+          "avg_ms": 0.0278,
+          "best_ms": 0.020992,
+          "in_gibs": 18.0658,
+          "out_gibs": 18.0658
+        },
+        "d2h": {
+          "avg_ms": 0.572688,
+          "best_ms": 0.015392,
+          "in_gibs": 0.876967,
+          "out_gibs": 0.876967
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.065459,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 1.12125,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 9.04268,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.75912,
+      "throughput_out_gibs": 0.113516,
+      "compression_fold": 15.4967,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00201656,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0177646,
+      "init_s": 0.0495049,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00163658,
+          "best_ms": 0.001262,
+          "in_gibs": 37.2944,
+          "out_gibs": 37.2944
+        },
+        "h2d": {
+          "avg_ms": 0.011904,
+          "best_ms": 0.011904,
+          "in_gibs": 5.12728,
+          "out_gibs": 5.12728
+        },
+        "scatter": {
+          "avg_ms": 0.0116508,
+          "best_ms": 0.010016,
+          "in_gibs": 5.23872,
+          "out_gibs": 5.23872
+        },
+        "compress": {
+          "avg_ms": 1.37177,
+          "best_ms": 1.13456,
+          "in_gibs": 5.6952,
+          "out_gibs": 0.366118
+        },
+        "aggregate": {
+          "avg_ms": 0.02688,
+          "best_ms": 0.019808,
+          "in_gibs": 18.6841,
+          "out_gibs": 18.6841
+        },
+        "d2h": {
+          "avg_ms": 0.578192,
+          "best_ms": 0.015648,
+          "in_gibs": 0.868619,
+          "out_gibs": 0.868619
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.06648,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 1.12165,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.76812,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.73525,
+      "throughput_out_gibs": 0.111975,
+      "compression_fold": 15.4967,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00201656,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0180089,
+      "init_s": 0.0488937,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00163111,
+          "best_ms": 0.001211,
+          "in_gibs": 37.4194,
+          "out_gibs": 37.4194
+        },
+        "h2d": {
+          "avg_ms": 0.012224,
+          "best_ms": 0.012224,
+          "in_gibs": 4.99306,
+          "out_gibs": 4.99306
+        },
+        "scatter": {
+          "avg_ms": 0.0116681,
+          "best_ms": 0.010016,
+          "in_gibs": 5.23093,
+          "out_gibs": 5.23093
+        },
+        "compress": {
+          "avg_ms": 1.37505,
+          "best_ms": 1.13501,
+          "in_gibs": 5.68162,
+          "out_gibs": 0.365245
+        },
+        "aggregate": {
+          "avg_ms": 0.025992,
+          "best_ms": 0.018688,
+          "in_gibs": 19.3224,
+          "out_gibs": 19.3224
+        },
+        "d2h": {
+          "avg_ms": 0.583056,
+          "best_ms": 0.015488,
+          "in_gibs": 0.861373,
+          "out_gibs": 0.861373
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.06641,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 1.12306,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.78964,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.28,
+      "status": "pass",
+      "throughput_in_gibs": 1.71766,
+      "throughput_out_gibs": 0.11084,
+      "compression_fold": 15.4967,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00201656,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0181934,
+      "init_s": 0.0486912,
+      "flush_s": 3.104e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00165186,
+          "best_ms": 0.001312,
+          "in_gibs": 36.9494,
+          "out_gibs": 36.9494
+        },
+        "h2d": {
+          "avg_ms": 0.01184,
+          "best_ms": 0.01184,
+          "in_gibs": 5.155,
+          "out_gibs": 5.155
+        },
+        "scatter": {
+          "avg_ms": 0.0116199,
+          "best_ms": 0.010016,
+          "in_gibs": 5.25263,
+          "out_gibs": 5.25263
+        },
+        "compress": {
+          "avg_ms": 1.37713,
+          "best_ms": 1.13466,
+          "in_gibs": 5.67304,
+          "out_gibs": 0.364693
+        },
+        "aggregate": {
+          "avg_ms": 0.038536,
+          "best_ms": 0.018816,
+          "in_gibs": 13.0327,
+          "out_gibs": 13.0327
+        },
+        "d2h": {
+          "avg_ms": 0.587456,
+          "best_ms": 0.015456,
+          "in_gibs": 0.854921,
+          "out_gibs": 0.854921
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.069604,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 1.12113,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.87324,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.73958,
+      "throughput_out_gibs": 0.112255,
+      "compression_fold": 15.4967,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00201656,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0179642,
+      "init_s": 0.0480522,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00163681,
+          "best_ms": 0.001322,
+          "in_gibs": 37.2891,
+          "out_gibs": 37.2891
+        },
+        "h2d": {
+          "avg_ms": 0.013856,
+          "best_ms": 0.013856,
+          "in_gibs": 4.40496,
+          "out_gibs": 4.40496
+        },
+        "scatter": {
+          "avg_ms": 0.0115949,
+          "best_ms": 0.010016,
+          "in_gibs": 5.26396,
+          "out_gibs": 5.26396
+        },
+        "compress": {
+          "avg_ms": 1.37307,
+          "best_ms": 1.13376,
+          "in_gibs": 5.6898,
+          "out_gibs": 0.36577
+        },
+        "aggregate": {
+          "avg_ms": 0.026264,
+          "best_ms": 0.020704,
+          "in_gibs": 19.1223,
+          "out_gibs": 19.1223
+        },
+        "d2h": {
+          "avg_ms": 0.581352,
+          "best_ms": 0.015584,
+          "in_gibs": 0.863898,
+          "out_gibs": 0.863898
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.068603,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 1.12194,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.78604,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.38,
+      "status": "pass",
+      "throughput_in_gibs": 0.693588,
+      "throughput_out_gibs": 0.0851325,
+      "compression_fold": 8.14716,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00383569,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0450555,
+      "init_s": 0.0463946,
+      "flush_s": 5.5e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000517483,
+          "best_ms": 0.00029,
+          "in_gibs": 29.4866,
+          "out_gibs": 29.4866
+        },
+        "h2d": {
+          "avg_ms": 0.014496,
+          "best_ms": 0.014496,
+          "in_gibs": 1.05262,
+          "out_gibs": 1.05262
+        },
+        "scatter": {
+          "avg_ms": 0.0115606,
+          "best_ms": 0.010016,
+          "in_gibs": 1.3199,
+          "out_gibs": 1.3199
+        },
+        "compress": {
+          "avg_ms": 2.08301,
+          "best_ms": 2.00874,
+          "in_gibs": 0.937645,
+          "out_gibs": 0.114172
+        },
+        "aggregate": {
+          "avg_ms": 0.022876,
+          "best_ms": 0.01536,
+          "in_gibs": 10.3962,
+          "out_gibs": 10.3962
+        },
+        "d2h": {
+          "avg_ms": 0.105084,
+          "best_ms": 0.010336,
+          "in_gibs": 2.26317,
+          "out_gibs": 2.26317
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 8.78246,
+        "flush_stall_count": 15,
+        "kick_sync_ms": 10.4984,
+        "kick_sync_count": 16,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 35.336,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.3,
+      "status": "pass",
+      "throughput_in_gibs": 0.71053,
+      "throughput_out_gibs": 0.0840462,
+      "compression_fold": 8.45404,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00369646,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0439812,
+      "init_s": 0.0460873,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000969019,
+          "best_ms": 0.000611,
+          "in_gibs": 31.4933,
+          "out_gibs": 31.4933
+        },
+        "scatter": {
+          "avg_ms": 0.0114225,
+          "best_ms": 0.010016,
+          "in_gibs": 2.6717,
+          "out_gibs": 2.6717
+        },
+        "compress": {
+          "avg_ms": 4.03908,
+          "best_ms": 3.92877,
+          "in_gibs": 0.967115,
+          "out_gibs": 0.113924
+        },
+        "aggregate": {
+          "avg_ms": 0.035308,
+          "best_ms": 0.026592,
+          "in_gibs": 13.0324,
+          "out_gibs": 13.0324
+        },
+        "d2h": {
+          "avg_ms": 0.213776,
+          "best_ms": 0.014752,
+          "in_gibs": 2.15248,
+          "out_gibs": 2.15248
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.2168,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 18.9256,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 32.1669,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.34,
+      "status": "pass",
+      "throughput_in_gibs": 0.711631,
+      "throughput_out_gibs": 0.0825259,
+      "compression_fold": 8.62312,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00362398,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0439132,
+      "init_s": 0.0478129,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00163618,
+          "best_ms": 0.001252,
+          "in_gibs": 37.3034,
+          "out_gibs": 37.3034
+        },
+        "h2d": {
+          "avg_ms": 0.0115093,
+          "best_ms": 0.010336,
+          "in_gibs": 5.3031,
+          "out_gibs": 5.3031
+        },
+        "scatter": {
+          "avg_ms": 0.0116234,
+          "best_ms": 0.010016,
+          "in_gibs": 5.25107,
+          "out_gibs": 5.25107
+        },
+        "compress": {
+          "avg_ms": 7.89094,
+          "best_ms": 7.81101,
+          "in_gibs": 0.990059,
+          "out_gibs": 0.114572
+        },
+        "aggregate": {
+          "avg_ms": 0.04504,
+          "best_ms": 0.030688,
+          "in_gibs": 20.0729,
+          "out_gibs": 20.0729
+        },
+        "d2h": {
+          "avg_ms": 0.434616,
+          "best_ms": 0.023776,
+          "in_gibs": 2.08019,
+          "out_gibs": 2.08019
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.4365,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 20.104,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 27.5839,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.3,
+      "status": "pass",
+      "throughput_in_gibs": 0.716265,
+      "throughput_out_gibs": 0.0830633,
+      "compression_fold": 8.62312,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00362398,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0436291,
+      "init_s": 0.0476809,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00176676,
+          "best_ms": 0.001272,
+          "in_gibs": 34.5463,
+          "out_gibs": 34.5463
+        },
+        "h2d": {
+          "avg_ms": 0.0108053,
+          "best_ms": 0.010528,
+          "in_gibs": 5.64861,
+          "out_gibs": 5.64861
+        },
+        "scatter": {
+          "avg_ms": 0.0117745,
+          "best_ms": 0.010016,
+          "in_gibs": 5.18367,
+          "out_gibs": 5.18367
+        },
+        "compress": {
+          "avg_ms": 7.89357,
+          "best_ms": 7.81379,
+          "in_gibs": 0.98973,
+          "out_gibs": 0.114534
+        },
+        "aggregate": {
+          "avg_ms": 0.034288,
+          "best_ms": 0.030688,
+          "in_gibs": 26.3673,
+          "out_gibs": 26.3673
+        },
+        "d2h": {
+          "avg_ms": 0.469752,
+          "best_ms": 0.023424,
+          "in_gibs": 1.9246,
+          "out_gibs": 1.9246
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.4702,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 20.1699,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 27.6898,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.31,
+      "status": "pass",
+      "throughput_in_gibs": 0.717476,
+      "throughput_out_gibs": 0.0832037,
+      "compression_fold": 8.62312,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00362398,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0435555,
+      "init_s": 0.048391,
+      "flush_s": 5.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00177966,
+          "best_ms": 0.001362,
+          "in_gibs": 34.296,
+          "out_gibs": 34.296
+        },
+        "h2d": {
+          "avg_ms": 0.0109973,
+          "best_ms": 0.01056,
+          "in_gibs": 5.55,
+          "out_gibs": 5.55
+        },
+        "scatter": {
+          "avg_ms": 0.0116669,
+          "best_ms": 0.010016,
+          "in_gibs": 5.2315,
+          "out_gibs": 5.2315
+        },
+        "compress": {
+          "avg_ms": 7.97162,
+          "best_ms": 7.94694,
+          "in_gibs": 0.980039,
+          "out_gibs": 0.113413
+        },
+        "aggregate": {
+          "avg_ms": 0.0458,
+          "best_ms": 0.030688,
+          "in_gibs": 19.7398,
+          "out_gibs": 19.7398
+        },
+        "d2h": {
+          "avg_ms": 0.438848,
+          "best_ms": 0.02384,
+          "in_gibs": 2.06013,
+          "out_gibs": 2.06013
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.7196,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 20.5208,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 27.8278,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.31,
+      "status": "pass",
+      "throughput_in_gibs": 0.720607,
+      "throughput_out_gibs": 0.0835668,
+      "compression_fold": 8.62312,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00362398,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0433662,
+      "init_s": 0.0484429,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00163729,
+          "best_ms": 0.001262,
+          "in_gibs": 37.2782,
+          "out_gibs": 37.2782
+        },
+        "h2d": {
+          "avg_ms": 0.0108288,
+          "best_ms": 0.010176,
+          "in_gibs": 5.63637,
+          "out_gibs": 5.63637
+        },
+        "scatter": {
+          "avg_ms": 0.0117008,
+          "best_ms": 0.010016,
+          "in_gibs": 5.21634,
+          "out_gibs": 5.21634
+        },
+        "compress": {
+          "avg_ms": 7.9257,
+          "best_ms": 7.82816,
+          "in_gibs": 0.985718,
+          "out_gibs": 0.11407
+        },
+        "aggregate": {
+          "avg_ms": 0.045296,
+          "best_ms": 0.030688,
+          "in_gibs": 19.9595,
+          "out_gibs": 19.9595
+        },
+        "d2h": {
+          "avg_ms": 0.434304,
+          "best_ms": 0.023456,
+          "in_gibs": 2.08168,
+          "out_gibs": 2.08168
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.6056,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 20.2942,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 27.7444,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.33,
+      "status": "pass",
+      "throughput_in_gibs": 0.721156,
+      "throughput_out_gibs": 0.0836305,
+      "compression_fold": 8.62312,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00362398,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0433332,
+      "init_s": 0.0482442,
+      "flush_s": 5.5e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0016577,
+          "best_ms": 0.001282,
+          "in_gibs": 36.8193,
+          "out_gibs": 36.8193
+        },
+        "h2d": {
+          "avg_ms": 0.011168,
+          "best_ms": 0.010688,
+          "in_gibs": 5.46518,
+          "out_gibs": 5.46518
+        },
+        "scatter": {
+          "avg_ms": 0.011708,
+          "best_ms": 0.010016,
+          "in_gibs": 5.21312,
+          "out_gibs": 5.21312
+        },
+        "compress": {
+          "avg_ms": 7.86643,
+          "best_ms": 7.84454,
+          "in_gibs": 0.993144,
+          "out_gibs": 0.114929
+        },
+        "aggregate": {
+          "avg_ms": 0.034288,
+          "best_ms": 0.030688,
+          "in_gibs": 26.3673,
+          "out_gibs": 26.3673
+        },
+        "d2h": {
+          "avg_ms": 0.42912,
+          "best_ms": 0.023552,
+          "in_gibs": 2.10683,
+          "out_gibs": 2.10683
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.2227,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 19.9339,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 27.432,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.34,
+      "status": "pass",
+      "throughput_in_gibs": 0.716326,
+      "throughput_out_gibs": 0.0830703,
+      "compression_fold": 8.62312,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00362398,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0436254,
+      "init_s": 0.0479093,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00167325,
+          "best_ms": 0.001262,
+          "in_gibs": 36.477,
+          "out_gibs": 36.477
+        },
+        "h2d": {
+          "avg_ms": 0.0117504,
+          "best_ms": 0.01104,
+          "in_gibs": 5.1943,
+          "out_gibs": 5.1943
+        },
+        "scatter": {
+          "avg_ms": 0.0116401,
+          "best_ms": 0.010016,
+          "in_gibs": 5.24351,
+          "out_gibs": 5.24351
+        },
+        "compress": {
+          "avg_ms": 7.90554,
+          "best_ms": 7.81789,
+          "in_gibs": 0.988232,
+          "out_gibs": 0.114361
+        },
+        "aggregate": {
+          "avg_ms": 0.03328,
+          "best_ms": 0.03072,
+          "in_gibs": 27.166,
+          "out_gibs": 27.166
+        },
+        "d2h": {
+          "avg_ms": 0.432368,
+          "best_ms": 0.023424,
+          "in_gibs": 2.091,
+          "out_gibs": 2.091
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.5363,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 20.2056,
+        "kick_sync_count": 4,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 27.5993,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.44,
+      "status": "pass",
+      "throughput_in_gibs": 6.9445,
+      "throughput_out_gibs": 6.95264,
+      "compression_fold": 0.998829,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51975,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.506246,
+      "init_s": 0.00053342,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.12813,
+          "best_ms": 0.601884,
+          "in_gibs": 22.0264,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.39336,
+          "best_ms": 1.92618,
+          "in_gibs": 58.7563,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.15931,
+          "best_ms": 1.82804,
+          "in_gibs": 65.1251,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.45,
+      "status": "pass",
+      "throughput_in_gibs": 6.64707,
+      "throughput_out_gibs": 6.65103,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.528898,
+      "init_s": 0.000263034,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.22818,
+          "best_ms": 0.509024,
+          "in_gibs": 21.0374,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.6977,
+          "best_ms": 2.19926,
+          "in_gibs": 52.1278,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.43028,
+          "best_ms": 1.97294,
+          "in_gibs": 57.8638,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.46,
+      "status": "pass",
+      "throughput_in_gibs": 6.11497,
+      "throughput_out_gibs": 6.11676,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51666,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.574921,
+      "init_s": 0.00018,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.52804,
+          "best_ms": 0.538858,
+          "in_gibs": 18.542,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.18951,
+          "best_ms": 2.19384,
+          "in_gibs": 44.0899,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.15711,
+          "best_ms": 1.80141,
+          "in_gibs": 44.5424,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.24,
+      "status": "pass",
+      "throughput_in_gibs": 6.27718,
+      "throughput_out_gibs": 6.27819,
+      "compression_fold": 0.99984,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51619,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.560064,
+      "init_s": 0.000165568,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.40604,
+          "best_ms": 0.502024,
+          "in_gibs": 19.4822,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.9537,
+          "best_ms": 2.40008,
+          "in_gibs": 45.4226,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.75263,
+          "best_ms": 2.24354,
+          "in_gibs": 47.0103,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.29,
+      "status": "pass",
+      "throughput_in_gibs": 6.00898,
+      "throughput_out_gibs": 6.00947,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.585062,
+      "init_s": 0.000162214,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.70411,
+          "best_ms": 0.503446,
+          "in_gibs": 17.3347,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.4259,
+          "best_ms": 7.7595,
+          "in_gibs": 43.9557,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.0699,
+          "best_ms": 7.58366,
+          "in_gibs": 49.8748,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.37,
+      "status": "pass",
+      "throughput_in_gibs": 6.51531,
+      "throughput_out_gibs": 6.77619,
+      "compression_fold": 0.999961,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65639,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.539594,
+      "init_s": 0.000141082,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.58366,
+          "best_ms": 0.493891,
+          "in_gibs": 21.5987,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.4841,
+          "best_ms": 14.6896,
+          "in_gibs": 46.9134,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 18.5684,
+          "best_ms": 14.5571,
+          "in_gibs": 49.2267,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.43,
+      "status": "pass",
+      "throughput_in_gibs": 5.91426,
+      "throughput_out_gibs": 6.15094,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65631,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.594432,
+      "init_s": 0.000141933,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.30292,
+          "best_ms": 1.09692,
+          "in_gibs": 16.8952,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 39.0911,
+          "best_ms": 34.0423,
+          "in_gibs": 46.7657,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 40.2731,
+          "best_ms": 36.0626,
+          "in_gibs": 45.3932,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.62,
+      "status": "pass",
+      "throughput_in_gibs": 6.932,
+      "throughput_out_gibs": 7.20934,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.507159,
+      "init_s": 0.000133901,
+      "flush_s": 6.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.16879,
+          "best_ms": 0.581112,
+          "in_gibs": 25.7303,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 72.6241,
+          "best_ms": 72.6241,
+          "in_gibs": 50.3449,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 77.8101,
+          "best_ms": 77.8101,
+          "in_gibs": 46.9894,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.64,
+      "status": "pass",
+      "throughput_in_gibs": 4.72506,
+      "throughput_out_gibs": 0.275772,
+      "compression_fold": 17.134,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.205185,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.744038,
+      "init_s": 0.000450876,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.27852,
+          "best_ms": 0.602554,
+          "in_gibs": 14.2976,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.10765,
+          "best_ms": 7.41189,
+          "in_gibs": 15.4403,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.64802,
+          "best_ms": 0.184147,
+          "in_gibs": 4.88015,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.57,
+      "status": "pass",
+      "throughput_in_gibs": 4.89179,
+      "throughput_out_gibs": 0.229436,
+      "compression_fold": 21.3209,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.164891,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.718678,
+      "init_s": 0.000252899,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.22239,
+          "best_ms": 0.510907,
+          "in_gibs": 14.5467,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.37892,
+          "best_ms": 6.7379,
+          "in_gibs": 16.7832,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.62251,
+          "best_ms": 0.147131,
+          "in_gibs": 4.01351,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.33,
+      "status": "pass",
+      "throughput_in_gibs": 5.86053,
+      "throughput_out_gibs": 0.198715,
+      "compression_fold": 29.4922,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.119205,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.599882,
+      "init_s": 0.000177707,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.39878,
+          "best_ms": 0.622364,
+          "in_gibs": 19.5412,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.59559,
+          "best_ms": 7.36667,
+          "in_gibs": 18.514,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.328697,
+          "best_ms": 0.09984,
+          "in_gibs": 14.3811,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.34,
+      "status": "pass",
+      "throughput_in_gibs": 6.35415,
+      "throughput_out_gibs": 0.188336,
+      "compression_fold": 33.7384,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.104202,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.55328,
+      "init_s": 0.000149064,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.93079,
+          "best_ms": 0.550697,
+          "in_gibs": 24.2776,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.5991,
+          "best_ms": 11.6579,
+          "in_gibs": 19.8861,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.60101,
+          "best_ms": 0.14683,
+          "in_gibs": 13.2647,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.44,
+      "status": "pass",
+      "throughput_in_gibs": 4.72564,
+      "throughput_out_gibs": 0.116896,
+      "compression_fold": 40.4259,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0869647,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.743947,
+      "init_s": 0.000151047,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.19271,
+          "best_ms": 0.501372,
+          "in_gibs": 21.3776,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 49.657,
+          "best_ms": 28.228,
+          "in_gibs": 10.114,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.43516,
+          "best_ms": 0.231898,
+          "in_gibs": 8.62805,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.89,
+      "status": "pass",
+      "throughput_in_gibs": 3.86256,
+      "throughput_out_gibs": 0.0770181,
+      "compression_fold": 52.1574,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0701003,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.910181,
+      "init_s": 0.000155103,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.42736,
+          "best_ms": 0.559139,
+          "in_gibs": 22.9894,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 133.728,
+          "best_ms": 59.4867,
+          "in_gibs": 6.83522,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.418853,
+          "best_ms": 0.372809,
+          "in_gibs": 41.7551,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.56,
+      "status": "pass",
+      "throughput_in_gibs": 6.34682,
+      "throughput_out_gibs": 0.176222,
+      "compression_fold": 37.4567,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0976128,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.553919,
+      "init_s": 0.000141001,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.24856,
+          "best_ms": 0.485819,
+          "in_gibs": 24.8175,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 93.6462,
+          "best_ms": 70.904,
+          "in_gibs": 19.5216,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.953511,
+          "best_ms": 0.645459,
+          "in_gibs": 51.1521,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.59,
+      "status": "pass",
+      "throughput_in_gibs": 6.29021,
+      "throughput_out_gibs": 0.174321,
+      "compression_fold": 37.5275,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0974285,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.558904,
+      "init_s": 0.000125919,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.26389,
+          "best_ms": 1.10863,
+          "in_gibs": 24.6494,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 192.543,
+          "best_ms": 192.543,
+          "in_gibs": 18.9892,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.07295,
+          "best_ms": 2.07295,
+          "in_gibs": 46.9843,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.46,
+      "status": "pass",
+      "throughput_in_gibs": 4.31251,
+      "throughput_out_gibs": 0.412751,
+      "compression_fold": 10.4482,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.336481,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.815215,
+      "init_s": 0.000709645,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.7359,
+          "best_ms": 0.616926,
+          "in_gibs": 12.5472,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.52166,
+          "best_ms": 7.33719,
+          "in_gibs": 14.769,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.38411,
+          "best_ms": 0.281273,
+          "in_gibs": 5.57626,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.47,
+      "status": "pass",
+      "throughput_in_gibs": 5.85793,
+      "throughput_out_gibs": 0.603778,
+      "compression_fold": 9.70212,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.362356,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.600148,
+      "init_s": 0.00026609,
+      "flush_s": 2.734e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.33245,
+          "best_ms": 0.507291,
+          "in_gibs": 20.0969,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.6219,
+          "best_ms": 7.3185,
+          "in_gibs": 18.4501,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.504761,
+          "best_ms": 0.234492,
+          "in_gibs": 28.5492,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.22,
+      "status": "pass",
+      "throughput_in_gibs": 6.1855,
+      "throughput_out_gibs": 0.600145,
+      "compression_fold": 10.3067,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.341102,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.568365,
+      "init_s": 0.000162885,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.06706,
+          "best_ms": 0.614362,
+          "in_gibs": 22.6772,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.09789,
+          "best_ms": 6.82778,
+          "in_gibs": 19.8122,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.50391,
+          "best_ms": 0.211397,
+          "in_gibs": 26.9946,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.31,
+      "status": "pass",
+      "throughput_in_gibs": 5.38649,
+      "throughput_out_gibs": 0.560584,
+      "compression_fold": 9.60871,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.365879,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.652675,
+      "init_s": 0.000147431,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.76632,
+          "best_ms": 0.522505,
+          "in_gibs": 16.9449,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.4092,
+          "best_ms": 6.82141,
+          "in_gibs": 18.7681,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.99245,
+          "best_ms": 0.253099,
+          "in_gibs": 14.1038,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.43,
+      "status": "pass",
+      "throughput_in_gibs": 4.64508,
+      "throughput_out_gibs": 0.467959,
+      "compression_fold": 9.92626,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.354174,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.756849,
+      "init_s": 0.00013967,
+      "flush_s": 5.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.29223,
+          "best_ms": 0.497787,
+          "in_gibs": 20.4495,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 50.092,
+          "best_ms": 26.9038,
+          "in_gibs": 10.0262,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.68546,
+          "best_ms": 0.886931,
+          "in_gibs": 29.995,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.95,
+      "status": "pass",
+      "throughput_in_gibs": 3.58155,
+      "throughput_out_gibs": 0.362228,
+      "compression_fold": 10.2831,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.35556,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.981594,
+      "init_s": 0.000162825,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.77937,
+          "best_ms": 0.53305,
+          "in_gibs": 20.0777,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 143.717,
+          "best_ms": 53.7495,
+          "in_gibs": 6.36016,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.74251,
+          "best_ms": 1.4877,
+          "in_gibs": 32.3989,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.53,
+      "status": "pass",
+      "throughput_in_gibs": 6.477,
+      "throughput_out_gibs": 0.677494,
+      "compression_fold": 9.94265,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.367734,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.542786,
+      "init_s": 0.000282394,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.32001,
+          "best_ms": 0.483285,
+          "in_gibs": 24.0532,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 85.4727,
+          "best_ms": 63.706,
+          "in_gibs": 21.3884,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.86186,
+          "best_ms": 2.68728,
+          "in_gibs": 47.6027,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.58,
+      "status": "pass",
+      "throughput_in_gibs": 6.36918,
+      "throughput_out_gibs": 0.6075,
+      "compression_fold": 10.9036,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.335324,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.551975,
+      "init_s": 0.000147261,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.63289,
+          "best_ms": 0.593071,
+          "in_gibs": 21.1948,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 158.948,
+          "best_ms": 158.948,
+          "in_gibs": 23.0028,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.89022,
+          "best_ms": 6.89022,
+          "in_gibs": 48.662,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.36,
+      "status": "pass",
+      "throughput_in_gibs": 6.50044,
+      "throughput_out_gibs": 4.10489,
+      "compression_fold": 1.58358,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.22005,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.540829,
+      "init_s": 0.000462815,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.28758,
+          "best_ms": 0.603626,
+          "in_gibs": 20.4911,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.96585,
+          "best_ms": 3.28873,
+          "in_gibs": 35.4589,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.59764,
+          "best_ms": 1.4459,
+          "in_gibs": 55.48,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.46,
+      "status": "pass",
+      "throughput_in_gibs": 6.24831,
+      "throughput_out_gibs": 3.59246,
+      "compression_fold": 1.73928,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.02131,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.562652,
+      "init_s": 0.000289124,
+      "flush_s": 5.7e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.51117,
+          "best_ms": 0.518719,
+          "in_gibs": 18.6666,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.01781,
+          "best_ms": 2.93843,
+          "in_gibs": 35.0004,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.91353,
+          "best_ms": 1.23221,
+          "in_gibs": 42.2093,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.14,
+      "status": "pass",
+      "throughput_in_gibs": 7.34152,
+      "throughput_out_gibs": 4.19813,
+      "compression_fold": 1.74876,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.01035,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.478869,
+      "init_s": 0.00016657,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.86809,
+          "best_ms": 0.549394,
+          "in_gibs": 25.0925,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.14661,
+          "best_ms": 3.0025,
+          "in_gibs": 44.691,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.33585,
+          "best_ms": 1.20394,
+          "in_gibs": 60.1661,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.44,
+      "status": "pass",
+      "throughput_in_gibs": 6.998,
+      "throughput_out_gibs": 4.11627,
+      "compression_fold": 1.70008,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.06792,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.502376,
+      "init_s": 0.000175743,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.92013,
+          "best_ms": 0.541402,
+          "in_gibs": 24.4124,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.09775,
+          "best_ms": 3.37244,
+          "in_gibs": 38.1012,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.15119,
+          "best_ms": 1.47589,
+          "in_gibs": 50.4656,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.52,
+      "status": "pass",
+      "throughput_in_gibs": 5.55258,
+      "throughput_out_gibs": 3.28758,
+      "compression_fold": 1.68896,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.08153,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.633151,
+      "init_s": 0.000146119,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.69652,
+          "best_ms": 0.529986,
+          "in_gibs": 27.6302,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.7504,
+          "best_ms": 13.3607,
+          "in_gibs": 14.4526,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.80254,
+          "best_ms": 4.53766,
+          "in_gibs": 51.2398,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.79,
+      "status": "pass",
+      "throughput_in_gibs": 4.3494,
+      "throughput_out_gibs": 2.67796,
+      "compression_fold": 1.68911,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.1646,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.808301,
+      "init_s": 0.000139359,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.50445,
+          "best_ms": 0.494122,
+          "in_gibs": 22.2818,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 96.2803,
+          "best_ms": 23.9493,
+          "in_gibs": 9.49376,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.102,
+          "best_ms": 8.39446,
+          "in_gibs": 48.7401,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.47,
+      "status": "pass",
+      "throughput_in_gibs": 7.29776,
+      "throughput_out_gibs": 4.03722,
+      "compression_fold": 1.87993,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.94489,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.48174,
+      "init_s": 0.000127421,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.21489,
+          "best_ms": 0.477727,
+          "in_gibs": 25.1947,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 42.6792,
+          "best_ms": 28.1794,
+          "in_gibs": 42.8341,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 18.0454,
+          "best_ms": 12.6792,
+          "in_gibs": 53.8871,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.39,
+      "status": "pass",
+      "throughput_in_gibs": 6.5825,
+      "throughput_out_gibs": 3.50223,
+      "compression_fold": 1.95469,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.8705,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.534087,
+      "init_s": 0.000137466,
+      "flush_s": 6e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.84068,
+          "best_ms": 1.11477,
+          "in_gibs": 19.6444,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 93.9009,
+          "best_ms": 93.9009,
+          "in_gibs": 38.9373,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 38.4609,
+          "best_ms": 38.4609,
+          "in_gibs": 48.6329,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.39,
+      "status": "pass",
+      "throughput_in_gibs": 4.70638,
+      "throughput_out_gibs": 0.156608,
+      "compression_fold": 30.052,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.116985,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.746991,
+      "init_s": 0.000487262,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.53992,
+          "best_ms": 0.721143,
+          "in_gibs": 13.2418,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.35247,
+          "best_ms": 6.48882,
+          "in_gibs": 16.8363,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.69997,
+          "best_ms": 0.123525,
+          "in_gibs": 2.65568,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.41,
+      "status": "pass",
+      "throughput_in_gibs": 6.42704,
+      "throughput_out_gibs": 0.130978,
+      "compression_fold": 49.0695,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0716459,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.547005,
+      "init_s": 0.00027294,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.49589,
+          "best_ms": 0.51325,
+          "in_gibs": 18.7809,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.28492,
+          "best_ms": 3.40563,
+          "in_gibs": 32.8186,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.845066,
+          "best_ms": 0.078939,
+          "in_gibs": 3.29221,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.49,
+      "status": "pass",
+      "throughput_in_gibs": 5.8275,
+      "throughput_out_gibs": 0.101055,
+      "compression_fold": 57.6665,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0609648,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.603282,
+      "init_s": 0.000163416,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.94052,
+          "best_ms": 0.636385,
+          "in_gibs": 15.9411,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.69037,
+          "best_ms": 3.10442,
+          "in_gibs": 29.9817,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.80259,
+          "best_ms": 0.060291,
+          "in_gibs": 1.32997,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.14,
+      "status": "pass",
+      "throughput_in_gibs": 7.21543,
+      "throughput_out_gibs": 0.17225,
+      "compression_fold": 41.8892,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0839267,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.487237,
+      "init_s": 0.000144787,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.89937,
+          "best_ms": 0.528783,
+          "in_gibs": 24.6792,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.07755,
+          "best_ms": 4.51245,
+          "in_gibs": 29.7914,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.326165,
+          "best_ms": 0.081472,
+          "in_gibs": 19.6604,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.45,
+      "status": "pass",
+      "throughput_in_gibs": 6.82801,
+      "throughput_out_gibs": 0.101385,
+      "compression_fold": 67.3474,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0522013,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.514883,
+      "init_s": 0.000179059,
+      "flush_s": 2.304e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.16591,
+          "best_ms": 0.535994,
+          "in_gibs": 21.6422,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.5246,
+          "best_ms": 9.68916,
+          "in_gibs": 27.1117,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.173253,
+          "best_ms": 0.142905,
+          "in_gibs": 42.8069,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.46,
+      "status": "pass",
+      "throughput_in_gibs": 6.31794,
+      "throughput_out_gibs": 0.0970852,
+      "compression_fold": 67.6793,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0540232,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.556451,
+      "init_s": 0.000140981,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.18113,
+          "best_ms": 0.524337,
+          "in_gibs": 25.5847,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 47.1463,
+          "best_ms": 18.1019,
+          "in_gibs": 19.3878,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.11511,
+          "best_ms": 0.260491,
+          "in_gibs": 6.36846,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.45,
+      "status": "pass",
+      "throughput_in_gibs": 8.10416,
+      "throughput_out_gibs": 0.113378,
+      "compression_fold": 74.338,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0491842,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.433805,
+      "init_s": 0.000149214,
+      "flush_s": 6.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.43844,
+          "best_ms": 0.542774,
+          "in_gibs": 22.8849,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.4903,
+          "best_ms": 17.3084,
+          "in_gibs": 69.0111,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.04828,
+          "best_ms": 0.301162,
+          "in_gibs": 8.05693,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.24,
+      "status": "pass",
+      "throughput_in_gibs": 8.78223,
+      "throughput_out_gibs": 0.128458,
+      "compression_fold": 71.1014,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0514231,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.400311,
+      "init_s": 0.000126881,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.10291,
+          "best_ms": 0.581853,
+          "in_gibs": 26.5364,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.8529,
+          "best_ms": 43.8529,
+          "in_gibs": 83.3754,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.08369,
+          "best_ms": 1.08369,
+          "in_gibs": 47.422,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 11.79,
+      "status": "pass",
+      "throughput_in_gibs": 5.43118,
+      "throughput_out_gibs": 5.43648,
+      "compression_fold": 0.999024,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75366,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.690458,
+      "init_s": 0.000590997,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.25857,
+          "best_ms": 4.51725,
+          "in_gibs": 11.8854,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.67185,
+          "best_ms": 2.88501,
+          "in_gibs": 51.0642,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.19948,
+          "best_ms": 2.81469,
+          "in_gibs": 58.6033,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 12.22,
+      "status": "pass",
+      "throughput_in_gibs": 5.45388,
+      "throughput_out_gibs": 5.45654,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.687584,
+      "init_s": 0.000328804,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.15476,
+          "best_ms": 4.42549,
+          "in_gibs": 12.1247,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.6901,
+          "best_ms": 2.88606,
+          "in_gibs": 50.8117,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.28863,
+          "best_ms": 2.77282,
+          "in_gibs": 57.0147,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.46,
+      "status": "pass",
+      "throughput_in_gibs": 5.69309,
+      "throughput_out_gibs": 5.69448,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75092,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.658694,
+      "init_s": 0.000214512,
+      "flush_s": 2.744e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.91588,
+          "best_ms": 4.3367,
+          "in_gibs": 12.7139,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.34612,
+          "best_ms": 2.7824,
+          "in_gibs": 56.035,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.17788,
+          "best_ms": 2.74931,
+          "in_gibs": 59.0016,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 12.03,
+      "status": "pass",
+      "throughput_in_gibs": 5.56886,
+      "throughput_out_gibs": 5.56954,
+      "compression_fold": 0.999878,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75046,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.673388,
+      "init_s": 0.000197597,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.0708,
+          "best_ms": 4.35992,
+          "in_gibs": 12.3255,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.54612,
+          "best_ms": 6.19622,
+          "in_gibs": 57.2858,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.82663,
+          "best_ms": 5.95761,
+          "in_gibs": 54.9319,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.87,
+      "status": "pass",
+      "throughput_in_gibs": 5.31403,
+      "throughput_out_gibs": 5.31436,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.705679,
+      "init_s": 0.000215263,
+      "flush_s": 4.6e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.67576,
+          "best_ms": 4.70738,
+          "in_gibs": 11.0117,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.332,
+          "best_ms": 12.7192,
+          "in_gibs": 56.2554,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.0755,
+          "best_ms": 12.5709,
+          "in_gibs": 57.3593,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 11.88,
+      "status": "pass",
+      "throughput_in_gibs": 5.68633,
+      "throughput_out_gibs": 5.6865,
+      "compression_fold": 0.999969,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75011,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.659477,
+      "init_s": 0.000198458,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.84629,
+          "best_ms": 4.26213,
+          "in_gibs": 12.8965,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 22.9552,
+          "best_ms": 12.9928,
+          "in_gibs": 54.4538,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 22.5451,
+          "best_ms": 12.5656,
+          "in_gibs": 55.4443,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.17,
+      "status": "pass",
+      "throughput_in_gibs": 4.84047,
+      "throughput_out_gibs": 4.84054,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75006,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.774718,
+      "init_s": 0.000175463,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.56354,
+          "best_ms": 3.99617,
+          "in_gibs": 11.2338,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 51.5864,
+          "best_ms": 43.9909,
+          "in_gibs": 36.3468,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 51.0257,
+          "best_ms": 42.9405,
+          "in_gibs": 36.7462,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.28,
+      "status": "pass",
+      "throughput_in_gibs": 5.49155,
+      "throughput_out_gibs": 5.4916,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.682868,
+      "init_s": 0.000172198,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.05537,
+          "best_ms": 4.34901,
+          "in_gibs": 12.3631,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 73.4595,
+          "best_ms": 73.4595,
+          "in_gibs": 51.0485,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 73.1378,
+          "best_ms": 73.1378,
+          "in_gibs": 51.2731,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.26,
+      "status": "pass",
+      "throughput_in_gibs": 4.8603,
+      "throughput_out_gibs": 0.167955,
+      "compression_fold": 28.9382,
+      "input_gib": 3.75,
+      "compressed_gib": 0.129587,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.771558,
+      "init_s": 0.000587021,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.41223,
+          "best_ms": 4.6399,
+          "in_gibs": 11.5479,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.7181,
+          "best_ms": 9.18064,
+          "in_gibs": 19.2939,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.778117,
+          "best_ms": 0.175724,
+          "in_gibs": 8.0916,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 11.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.9345,
+      "throughput_out_gibs": 0.124278,
+      "compression_fold": 39.7053,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0944458,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.759955,
+      "init_s": 0.000327772,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.48407,
+          "best_ms": 4.54176,
+          "in_gibs": 11.3966,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.01378,
+          "best_ms": 8.36358,
+          "in_gibs": 20.8015,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.732121,
+          "best_ms": 0.122674,
+          "in_gibs": 6.32509,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.59,
+      "status": "pass",
+      "throughput_in_gibs": 5.20424,
+      "throughput_out_gibs": 0.102712,
+      "compression_fold": 50.6683,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0740108,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.720567,
+      "init_s": 0.000202314,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.25068,
+          "best_ms": 4.50911,
+          "in_gibs": 11.9032,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.36811,
+          "best_ms": 7.83792,
+          "in_gibs": 22.4065,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.3914,
+          "best_ms": 0.084316,
+          "in_gibs": 9.33763,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 11.55,
+      "status": "pass",
+      "throughput_in_gibs": 5.14694,
+      "throughput_out_gibs": 0.0686278,
+      "compression_fold": 74.9979,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0500014,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.728588,
+      "init_s": 0.000179079,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.46182,
+          "best_ms": 4.35833,
+          "in_gibs": 11.4431,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.8498,
+          "best_ms": 16.3815,
+          "in_gibs": 22.2555,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.127035,
+          "best_ms": 0.108072,
+          "in_gibs": 38.9999,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.87,
+      "status": "pass",
+      "throughput_in_gibs": 5.36613,
+      "throughput_out_gibs": 0.0523495,
+      "compression_fold": 102.506,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0365832,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.698827,
+      "init_s": 0.000170997,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.12367,
+          "best_ms": 4.3794,
+          "in_gibs": 12.1983,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.3936,
+          "best_ms": 32.0163,
+          "in_gibs": 23.1527,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.342877,
+          "best_ms": 0.136525,
+          "in_gibs": 21.2053,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.42,
+      "status": "pass",
+      "throughput_in_gibs": 5.60266,
+      "throughput_out_gibs": 0.0490552,
+      "compression_fold": 114.211,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0328338,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.669325,
+      "init_s": 0.00016651,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.34309,
+          "best_ms": 3.96311,
+          "in_gibs": 14.3907,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 56.6536,
+          "best_ms": 32.6635,
+          "in_gibs": 22.0639,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.15105,
+          "best_ms": 0.121593,
+          "in_gibs": 5.07024,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.78,
+      "status": "pass",
+      "throughput_in_gibs": 2.22441,
+      "throughput_out_gibs": 0.022341,
+      "compression_fold": 99.566,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0376635,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 1.68584,
+      "init_s": 0.000173921,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.14182,
+          "best_ms": 5.90652,
+          "in_gibs": 7.67642,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 472.887,
+          "best_ms": 155.859,
+          "in_gibs": 3.965,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.15375,
+          "best_ms": 0.565228,
+          "in_gibs": 4.52675,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 13.82,
+      "status": "pass",
+      "throughput_in_gibs": 3.83035,
+      "throughput_out_gibs": 0.0354402,
+      "compression_fold": 108.079,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0346968,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.979023,
+      "init_s": 0.000204016,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.76376,
+          "best_ms": 4.90001,
+          "in_gibs": 7.13164,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 204.955,
+          "best_ms": 204.955,
+          "in_gibs": 18.2967,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.04738,
+          "best_ms": 6.04738,
+          "in_gibs": 5.73113,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.84,
+      "status": "pass",
+      "throughput_in_gibs": 2.87428,
+      "throughput_out_gibs": 0.25582,
+      "compression_fold": 11.2356,
+      "input_gib": 3.75,
+      "compressed_gib": 0.333762,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 1.30467,
+      "init_s": 0.00071995,
+      "flush_s": 5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 9.9316,
+          "best_ms": 7.12423,
+          "in_gibs": 6.29304,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.4758,
+          "best_ms": 11.7938,
+          "in_gibs": 11.3803,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.53778,
+          "best_ms": 0.558979,
+          "in_gibs": 2.98043,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 13.46,
+      "status": "pass",
+      "throughput_in_gibs": 3.05944,
+      "throughput_out_gibs": 0.281303,
+      "compression_fold": 10.876,
+      "input_gib": 3.75,
+      "compressed_gib": 0.344796,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 1.22571,
+      "init_s": 0.000368093,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 9.04356,
+          "best_ms": 6.16387,
+          "in_gibs": 6.911,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.6796,
+          "best_ms": 12.7696,
+          "in_gibs": 11.9582,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.19159,
+          "best_ms": 5.01105,
+          "in_gibs": 2.7696,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.09,
+      "status": "pass",
+      "throughput_in_gibs": 3.09826,
+      "throughput_out_gibs": 0.277691,
+      "compression_fold": 11.1572,
+      "input_gib": 3.75,
+      "compressed_gib": 0.336106,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 1.21036,
+      "init_s": 0.000258868,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 9.37564,
+          "best_ms": 6.28548,
+          "in_gibs": 6.66621,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.3907,
+          "best_ms": 10.2082,
+          "in_gibs": 13.0292,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.61246,
+          "best_ms": 0.39962,
+          "in_gibs": 2.98613,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 12.73,
+      "status": "pass",
+      "throughput_in_gibs": 3.75256,
+      "throughput_out_gibs": 0.330241,
+      "compression_fold": 11.3631,
+      "input_gib": 3.75,
+      "compressed_gib": 0.330016,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.999317,
+      "init_s": 0.000197256,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.15888,
+          "best_ms": 4.95917,
+          "in_gibs": 7.66037,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 21.8769,
+          "best_ms": 18.4762,
+          "in_gibs": 17.1414,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.58668,
+          "best_ms": 0.788944,
+          "in_gibs": 7.1851,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.09,
+      "status": "pass",
+      "throughput_in_gibs": 3.5868,
+      "throughput_out_gibs": 0.312732,
+      "compression_fold": 11.4692,
+      "input_gib": 3.75,
+      "compressed_gib": 0.326962,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 1.0455,
+      "init_s": 0.000170426,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 9.08481,
+          "best_ms": 6.72733,
+          "in_gibs": 6.87962,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.0015,
+          "best_ms": 41.1844,
+          "in_gibs": 17.4413,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.43915,
+          "best_ms": 5.89557,
+          "in_gibs": 10.1483,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.49,
+      "status": "pass",
+      "throughput_in_gibs": 4.16745,
+      "throughput_out_gibs": 0.356417,
+      "compression_fold": 11.6926,
+      "input_gib": 3.75,
+      "compressed_gib": 0.320715,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.899831,
+      "init_s": 0.000240851,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 7.64667,
+          "best_ms": 4.771,
+          "in_gibs": 8.1735,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 60.2812,
+          "best_ms": 39.5755,
+          "in_gibs": 20.7361,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.16307,
+          "best_ms": 3.72056,
+          "in_gibs": 20.6983,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.25,
+      "status": "pass",
+      "throughput_in_gibs": 2.0938,
+      "throughput_out_gibs": 0.174752,
+      "compression_fold": 11.9815,
+      "input_gib": 3.75,
+      "compressed_gib": 0.312982,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 1.791,
+      "init_s": 0.000174342,
+      "flush_s": 7.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.82589,
+          "best_ms": 5.28964,
+          "in_gibs": 7.08144,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 503.716,
+          "best_ms": 145.905,
+          "in_gibs": 3.72234,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.31193,
+          "best_ms": 3.57572,
+          "in_gibs": 21.3982,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.81,
+      "status": "pass",
+      "throughput_in_gibs": 3.91408,
+      "throughput_out_gibs": 0.323145,
+      "compression_fold": 12.1125,
+      "input_gib": 3.75,
+      "compressed_gib": 0.309599,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.958081,
+      "init_s": 0.000200801,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.94182,
+          "best_ms": 6.78375,
+          "in_gibs": 6.98963,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 173.957,
+          "best_ms": 173.957,
+          "in_gibs": 21.5571,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.655,
+          "best_ms": 10.655,
+          "in_gibs": 29.053,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.77,
+      "status": "pass",
+      "throughput_in_gibs": 3.06652,
+      "throughput_out_gibs": 2.04948,
+      "compression_fold": 1.49624,
+      "input_gib": 3.75,
+      "compressed_gib": 2.50627,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 1.22289,
+      "init_s": 0.000595263,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 9.4394,
+          "best_ms": 5.4118,
+          "in_gibs": 6.62118,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.9774,
+          "best_ms": 5.47247,
+          "in_gibs": 15.6545,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.61276,
+          "best_ms": 2.60555,
+          "in_gibs": 16.437,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 13.57,
+      "status": "pass",
+      "throughput_in_gibs": 3.42171,
+      "throughput_out_gibs": 2.04643,
+      "compression_fold": 1.67204,
+      "input_gib": 3.75,
+      "compressed_gib": 2.24277,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 1.09594,
+      "init_s": 0.00035322,
+      "flush_s": 6.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.72133,
+          "best_ms": 5.83649,
+          "in_gibs": 7.16634,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.1564,
+          "best_ms": 6.23948,
+          "in_gibs": 18.4613,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.94128,
+          "best_ms": 2.2639,
+          "in_gibs": 18.8591,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.26,
+      "status": "pass",
+      "throughput_in_gibs": 3.25215,
+      "throughput_out_gibs": 2.04996,
+      "compression_fold": 1.58644,
+      "input_gib": 3.75,
+      "compressed_gib": 2.36378,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 1.15308,
+      "init_s": 0.000201953,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 9.20161,
+          "best_ms": 7.21363,
+          "in_gibs": 6.79229,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.0537,
+          "best_ms": 5.44898,
+          "in_gibs": 16.9627,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.16081,
+          "best_ms": 2.53906,
+          "in_gibs": 19.1766,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 13.07,
+      "status": "pass",
+      "throughput_in_gibs": 3.55212,
+      "throughput_out_gibs": 2.31773,
+      "compression_fold": 1.53259,
+      "input_gib": 3.75,
+      "compressed_gib": 2.44684,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 1.05571,
+      "init_s": 0.000237757,
+      "flush_s": 3.225e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 9.09997,
+          "best_ms": 6.67014,
+          "in_gibs": 6.86815,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.5557,
+          "best_ms": 13.1578,
+          "in_gibs": 22.6509,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.44092,
+          "best_ms": 5.24477,
+          "in_gibs": 25.9126,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.9,
+      "status": "pass",
+      "throughput_in_gibs": 5.56471,
+      "throughput_out_gibs": 3.63025,
+      "compression_fold": 1.53287,
+      "input_gib": 3.75,
+      "compressed_gib": 2.44639,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.67389,
+      "init_s": 0.000175774,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.94577,
+          "best_ms": 4.29915,
+          "in_gibs": 12.6371,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 20.3796,
+          "best_ms": 18.0285,
+          "in_gibs": 36.8015,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.14457,
+          "best_ms": 8.39038,
+          "in_gibs": 53.4997,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 11.65,
+      "status": "pass",
+      "throughput_in_gibs": 5.95763,
+      "throughput_out_gibs": 3.25758,
+      "compression_fold": 1.82885,
+      "input_gib": 3.75,
+      "compressed_gib": 2.05047,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.629445,
+      "init_s": 0.000175844,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.44839,
+          "best_ms": 3.97606,
+          "in_gibs": 14.05,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 30.258,
+          "best_ms": 17.4306,
+          "in_gibs": 41.3114,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.1403,
+          "best_ms": 7.11441,
+          "in_gibs": 48.3337,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.45,
+      "status": "pass",
+      "throughput_in_gibs": 2.55733,
+      "throughput_out_gibs": 1.44198,
+      "compression_fold": 1.77349,
+      "input_gib": 3.75,
+      "compressed_gib": 2.11448,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 1.46637,
+      "init_s": 0.000171257,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.24057,
+          "best_ms": 4.01134,
+          "in_gibs": 11.9262,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 429.204,
+          "best_ms": 84.6001,
+          "in_gibs": 4.36855,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 27.624,
+          "best_ms": 21.2803,
+          "in_gibs": 38.2714,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 11.92,
+      "status": "pass",
+      "throughput_in_gibs": 5.33254,
+      "throughput_out_gibs": 3.00674,
+      "compression_fold": 1.77353,
+      "input_gib": 3.75,
+      "compressed_gib": 2.11443,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.703229,
+      "init_s": 0.000175413,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.40544,
+          "best_ms": 4.34193,
+          "in_gibs": 11.5624,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 99.3787,
+          "best_ms": 99.3787,
+          "in_gibs": 37.7345,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 41.5389,
+          "best_ms": 41.5389,
+          "in_gibs": 50.9015,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.16,
+      "status": "pass",
+      "throughput_in_gibs": 4.84825,
+      "throughput_out_gibs": 0.156834,
+      "compression_fold": 30.9131,
+      "input_gib": 3.75,
+      "compressed_gib": 0.121308,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.773475,
+      "init_s": 0.000602474,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.60503,
+          "best_ms": 4.621,
+          "in_gibs": 11.1507,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.27952,
+          "best_ms": 8.45899,
+          "in_gibs": 20.2058,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.765216,
+          "best_ms": 0.161342,
+          "in_gibs": 7.68706,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 11.8,
+      "status": "pass",
+      "throughput_in_gibs": 4.91002,
+      "throughput_out_gibs": 0.110396,
+      "compression_fold": 44.4765,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0843141,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.763744,
+      "init_s": 0.000338849,
+      "flush_s": 3.255e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.7051,
+          "best_ms": 4.57599,
+          "in_gibs": 10.9551,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.51916,
+          "best_ms": 7.28214,
+          "in_gibs": 22.0092,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.07094,
+          "best_ms": 0.102103,
+          "in_gibs": 3.85097,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.71,
+      "status": "pass",
+      "throughput_in_gibs": 5.45355,
+      "throughput_out_gibs": 0.126992,
+      "compression_fold": 42.9439,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0873231,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.687625,
+      "init_s": 0.000197907,
+      "flush_s": 1.973e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.9919,
+          "best_ms": 4.36808,
+          "in_gibs": 12.5203,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.95318,
+          "best_ms": 6.26122,
+          "in_gibs": 26.9661,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.685383,
+          "best_ms": 0.091257,
+          "in_gibs": 6.30358,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 11.57,
+      "status": "pass",
+      "throughput_in_gibs": 5.53838,
+      "throughput_out_gibs": 0.124681,
+      "compression_fold": 44.4205,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0844204,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.677093,
+      "init_s": 0.000180611,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.09282,
+          "best_ms": 4.38574,
+          "in_gibs": 12.2722,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.7635,
+          "best_ms": 11.7828,
+          "in_gibs": 29.3806,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.20527,
+          "best_ms": 0.140952,
+          "in_gibs": 6.96627,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.76,
+      "status": "pass",
+      "throughput_in_gibs": 5.51486,
+      "throughput_out_gibs": 0.123478,
+      "compression_fold": 44.6627,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0839627,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.679981,
+      "init_s": 0.000229594,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.18698,
+          "best_ms": 4.36249,
+          "in_gibs": 12.0494,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.7434,
+          "best_ms": 23.4596,
+          "in_gibs": 29.1337,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.54655,
+          "best_ms": 0.265438,
+          "in_gibs": 6.57623,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 11.45,
+      "status": "pass",
+      "throughput_in_gibs": 6.25754,
+      "throughput_out_gibs": 0.0878084,
+      "compression_fold": 71.2635,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0526216,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.599277,
+      "init_s": 0.000165198,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.69861,
+          "best_ms": 3.95804,
+          "in_gibs": 13.3018,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.1214,
+          "best_ms": 17.2727,
+          "in_gibs": 44.4502,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.314792,
+          "best_ms": 0.165829,
+          "in_gibs": 55.5994,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.47,
+      "status": "pass",
+      "throughput_in_gibs": 3.82027,
+      "throughput_out_gibs": 0.0574359,
+      "compression_fold": 66.5137,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0563794,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.981605,
+      "init_s": 0.000175793,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.66626,
+          "best_ms": 4.00364,
+          "in_gibs": 13.394,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 234.51,
+          "best_ms": 57.4409,
+          "in_gibs": 7.99539,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.811648,
+          "best_ms": 0.709264,
+          "in_gibs": 34.696,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 11.75,
+      "status": "pass",
+      "throughput_in_gibs": 6.50168,
+      "throughput_out_gibs": 0.0976669,
+      "compression_fold": 66.57,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0563317,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.576774,
+      "init_s": 0.000174492,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.5066,
+          "best_ms": 4.33142,
+          "in_gibs": 13.8686,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 73.5229,
+          "best_ms": 73.5229,
+          "in_gibs": 51.0045,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.09649,
+          "best_ms": 1.09649,
+          "in_gibs": 51.3393,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 28.11,
+      "status": "pass",
+      "throughput_in_gibs": 7.06152,
+      "throughput_out_gibs": 7.06841,
+      "compression_fold": 0.999024,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93255,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.414881,
+      "init_s": 0.00106624,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.42397,
+          "best_ms": 0.394111,
+          "in_gibs": 23.6987,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.1117,
+          "best_ms": 9.74306,
+          "in_gibs": 57.9463,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.2553,
+          "best_ms": 9.8732,
+          "in_gibs": 57.135,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 27.62,
+      "status": "pass",
+      "throughput_in_gibs": 7.05659,
+      "throughput_out_gibs": 7.06004,
+      "compression_fold": 0.999512,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93112,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.41517,
+      "init_s": 0.000553821,
+      "flush_s": 6.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.31053,
+          "best_ms": 0.368223,
+          "in_gibs": 24.8622,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.2291,
+          "best_ms": 9.85482,
+          "in_gibs": 52.1802,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.1559,
+          "best_ms": 9.81373,
+          "in_gibs": 57.6941,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 27.72,
+      "status": "pass",
+      "throughput_in_gibs": 7.13542,
+      "throughput_out_gibs": 7.13716,
+      "compression_fold": 0.999756,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.9304,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.410584,
+      "init_s": 0.000337316,
+      "flush_s": 6.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.2937,
+          "best_ms": 0.350026,
+          "in_gibs": 25.0446,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.3149,
+          "best_ms": 9.97638,
+          "in_gibs": 51.7846,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.3926,
+          "best_ms": 9.76667,
+          "in_gibs": 56.3803,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 27.6,
+      "status": "pass",
+      "throughput_in_gibs": 7.47295,
+      "throughput_out_gibs": 7.47387,
+      "compression_fold": 0.999878,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93005,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.392039,
+      "init_s": 0.000196504,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.01044,
+          "best_ms": 0.351207,
+          "in_gibs": 28.5733,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.2412,
+          "best_ms": 9.86246,
+          "in_gibs": 57.214,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.1031,
+          "best_ms": 9.76727,
+          "in_gibs": 57.996,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 28.49,
+      "status": "pass",
+      "throughput_in_gibs": 7.39659,
+      "throughput_out_gibs": 7.39704,
+      "compression_fold": 0.999939,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92987,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.396086,
+      "init_s": 0.000176825,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.09132,
+          "best_ms": 0.384286,
+          "in_gibs": 27.4682,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.3388,
+          "best_ms": 9.8164,
+          "in_gibs": 56.6736,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.1766,
+          "best_ms": 9.77362,
+          "in_gibs": 57.5772,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 28.71,
+      "status": "pass",
+      "throughput_in_gibs": 5.16275,
+      "throughput_out_gibs": 5.16292,
+      "compression_fold": 0.999967,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92978,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.567467,
+      "init_s": 0.000125558,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.61567,
+          "best_ms": 2.22521,
+          "in_gibs": 12.4456,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 22.2854,
+          "best_ms": 14.2847,
+          "in_gibs": 43.8207,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 23.1879,
+          "best_ms": 14.9387,
+          "in_gibs": 42.1153,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 29.53,
+      "status": "pass",
+      "throughput_in_gibs": 4.57693,
+      "throughput_out_gibs": 4.577,
+      "compression_fold": 0.999985,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92973,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.640098,
+      "init_s": 0.000126851,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.96037,
+          "best_ms": 1.25229,
+          "in_gibs": 11.5808,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 46.4445,
+          "best_ms": 36.5809,
+          "in_gibs": 31.5397,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 46.5223,
+          "best_ms": 37.2139,
+          "in_gibs": 31.4869,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 30.92,
+      "status": "pass",
+      "throughput_in_gibs": 4.56543,
+      "throughput_out_gibs": 5.47856,
+      "compression_fold": 0.999992,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.51565,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.641711,
+      "init_s": 0.000144858,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.24646,
+          "best_ms": 2.5241,
+          "in_gibs": 11.3962,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 83.2887,
+          "best_ms": 83.2887,
+          "in_gibs": 42.2101,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 89.2133,
+          "best_ms": 89.2133,
+          "in_gibs": 39.4069,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 29.53,
+      "status": "pass",
+      "throughput_in_gibs": 3.96205,
+      "throughput_out_gibs": 0.393909,
+      "compression_fold": 10.0583,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.291271,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.739437,
+      "init_s": 0.00108878,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.37787,
+          "best_ms": 3.58323,
+          "in_gibs": 10.6817,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.7215,
+          "best_ms": 40.8083,
+          "in_gibs": 13.4016,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.70494,
+          "best_ms": 6.16538,
+          "in_gibs": 8.60289,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 29.79,
+      "status": "pass",
+      "throughput_in_gibs": 4.29255,
+      "throughput_out_gibs": 0.391552,
+      "compression_fold": 10.9629,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.267236,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.682506,
+      "init_s": 0.000571728,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.7647,
+          "best_ms": 2.1325,
+          "in_gibs": 12.0564,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 42.0387,
+          "best_ms": 40.7895,
+          "in_gibs": 13.9381,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.86846,
+          "best_ms": 3.11844,
+          "in_gibs": 9.05878,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 28.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.1162,
+      "throughput_out_gibs": 0.238705,
+      "compression_fold": 17.2439,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.169897,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.711745,
+      "init_s": 0.0003532,
+      "flush_s": 6.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.31423,
+          "best_ms": 2.96274,
+          "in_gibs": 10.8096,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 40.5781,
+          "best_ms": 38.0566,
+          "in_gibs": 14.4397,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.84391,
+          "best_ms": 4.99804,
+          "in_gibs": 5.79001,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 30.3,
+      "status": "pass",
+      "throughput_in_gibs": 6.09351,
+      "throughput_out_gibs": 0.370534,
+      "compression_fold": 16.4452,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.178149,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.480788,
+      "init_s": 0.000242134,
+      "flush_s": 2.985e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.25101,
+          "best_ms": 0.363966,
+          "in_gibs": 25.5195,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.5071,
+          "best_ms": 32.3127,
+          "in_gibs": 16.9802,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.69389,
+          "best_ms": 0.600752,
+          "in_gibs": 20.992,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 27.59,
+      "status": "pass",
+      "throughput_in_gibs": 6.53974,
+      "throughput_out_gibs": 0.286331,
+      "compression_fold": 22.8398,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.128271,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.447982,
+      "init_s": 0.000132208,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.93915,
+          "best_ms": 0.358127,
+          "in_gibs": 29.6237,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.3812,
+          "best_ms": 31.9771,
+          "in_gibs": 18.095,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.472621,
+          "best_ms": 0.445348,
+          "in_gibs": 54.205,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 28.2,
+      "status": "pass",
+      "throughput_in_gibs": 5.7046,
+      "throughput_out_gibs": 0.375504,
+      "compression_fold": 15.1919,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.192846,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.513566,
+      "init_s": 0.000130335,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.67075,
+          "best_ms": 0.894813,
+          "in_gibs": 21.5089,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 61.9229,
+          "best_ms": 36.3083,
+          "in_gibs": 15.7706,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.6606,
+          "best_ms": 0.668062,
+          "in_gibs": 24.1487,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.94,
+      "status": "pass",
+      "throughput_in_gibs": 2.23814,
+      "throughput_out_gibs": 0.130864,
+      "compression_fold": 17.1028,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.171299,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.30898,
+      "init_s": 0.000126811,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.84822,
+          "best_ms": 0.34645,
+          "in_gibs": 20.1687,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 485.271,
+          "best_ms": 146.083,
+          "in_gibs": 3.01861,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.2667,
+          "best_ms": 1.83686,
+          "in_gibs": 37.776,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 28.3,
+      "status": "pass",
+      "throughput_in_gibs": 5.87607,
+      "throughput_out_gibs": 0.330883,
+      "compression_fold": 21.3105,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.164972,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.49858,
+      "init_s": 0.000125418,
+      "flush_s": 8.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.59245,
+          "best_ms": 0.641072,
+          "in_gibs": 23.063,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 184.161,
+          "best_ms": 184.161,
+          "in_gibs": 19.0899,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.39243,
+          "best_ms": 3.39243,
+          "in_gibs": 48.6214,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 28.48,
+      "status": "pass",
+      "throughput_in_gibs": 5.26184,
+      "throughput_out_gibs": 0.550682,
+      "compression_fold": 9.55515,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.306608,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.55678,
+      "init_s": 0.00111807,
+      "flush_s": 7.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.15932,
+          "best_ms": 1.06357,
+          "in_gibs": 18.1827,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 35.2216,
+          "best_ms": 31.7511,
+          "in_gibs": 16.6358,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.14214,
+          "best_ms": 1.12116,
+          "in_gibs": 19.3338,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 28.09,
+      "status": "pass",
+      "throughput_in_gibs": 5.56791,
+      "throughput_out_gibs": 0.630973,
+      "compression_fold": 8.82433,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.332001,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.526174,
+      "init_s": 0.000555283,
+      "flush_s": 2.293e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.83399,
+          "best_ms": 0.348653,
+          "in_gibs": 20.27,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 33.5804,
+          "best_ms": 31.0412,
+          "in_gibs": 17.4488,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.50996,
+          "best_ms": 1.10347,
+          "in_gibs": 18.8361,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 27.63,
+      "status": "pass",
+      "throughput_in_gibs": 5.93722,
+      "throughput_out_gibs": 0.632088,
+      "compression_fold": 9.39303,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.3119,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.493444,
+      "init_s": 0.000350837,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.51553,
+          "best_ms": 0.358167,
+          "in_gibs": 22.8361,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 31.842,
+          "best_ms": 28.7907,
+          "in_gibs": 18.4014,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.1086,
+          "best_ms": 1.02332,
+          "in_gibs": 20.0209,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 28.24,
+      "status": "pass",
+      "throughput_in_gibs": 5.71087,
+      "throughput_out_gibs": 0.64599,
+      "compression_fold": 8.8405,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.331394,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.513002,
+      "init_s": 0.000201663,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.95157,
+          "best_ms": 0.348063,
+          "in_gibs": 19.4625,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 30.8709,
+          "best_ms": 28.3817,
+          "in_gibs": 18.9803,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.86971,
+          "best_ms": 1.06776,
+          "in_gibs": 23.0711,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 27.64,
+      "status": "pass",
+      "throughput_in_gibs": 5.77913,
+      "throughput_out_gibs": 0.62571,
+      "compression_fold": 9.23613,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.317199,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.506942,
+      "init_s": 0.000142053,
+      "flush_s": 6.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.9968,
+          "best_ms": 0.354492,
+          "in_gibs": 19.1687,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.6569,
+          "best_ms": 28.295,
+          "in_gibs": 19.7572,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.64424,
+          "best_ms": 0.999159,
+          "in_gibs": 23.9781,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 28.05,
+      "status": "pass",
+      "throughput_in_gibs": 6.53876,
+      "throughput_out_gibs": 0.765122,
+      "compression_fold": 8.54603,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.342813,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.448049,
+      "init_s": 0.000125227,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.97762,
+          "best_ms": 0.281302,
+          "in_gibs": 29.0474,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 50.5282,
+          "best_ms": 29.2076,
+          "in_gibs": 19.3271,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.2298,
+          "best_ms": 1.15017,
+          "in_gibs": 27.0081,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 30.2,
+      "status": "pass",
+      "throughput_in_gibs": 1.92167,
+      "throughput_out_gibs": 0.221138,
+      "compression_fold": 8.6899,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.337137,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.52455,
+      "init_s": 0.000138528,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.3166,
+          "best_ms": 2.88029,
+          "in_gibs": 10.8048,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 523.337,
+          "best_ms": 134.758,
+          "in_gibs": 2.79905,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.05106,
+          "best_ms": 3.82502,
+          "in_gibs": 23.9037,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 30.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.644,
+      "throughput_out_gibs": 0.531089,
+      "compression_fold": 10.4932,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.33504,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.630854,
+      "init_s": 0.000156415,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.09648,
+          "best_ms": 2.83487,
+          "in_gibs": 11.7315,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 171.706,
+          "best_ms": 171.706,
+          "in_gibs": 20.4747,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.7708,
+          "best_ms": 11.7708,
+          "in_gibs": 28.4613,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 29.72,
+      "status": "pass",
+      "throughput_in_gibs": 4.50494,
+      "throughput_out_gibs": 2.72082,
+      "compression_fold": 1.65573,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.76942,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.650328,
+      "init_s": 0.0010763,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.86895,
+          "best_ms": 1.199,
+          "in_gibs": 11.7982,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.5976,
+          "best_ms": 17.7469,
+          "in_gibs": 22.0297,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.5857,
+          "best_ms": 8.75409,
+          "in_gibs": 30.4957,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 31.02,
+      "status": "pass",
+      "throughput_in_gibs": 4.78263,
+      "throughput_out_gibs": 3.07402,
+      "compression_fold": 1.55582,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.88305,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.612569,
+      "init_s": 0.000556635,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.66271,
+          "best_ms": 1.01736,
+          "in_gibs": 12.32,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.1525,
+          "best_ms": 17.4662,
+          "in_gibs": 24.26,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.7121,
+          "best_ms": 8.48409,
+          "in_gibs": 32.131,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 29.57,
+      "status": "pass",
+      "throughput_in_gibs": 4.64471,
+      "throughput_out_gibs": 2.85712,
+      "compression_fold": 1.62566,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.80215,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.630758,
+      "init_s": 0.000350996,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.11597,
+          "best_ms": 2.94158,
+          "in_gibs": 11.2285,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 21.2098,
+          "best_ms": 16.01,
+          "in_gibs": 27.6257,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.4227,
+          "best_ms": 12.0503,
+          "in_gibs": 29.0023,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 29.21,
+      "status": "pass",
+      "throughput_in_gibs": 5.37926,
+      "throughput_out_gibs": 2.85649,
+      "compression_fold": 1.88317,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.55572,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.544627,
+      "init_s": 0.000238748,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.22141,
+          "best_ms": 1.34439,
+          "in_gibs": 13.608,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.3301,
+          "best_ms": 16.9945,
+          "in_gibs": 31.9658,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.77178,
+          "best_ms": 9.06043,
+          "in_gibs": 31.8337,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 29.16,
+      "status": "pass",
+      "throughput_in_gibs": 7.53989,
+      "throughput_out_gibs": 4.0029,
+      "compression_fold": 1.8836,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.55536,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.388558,
+      "init_s": 0.00013331,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.17758,
+          "best_ms": 0.357236,
+          "in_gibs": 26.3802,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.0486,
+          "best_ms": 11.6943,
+          "in_gibs": 44.9043,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.35317,
+          "best_ms": 5.17515,
+          "in_gibs": 58.1032,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 27.47,
+      "status": "pass",
+      "throughput_in_gibs": 6.73325,
+      "throughput_out_gibs": 3.7816,
+      "compression_fold": 1.78053,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.6454,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.435107,
+      "init_s": 0.000123966,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.76915,
+          "best_ms": 0.900632,
+          "in_gibs": 20.7446,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.2808,
+          "best_ms": 12.667,
+          "in_gibs": 41.9471,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.3358,
+          "best_ms": 5.85037,
+          "in_gibs": 44.4588,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.34,
+      "status": "pass",
+      "throughput_in_gibs": 3.0789,
+      "throughput_out_gibs": 1.7291,
+      "compression_fold": 1.78063,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.64531,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.951539,
+      "init_s": 0.000125358,
+      "flush_s": 6.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.50614,
+          "best_ms": 0.658317,
+          "in_gibs": 22.9216,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 298.658,
+          "best_ms": 60.8579,
+          "in_gibs": 4.90475,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 21.3106,
+          "best_ms": 17.1133,
+          "in_gibs": 38.602,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 28.05,
+      "status": "pass",
+      "throughput_in_gibs": 6.47249,
+      "throughput_out_gibs": 3.64025,
+      "compression_fold": 2.13364,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.64771,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.452637,
+      "init_s": 0.000126089,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.18998,
+          "best_ms": 0.648974,
+          "in_gibs": 18.7429,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 79.1351,
+          "best_ms": 79.1351,
+          "in_gibs": 44.4256,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 33.9055,
+          "best_ms": 33.9055,
+          "in_gibs": 48.5964,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 27.68,
+      "status": "pass",
+      "throughput_in_gibs": 6.50338,
+      "throughput_out_gibs": 0.235485,
+      "compression_fold": 27.617,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.106083,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.450487,
+      "init_s": 0.00105,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.29889,
+          "best_ms": 0.412529,
+          "in_gibs": 24.9881,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.564,
+          "best_ms": 26.1815,
+          "in_gibs": 21.2573,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.52883,
+          "best_ms": 0.463125,
+          "in_gibs": 39.0377,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 28.1,
+      "status": "pass",
+      "throughput_in_gibs": 6.67207,
+      "throughput_out_gibs": 0.160552,
+      "compression_fold": 41.5572,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0704978,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.439097,
+      "init_s": 0.000565398,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.09093,
+          "best_ms": 0.345849,
+          "in_gibs": 18.585,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.8174,
+          "best_ms": 11.75,
+          "in_gibs": 42.4058,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.63269,
+          "best_ms": 0.303716,
+          "in_gibs": 5.24687,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 27.39,
+      "status": "pass",
+      "throughput_in_gibs": 7.56324,
+      "throughput_out_gibs": 0.139123,
+      "compression_fold": 54.3638,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0538904,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.387359,
+      "init_s": 0.000341843,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.37238,
+          "best_ms": 0.339139,
+          "in_gibs": 24.214,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.4399,
+          "best_ms": 11.1222,
+          "in_gibs": 43.5968,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.55094,
+          "best_ms": 0.222003,
+          "in_gibs": 4.16904,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 27.42,
+      "status": "pass",
+      "throughput_in_gibs": 8.32218,
+      "throughput_out_gibs": 0.113715,
+      "compression_fold": 73.1844,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0400316,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.352034,
+      "init_s": 0.000201392,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.15948,
+          "best_ms": 0.363575,
+          "in_gibs": 26.6012,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.86607,
+          "best_ms": 7.10327,
+          "in_gibs": 66.0876,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.51077,
+          "best_ms": 0.152218,
+          "in_gibs": 3.16028,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 28.0,
+      "status": "pass",
+      "throughput_in_gibs": 7.82643,
+      "throughput_out_gibs": 0.115239,
+      "compression_fold": 67.9147,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0431377,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.374332,
+      "init_s": 0.000159919,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.58431,
+          "best_ms": 0.343706,
+          "in_gibs": 22.2283,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.31384,
+          "best_ms": 7.30222,
+          "in_gibs": 62.9104,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.4378,
+          "best_ms": 0.14001,
+          "in_gibs": 3.52438,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 27.65,
+      "status": "pass",
+      "throughput_in_gibs": 7.96925,
+      "throughput_out_gibs": 0.186974,
+      "compression_fold": 42.6223,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0687361,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.367624,
+      "init_s": 0.000124747,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.57346,
+          "best_ms": 0.499409,
+          "in_gibs": 22.3221,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.4429,
+          "best_ms": 9.01339,
+          "in_gibs": 59.3911,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.41353,
+          "best_ms": 0.231838,
+          "in_gibs": 55.3287,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.49,
+      "status": "pass",
+      "throughput_in_gibs": 4.81771,
+      "throughput_out_gibs": 0.112876,
+      "compression_fold": 42.6815,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0686407,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.608108,
+      "init_s": 0.000118538,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.63881,
+          "best_ms": 0.347351,
+          "in_gibs": 21.7692,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 141.639,
+          "best_ms": 36.4403,
+          "in_gibs": 10.3421,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.951808,
+          "best_ms": 0.82004,
+          "in_gibs": 36.0344,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 30.14,
+      "status": "pass",
+      "throughput_in_gibs": 5.63566,
+      "throughput_out_gibs": 0.132229,
+      "compression_fold": 51.1446,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0687389,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.519848,
+      "init_s": 0.000143876,
+      "flush_s": 7.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.40401,
+          "best_ms": 3.40099,
+          "in_gibs": 11.0639,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 56.116,
+          "best_ms": 56.116,
+          "in_gibs": 62.6492,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.43136,
+          "best_ms": 2.43136,
+          "in_gibs": 28.2607,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.06,
+      "status": "pass",
+      "throughput_in_gibs": 0.569381,
+      "throughput_out_gibs": 0.569938,
+      "compression_fold": 0.999024,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312805,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0548841,
+      "init_s": 6.9164e-05,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0210253,
+          "best_ms": 0.00671,
+          "in_gibs": 0.725733,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.0859401,
+          "best_ms": 0.051457,
+          "in_gibs": 22.7266,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0691877,
+          "best_ms": 0.03326,
+          "in_gibs": 28.2294,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.06,
+      "status": "pass",
+      "throughput_in_gibs": 0.594239,
+      "throughput_out_gibs": 0.59453,
+      "compression_fold": 0.999511,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312653,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0525882,
+      "init_s": 6.0681e-05,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0383628,
+          "best_ms": 0.008162,
+          "in_gibs": 0.795498,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.318145,
+          "best_ms": 0.210075,
+          "in_gibs": 12.2782,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.264487,
+          "best_ms": 0.131146,
+          "in_gibs": 14.7692,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.21648,
+      "throughput_out_gibs": 1.21677,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.025689,
+      "init_s": 7.2449e-05,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0216309,
+          "best_ms": 0.009954,
+          "in_gibs": 2.82166,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.715298,
+          "best_ms": 0.20026,
+          "in_gibs": 10.922,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.686492,
+          "best_ms": 0.133971,
+          "in_gibs": 11.3803,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 1.24,
+      "status": "pass",
+      "throughput_in_gibs": 0.0253969,
+      "throughput_out_gibs": 0.0254031,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.23046,
+      "init_s": 6.1282e-05,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.3701,
+          "best_ms": 0.009735,
+          "in_gibs": 0.0257522,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 1.32455,
+          "best_ms": 0.249454,
+          "in_gibs": 5.89824,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.718333,
+          "best_ms": 0.187231,
+          "in_gibs": 10.8759,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.17,
+      "status": "pass",
+      "throughput_in_gibs": 0.189966,
+      "throughput_out_gibs": 0.190013,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.164503,
+      "init_s": 5.1447e-05,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.294387,
+          "best_ms": 0.010126,
+          "in_gibs": 0.20733,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.615491,
+          "best_ms": 0.223816,
+          "in_gibs": 12.6931,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.585561,
+          "best_ms": 0.141963,
+          "in_gibs": 13.3419,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.13,
+      "status": "pass",
+      "throughput_in_gibs": 0.258905,
+      "throughput_out_gibs": 0.258969,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.120701,
+      "init_s": 5.1067e-05,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.208525,
+          "best_ms": 0.010275,
+          "in_gibs": 0.2927,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.659727,
+          "best_ms": 0.200611,
+          "in_gibs": 11.842,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.623983,
+          "best_ms": 0.122424,
+          "in_gibs": 12.5204,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.47,
+      "status": "pass",
+      "throughput_in_gibs": 0.067513,
+      "throughput_out_gibs": 0.0675295,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.462874,
+      "init_s": 5.4151e-05,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.877916,
+          "best_ms": 0.010266,
+          "in_gibs": 0.0695228,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.622551,
+          "best_ms": 0.204887,
+          "in_gibs": 12.5492,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.591304,
+          "best_ms": 0.119669,
+          "in_gibs": 13.2123,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.67,
+      "status": "pass",
+      "throughput_in_gibs": 0.047297,
+      "throughput_out_gibs": 0.0473086,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.660718,
+      "init_s": 5.8758e-05,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.2603,
+          "best_ms": 0.010035,
+          "in_gibs": 0.0484289,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.815516,
+          "best_ms": 0.312138,
+          "in_gibs": 9.57983,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.883763,
+          "best_ms": 0.323515,
+          "in_gibs": 8.84004,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 1.54,
+      "status": "pass",
+      "throughput_in_gibs": 0.0203818,
+      "throughput_out_gibs": 0.000649382,
+      "compression_fold": 31.3865,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000995651,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.53323,
+      "init_s": 5.7015e-05,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.727131,
+          "best_ms": 0.007301,
+          "in_gibs": 0.0209849,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.2441,
+          "best_ms": 1.93971,
+          "in_gibs": 0.87034,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.00346969,
+          "best_ms": 0.001933,
+          "in_gibs": 17.3848,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 1.22,
+      "status": "pass",
+      "throughput_in_gibs": 0.0257226,
+      "throughput_out_gibs": 0.000460017,
+      "compression_fold": 55.9166,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000558868,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.21488,
+      "init_s": 5.7026e-05,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.16216,
+          "best_ms": 0.008472,
+          "in_gibs": 0.0262593,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.26969,
+          "best_ms": 1.93762,
+          "in_gibs": 1.72105,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.00645962,
+          "best_ms": 0.002584,
+          "in_gibs": 10.5191,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.1752,
+      "throughput_out_gibs": 0.0128041,
+      "compression_fold": 91.7831,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000340477,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0265913,
+      "init_s": 5.8648e-05,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0192602,
+          "best_ms": 0.009784,
+          "in_gibs": 3.16898,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.3122,
+          "best_ms": 2.22712,
+          "in_gibs": 3.37882,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.00861275,
+          "best_ms": 0.004847,
+          "in_gibs": 9.66104,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.1,
+      "status": "pass",
+      "throughput_in_gibs": 0.309049,
+      "throughput_out_gibs": 0.00336717,
+      "compression_fold": 91.7831,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000340477,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.101117,
+      "init_s": 5.7386e-05,
+      "flush_s": 1.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.160067,
+          "best_ms": 0.010286,
+          "in_gibs": 0.381309,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.8245,
+          "best_ms": 2.47828,
+          "in_gibs": 2.76598,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.00835725,
+          "best_ms": 0.003095,
+          "in_gibs": 9.9564,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.19,
+      "status": "pass",
+      "throughput_in_gibs": 0.168303,
+      "throughput_out_gibs": 0.00183371,
+      "compression_fold": 91.7831,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000340477,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.185677,
+      "init_s": 7.6435e-05,
+      "flush_s": 1.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.3281,
+          "best_ms": 0.010106,
+          "in_gibs": 0.186026,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.38757,
+          "best_ms": 2.22409,
+          "in_gibs": 3.27215,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.010573,
+          "best_ms": 0.003545,
+          "in_gibs": 7.86987,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.51,
+      "status": "pass",
+      "throughput_in_gibs": 0.0612053,
+      "throughput_out_gibs": 0.000666847,
+      "compression_fold": 91.7831,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000340477,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.510577,
+      "init_s": 7.2449e-05,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.954889,
+          "best_ms": 0.009674,
+          "in_gibs": 0.0639186,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.16178,
+          "best_ms": 2.53423,
+          "in_gibs": 2.47092,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.015596,
+          "best_ms": 0.005589,
+          "in_gibs": 5.33522,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.83,
+      "status": "pass",
+      "throughput_in_gibs": 0.0375841,
+      "throughput_out_gibs": 0.000409488,
+      "compression_fold": 91.7831,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000340477,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.831469,
+      "init_s": 7.1177e-05,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.5842,
+          "best_ms": 0.010265,
+          "in_gibs": 0.0385275,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.58383,
+          "best_ms": 2.40144,
+          "in_gibs": 3.02362,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0133302,
+          "best_ms": 0.008012,
+          "in_gibs": 6.24205,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.67,
+      "status": "pass",
+      "throughput_in_gibs": 0.047228,
+      "throughput_out_gibs": 0.000514561,
+      "compression_fold": 91.7831,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000340477,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.661683,
+      "init_s": 6.1923e-05,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.25639,
+          "best_ms": 0.009714,
+          "in_gibs": 0.0485799,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.46482,
+          "best_ms": 2.39543,
+          "in_gibs": 3.1696,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0088085,
+          "best_ms": 0.004417,
+          "in_gibs": 9.44634,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.81,
+      "status": "pass",
+      "throughput_in_gibs": 0.0388123,
+      "throughput_out_gibs": 0.00344679,
+      "compression_fold": 11.2604,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00277521,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.805157,
+      "init_s": 5.8388e-05,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.361916,
+          "best_ms": 0.00671,
+          "in_gibs": 0.0421612,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.40379,
+          "best_ms": 3.14465,
+          "in_gibs": 0.57381,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0107531,
+          "best_ms": 0.003956,
+          "in_gibs": 15.9528,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.61,
+      "status": "pass",
+      "throughput_in_gibs": 0.0086754,
+      "throughput_out_gibs": 0.000743958,
+      "compression_fold": 11.6611,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00267984,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 3.60214,
+      "init_s": 5.5914e-05,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.46149,
+          "best_ms": 0.007521,
+          "in_gibs": 0.00881632,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.19373,
+          "best_ms": 5.39803,
+          "in_gibs": 0.630678,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0360854,
+          "best_ms": 0.020791,
+          "in_gibs": 9.23008,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.9,
+      "status": "pass",
+      "throughput_in_gibs": 0.0346783,
+      "throughput_out_gibs": 0.00291192,
+      "compression_fold": 11.9091,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00262405,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.901141,
+      "init_s": 5.8698e-05,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.655,
+          "best_ms": 0.009655,
+          "in_gibs": 0.0368792,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.0796,
+          "best_ms": 10.5209,
+          "in_gibs": 0.705127,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0824485,
+          "best_ms": 0.042924,
+          "in_gibs": 7.93345,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.07,
+      "status": "pass",
+      "throughput_in_gibs": 0.0151509,
+      "throughput_out_gibs": 0.00127222,
+      "compression_fold": 11.9091,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00262405,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 2.06258,
+      "init_s": 5.8918e-05,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.9369,
+          "best_ms": 0.010105,
+          "in_gibs": 0.0155033,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.1662,
+          "best_ms": 9.66577,
+          "in_gibs": 0.768475,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0564122,
+          "best_ms": 0.025769,
+          "in_gibs": 11.595,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.36,
+      "status": "pass",
+      "throughput_in_gibs": 0.0132583,
+      "throughput_out_gibs": 0.0011133,
+      "compression_fold": 11.9091,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00262405,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 2.35701,
+      "init_s": 5.0536e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.49752,
+          "best_ms": 0.020841,
+          "in_gibs": 0.0135709,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.1783,
+          "best_ms": 10.2987,
+          "in_gibs": 0.698899,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0777268,
+          "best_ms": 0.047721,
+          "in_gibs": 8.4154,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 1.71,
+      "status": "pass",
+      "throughput_in_gibs": 0.0183712,
+      "throughput_out_gibs": 0.00154262,
+      "compression_fold": 11.9091,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00262405,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.70104,
+      "init_s": 7.4822e-05,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.21889,
+          "best_ms": 0.009975,
+          "in_gibs": 0.0189616,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.8224,
+          "best_ms": 10.2507,
+          "in_gibs": 0.721879,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0749972,
+          "best_ms": 0.03993,
+          "in_gibs": 8.72167,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 1.21,
+      "status": "pass",
+      "throughput_in_gibs": 0.0259075,
+      "throughput_out_gibs": 0.00217544,
+      "compression_fold": 11.9091,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00262405,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.20621,
+      "init_s": 6.2864e-05,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.24473,
+          "best_ms": 0.009664,
+          "in_gibs": 0.0271904,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.9757,
+          "best_ms": 11.0059,
+          "in_gibs": 0.652362,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0744745,
+          "best_ms": 0.031788,
+          "in_gibs": 8.78289,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 1.9,
+      "status": "pass",
+      "throughput_in_gibs": 0.0164675,
+      "throughput_out_gibs": 0.00138277,
+      "compression_fold": 11.9091,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00262405,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.89768,
+      "init_s": 6.8303e-05,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.60007,
+          "best_ms": 0.009945,
+          "in_gibs": 0.0169539,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.2886,
+          "best_ms": 10.9518,
+          "in_gibs": 0.69207,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0718025,
+          "best_ms": 0.042173,
+          "in_gibs": 9.10973,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.1,
+      "status": "pass",
+      "throughput_in_gibs": 0.328682,
+      "throughput_out_gibs": 0.21971,
+      "compression_fold": 1.49598,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0208893,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0950768,
+      "init_s": 6.1232e-05,
+      "flush_s": 1.392e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.026195,
+          "best_ms": 0.0068,
+          "in_gibs": 0.582507,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.03782,
+          "best_ms": 2.00861,
+          "in_gibs": 0.958436,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0473435,
+          "best_ms": 0.020921,
+          "in_gibs": 27.5365,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 4.1,
+      "status": "pass",
+      "throughput_in_gibs": 0.00762509,
+      "throughput_out_gibs": 0.00510868,
+      "compression_fold": 1.49257,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.020937,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 4.09831,
+      "init_s": 5.9699e-05,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.94918,
+          "best_ms": 0.007852,
+          "in_gibs": 0.00772758,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.48131,
+          "best_ms": 4.2396,
+          "in_gibs": 0.712649,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.159057,
+          "best_ms": 0.052689,
+          "in_gibs": 16.4419,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 1.14,
+      "status": "pass",
+      "throughput_in_gibs": 0.0276386,
+      "throughput_out_gibs": 0.0185385,
+      "compression_fold": 1.49088,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209608,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.13066,
+      "init_s": 5.5013e-05,
+      "flush_s": 2.163e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.10739,
+          "best_ms": 0.009574,
+          "in_gibs": 0.0289624,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.4271,
+          "best_ms": 9.70152,
+          "in_gibs": 0.749249,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.50325,
+          "best_ms": 0.196925,
+          "in_gibs": 10.4089,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 1.52,
+      "status": "pass",
+      "throughput_in_gibs": 0.0205748,
+      "throughput_out_gibs": 0.0138005,
+      "compression_fold": 1.49088,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209608,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.51885,
+      "init_s": 6.0741e-05,
+      "flush_s": 6.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.86656,
+          "best_ms": 0.009825,
+          "in_gibs": 0.0212921,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.94998,
+          "best_ms": 9.60646,
+          "in_gibs": 0.785177,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.56459,
+          "best_ms": 0.221823,
+          "in_gibs": 9.27805,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.12,
+      "status": "pass",
+      "throughput_in_gibs": 0.0147949,
+      "throughput_out_gibs": 0.00992366,
+      "compression_fold": 1.49088,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209608,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 2.11221,
+      "init_s": 6.2825e-05,
+      "flush_s": 8.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.02006,
+          "best_ms": 0.009614,
+          "in_gibs": 0.0151826,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.8139,
+          "best_ms": 9.56397,
+          "in_gibs": 0.722451,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.439807,
+          "best_ms": 0.147802,
+          "in_gibs": 11.9104,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 1.29,
+      "status": "pass",
+      "throughput_in_gibs": 0.0243276,
+      "throughput_out_gibs": 0.0163176,
+      "compression_fold": 1.49088,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209608,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.28455,
+      "init_s": 5.6975e-05,
+      "flush_s": 6.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.41663,
+          "best_ms": 0.010146,
+          "in_gibs": 0.0252564,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.15238,
+          "best_ms": 8.34842,
+          "in_gibs": 0.853603,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.463996,
+          "best_ms": 0.158207,
+          "in_gibs": 11.2895,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 1.9,
+      "status": "pass",
+      "throughput_in_gibs": 0.0164455,
+      "throughput_out_gibs": 0.0110308,
+      "compression_fold": 1.49088,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209608,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.90022,
+      "init_s": 6.0771e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.61466,
+          "best_ms": 0.010115,
+          "in_gibs": 0.0168854,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.78695,
+          "best_ms": 8.37434,
+          "in_gibs": 0.798257,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.380554,
+          "best_ms": 0.120291,
+          "in_gibs": 13.7649,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.34,
+      "status": "pass",
+      "throughput_in_gibs": 0.0133881,
+      "throughput_out_gibs": 0.00898001,
+      "compression_fold": 1.49088,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209608,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 2.33417,
+      "init_s": 5.7727e-05,
+      "flush_s": 8.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.46737,
+          "best_ms": 0.020621,
+          "in_gibs": 0.0136624,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.09962,
+          "best_ms": 8.30754,
+          "in_gibs": 0.858553,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.440428,
+          "best_ms": 0.144967,
+          "in_gibs": 11.8936,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.75,
+      "status": "pass",
+      "throughput_in_gibs": 0.0416282,
+      "throughput_out_gibs": 0.00136696,
+      "compression_fold": 30.4531,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102617,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.750693,
+      "init_s": 5.8948e-05,
+      "flush_s": 2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.337561,
+          "best_ms": 0.00655,
+          "in_gibs": 0.0452031,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.19595,
+          "best_ms": 2.98684,
+          "in_gibs": 0.611125,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.00439719,
+          "best_ms": 0.001923,
+          "in_gibs": 14.1516,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.22,
+      "status": "pass",
+      "throughput_in_gibs": 0.00972805,
+      "throughput_out_gibs": 0.000345866,
+      "compression_fold": 28.1267,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00111105,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 3.21236,
+      "init_s": 5.958e-05,
+      "flush_s": 4.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.06774,
+          "best_ms": 0.006971,
+          "in_gibs": 0.00994789,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.56025,
+          "best_ms": 6.38123,
+          "in_gibs": 0.516683,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0143126,
+          "best_ms": 0.007221,
+          "in_gibs": 9.56998,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.32,
+      "status": "pass",
+      "throughput_in_gibs": 0.0134849,
+      "throughput_out_gibs": 0.000444249,
+      "compression_fold": 30.3544,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102951,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 2.31741,
+      "init_s": 5.9229e-05,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.40106,
+          "best_ms": 0.021121,
+          "in_gibs": 0.0138683,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.7956,
+          "best_ms": 12.5489,
+          "in_gibs": 0.566304,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0409918,
+          "best_ms": 0.018168,
+          "in_gibs": 6.23212,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 1.09,
+      "status": "pass",
+      "throughput_in_gibs": 0.0286422,
+      "throughput_out_gibs": 0.000943594,
+      "compression_fold": 30.3544,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102951,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.09105,
+      "init_s": 6.7481e-05,
+      "flush_s": 3.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.01228,
+          "best_ms": 0.010105,
+          "in_gibs": 0.0303313,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.2083,
+          "best_ms": 12.3492,
+          "in_gibs": 0.591482,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.038503,
+          "best_ms": 0.017055,
+          "in_gibs": 6.63495,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 1.38,
+      "status": "pass",
+      "throughput_in_gibs": 0.0226711,
+      "throughput_out_gibs": 0.00074688,
+      "compression_fold": 30.3544,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102951,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.37841,
+      "init_s": 6.1542e-05,
+      "flush_s": 2.224e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.57449,
+          "best_ms": 0.009945,
+          "in_gibs": 0.0237077,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.8692,
+          "best_ms": 11.6657,
+          "in_gibs": 0.607069,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0329068,
+          "best_ms": 0.018587,
+          "in_gibs": 7.76332,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.53,
+      "status": "pass",
+      "throughput_in_gibs": 0.0597692,
+      "throughput_out_gibs": 0.00196905,
+      "compression_fold": 30.3544,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102951,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.522845,
+      "init_s": 7.0776e-05,
+      "flush_s": 4.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.890006,
+          "best_ms": 0.010105,
+          "in_gibs": 0.0685784,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.2617,
+          "best_ms": 13.5362,
+          "in_gibs": 0.547796,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0409262,
+          "best_ms": 0.02664,
+          "in_gibs": 6.24209,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 1.11,
+      "status": "pass",
+      "throughput_in_gibs": 0.0281964,
+      "throughput_out_gibs": 0.000928907,
+      "compression_fold": 30.3544,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102951,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.1083,
+      "init_s": 9.4181e-05,
+      "flush_s": 3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.04752,
+          "best_ms": 0.009504,
+          "in_gibs": 0.0298093,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.507,
+          "best_ms": 11.7214,
+          "in_gibs": 0.624648,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0330945,
+          "best_ms": 0.015283,
+          "in_gibs": 7.71927,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.07,
+      "status": "pass",
+      "throughput_in_gibs": 0.0151161,
+      "throughput_out_gibs": 0.000497988,
+      "compression_fold": 30.3544,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102951,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 2.06733,
+      "init_s": 5.8959e-05,
+      "flush_s": 7.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.91442,
+          "best_ms": 0.009935,
+          "in_gibs": 0.0155924,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.3238,
+          "best_ms": 12.7532,
+          "in_gibs": 0.586358,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0428242,
+          "best_ms": 0.019589,
+          "in_gibs": 5.96544,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.74,
+      "status": "pass",
+      "throughput_in_gibs": 7.14769,
+      "throughput_out_gibs": 9.56408,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.70414,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.491854,
+      "init_s": 0.148649,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.45718,
+          "best_ms": 0.808192,
+          "in_gibs": 19.0768,
+          "out_gibs": 19.0768
+        },
+        "h2d": {
+          "avg_ms": 0.912643,
+          "best_ms": 0.296384,
+          "in_gibs": 51.5963,
+          "out_gibs": 51.5963
+        },
+        "scatter": {
+          "avg_ms": 0.0500712,
+          "best_ms": 0.013184,
+          "in_gibs": 940.441,
+          "out_gibs": 940.441
+        },
+        "lod_gather": {
+          "avg_ms": 0.229174,
+          "best_ms": 0.222848,
+          "in_gibs": 613.617,
+          "out_gibs": 613.617
+        },
+        "lod_reduce": {
+          "avg_ms": 0.802107,
+          "best_ms": 0.76496,
+          "in_gibs": 175.32,
+          "out_gibs": 233.854
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.324659,
+          "best_ms": 0.312992,
+          "in_gibs": 577.764,
+          "out_gibs": 579.409
+        },
+        "compress": {
+          "avg_ms": 0.261158,
+          "best_ms": 0.2512,
+          "in_gibs": 720.292,
+          "out_gibs": 720.292
+        },
+        "aggregate": {
+          "avg_ms": 2.68205,
+          "best_ms": 1.18813,
+          "in_gibs": 70.1369,
+          "out_gibs": 70.1369
+        },
+        "d2h": {
+          "avg_ms": 17.0197,
+          "best_ms": 3.59242,
+          "in_gibs": 11.0525,
+          "out_gibs": 11.0525
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 96.716,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 0.688577,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.12032,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 9.09,
+      "status": "pass",
+      "throughput_in_gibs": 1.03677,
+      "throughput_out_gibs": 1.38727,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.70414,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 3.39093,
+      "init_s": 3.73271,
+      "flush_s": 3.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.8172,
+          "best_ms": 0.860951,
+          "in_gibs": 16.6388,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.3302,
+          "best_ms": 7.43571,
+          "in_gibs": 15.072,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 52.04,
+          "best_ms": 45.5627,
+          "in_gibs": 3.60446,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 37.8389,
+          "best_ms": 10.6934,
+          "in_gibs": 4.97135,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.5442,
+          "best_ms": 3.46033,
+          "in_gibs": 24.9344,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.38663,
+          "best_ms": 0.00655,
+          "in_gibs": 19.38,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.78,
+      "status": "pass",
+      "throughput_in_gibs": 6.61021,
+      "throughput_out_gibs": 1.07581,
+      "compression_fold": 8.21924,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.572165,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.531848,
+      "init_s": 0.137843,
+      "flush_s": 4.9e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.45484,
+          "best_ms": 0.789935,
+          "in_gibs": 19.0949,
+          "out_gibs": 19.0949
+        },
+        "h2d": {
+          "avg_ms": 0.891374,
+          "best_ms": 0.295776,
+          "in_gibs": 52.8275,
+          "out_gibs": 52.8275
+        },
+        "scatter": {
+          "avg_ms": 0.116001,
+          "best_ms": 0.014688,
+          "in_gibs": 405.963,
+          "out_gibs": 405.963
+        },
+        "lod_gather": {
+          "avg_ms": 0.323611,
+          "best_ms": 0.206176,
+          "in_gibs": 434.55,
+          "out_gibs": 434.55
+        },
+        "lod_reduce": {
+          "avg_ms": 0.837565,
+          "best_ms": 0.75728,
+          "in_gibs": 167.897,
+          "out_gibs": 223.954
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.4465,
+          "best_ms": 0.307872,
+          "in_gibs": 420.104,
+          "out_gibs": 421.3
+        },
+        "compress": {
+          "avg_ms": 19.2513,
+          "best_ms": 18.1776,
+          "in_gibs": 9.77133,
+          "out_gibs": 1.18597
+        },
+        "aggregate": {
+          "avg_ms": 0.309409,
+          "best_ms": 0.179808,
+          "in_gibs": 73.7905,
+          "out_gibs": 73.7905
+        },
+        "d2h": {
+          "avg_ms": 0.634323,
+          "best_ms": 0.454592,
+          "in_gibs": 35.9934,
+          "out_gibs": 35.9934
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 114.734,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 117.733,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.8226,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 9.4,
+      "status": "pass",
+      "throughput_in_gibs": 0.979925,
+      "throughput_out_gibs": 0.125628,
+      "compression_fold": 10.4341,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.450709,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 3.58765,
+      "init_s": 3.81337,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.86262,
+          "best_ms": 0.802765,
+          "in_gibs": 16.3748,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.79614,
+          "best_ms": 7.64573,
+          "in_gibs": 14.3551,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 52.6515,
+          "best_ms": 46.3241,
+          "in_gibs": 3.5626,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 39.3464,
+          "best_ms": 19.7099,
+          "in_gibs": 4.78088,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.6528,
+          "best_ms": 9.78588,
+          "in_gibs": 12.0177,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.842031,
+          "best_ms": 0.00059,
+          "in_gibs": 3.0493,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 8.97,
+      "status": "pass",
+      "throughput_in_gibs": 1.03987,
+      "throughput_out_gibs": 0.72578,
+      "compression_fold": 1.91658,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.45373,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 3.38082,
+      "init_s": 3.77026,
+      "flush_s": 6.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.84736,
+          "best_ms": 0.865959,
+          "in_gibs": 16.4626,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.25068,
+          "best_ms": 7.14344,
+          "in_gibs": 15.2016,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 51.0406,
+          "best_ms": 27.9192,
+          "in_gibs": 3.67504,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 38.6054,
+          "best_ms": 13.663,
+          "in_gibs": 4.87265,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.22046,
+          "best_ms": 3.97726,
+          "in_gibs": 20.4014,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.06623,
+          "best_ms": 0.000891,
+          "in_gibs": 13.143,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 8.72,
+      "status": "pass",
+      "throughput_in_gibs": 1.10008,
+      "throughput_out_gibs": 0.0243451,
+      "compression_fold": 60.4457,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0778014,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 3.19578,
+      "init_s": 3.78342,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.84318,
+          "best_ms": 0.779229,
+          "in_gibs": 16.4868,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.61136,
+          "best_ms": 7.82211,
+          "in_gibs": 14.6311,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 48.2677,
+          "best_ms": 25.3735,
+          "in_gibs": 3.88617,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 36.1448,
+          "best_ms": 7.83194,
+          "in_gibs": 5.20435,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.32661,
+          "best_ms": 4.42554,
+          "in_gibs": 22.5915,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.693442,
+          "best_ms": 0.000461,
+          "in_gibs": 0.629763,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.15,
+      "status": "pass",
+      "throughput_in_gibs": 7.05212,
+      "throughput_out_gibs": 9.52603,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.74892,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.49852,
+      "init_s": 0.323895,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.49647,
+          "best_ms": 0.816435,
+          "in_gibs": 18.7765,
+          "out_gibs": 18.7765
+        },
+        "h2d": {
+          "avg_ms": 0.905153,
+          "best_ms": 0.297024,
+          "in_gibs": 52.0233,
+          "out_gibs": 52.0233
+        },
+        "scatter": {
+          "avg_ms": 0.0479106,
+          "best_ms": 0.013632,
+          "in_gibs": 982.853,
+          "out_gibs": 982.853
+        },
+        "lod_gather": {
+          "avg_ms": 0.231305,
+          "best_ms": 0.220576,
+          "in_gibs": 607.963,
+          "out_gibs": 607.963
+        },
+        "lod_reduce": {
+          "avg_ms": 0.803022,
+          "best_ms": 0.785024,
+          "in_gibs": 175.12,
+          "out_gibs": 233.873
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.31968,
+          "best_ms": 0.302784,
+          "in_gibs": 587.479,
+          "out_gibs": 594.161
+        },
+        "compress": {
+          "avg_ms": 0.989303,
+          "best_ms": 0.255808,
+          "in_gibs": 685.697,
+          "out_gibs": 685.697
+        },
+        "aggregate": {
+          "avg_ms": 11.7918,
+          "best_ms": 2.34086,
+          "in_gibs": 57.5283,
+          "out_gibs": 57.5283
+        },
+        "d2h": {
+          "avg_ms": 55.569,
+          "best_ms": 3.62672,
+          "in_gibs": 12.2076,
+          "out_gibs": 12.2076
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 76.506,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 2.42067,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 18.9194,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 8.62,
+      "status": "pass",
+      "throughput_in_gibs": 1.1669,
+      "throughput_out_gibs": 1.57626,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.74892,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 3.01278,
+      "init_s": 3.66683,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.84737,
+          "best_ms": 0.780591,
+          "in_gibs": 16.4626,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.2985,
+          "best_ms": 7.80371,
+          "in_gibs": 15.1234,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 44.1141,
+          "best_ms": 19.4465,
+          "in_gibs": 4.25726,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 33.662,
+          "best_ms": 9.98988,
+          "in_gibs": 5.64261,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.8094,
+          "best_ms": 11.0934,
+          "in_gibs": 38.0902,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.8288,
+          "best_ms": 0.025628,
+          "in_gibs": 23.4137,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.6,
+      "status": "pass",
+      "throughput_in_gibs": 3.77387,
+      "throughput_out_gibs": 0.618182,
+      "compression_fold": 8.24569,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.575881,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.931571,
+      "init_s": 0.364047,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.44884,
+          "best_ms": 0.800632,
+          "in_gibs": 19.1417,
+          "out_gibs": 19.1417
+        },
+        "h2d": {
+          "avg_ms": 0.897015,
+          "best_ms": 0.296064,
+          "in_gibs": 52.4953,
+          "out_gibs": 52.4953
+        },
+        "scatter": {
+          "avg_ms": 0.153785,
+          "best_ms": 0.0136,
+          "in_gibs": 315.424,
+          "out_gibs": 315.424
+        },
+        "lod_gather": {
+          "avg_ms": 2.50488,
+          "best_ms": 0.2224,
+          "in_gibs": 56.1405,
+          "out_gibs": 56.1405
+        },
+        "lod_reduce": {
+          "avg_ms": 2.8199,
+          "best_ms": 0.789152,
+          "in_gibs": 49.8687,
+          "out_gibs": 66.5998
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.0007,
+          "best_ms": 0.304832,
+          "in_gibs": 93.8695,
+          "out_gibs": 94.9373
+        },
+        "compress": {
+          "avg_ms": 114.117,
+          "best_ms": 28.0517,
+          "in_gibs": 5.94442,
+          "out_gibs": 0.720431
+        },
+        "aggregate": {
+          "avg_ms": 0.477202,
+          "best_ms": 0.220768,
+          "in_gibs": 172.283,
+          "out_gibs": 172.283
+        },
+        "d2h": {
+          "avg_ms": 7.97995,
+          "best_ms": 0.458016,
+          "in_gibs": 10.3026,
+          "out_gibs": 10.3026
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 299.765,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 426.261,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 106.547,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 8.75,
+      "status": "pass",
+      "throughput_in_gibs": 1.08302,
+      "throughput_out_gibs": 0.141264,
+      "compression_fold": 10.3553,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.458563,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 3.24614,
+      "init_s": 3.66494,
+      "flush_s": 6.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.84356,
+          "best_ms": 0.834001,
+          "in_gibs": 16.4846,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.56833,
+          "best_ms": 8.02981,
+          "in_gibs": 14.6969,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 44.2279,
+          "best_ms": 28.8177,
+          "in_gibs": 4.24631,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 33.7068,
+          "best_ms": 17.8023,
+          "in_gibs": 5.6351,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 71.0423,
+          "best_ms": 41.9524,
+          "in_gibs": 9.5487,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.02046,
+          "best_ms": 0.000891,
+          "in_gibs": 10.6903,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 8.48,
+      "status": "pass",
+      "throughput_in_gibs": 1.16475,
+      "throughput_out_gibs": 0.829824,
+      "compression_fold": 1.89585,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.5047,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 3.01836,
+      "init_s": 3.68082,
+      "flush_s": 3.9e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.84795,
+          "best_ms": 0.828583,
+          "in_gibs": 16.4592,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.27324,
+          "best_ms": 7.25932,
+          "in_gibs": 15.1646,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 43.4814,
+          "best_ms": 20.3505,
+          "in_gibs": 4.3192,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 31.5827,
+          "best_ms": 6.46734,
+          "in_gibs": 6.0141,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 41.1607,
+          "best_ms": 17.8426,
+          "in_gibs": 16.4808,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.67551,
+          "best_ms": 0.002864,
+          "in_gibs": 22.2861,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 8.7,
+      "status": "pass",
+      "throughput_in_gibs": 1.17442,
+      "throughput_out_gibs": 0.0222613,
+      "compression_fold": 71.2575,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0666391,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.99349,
+      "init_s": 3.74678,
+      "flush_s": 4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.88608,
+          "best_ms": 0.805588,
+          "in_gibs": 16.2417,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.36972,
+          "best_ms": 7.79706,
+          "in_gibs": 15.0084,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 45.8575,
+          "best_ms": 38.9438,
+          "in_gibs": 4.09541,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 34.9077,
+          "best_ms": 32.3273,
+          "in_gibs": 5.44125,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.1864,
+          "best_ms": 14.8109,
+          "in_gibs": 26.9337,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.914194,
+          "best_ms": 0.000751,
+          "in_gibs": 1.72557,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.98,
+      "status": "pass",
+      "throughput_in_gibs": 6.91772,
+      "throughput_out_gibs": 10.0424,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 5.10361,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 0.508206,
+      "init_s": 1.08078,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.96732,
+          "best_ms": 0.811627,
+          "in_gibs": 18.8061,
+          "out_gibs": 18.8061
+        },
+        "h2d": {
+          "avg_ms": 1.06974,
+          "best_ms": 0.590816,
+          "in_gibs": 52.6788,
+          "out_gibs": 52.6788
+        },
+        "scatter": {
+          "avg_ms": 0.126234,
+          "best_ms": 0.027712,
+          "in_gibs": 446.412,
+          "out_gibs": 446.412
+        },
+        "lod_gather": {
+          "avg_ms": 0.42176,
+          "best_ms": 0.414112,
+          "in_gibs": 666.848,
+          "out_gibs": 666.848
+        },
+        "lod_reduce": {
+          "avg_ms": 1.53118,
+          "best_ms": 1.51754,
+          "in_gibs": 183.681,
+          "out_gibs": 245.227
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.592048,
+          "best_ms": 0.590528,
+          "in_gibs": 634.219,
+          "out_gibs": 663.085
+        },
+        "compress": {
+          "avg_ms": 3.70354,
+          "best_ms": 2.84608,
+          "in_gibs": 689.006,
+          "out_gibs": 689.006
+        },
+        "aggregate": {
+          "avg_ms": 11.7295,
+          "best_ms": 9.54022,
+          "in_gibs": 217.55,
+          "out_gibs": 217.55
+        },
+        "d2h": {
+          "avg_ms": 105.717,
+          "best_ms": 37.3231,
+          "in_gibs": 24.1377,
+          "out_gibs": 24.1377
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 14.7001,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.64946,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.75,
+      "status": "pass",
+      "throughput_in_gibs": 1.46007,
+      "throughput_out_gibs": 2.11958,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 5.10361,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.40784,
+      "init_s": 7.11351,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.78799,
+          "best_ms": 0.834662,
+          "in_gibs": 14.7317,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 15.1523,
+          "best_ms": 13.122,
+          "in_gibs": 18.5615,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 55.3019,
+          "best_ms": 51.1912,
+          "in_gibs": 6.78979,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 43.7183,
+          "best_ms": 38.2895,
+          "in_gibs": 8.97971,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 60.5682,
+          "best_ms": 47.7541,
+          "in_gibs": 42.1303,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 28.3786,
+          "best_ms": 0.604157,
+          "in_gibs": 17.9837,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 4.91,
+      "status": "pass",
+      "throughput_in_gibs": 2.7537,
+      "throughput_out_gibs": 0.47613,
+      "compression_fold": 8.39571,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.607872,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.27669,
+      "init_s": 1.11914,
+      "flush_s": 2.514e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.9201,
+          "best_ms": 0.809895,
+          "in_gibs": 19.1101,
+          "out_gibs": 19.1101
+        },
+        "h2d": {
+          "avg_ms": 1.06673,
+          "best_ms": 0.590816,
+          "in_gibs": 52.8275,
+          "out_gibs": 52.8275
+        },
+        "scatter": {
+          "avg_ms": 0.0577972,
+          "best_ms": 0.025568,
+          "in_gibs": 975.003,
+          "out_gibs": 975.003
+        },
+        "lod_gather": {
+          "avg_ms": 0.427584,
+          "best_ms": 0.424352,
+          "in_gibs": 657.766,
+          "out_gibs": 657.766
+        },
+        "lod_reduce": {
+          "avg_ms": 1.52832,
+          "best_ms": 1.52166,
+          "in_gibs": 184.026,
+          "out_gibs": 245.687
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.589984,
+          "best_ms": 0.588448,
+          "in_gibs": 636.438,
+          "out_gibs": 665.405
+        },
+        "compress": {
+          "avg_ms": 435.856,
+          "best_ms": 336.54,
+          "in_gibs": 5.85458,
+          "out_gibs": 0.697223
+        },
+        "aggregate": {
+          "avg_ms": 2.08414,
+          "best_ms": 0.953952,
+          "in_gibs": 145.81,
+          "out_gibs": 145.81
+        },
+        "d2h": {
+          "avg_ms": 70.9712,
+          "best_ms": 4.47843,
+          "in_gibs": 4.28187,
+          "out_gibs": 4.28187
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 339.76,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 542.373,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.38,
+      "status": "pass",
+      "throughput_in_gibs": 2.52782,
+      "throughput_out_gibs": 0.31586,
+      "compression_fold": 11.6176,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.43929,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.39077,
+      "init_s": 5.94122,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.64791,
+          "best_ms": 0.763986,
+          "in_gibs": 15.2974,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.3699,
+          "best_ms": 9.33682,
+          "in_gibs": 27.1217,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 25.0995,
+          "best_ms": 23.2427,
+          "in_gibs": 14.96,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 16.7461,
+          "best_ms": 10.9228,
+          "in_gibs": 23.4429,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 102.888,
+          "best_ms": 79.2301,
+          "in_gibs": 24.8013,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.26647,
+          "best_ms": 0.038558,
+          "in_gibs": 19.378,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.38,
+      "status": "pass",
+      "throughput_in_gibs": 2.42037,
+      "throughput_out_gibs": 1.76597,
+      "compression_fold": 1.9896,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.5651,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.45251,
+      "init_s": 5.86618,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.64392,
+          "best_ms": 0.772769,
+          "in_gibs": 15.3142,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.8129,
+          "best_ms": 9.44302,
+          "in_gibs": 26.0105,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 27.712,
+          "best_ms": 23.2454,
+          "in_gibs": 13.5497,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 17.39,
+          "best_ms": 10.901,
+          "in_gibs": 22.5749,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 61.3209,
+          "best_ms": 40.3166,
+          "in_gibs": 41.6132,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.2811,
+          "best_ms": 0.122865,
+          "in_gibs": 20.8857,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.15,
+      "status": "pass",
+      "throughput_in_gibs": 2.5464,
+      "throughput_out_gibs": 0.0503151,
+      "compression_fold": 73.4675,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0694663,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.38063,
+      "init_s": 5.90856,
+      "flush_s": 6.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.62355,
+          "best_ms": 0.770546,
+          "in_gibs": 15.4002,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.1534,
+          "best_ms": 9.44012,
+          "in_gibs": 23.1417,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 33.421,
+          "best_ms": 24.2074,
+          "in_gibs": 11.2351,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 18.1783,
+          "best_ms": 10.9547,
+          "in_gibs": 21.596,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.4753,
+          "best_ms": 27.4788,
+          "in_gibs": 78.5753,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.729345,
+          "best_ms": 0.013741,
+          "in_gibs": 9.51162,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.44,
+      "status": "pass",
+      "throughput_in_gibs": 7.83562,
+      "throughput_out_gibs": 8.96265,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28938,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.478583,
+      "init_s": 0.142839,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.06888,
+          "best_ms": 3.03474,
+          "in_gibs": 20.3658,
+          "out_gibs": 20.3658
+        },
+        "h2d": {
+          "avg_ms": 1.21706,
+          "best_ms": 1.17907,
+          "in_gibs": 51.3531,
+          "out_gibs": 51.3531
+        },
+        "scatter": {
+          "avg_ms": 0.067824,
+          "best_ms": 0.06224,
+          "in_gibs": 921.503,
+          "out_gibs": 921.503
+        },
+        "lod_gather": {
+          "avg_ms": 1.02129,
+          "best_ms": 0.99632,
+          "in_gibs": 183.591,
+          "out_gibs": 183.591
+        },
+        "lod_reduce": {
+          "avg_ms": 0.840438,
+          "best_ms": 0.810688,
+          "in_gibs": 223.098,
+          "out_gibs": 255.125
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.552918,
+          "best_ms": 0.525984,
+          "in_gibs": 387.791,
+          "out_gibs": 387.791
+        },
+        "compress": {
+          "avg_ms": 0.296586,
+          "best_ms": 0.284288,
+          "in_gibs": 722.95,
+          "out_gibs": 722.95
+        },
+        "aggregate": {
+          "avg_ms": 1.37863,
+          "best_ms": 0.995776,
+          "in_gibs": 155.528,
+          "out_gibs": 155.528
+        },
+        "d2h": {
+          "avg_ms": 21.0835,
+          "best_ms": 4.08986,
+          "in_gibs": 10.1699,
+          "out_gibs": 10.1699
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 84.6505,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 0.993781,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.07023,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 17.04,
+      "status": "pass",
+      "throughput_in_gibs": 2.60966,
+      "throughput_out_gibs": 2.98502,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28938,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.43697,
+      "init_s": 3.6697,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.74842,
+          "best_ms": 3.13909,
+          "in_gibs": 16.6737,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 13.9603,
+          "best_ms": 12.3317,
+          "in_gibs": 13.4309,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.7027,
+          "best_ms": 9.53236,
+          "in_gibs": 14.5835,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 10.102,
+          "best_ms": 7.8898,
+          "in_gibs": 21.2251,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.87426,
+          "best_ms": 3.51322,
+          "in_gibs": 55.3439,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.06574,
+          "best_ms": 0.008973,
+          "in_gibs": 40.238,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.06,
+      "status": "pass",
+      "throughput_in_gibs": 8.67803,
+      "throughput_out_gibs": 1.16004,
+      "compression_fold": 8.55468,
+      "input_gib": 3.75,
+      "compressed_gib": 0.501284,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.432126,
+      "init_s": 0.13704,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.08264,
+          "best_ms": 3.05247,
+          "in_gibs": 20.2749,
+          "out_gibs": 20.2749
+        },
+        "h2d": {
+          "avg_ms": 1.19673,
+          "best_ms": 1.17827,
+          "in_gibs": 52.2255,
+          "out_gibs": 52.2255
+        },
+        "scatter": {
+          "avg_ms": 0.0977743,
+          "best_ms": 0.04912,
+          "in_gibs": 639.227,
+          "out_gibs": 639.227
+        },
+        "lod_gather": {
+          "avg_ms": 0.993485,
+          "best_ms": 0.9872,
+          "in_gibs": 188.73,
+          "out_gibs": 188.73
+        },
+        "lod_reduce": {
+          "avg_ms": 0.80592,
+          "best_ms": 0.800384,
+          "in_gibs": 232.653,
+          "out_gibs": 266.052
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.523117,
+          "best_ms": 0.51984,
+          "in_gibs": 409.883,
+          "out_gibs": 409.883
+        },
+        "compress": {
+          "avg_ms": 11.2528,
+          "best_ms": 11.0971,
+          "in_gibs": 19.0544,
+          "out_gibs": 2.22272
+        },
+        "aggregate": {
+          "avg_ms": 0.187875,
+          "best_ms": 0.167552,
+          "in_gibs": 133.13,
+          "out_gibs": 133.13
+        },
+        "d2h": {
+          "avg_ms": 5.64732,
+          "best_ms": 0.489344,
+          "in_gibs": 4.42898,
+          "out_gibs": 4.42898
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.8979,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 14.1727,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 17.925,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 16.67,
+      "status": "pass",
+      "throughput_in_gibs": 2.40371,
+      "throughput_out_gibs": 0.246275,
+      "compression_fold": 11.1614,
+      "input_gib": 3.75,
+      "compressed_gib": 0.38421,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.56009,
+      "init_s": 3.64867,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.74436,
+          "best_ms": 3.17029,
+          "in_gibs": 16.6918,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 14.453,
+          "best_ms": 12.6178,
+          "in_gibs": 12.9731,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 16.668,
+          "best_ms": 9.55687,
+          "in_gibs": 12.864,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 10.287,
+          "best_ms": 7.86697,
+          "in_gibs": 20.8434,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.0964,
+          "best_ms": 10.0696,
+          "in_gibs": 19.3231,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.239905,
+          "best_ms": 0.001042,
+          "in_gibs": 15.9715,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 15.96,
+      "status": "pass",
+      "throughput_in_gibs": 2.7105,
+      "throughput_out_gibs": 1.95188,
+      "compression_fold": 1.58801,
+      "input_gib": 3.75,
+      "compressed_gib": 2.70044,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.38351,
+      "init_s": 3.64238,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.75396,
+          "best_ms": 3.15977,
+          "in_gibs": 16.6491,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 13.5578,
+          "best_ms": 12.4007,
+          "in_gibs": 13.8297,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 13.916,
+          "best_ms": 9.55305,
+          "in_gibs": 15.408,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 9.00662,
+          "best_ms": 8.00569,
+          "in_gibs": 23.8066,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.26881,
+          "best_ms": 5.00083,
+          "in_gibs": 40.6954,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.666395,
+          "best_ms": 0.001892,
+          "in_gibs": 40.5074,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 15.96,
+      "status": "pass",
+      "throughput_in_gibs": 2.52955,
+      "throughput_out_gibs": 0.0673918,
+      "compression_fold": 42.9234,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0999066,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.48248,
+      "init_s": 3.643,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.74681,
+          "best_ms": 3.11359,
+          "in_gibs": 16.6808,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 13.8638,
+          "best_ms": 12.5718,
+          "in_gibs": 13.5244,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.4507,
+          "best_ms": 9.56315,
+          "in_gibs": 14.8378,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 11.7443,
+          "best_ms": 8.22167,
+          "in_gibs": 18.2571,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.48425,
+          "best_ms": 7.3606,
+          "in_gibs": 25.2723,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.191348,
+          "best_ms": 0.000521,
+          "in_gibs": 5.16648,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.41,
+      "status": "pass",
+      "throughput_in_gibs": 7.74341,
+      "throughput_out_gibs": 8.84799,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28493,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.484283,
+      "init_s": 0.35696,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.0967,
+          "best_ms": 3.05214,
+          "in_gibs": 20.1827,
+          "out_gibs": 20.1827
+        },
+        "h2d": {
+          "avg_ms": 1.18663,
+          "best_ms": 1.17827,
+          "in_gibs": 52.6701,
+          "out_gibs": 52.6701
+        },
+        "scatter": {
+          "avg_ms": 0.0664408,
+          "best_ms": 0.064224,
+          "in_gibs": 940.687,
+          "out_gibs": 940.687
+        },
+        "lod_gather": {
+          "avg_ms": 2.00824,
+          "best_ms": 1.96675,
+          "in_gibs": 186.73,
+          "out_gibs": 186.73
+        },
+        "lod_reduce": {
+          "avg_ms": 1.64405,
+          "best_ms": 1.59437,
+          "in_gibs": 228.095,
+          "out_gibs": 260.616
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.11337,
+          "best_ms": 1.07485,
+          "in_gibs": 384.838,
+          "out_gibs": 384.838
+        },
+        "compress": {
+          "avg_ms": 1.25364,
+          "best_ms": 1.2271,
+          "in_gibs": 683.557,
+          "out_gibs": 683.557
+        },
+        "aggregate": {
+          "avg_ms": 11.177,
+          "best_ms": 3.49184,
+          "in_gibs": 76.6693,
+          "out_gibs": 76.6693
+        },
+        "d2h": {
+          "avg_ms": 74.1774,
+          "best_ms": 16.2974,
+          "in_gibs": 11.5525,
+          "out_gibs": 11.5525
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 68.3959,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 3.31055,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 20.3424,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 19.38,
+      "status": "pass",
+      "throughput_in_gibs": 2.47564,
+      "throughput_out_gibs": 2.82878,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28493,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.51476,
+      "init_s": 6.80859,
+      "flush_s": 5.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.26368,
+          "best_ms": 3.17396,
+          "in_gibs": 14.6587,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.421,
+          "best_ms": 23.9114,
+          "in_gibs": 14.1933,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 30.44,
+          "best_ms": 19.0224,
+          "in_gibs": 14.0758,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 24.7503,
+          "best_ms": 15.1519,
+          "in_gibs": 17.3115,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.0834,
+          "best_ms": 14.3008,
+          "in_gibs": 53.2807,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.4022,
+          "best_ms": 0.073671,
+          "in_gibs": 39.6567,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.3,
+      "status": "pass",
+      "throughput_in_gibs": 7.60497,
+      "throughput_out_gibs": 0.999841,
+      "compression_fold": 8.69066,
+      "input_gib": 3.75,
+      "compressed_gib": 0.49302,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.493098,
+      "init_s": 0.387725,
+      "flush_s": 2.214e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.07051,
+          "best_ms": 3.04942,
+          "in_gibs": 20.3549,
+          "out_gibs": 20.3549
+        },
+        "h2d": {
+          "avg_ms": 1.18697,
+          "best_ms": 1.17802,
+          "in_gibs": 52.6551,
+          "out_gibs": 52.6551
+        },
+        "scatter": {
+          "avg_ms": 0.0969942,
+          "best_ms": 0.0624,
+          "in_gibs": 644.368,
+          "out_gibs": 644.368
+        },
+        "lod_gather": {
+          "avg_ms": 1.97712,
+          "best_ms": 1.95242,
+          "in_gibs": 189.67,
+          "out_gibs": 189.67
+        },
+        "lod_reduce": {
+          "avg_ms": 1.59436,
+          "best_ms": 1.59232,
+          "in_gibs": 235.205,
+          "out_gibs": 268.74
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.07281,
+          "best_ms": 1.07075,
+          "in_gibs": 399.386,
+          "out_gibs": 399.386
+        },
+        "compress": {
+          "avg_ms": 45.7727,
+          "best_ms": 42.5847,
+          "in_gibs": 18.7215,
+          "out_gibs": 2.15306
+        },
+        "aggregate": {
+          "avg_ms": 0.514259,
+          "best_ms": 0.393248,
+          "in_gibs": 191.638,
+          "out_gibs": 191.638
+        },
+        "d2h": {
+          "avg_ms": 30.2152,
+          "best_ms": 1.88621,
+          "in_gibs": 3.26166,
+          "out_gibs": 3.26166
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 8.56546,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 47.2862,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 51.6713,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 19.36,
+      "status": "pass",
+      "throughput_in_gibs": 2.63243,
+      "throughput_out_gibs": 0.26227,
+      "compression_fold": 11.4682,
+      "input_gib": 3.75,
+      "compressed_gib": 0.373613,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.42454,
+      "init_s": 6.84205,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.27029,
+          "best_ms": 3.1516,
+          "in_gibs": 14.636,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.9403,
+          "best_ms": 24.5812,
+          "in_gibs": 14.4563,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 25.8584,
+          "best_ms": 19.1142,
+          "in_gibs": 16.5698,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 18.8364,
+          "best_ms": 14.885,
+          "in_gibs": 22.7468,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 39.3367,
+          "best_ms": 38.5997,
+          "in_gibs": 21.7846,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.531241,
+          "best_ms": 0.009445,
+          "in_gibs": 35.1395,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 19.09,
+      "status": "pass",
+      "throughput_in_gibs": 2.6592,
+      "throughput_out_gibs": 1.9822,
+      "compression_fold": 1.53281,
+      "input_gib": 3.75,
+      "compressed_gib": 2.7953,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.4102,
+      "init_s": 6.78765,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.28371,
+          "best_ms": 3.17085,
+          "in_gibs": 14.5902,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.3575,
+          "best_ms": 24.0843,
+          "in_gibs": 14.2275,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 26.6096,
+          "best_ms": 19.0233,
+          "in_gibs": 16.102,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 17.7206,
+          "best_ms": 14.9871,
+          "in_gibs": 24.179,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.1375,
+          "best_ms": 20.4641,
+          "in_gibs": 37.0365,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.81947,
+          "best_ms": 0.051438,
+          "in_gibs": 36.5894,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 19.14,
+      "status": "pass",
+      "throughput_in_gibs": 2.74963,
+      "throughput_out_gibs": 0.0703468,
+      "compression_fold": 44.6598,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0959402,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.36382,
+      "init_s": 6.82574,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.29213,
+          "best_ms": 3.18197,
+          "in_gibs": 14.5615,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.301,
+          "best_ms": 23.6973,
+          "in_gibs": 14.258,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 26.0412,
+          "best_ms": 19.0852,
+          "in_gibs": 16.4534,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 18.244,
+          "best_ms": 15.4296,
+          "in_gibs": 23.4854,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.1333,
+          "best_ms": 26.6973,
+          "in_gibs": 30.4598,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.15754,
+          "best_ms": 0.003595,
+          "in_gibs": 30.3664,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.2,
+      "status": "pass",
+      "throughput_in_gibs": 7.66595,
+      "throughput_out_gibs": 8.804,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 4.30671,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.489176,
+      "init_s": 1.10788,
+      "flush_s": 2.474e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.0931,
+          "best_ms": 3.06499,
+          "in_gibs": 20.2063,
+          "out_gibs": 20.2063
+        },
+        "h2d": {
+          "avg_ms": 1.18337,
+          "best_ms": 1.17837,
+          "in_gibs": 52.8151,
+          "out_gibs": 52.8151
+        },
+        "scatter": {
+          "avg_ms": 0.0667868,
+          "best_ms": 0.062304,
+          "in_gibs": 935.814,
+          "out_gibs": 935.814
+        },
+        "lod_gather": {
+          "avg_ms": 1.98882,
+          "best_ms": 1.96675,
+          "in_gibs": 188.554,
+          "out_gibs": 188.554
+        },
+        "lod_reduce": {
+          "avg_ms": 1.63426,
+          "best_ms": 1.60461,
+          "in_gibs": 229.462,
+          "out_gibs": 263.523
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.02094,
+          "best_ms": 0.945824,
+          "in_gibs": 421.829,
+          "out_gibs": 421.829
+        },
+        "compress": {
+          "avg_ms": 3.11978,
+          "best_ms": 1.23389,
+          "in_gibs": 690.216,
+          "out_gibs": 690.216
+        },
+        "aggregate": {
+          "avg_ms": 10.1345,
+          "best_ms": 6.24947,
+          "in_gibs": 212.474,
+          "out_gibs": 212.474
+        },
+        "d2h": {
+          "avg_ms": 71.4604,
+          "best_ms": 16.3821,
+          "in_gibs": 30.133,
+          "out_gibs": 30.133
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 7.36163,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.0092,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 19.55,
+      "status": "pass",
+      "throughput_in_gibs": 2.16105,
+      "throughput_out_gibs": 2.48187,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 4.30671,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.73526,
+      "init_s": 6.75135,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.28986,
+          "best_ms": 3.17758,
+          "in_gibs": 14.5693,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.0511,
+          "best_ms": 24.2844,
+          "in_gibs": 14.3948,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 29.9504,
+          "best_ms": 19.5311,
+          "in_gibs": 14.3793,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 35.2604,
+          "best_ms": 28.5612,
+          "in_gibs": 12.2138,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 59.1399,
+          "best_ms": 48.9769,
+          "in_gibs": 36.4106,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 23.311,
+          "best_ms": 0.337206,
+          "in_gibs": 23.0934,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.66,
+      "status": "pass",
+      "throughput_in_gibs": 4.12288,
+      "throughput_out_gibs": 0.553245,
+      "compression_fold": 8.55836,
+      "input_gib": 3.75,
+      "compressed_gib": 0.503209,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.909558,
+      "init_s": 1.10778,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.17572,
+          "best_ms": 3.14665,
+          "in_gibs": 19.6806,
+          "out_gibs": 19.6806
+        },
+        "h2d": {
+          "avg_ms": 1.18239,
+          "best_ms": 1.17834,
+          "in_gibs": 52.8588,
+          "out_gibs": 52.8588
+        },
+        "scatter": {
+          "avg_ms": 0.0658262,
+          "best_ms": 0.064288,
+          "in_gibs": 949.47,
+          "out_gibs": 949.47
+        },
+        "lod_gather": {
+          "avg_ms": 1.99318,
+          "best_ms": 1.95856,
+          "in_gibs": 188.141,
+          "out_gibs": 188.141
+        },
+        "lod_reduce": {
+          "avg_ms": 1.6307,
+          "best_ms": 1.5985,
+          "in_gibs": 229.962,
+          "out_gibs": 264.097
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.02501,
+          "best_ms": 0.945792,
+          "in_gibs": 420.157,
+          "out_gibs": 420.157
+        },
+        "compress": {
+          "avg_ms": 250.697,
+          "best_ms": 65.2117,
+          "in_gibs": 8.58933,
+          "out_gibs": 1.00349
+        },
+        "aggregate": {
+          "avg_ms": 2.16301,
+          "best_ms": 0.716416,
+          "in_gibs": 116.306,
+          "out_gibs": 116.306
+        },
+        "d2h": {
+          "avg_ms": 40.9022,
+          "best_ms": 1.92547,
+          "in_gibs": 6.15056,
+          "out_gibs": 6.15056
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 65.7913,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 445.285,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 20.67,
+      "status": "pass",
+      "throughput_in_gibs": 1.45261,
+      "throughput_out_gibs": 0.136932,
+      "compression_fold": 12.1829,
+      "input_gib": 3.75,
+      "compressed_gib": 0.353498,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.58156,
+      "init_s": 6.82159,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.29968,
+          "best_ms": 3.19243,
+          "in_gibs": 14.536,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.9063,
+          "best_ms": 24.1615,
+          "in_gibs": 13.9372,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 28.091,
+          "best_ms": 19.5569,
+          "in_gibs": 15.331,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 34.1463,
+          "best_ms": 30.0091,
+          "in_gibs": 12.6123,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 578.734,
+          "best_ms": 146.363,
+          "in_gibs": 3.72075,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.97734,
+          "best_ms": 0.006029,
+          "in_gibs": 22.3426,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 21.75,
+      "status": "pass",
+      "throughput_in_gibs": 1.2974,
+      "throughput_out_gibs": 0.832541,
+      "compression_fold": 1.78969,
+      "input_gib": 3.75,
+      "compressed_gib": 2.40637,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.89039,
+      "init_s": 7.75912,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.48635,
+          "best_ms": 3.22945,
+          "in_gibs": 13.9311,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 33.2283,
+          "best_ms": 30.7749,
+          "in_gibs": 11.2855,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 45.4827,
+          "best_ms": 42.9666,
+          "in_gibs": 9.46873,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 49.3893,
+          "best_ms": 44.4275,
+          "in_gibs": 8.71979,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 478.113,
+          "best_ms": 110.334,
+          "in_gibs": 4.50379,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.2788,
+          "best_ms": 0.037847,
+          "in_gibs": 21.0654,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 21.95,
+      "status": "pass",
+      "throughput_in_gibs": 1.60129,
+      "throughput_out_gibs": 0.0275765,
+      "compression_fold": 66.6864,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0645805,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.34186,
+      "init_s": 8.11432,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.55638,
+          "best_ms": 3.22807,
+          "in_gibs": 13.717,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 32.3738,
+          "best_ms": 29.9581,
+          "in_gibs": 11.5834,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 46.1038,
+          "best_ms": 43.381,
+          "in_gibs": 9.34117,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 49.1083,
+          "best_ms": 40.7852,
+          "in_gibs": 8.76968,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 253.988,
+          "best_ms": 71.9938,
+          "in_gibs": 8.47803,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.08489,
+          "best_ms": 0.003275,
+          "in_gibs": 7.4333,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.91,
+      "status": "pass",
+      "throughput_in_gibs": 7.13896,
+      "throughput_out_gibs": 8.2179,
+      "compression_fold": 1.16205,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04695,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.492456,
+      "init_s": 0.161764,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.48837,
+          "best_ms": 0.80634,
+          "in_gibs": 18.8376,
+          "out_gibs": 18.8376
+        },
+        "h2d": {
+          "avg_ms": 0.921391,
+          "best_ms": 0.298976,
+          "in_gibs": 51.1065,
+          "out_gibs": 51.1065
+        },
+        "scatter": {
+          "avg_ms": 0.0500975,
+          "best_ms": 0.013312,
+          "in_gibs": 939.947,
+          "out_gibs": 939.947
+        },
+        "lod_gather": {
+          "avg_ms": 0.229136,
+          "best_ms": 0.222528,
+          "in_gibs": 613.719,
+          "out_gibs": 613.719
+        },
+        "lod_reduce": {
+          "avg_ms": 0.80335,
+          "best_ms": 0.763936,
+          "in_gibs": 175.048,
+          "out_gibs": 233.493
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.115333,
+          "best_ms": 0.067552,
+          "in_gibs": 407.094,
+          "out_gibs": 407.094
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.14236,
+          "best_ms": 0.231424,
+          "in_gibs": 164.2,
+          "out_gibs": 164.668
+        },
+        "compress": {
+          "avg_ms": 0.254006,
+          "best_ms": 0.23712,
+          "in_gibs": 740.574,
+          "out_gibs": 612.61
+        },
+        "aggregate": {
+          "avg_ms": 1.51058,
+          "best_ms": 0.374208,
+          "in_gibs": 103.011,
+          "out_gibs": 103.011
+        },
+        "d2h": {
+          "avg_ms": 16.911,
+          "best_ms": 0.917696,
+          "in_gibs": 9.20154,
+          "out_gibs": 9.20154
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 85.0884,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 0.657457,
+        "kick_sync_count": 26,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.92369,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 9.53,
+      "status": "pass",
+      "throughput_in_gibs": 0.906388,
+      "throughput_out_gibs": 1.04337,
+      "compression_fold": 1.16205,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04695,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 3.87872,
+      "init_s": 3.78386,
+      "flush_s": 3.9e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.89231,
+          "best_ms": 0.783355,
+          "in_gibs": 16.2068,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.096,
+          "best_ms": 7.60306,
+          "in_gibs": 15.4601,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 49.3942,
+          "best_ms": 33.3184,
+          "in_gibs": 3.79754,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 42.9346,
+          "best_ms": 32.991,
+          "in_gibs": 1.09355,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 15.3237,
+          "best_ms": 9.0961,
+          "in_gibs": 12.2758,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.4621,
+          "best_ms": 6.10121,
+          "in_gibs": 22.2298,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.9081,
+          "best_ms": 0.029694,
+          "in_gibs": 19.5326,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.86,
+      "status": "pass",
+      "throughput_in_gibs": 7.57425,
+      "throughput_out_gibs": 1.05184,
+      "compression_fold": 9.63252,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.488217,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.464155,
+      "init_s": 0.141122,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.5254,
+          "best_ms": 0.857086,
+          "in_gibs": 18.5614,
+          "out_gibs": 18.5614
+        },
+        "h2d": {
+          "avg_ms": 0.898711,
+          "best_ms": 0.296704,
+          "in_gibs": 52.3962,
+          "out_gibs": 52.3962
+        },
+        "scatter": {
+          "avg_ms": 0.0829681,
+          "best_ms": 0.014304,
+          "in_gibs": 567.556,
+          "out_gibs": 567.556
+        },
+        "lod_gather": {
+          "avg_ms": 0.25774,
+          "best_ms": 0.20448,
+          "in_gibs": 545.607,
+          "out_gibs": 545.607
+        },
+        "lod_reduce": {
+          "avg_ms": 0.786225,
+          "best_ms": 0.759712,
+          "in_gibs": 178.861,
+          "out_gibs": 238.578
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.107318,
+          "best_ms": 0.063456,
+          "in_gibs": 437.496,
+          "out_gibs": 437.496
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.30454,
+          "best_ms": 0.227296,
+          "in_gibs": 143.788,
+          "out_gibs": 144.197
+        },
+        "compress": {
+          "avg_ms": 12.9276,
+          "best_ms": 8.80982,
+          "in_gibs": 14.5511,
+          "out_gibs": 1.44902
+        },
+        "aggregate": {
+          "avg_ms": 0.198214,
+          "best_ms": 0.0512,
+          "in_gibs": 94.5054,
+          "out_gibs": 94.5054
+        },
+        "d2h": {
+          "avg_ms": 2.59892,
+          "best_ms": 0.118816,
+          "in_gibs": 7.20771,
+          "out_gibs": 7.20771
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 33.392,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 38.9593,
+        "kick_sync_count": 26,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 15.921,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 9.72,
+      "status": "pass",
+      "throughput_in_gibs": 0.898614,
+      "throughput_out_gibs": 0.0932896,
+      "compression_fold": 12.8852,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.364974,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 3.91227,
+      "init_s": 3.79217,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.9131,
+          "best_ms": 0.832729,
+          "in_gibs": 16.0911,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.35677,
+          "best_ms": 7.71881,
+          "in_gibs": 15.0292,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 50.7382,
+          "best_ms": 42.0008,
+          "in_gibs": 3.69694,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 39.5886,
+          "best_ms": 5.98901,
+          "in_gibs": 1.18598,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 15.0641,
+          "best_ms": 5.87899,
+          "in_gibs": 12.4873,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.8214,
+          "best_ms": 10.0768,
+          "in_gibs": 14.6716,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.76017,
+          "best_ms": 0.000761,
+          "in_gibs": 2.48684,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 9.32,
+      "status": "pass",
+      "throughput_in_gibs": 0.95974,
+      "throughput_out_gibs": 0.571996,
+      "compression_fold": 2.24446,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.09528,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 3.6631,
+      "init_s": 3.74955,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.87219,
+          "best_ms": 0.85971,
+          "in_gibs": 16.3203,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.19064,
+          "best_ms": 6.96978,
+          "in_gibs": 15.3009,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 48.1117,
+          "best_ms": 18.2877,
+          "in_gibs": 3.89877,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 38.733,
+          "best_ms": 3.30639,
+          "in_gibs": 1.21218,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.7492,
+          "best_ms": 7.46228,
+          "in_gibs": 13.6815,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.73954,
+          "best_ms": 3.8025,
+          "in_gibs": 21.524,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.96631,
+          "best_ms": 0.002885,
+          "in_gibs": 13.32,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 9.55,
+      "status": "pass",
+      "throughput_in_gibs": 0.907381,
+      "throughput_out_gibs": 0.017821,
+      "compression_fold": 68.1096,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0690469,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 3.87448,
+      "init_s": 3.768,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.86455,
+          "best_ms": 0.800792,
+          "in_gibs": 16.3638,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.33903,
+          "best_ms": 7.85083,
+          "in_gibs": 15.0578,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 51.7876,
+          "best_ms": 46.0115,
+          "in_gibs": 3.62203,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 40.9965,
+          "best_ms": 4.28664,
+          "in_gibs": 1.14525,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.5883,
+          "best_ms": 5.52873,
+          "in_gibs": 12.8946,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.71529,
+          "best_ms": 7.13031,
+          "in_gibs": 19.3623,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.86726,
+          "best_ms": 0.00061,
+          "in_gibs": 0.446616,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.84,
+      "status": "pass",
+      "throughput_in_gibs": 7.46981,
+      "throughput_out_gibs": 8.61691,
+      "compression_fold": 1.17089,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.0555,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.470645,
+      "init_s": 0.300313,
+      "flush_s": 6.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.42494,
+          "best_ms": 0.823496,
+          "in_gibs": 19.3304,
+          "out_gibs": 19.3304
+        },
+        "h2d": {
+          "avg_ms": 0.899953,
+          "best_ms": 0.296192,
+          "in_gibs": 52.3239,
+          "out_gibs": 52.3239
+        },
+        "scatter": {
+          "avg_ms": 0.0477589,
+          "best_ms": 0.013632,
+          "in_gibs": 985.974,
+          "out_gibs": 985.974
+        },
+        "lod_gather": {
+          "avg_ms": 0.22894,
+          "best_ms": 0.221056,
+          "in_gibs": 614.244,
+          "out_gibs": 614.244
+        },
+        "lod_reduce": {
+          "avg_ms": 0.84914,
+          "best_ms": 0.78496,
+          "in_gibs": 165.609,
+          "out_gibs": 221.171
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.136852,
+          "best_ms": 0.071872,
+          "in_gibs": 344.753,
+          "out_gibs": 344.753
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.12745,
+          "best_ms": 0.240448,
+          "in_gibs": 88.277,
+          "out_gibs": 89.2812
+        },
+        "compress": {
+          "avg_ms": 0.896104,
+          "best_ms": 0.24192,
+          "in_gibs": 688.882,
+          "out_gibs": 565.668
+        },
+        "aggregate": {
+          "avg_ms": 7.96882,
+          "best_ms": 0.464928,
+          "in_gibs": 63.61,
+          "out_gibs": 63.61
+        },
+        "d2h": {
+          "avg_ms": 46.4247,
+          "best_ms": 0.95024,
+          "in_gibs": 10.9187,
+          "out_gibs": 10.9187
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 65.4185,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 1.99058,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 16.5199,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 9.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.06138,
+      "throughput_out_gibs": 1.22437,
+      "compression_fold": 1.17089,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.0555,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 3.31231,
+      "init_s": 3.74853,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.8428,
+          "best_ms": 0.822965,
+          "in_gibs": 16.489,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 8.99021,
+          "best_ms": 7.23646,
+          "in_gibs": 15.642,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 45.521,
+          "best_ms": 18.2111,
+          "in_gibs": 4.12568,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 31.8889,
+          "best_ms": 0.884417,
+          "in_gibs": 1.47952,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.2329,
+          "best_ms": 3.86338,
+          "in_gibs": 13.3453,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.1291,
+          "best_ms": 9.84329,
+          "in_gibs": 40.8027,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.63975,
+          "best_ms": 0.051728,
+          "in_gibs": 31.2145,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.45,
+      "status": "pass",
+      "throughput_in_gibs": 4.50711,
+      "throughput_out_gibs": 0.639514,
+      "compression_fold": 9.5193,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.498832,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.780018,
+      "init_s": 0.325565,
+      "flush_s": 5.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.46687,
+          "best_ms": 0.844908,
+          "in_gibs": 19.0018,
+          "out_gibs": 19.0018
+        },
+        "h2d": {
+          "avg_ms": 0.896063,
+          "best_ms": 0.298848,
+          "in_gibs": 52.551,
+          "out_gibs": 52.551
+        },
+        "scatter": {
+          "avg_ms": 0.135142,
+          "best_ms": 0.013632,
+          "in_gibs": 345.229,
+          "out_gibs": 345.229
+        },
+        "lod_gather": {
+          "avg_ms": 1.83365,
+          "best_ms": 0.222464,
+          "in_gibs": 76.6914,
+          "out_gibs": 76.6914
+        },
+        "lod_reduce": {
+          "avg_ms": 1.92101,
+          "best_ms": 0.789152,
+          "in_gibs": 73.2036,
+          "out_gibs": 97.7637
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.60124,
+          "best_ms": 0.141312,
+          "in_gibs": 78.4714,
+          "out_gibs": 78.4714
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.7664,
+          "best_ms": 0.3072,
+          "in_gibs": 13.6423,
+          "out_gibs": 13.7974
+        },
+        "compress": {
+          "avg_ms": 80.988,
+          "best_ms": 26.4237,
+          "in_gibs": 7.62224,
+          "out_gibs": 0.769412
+        },
+        "aggregate": {
+          "avg_ms": 0.35254,
+          "best_ms": 0.055328,
+          "in_gibs": 176.755,
+          "out_gibs": 176.755
+        },
+        "d2h": {
+          "avg_ms": 6.88716,
+          "best_ms": 0.119328,
+          "in_gibs": 9.04772,
+          "out_gibs": 9.04772
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 177.939,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 301.416,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 77.771,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 9.83,
+      "status": "pass",
+      "throughput_in_gibs": 0.894775,
+      "throughput_out_gibs": 0.0958375,
+      "compression_fold": 12.6106,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.376552,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 3.92906,
+      "init_s": 3.82541,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.86356,
+          "best_ms": 0.8129,
+          "in_gibs": 16.3695,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.29308,
+          "best_ms": 7.97092,
+          "in_gibs": 15.1322,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 44.2669,
+          "best_ms": 38.0389,
+          "in_gibs": 4.24256,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 36.6573,
+          "best_ms": 28.9837,
+          "in_gibs": 1.28706,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 15.2145,
+          "best_ms": 9.17215,
+          "in_gibs": 12.4842,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 88.7033,
+          "best_ms": 35.0484,
+          "in_gibs": 6.95926,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.40184,
+          "best_ms": 0.001963,
+          "in_gibs": 9.58495,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 9.36,
+      "status": "pass",
+      "throughput_in_gibs": 0.966226,
+      "throughput_out_gibs": 0.59381,
+      "compression_fold": 2.1978,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.16058,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 3.63851,
+      "init_s": 3.7251,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.86409,
+          "best_ms": 0.821333,
+          "in_gibs": 16.3665,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.56115,
+          "best_ms": 7.31958,
+          "in_gibs": 14.708,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 43.8481,
+          "best_ms": 24.8735,
+          "in_gibs": 4.28308,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 34.8252,
+          "best_ms": 1.09724,
+          "in_gibs": 1.35477,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 15.5461,
+          "best_ms": 4.63888,
+          "in_gibs": 12.2179,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 52.0381,
+          "best_ms": 18.0295,
+          "in_gibs": 11.8626,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.89082,
+          "best_ms": 0.011928,
+          "in_gibs": 26.6887,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 8.91,
+      "status": "pass",
+      "throughput_in_gibs": 1.04219,
+      "throughput_out_gibs": 0.0174332,
+      "compression_fold": 80.7471,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0588075,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 3.37331,
+      "init_s": 3.79565,
+      "flush_s": 6.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.85837,
+          "best_ms": 0.802063,
+          "in_gibs": 16.3992,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 9.50697,
+          "best_ms": 8.03572,
+          "in_gibs": 14.7918,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 44.2173,
+          "best_ms": 27.4862,
+          "in_gibs": 4.24733,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 33.7796,
+          "best_ms": 5.41534,
+          "in_gibs": 1.39671,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.6197,
+          "best_ms": 8.4979,
+          "in_gibs": 12.9922,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.1234,
+          "best_ms": 11.8391,
+          "in_gibs": 21.1964,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.06879,
+          "best_ms": 0.00054,
+          "in_gibs": 1.95415,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.79,
+      "status": "pass",
+      "throughput_in_gibs": 7.2144,
+      "throughput_out_gibs": 8.85383,
+      "compression_fold": 1.18287,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31453,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 0.487307,
+      "init_s": 1.01582,
+      "flush_s": 5.7e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.91465,
+          "best_ms": 0.835734,
+          "in_gibs": 19.1459,
+          "out_gibs": 19.1459
+        },
+        "h2d": {
+          "avg_ms": 1.06527,
+          "best_ms": 0.590112,
+          "in_gibs": 52.8996,
+          "out_gibs": 52.8996
+        },
+        "scatter": {
+          "avg_ms": 0.126472,
+          "best_ms": 0.023712,
+          "in_gibs": 445.573,
+          "out_gibs": 445.573
+        },
+        "lod_gather": {
+          "avg_ms": 0.426795,
+          "best_ms": 0.425376,
+          "in_gibs": 658.982,
+          "out_gibs": 658.982
+        },
+        "lod_reduce": {
+          "avg_ms": 1.52459,
+          "best_ms": 1.51754,
+          "in_gibs": 184.476,
+          "out_gibs": 246.289
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.223232,
+          "best_ms": 0.1536,
+          "in_gibs": 422.154,
+          "out_gibs": 422.154
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.8187,
+          "best_ms": 0.449536,
+          "in_gibs": 27.1725,
+          "out_gibs": 28.4093
+        },
+        "compress": {
+          "avg_ms": 2.64857,
+          "best_ms": 0.548864,
+          "in_gibs": 691.707,
+          "out_gibs": 542.992
+        },
+        "aggregate": {
+          "avg_ms": 8.12622,
+          "best_ms": 5.74464,
+          "in_gibs": 176.977,
+          "out_gibs": 176.977
+        },
+        "d2h": {
+          "avg_ms": 65.7383,
+          "best_ms": 2.12973,
+          "in_gibs": 21.8769,
+          "out_gibs": 21.8769
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 18.2217,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.60301,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.74,
+      "status": "pass",
+      "throughput_in_gibs": 1.42804,
+      "throughput_out_gibs": 1.75255,
+      "compression_fold": 1.18287,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31453,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.46185,
+      "init_s": 7.06506,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.76893,
+          "best_ms": 0.85307,
+          "in_gibs": 14.8062,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 14.6212,
+          "best_ms": 12.7056,
+          "in_gibs": 19.2358,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 55.0616,
+          "best_ms": 45.1618,
+          "in_gibs": 6.81942,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 31.5763,
+          "best_ms": 13.1441,
+          "in_gibs": 2.98446,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.9066,
+          "best_ms": 13.7308,
+          "in_gibs": 18.7777,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 48.1486,
+          "best_ms": 25.1362,
+          "in_gibs": 38.0495,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 15.934,
+          "best_ms": 0.31987,
+          "in_gibs": 24.6154,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 4.87,
+      "status": "pass",
+      "throughput_in_gibs": 2.84601,
+      "throughput_out_gibs": 0.44342,
+      "compression_fold": 9.31728,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.547747,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.23528,
+      "init_s": 1.04704,
+      "flush_s": 6.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.93458,
+          "best_ms": 0.81932,
+          "in_gibs": 19.0159,
+          "out_gibs": 19.0159
+        },
+        "h2d": {
+          "avg_ms": 1.06742,
+          "best_ms": 0.590368,
+          "in_gibs": 52.793,
+          "out_gibs": 52.793
+        },
+        "scatter": {
+          "avg_ms": 0.0581707,
+          "best_ms": 0.023712,
+          "in_gibs": 966.982,
+          "out_gibs": 966.982
+        },
+        "lod_gather": {
+          "avg_ms": 0.422987,
+          "best_ms": 0.41968,
+          "in_gibs": 664.915,
+          "out_gibs": 664.915
+        },
+        "lod_reduce": {
+          "avg_ms": 1.52526,
+          "best_ms": 1.51549,
+          "in_gibs": 184.395,
+          "out_gibs": 246.18
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.223915,
+          "best_ms": 0.155648,
+          "in_gibs": 420.867,
+          "out_gibs": 420.867
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 96.6589,
+          "best_ms": 0.449536,
+          "in_gibs": 3.88467,
+          "out_gibs": 4.06148
+        },
+        "compress": {
+          "avg_ms": 281.448,
+          "best_ms": 56.9077,
+          "in_gibs": 6.5093,
+          "out_gibs": 0.648634
+        },
+        "aggregate": {
+          "avg_ms": 1.51575,
+          "best_ms": 0.241696,
+          "in_gibs": 120.44,
+          "out_gibs": 120.44
+        },
+        "d2h": {
+          "avg_ms": 41.6933,
+          "best_ms": 0.196736,
+          "in_gibs": 4.37857,
+          "out_gibs": 4.37857
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 343.782,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 492.735,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.12,
+      "status": "pass",
+      "throughput_in_gibs": 1.2797,
+      "throughput_out_gibs": 0.146414,
+      "compression_fold": 12.688,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.402231,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.74722,
+      "init_s": 7.22924,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.79198,
+          "best_ms": 0.870266,
+          "in_gibs": 14.7162,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 14.464,
+          "best_ms": 12.3384,
+          "in_gibs": 19.4449,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 53.4234,
+          "best_ms": 38.5231,
+          "in_gibs": 7.02854,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 29.7362,
+          "best_ms": 13.1025,
+          "in_gibs": 3.16914,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 21.1851,
+          "best_ms": 15.0317,
+          "in_gibs": 18.5309,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 211.159,
+          "best_ms": 77.6344,
+          "in_gibs": 8.67606,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.00288,
+          "best_ms": 0.004657,
+          "in_gibs": 18.2534,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.65,
+      "status": "pass",
+      "throughput_in_gibs": 1.32567,
+      "throughput_out_gibs": 0.843857,
+      "compression_fold": 2.28051,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.23788,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.65197,
+      "init_s": 6.94246,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.7675,
+          "best_ms": 0.846841,
+          "in_gibs": 14.8118,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 14.9092,
+          "best_ms": 13.0221,
+          "in_gibs": 18.8642,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 54.5559,
+          "best_ms": 37.5859,
+          "in_gibs": 6.88263,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 28.5507,
+          "best_ms": 4.75726,
+          "in_gibs": 3.30073,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.9019,
+          "best_ms": 12.3321,
+          "in_gibs": 18.7819,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 158.49,
+          "best_ms": 45.8648,
+          "in_gibs": 11.5593,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.79935,
+          "best_ms": 0.103716,
+          "in_gibs": 26.0838,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.81,
+      "status": "pass",
+      "throughput_in_gibs": 1.47207,
+      "throughput_out_gibs": 0.0245354,
+      "compression_fold": 87.097,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0585958,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.38821,
+      "init_s": 7.34611,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.78457,
+          "best_ms": 0.867802,
+          "in_gibs": 14.745,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 15.2212,
+          "best_ms": 12.9863,
+          "in_gibs": 18.4775,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 56.1908,
+          "best_ms": 39.1806,
+          "in_gibs": 6.68238,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 33.544,
+          "best_ms": 22.3896,
+          "in_gibs": 2.8094,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.2235,
+          "best_ms": 11.8147,
+          "in_gibs": 19.412,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 64.3997,
+          "best_ms": 26.7467,
+          "in_gibs": 28.4478,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.21994,
+          "best_ms": 0.00636,
+          "in_gibs": 4.36081,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.55,
+      "status": "pass",
+      "throughput_in_gibs": 7.89164,
+      "throughput_out_gibs": 8.41968,
+      "compression_fold": 1.07092,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00092,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.475186,
+      "init_s": 0.127299,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.33931,
+          "best_ms": 1.54263,
+          "in_gibs": 20.0379,
+          "out_gibs": 20.0379
+        },
+        "h2d": {
+          "avg_ms": 0.911627,
+          "best_ms": 0.590144,
+          "in_gibs": 51.419,
+          "out_gibs": 51.419
+        },
+        "scatter": {
+          "avg_ms": 0.0474334,
+          "best_ms": 0.023552,
+          "in_gibs": 988.227,
+          "out_gibs": 988.227
+        },
+        "lod_gather": {
+          "avg_ms": 0.435797,
+          "best_ms": 0.417408,
+          "in_gibs": 215.123,
+          "out_gibs": 215.123
+        },
+        "lod_reduce": {
+          "avg_ms": 0.425643,
+          "best_ms": 0.405504,
+          "in_gibs": 220.255,
+          "out_gibs": 251.658
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.052448,
+          "best_ms": 0.043008,
+          "in_gibs": 254.856,
+          "out_gibs": 254.856
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.279245,
+          "best_ms": 0.261152,
+          "in_gibs": 383.594,
+          "out_gibs": 383.594
+        },
+        "compress": {
+          "avg_ms": 0.300091,
+          "best_ms": 0.288768,
+          "in_gibs": 713.894,
+          "out_gibs": 666.454
+        },
+        "aggregate": {
+          "avg_ms": 1.9753,
+          "best_ms": 0.66352,
+          "in_gibs": 101.249,
+          "out_gibs": 101.249
+        },
+        "d2h": {
+          "avg_ms": 21.2721,
+          "best_ms": 3.83059,
+          "in_gibs": 9.40184,
+          "out_gibs": 9.40184
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 78.8079,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 0.89193,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.75505,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 14.64,
+      "status": "pass",
+      "throughput_in_gibs": 2.61805,
+      "throughput_out_gibs": 2.79323,
+      "compression_fold": 1.07092,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00092,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.43236,
+      "init_s": 2.06077,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.66226,
+          "best_ms": 1.57281,
+          "in_gibs": 17.6072,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.68198,
+          "best_ms": 6.63454,
+          "in_gibs": 12.2039,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.1779,
+          "best_ms": 4.74147,
+          "in_gibs": 14.9231,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.24392,
+          "best_ms": 9e-05,
+          "in_gibs": 10.7456,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.57183,
+          "best_ms": 2.92989,
+          "in_gibs": 29.9893,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.59504,
+          "best_ms": 3.47988,
+          "in_gibs": 59.5914,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.45563,
+          "best_ms": 0.009354,
+          "in_gibs": 49.9619,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.81,
+      "status": "pass",
+      "throughput_in_gibs": 8.93047,
+      "throughput_out_gibs": 1.11965,
+      "compression_fold": 9.11332,
+      "input_gib": 3.75,
+      "compressed_gib": 0.470155,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.419911,
+      "init_s": 0.124704,
+      "flush_s": 5.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.32732,
+          "best_ms": 1.51936,
+          "in_gibs": 20.1412,
+          "out_gibs": 20.1412
+        },
+        "h2d": {
+          "avg_ms": 0.898447,
+          "best_ms": 0.590144,
+          "in_gibs": 52.1734,
+          "out_gibs": 52.1734
+        },
+        "scatter": {
+          "avg_ms": 0.0725897,
+          "best_ms": 0.025472,
+          "in_gibs": 642.957,
+          "out_gibs": 642.957
+        },
+        "lod_gather": {
+          "avg_ms": 0.421795,
+          "best_ms": 0.417376,
+          "in_gibs": 222.264,
+          "out_gibs": 222.264
+        },
+        "lod_reduce": {
+          "avg_ms": 0.404469,
+          "best_ms": 0.401408,
+          "in_gibs": 231.786,
+          "out_gibs": 264.833
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.0445536,
+          "best_ms": 0.041984,
+          "in_gibs": 300.014,
+          "out_gibs": 300.014
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.264816,
+          "best_ms": 0.26,
+          "in_gibs": 404.495,
+          "out_gibs": 404.495
+        },
+        "compress": {
+          "avg_ms": 11.522,
+          "best_ms": 10.8186,
+          "in_gibs": 18.5934,
+          "out_gibs": 2.036
+        },
+        "aggregate": {
+          "avg_ms": 0.165322,
+          "best_ms": 0.11264,
+          "in_gibs": 141.899,
+          "out_gibs": 141.899
+        },
+        "d2h": {
+          "avg_ms": 5.90137,
+          "best_ms": 0.459712,
+          "in_gibs": 3.97516,
+          "out_gibs": 3.97516
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 11.7545,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 12.8954,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.68264,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 15.01,
+      "status": "pass",
+      "throughput_in_gibs": 2.08041,
+      "throughput_out_gibs": 0.198657,
+      "compression_fold": 11.9655,
+      "input_gib": 3.75,
+      "compressed_gib": 0.358085,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.80253,
+      "init_s": 2.06247,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.67667,
+          "best_ms": 1.59128,
+          "in_gibs": 17.5124,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 8.04469,
+          "best_ms": 6.72398,
+          "in_gibs": 11.6537,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 9.42308,
+          "best_ms": 4.73587,
+          "in_gibs": 11.3675,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.02749,
+          "best_ms": 0.000131,
+          "in_gibs": 3.31887,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.95387,
+          "best_ms": 2.91806,
+          "in_gibs": 21.6229,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.6476,
+          "best_ms": 9.57104,
+          "in_gibs": 20.1204,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.546814,
+          "best_ms": 0.001482,
+          "in_gibs": 11.874,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 14.42,
+      "status": "pass",
+      "throughput_in_gibs": 2.63632,
+      "throughput_out_gibs": 1.77228,
+      "compression_fold": 1.69962,
+      "input_gib": 3.75,
+      "compressed_gib": 2.52095,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.42244,
+      "init_s": 2.06121,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.57979,
+          "best_ms": 1.52295,
+          "in_gibs": 18.1701,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.44488,
+          "best_ms": 6.59262,
+          "in_gibs": 12.5926,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.80022,
+          "best_ms": 4.73175,
+          "in_gibs": 15.7519,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.50888,
+          "best_ms": 6e-05,
+          "in_gibs": 8.85867,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.72447,
+          "best_ms": 2.87339,
+          "in_gibs": 28.7603,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.12146,
+          "best_ms": 4.71393,
+          "in_gibs": 41.8305,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.02336,
+          "best_ms": 0.00709,
+          "in_gibs": 44.7717,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 14.41,
+      "status": "pass",
+      "throughput_in_gibs": 2.47149,
+      "throughput_out_gibs": 0.062581,
+      "compression_fold": 45.1234,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0949545,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.5173,
+      "init_s": 2.07246,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.65556,
+          "best_ms": 1.58466,
+          "in_gibs": 17.6516,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.61142,
+          "best_ms": 6.6195,
+          "in_gibs": 12.317,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.77772,
+          "best_ms": 4.7266,
+          "in_gibs": 13.7722,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.93143,
+          "best_ms": 0.0001,
+          "in_gibs": 6.92061,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.06832,
+          "best_ms": 2.9173,
+          "in_gibs": 26.3294,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.541,
+          "best_ms": 6.98134,
+          "in_gibs": 28.4091,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.265657,
+          "best_ms": 0.000972,
+          "in_gibs": 6.43192,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.11,
+      "status": "pass",
+      "throughput_in_gibs": 7.86267,
+      "throughput_out_gibs": 8.39299,
+      "compression_fold": 1.07587,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00293,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.476937,
+      "init_s": 0.30115,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.3374,
+          "best_ms": 1.53845,
+          "in_gibs": 20.0543,
+          "out_gibs": 20.0543
+        },
+        "h2d": {
+          "avg_ms": 0.891145,
+          "best_ms": 0.589888,
+          "in_gibs": 52.6008,
+          "out_gibs": 52.6008
+        },
+        "scatter": {
+          "avg_ms": 0.0450002,
+          "best_ms": 0.023712,
+          "in_gibs": 1041.66,
+          "out_gibs": 1041.66
+        },
+        "lod_gather": {
+          "avg_ms": 0.439251,
+          "best_ms": 0.417184,
+          "in_gibs": 213.431,
+          "out_gibs": 213.431
+        },
+        "lod_reduce": {
+          "avg_ms": 0.42409,
+          "best_ms": 0.407136,
+          "in_gibs": 221.062,
+          "out_gibs": 253.876
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.057728,
+          "best_ms": 0.0512,
+          "in_gibs": 241.062,
+          "out_gibs": 241.062
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.295302,
+          "best_ms": 0.279552,
+          "in_gibs": 364.596,
+          "out_gibs": 364.596
+        },
+        "compress": {
+          "avg_ms": 1.25844,
+          "best_ms": 1.23258,
+          "in_gibs": 684.442,
+          "out_gibs": 636.135
+        },
+        "aggregate": {
+          "avg_ms": 13.0358,
+          "best_ms": 3.4591,
+          "in_gibs": 61.4106,
+          "out_gibs": 61.4106
+        },
+        "d2h": {
+          "avg_ms": 73.4247,
+          "best_ms": 15.2243,
+          "in_gibs": 10.9028,
+          "out_gibs": 10.9028
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 63.6387,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 3.25895,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 19.2169,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 14.91,
+      "status": "pass",
+      "throughput_in_gibs": 2.5879,
+      "throughput_out_gibs": 2.76245,
+      "compression_fold": 1.07587,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00293,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.44905,
+      "init_s": 2.03933,
+      "flush_s": 6.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.64652,
+          "best_ms": 1.57421,
+          "in_gibs": 17.712,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.22342,
+          "best_ms": 6.63382,
+          "in_gibs": 12.9786,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.30492,
+          "best_ms": 4.87882,
+          "in_gibs": 17.0765,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.39047,
+          "best_ms": 4e-05,
+          "in_gibs": 10.0081,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.83872,
+          "best_ms": 3.58668,
+          "in_gibs": 22.2509,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.0316,
+          "best_ms": 14.2182,
+          "in_gibs": 57.3013,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.28625,
+          "best_ms": 0.037697,
+          "in_gibs": 46.6921,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.23,
+      "status": "pass",
+      "throughput_in_gibs": 5.59144,
+      "throughput_out_gibs": 0.7059,
+      "compression_fold": 9.09677,
+      "input_gib": 3.75,
+      "compressed_gib": 0.473425,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.670669,
+      "init_s": 0.303818,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.33735,
+          "best_ms": 1.54435,
+          "in_gibs": 20.0548,
+          "out_gibs": 20.0548
+        },
+        "h2d": {
+          "avg_ms": 0.88904,
+          "best_ms": 0.589952,
+          "in_gibs": 52.7254,
+          "out_gibs": 52.7254
+        },
+        "scatter": {
+          "avg_ms": 0.127446,
+          "best_ms": 0.023712,
+          "in_gibs": 367.804,
+          "out_gibs": 367.804
+        },
+        "lod_gather": {
+          "avg_ms": 2.14826,
+          "best_ms": 0.421216,
+          "in_gibs": 43.6401,
+          "out_gibs": 43.6401
+        },
+        "lod_reduce": {
+          "avg_ms": 1.05084,
+          "best_ms": 0.411296,
+          "in_gibs": 89.2147,
+          "out_gibs": 102.458
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.228883,
+          "best_ms": 0.0464,
+          "in_gibs": 60.7996,
+          "out_gibs": 60.7996
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.15409,
+          "best_ms": 0.2816,
+          "in_gibs": 93.2906,
+          "out_gibs": 93.2906
+        },
+        "compress": {
+          "avg_ms": 99.5075,
+          "best_ms": 83.7997,
+          "in_gibs": 8.65591,
+          "out_gibs": 0.951045
+        },
+        "aggregate": {
+          "avg_ms": 0.496563,
+          "best_ms": 0.366592,
+          "in_gibs": 190.582,
+          "out_gibs": 190.582
+        },
+        "d2h": {
+          "avg_ms": 16.8283,
+          "best_ms": 1.81098,
+          "in_gibs": 5.62363,
+          "out_gibs": 5.62363
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 108.011,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 183.559,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 89.4752,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 15.36,
+      "status": "pass",
+      "throughput_in_gibs": 2.32087,
+      "throughput_out_gibs": 0.21722,
+      "compression_fold": 12.2704,
+      "input_gib": 3.75,
+      "compressed_gib": 0.350978,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.61577,
+      "init_s": 2.01884,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.62389,
+          "best_ms": 1.51607,
+          "in_gibs": 17.8647,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.85321,
+          "best_ms": 6.67858,
+          "in_gibs": 11.9378,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 8.3751,
+          "best_ms": 4.92622,
+          "in_gibs": 12.8555,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.77502,
+          "best_ms": 0.00012,
+          "in_gibs": 7.83993,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.11146,
+          "best_ms": 3.61016,
+          "in_gibs": 21.0637,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 35.9314,
+          "best_ms": 34.0301,
+          "in_gibs": 23.9714,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.629803,
+          "best_ms": 0.001933,
+          "in_gibs": 27.8447,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 15.37,
+      "status": "pass",
+      "throughput_in_gibs": 1.90968,
+      "throughput_out_gibs": 1.14655,
+      "compression_fold": 1.91282,
+      "input_gib": 3.75,
+      "compressed_gib": 2.25146,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.96368,
+      "init_s": 2.10507,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.67714,
+          "best_ms": 1.57099,
+          "in_gibs": 17.5094,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 8.29113,
+          "best_ms": 6.46552,
+          "in_gibs": 11.3073,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 11.9431,
+          "best_ms": 4.91704,
+          "in_gibs": 9.01491,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.46333,
+          "best_ms": 0.000151,
+          "in_gibs": 2.15307,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 6.2992,
+          "best_ms": 3.66037,
+          "in_gibs": 17.092,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.1155,
+          "best_ms": 16.8268,
+          "in_gibs": 47.5464,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.4431,
+          "best_ms": 0.00673,
+          "in_gibs": 46.0729,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 14.79,
+      "status": "pass",
+      "throughput_in_gibs": 1.98399,
+      "throughput_out_gibs": 0.0320244,
+      "compression_fold": 71.1486,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0605302,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.89013,
+      "init_s": 2.06155,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.62878,
+          "best_ms": 1.54392,
+          "in_gibs": 17.8315,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 8.18658,
+          "best_ms": 6.70644,
+          "in_gibs": 11.4517,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 11.3443,
+          "best_ms": 4.91063,
+          "in_gibs": 9.49073,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.39078,
+          "best_ms": 5e-05,
+          "in_gibs": 2.17751,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 6.67739,
+          "best_ms": 3.6078,
+          "in_gibs": 16.124,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.5807,
+          "best_ms": 15.2209,
+          "in_gibs": 55.2817,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0933469,
+          "best_ms": 0.001081,
+          "in_gibs": 32.2912,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.41,
+      "status": "pass",
+      "throughput_in_gibs": 7.94332,
+      "throughput_out_gibs": 8.50201,
+      "compression_fold": 1.08027,
+      "input_gib": 3.75,
+      "compressed_gib": 4.01375,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 0.472095,
+      "init_s": 1.01087,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.3261,
+          "best_ms": 1.54058,
+          "in_gibs": 20.1517,
+          "out_gibs": 20.1517
+        },
+        "h2d": {
+          "avg_ms": 0.886722,
+          "best_ms": 0.589888,
+          "in_gibs": 52.8632,
+          "out_gibs": 52.8632
+        },
+        "scatter": {
+          "avg_ms": 0.0446616,
+          "best_ms": 0.023712,
+          "in_gibs": 1045.02,
+          "out_gibs": 1045.02
+        },
+        "lod_gather": {
+          "avg_ms": 0.43248,
+          "best_ms": 0.42272,
+          "in_gibs": 216.773,
+          "out_gibs": 216.773
+        },
+        "lod_reduce": {
+          "avg_ms": 0.41216,
+          "best_ms": 0.403456,
+          "in_gibs": 227.46,
+          "out_gibs": 263.001
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.05328,
+          "best_ms": 0.047104,
+          "in_gibs": 274.933,
+          "out_gibs": 274.933
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.303456,
+          "best_ms": 0.294912,
+          "in_gibs": 357.213,
+          "out_gibs": 357.213
+        },
+        "compress": {
+          "avg_ms": 3.13174,
+          "best_ms": 1.23226,
+          "in_gibs": 692.256,
+          "out_gibs": 640.805
+        },
+        "aggregate": {
+          "avg_ms": 8.54987,
+          "best_ms": 4.77802,
+          "in_gibs": 234.721,
+          "out_gibs": 234.721
+        },
+        "d2h": {
+          "avg_ms": 65.9542,
+          "best_ms": 15.2647,
+          "in_gibs": 30.4277,
+          "out_gibs": 30.4277
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 5.90868,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.33017,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 15.11,
+      "status": "pass",
+      "throughput_in_gibs": 2.17693,
+      "throughput_out_gibs": 2.33004,
+      "compression_fold": 1.08027,
+      "input_gib": 3.75,
+      "compressed_gib": 4.01375,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 1.72261,
+      "init_s": 2.04421,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.64802,
+          "best_ms": 1.5713,
+          "in_gibs": 17.7019,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.7597,
+          "best_ms": 6.62485,
+          "in_gibs": 12.0817,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.42104,
+          "best_ms": 5.28641,
+          "in_gibs": 14.6069,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.96861,
+          "best_ms": 0.00036,
+          "in_gibs": 7.44101,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 6.68012,
+          "best_ms": 3.8589,
+          "in_gibs": 16.227,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 61.2254,
+          "best_ms": 49.0493,
+          "in_gibs": 35.4096,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 23.8961,
+          "best_ms": 0.33284,
+          "in_gibs": 27.9939,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.56,
+      "status": "pass",
+      "throughput_in_gibs": 3.56446,
+      "throughput_out_gibs": 0.462225,
+      "compression_fold": 8.91647,
+      "input_gib": 3.75,
+      "compressed_gib": 0.486284,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 1.05205,
+      "init_s": 1.00639,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.33407,
+          "best_ms": 1.53287,
+          "in_gibs": 20.083,
+          "out_gibs": 20.083
+        },
+        "h2d": {
+          "avg_ms": 0.886183,
+          "best_ms": 0.589952,
+          "in_gibs": 52.8954,
+          "out_gibs": 52.8954
+        },
+        "scatter": {
+          "avg_ms": 0.0435676,
+          "best_ms": 0.023584,
+          "in_gibs": 1075.91,
+          "out_gibs": 1075.91
+        },
+        "lod_gather": {
+          "avg_ms": 0.427344,
+          "best_ms": 0.419488,
+          "in_gibs": 219.378,
+          "out_gibs": 219.378
+        },
+        "lod_reduce": {
+          "avg_ms": 0.414048,
+          "best_ms": 0.401408,
+          "in_gibs": 226.423,
+          "out_gibs": 261.802
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.051888,
+          "best_ms": 0.045056,
+          "in_gibs": 282.309,
+          "out_gibs": 282.309
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.304096,
+          "best_ms": 0.295936,
+          "in_gibs": 356.461,
+          "out_gibs": 356.461
+        },
+        "compress": {
+          "avg_ms": 326.552,
+          "best_ms": 74.3509,
+          "in_gibs": 6.63898,
+          "out_gibs": 0.74445
+        },
+        "aggregate": {
+          "avg_ms": 2.05568,
+          "best_ms": 0.600064,
+          "in_gibs": 118.258,
+          "out_gibs": 118.258
+        },
+        "d2h": {
+          "avg_ms": 40.2386,
+          "best_ms": 1.86032,
+          "in_gibs": 6.04149,
+          "out_gibs": 6.04149
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 74.8079,
+        "kick_sync_count": 2,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 584.456,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 16.08,
+      "status": "pass",
+      "throughput_in_gibs": 1.39645,
+      "throughput_out_gibs": 0.113748,
+      "compression_fold": 14.195,
+      "input_gib": 3.75,
+      "compressed_gib": 0.305456,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 2.68537,
+      "init_s": 2.08188,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.67231,
+          "best_ms": 1.58511,
+          "in_gibs": 17.541,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 8.12484,
+          "best_ms": 6.54161,
+          "in_gibs": 11.5387,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 9.60078,
+          "best_ms": 5.30077,
+          "in_gibs": 11.2906,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 5.56745,
+          "best_ms": 0.00029,
+          "in_gibs": 2.63109,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 7.54884,
+          "best_ms": 3.98084,
+          "in_gibs": 14.3596,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 464.757,
+          "best_ms": 120.844,
+          "in_gibs": 4.66473,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.78688,
+          "best_ms": 0.010917,
+          "in_gibs": 28.483,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 15.67,
+      "status": "pass",
+      "throughput_in_gibs": 1.59515,
+      "throughput_out_gibs": 1.00256,
+      "compression_fold": 1.83969,
+      "input_gib": 3.75,
+      "compressed_gib": 2.35689,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 2.35088,
+      "init_s": 2.05492,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.60416,
+          "best_ms": 1.5348,
+          "in_gibs": 18.0001,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.47779,
+          "best_ms": 6.48583,
+          "in_gibs": 12.5371,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.1602,
+          "best_ms": 5.27258,
+          "in_gibs": 15.139,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.61036,
+          "best_ms": 0.00025,
+          "in_gibs": 5.61166,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 6.27024,
+          "best_ms": 3.98064,
+          "in_gibs": 17.2878,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 411.644,
+          "best_ms": 95.956,
+          "in_gibs": 5.26661,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.7023,
+          "best_ms": 0.070365,
+          "in_gibs": 28.6669,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 15.34,
+      "status": "pass",
+      "throughput_in_gibs": 1.52614,
+      "throughput_out_gibs": 0.0383119,
+      "compression_fold": 46.0589,
+      "input_gib": 3.75,
+      "compressed_gib": 0.094139,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 2.45717,
+      "init_s": 1.98952,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.62845,
+          "best_ms": 1.52917,
+          "in_gibs": 17.8337,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 8.08347,
+          "best_ms": 6.62482,
+          "in_gibs": 11.5977,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 8.16313,
+          "best_ms": 5.31343,
+          "in_gibs": 13.279,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.91235,
+          "best_ms": 0.000361,
+          "in_gibs": 3.74415,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 6.92112,
+          "best_ms": 3.98514,
+          "in_gibs": 15.662,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 431.307,
+          "best_ms": 104.492,
+          "in_gibs": 5.0265,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.659947,
+          "best_ms": 0.004967,
+          "in_gibs": 23.7537,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__zeros__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.72,
+      "status": "pass",
+      "throughput_in_gibs": 11.1264,
+      "throughput_out_gibs": 11.133,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.315971,
+      "init_s": 0.0949532,
+      "flush_s": 5.5e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.12633,
+          "best_ms": 0.531728,
+          "in_gibs": 22.045,
+          "out_gibs": 22.045
+        },
+        "h2d": {
+          "avg_ms": 0.915879,
+          "best_ms": 0.297408,
+          "in_gibs": 51.4141,
+          "out_gibs": 51.4141
+        },
+        "scatter": {
+          "avg_ms": 0.198457,
+          "best_ms": 0.068576,
+          "in_gibs": 237.276,
+          "out_gibs": 237.276
+        },
+        "compress": {
+          "avg_ms": 0.176175,
+          "best_ms": 0.168928,
+          "in_gibs": 798.21,
+          "out_gibs": 798.21
+        },
+        "aggregate": {
+          "avg_ms": 1.95429,
+          "best_ms": 0.490496,
+          "in_gibs": 71.9572,
+          "out_gibs": 71.9572
+        },
+        "d2h": {
+          "avg_ms": 11.0579,
+          "best_ms": 2.68717,
+          "in_gibs": 12.7172,
+          "out_gibs": 12.7172
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 70.4444,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 0.030669,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.73308,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__zeros__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.82,
+      "status": "pass",
+      "throughput_in_gibs": 11.3566,
+      "throughput_out_gibs": 11.3575,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.309566,
+      "init_s": 0.234049,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.08074,
+          "best_ms": 0.703325,
+          "in_gibs": 22.5281,
+          "out_gibs": 22.5281
+        },
+        "h2d": {
+          "avg_ms": 0.897092,
+          "best_ms": 0.296032,
+          "in_gibs": 52.4907,
+          "out_gibs": 52.4907
+        },
+        "scatter": {
+          "avg_ms": 0.196103,
+          "best_ms": 0.068384,
+          "in_gibs": 240.123,
+          "out_gibs": 240.123
+        },
+        "compress": {
+          "avg_ms": 0.72443,
+          "best_ms": 0.170944,
+          "in_gibs": 693.279,
+          "out_gibs": 693.279
+        },
+        "aggregate": {
+          "avg_ms": 7.77619,
+          "best_ms": 0.454656,
+          "in_gibs": 64.5859,
+          "out_gibs": 64.5859
+        },
+        "d2h": {
+          "avg_ms": 35.2677,
+          "best_ms": 2.6801,
+          "in_gibs": 14.2406,
+          "out_gibs": 14.2406
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 55.8953,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 0.567311,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 13.9981,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__zeros__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.58,
+      "status": "pass",
+      "throughput_in_gibs": 10.8543,
+      "throughput_out_gibs": 11.2886,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.323892,
+      "init_s": 1.5168,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.48145,
+          "best_ms": 0.7395,
+          "in_gibs": 22.4883,
+          "out_gibs": 22.4883
+        },
+        "h2d": {
+          "avg_ms": 1.06651,
+          "best_ms": 0.590784,
+          "in_gibs": 52.8382,
+          "out_gibs": 52.8382
+        },
+        "scatter": {
+          "avg_ms": 0.233894,
+          "best_ms": 0.133888,
+          "in_gibs": 240.932,
+          "out_gibs": 240.932
+        },
+        "compress": {
+          "avg_ms": 5.5337,
+          "best_ms": 5.5337,
+          "in_gibs": 660.725,
+          "out_gibs": 660.725
+        },
+        "aggregate": {
+          "avg_ms": 8.07117,
+          "best_ms": 8.07117,
+          "in_gibs": 453.001,
+          "out_gibs": 453.001
+        },
+        "d2h": {
+          "avg_ms": 69.4902,
+          "best_ms": 69.4902,
+          "in_gibs": 52.6153,
+          "out_gibs": 52.6153
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 7.96534,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.31911,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__zeros__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.6,
+      "status": "pass",
+      "throughput_in_gibs": 14.115,
+      "throughput_out_gibs": 0.0682761,
+      "compression_fold": 206.735,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0170055,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.249069,
+      "init_s": 0.09574,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.11675,
+          "best_ms": 0.695593,
+          "in_gibs": 22.1448,
+          "out_gibs": 22.1448
+        },
+        "h2d": {
+          "avg_ms": 0.890358,
+          "best_ms": 0.297312,
+          "in_gibs": 52.8877,
+          "out_gibs": 52.8877
+        },
+        "scatter": {
+          "avg_ms": 0.220166,
+          "best_ms": 0.068576,
+          "in_gibs": 213.88,
+          "out_gibs": 213.88
+        },
+        "compress": {
+          "avg_ms": 1.0197,
+          "best_ms": 0.94208,
+          "in_gibs": 137.908,
+          "out_gibs": 0.584998
+        },
+        "aggregate": {
+          "avg_ms": 0.0505229,
+          "best_ms": 0.02864,
+          "in_gibs": 11.807,
+          "out_gibs": 11.807
+        },
+        "d2h": {
+          "avg_ms": 6.97212,
+          "best_ms": 0.01936,
+          "in_gibs": 0.0855584,
+          "out_gibs": 0.0855584
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 4.64359,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 0.585858,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.28588,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__zeros__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.76,
+      "status": "pass",
+      "throughput_in_gibs": 14.2413,
+      "throughput_out_gibs": 0.0575507,
+      "compression_fold": 247.456,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0142071,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.246862,
+      "init_s": 0.237072,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.12692,
+          "best_ms": 0.700862,
+          "in_gibs": 22.0389,
+          "out_gibs": 22.0389
+        },
+        "h2d": {
+          "avg_ms": 0.88976,
+          "best_ms": 0.296032,
+          "in_gibs": 52.9233,
+          "out_gibs": 52.9233
+        },
+        "scatter": {
+          "avg_ms": 0.195782,
+          "best_ms": 0.068416,
+          "in_gibs": 240.518,
+          "out_gibs": 240.518
+        },
+        "compress": {
+          "avg_ms": 3.59207,
+          "best_ms": 2.99418,
+          "in_gibs": 139.817,
+          "out_gibs": 0.553626
+        },
+        "aggregate": {
+          "avg_ms": 0.16267,
+          "best_ms": 0.03072,
+          "in_gibs": 12.2252,
+          "out_gibs": 12.2252
+        },
+        "d2h": {
+          "avg_ms": 22.8182,
+          "best_ms": 0.018848,
+          "in_gibs": 0.0871525,
+          "out_gibs": 0.0871525
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.800833,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 3.25572,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.02033,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__zeros__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.59,
+      "status": "pass",
+      "throughput_in_gibs": 13.2409,
+      "throughput_out_gibs": 0.0541957,
+      "compression_fold": 254.09,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0143896,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.265512,
+      "init_s": 1.45501,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.49024,
+          "best_ms": 0.821492,
+          "in_gibs": 22.4089,
+          "out_gibs": 22.4089
+        },
+        "h2d": {
+          "avg_ms": 1.06388,
+          "best_ms": 0.589952,
+          "in_gibs": 52.9687,
+          "out_gibs": 52.9687
+        },
+        "scatter": {
+          "avg_ms": 0.233842,
+          "best_ms": 0.133984,
+          "in_gibs": 240.985,
+          "out_gibs": 240.985
+        },
+        "compress": {
+          "avg_ms": 23.9759,
+          "best_ms": 23.9759,
+          "in_gibs": 152.497,
+          "out_gibs": 0.598818
+        },
+        "aggregate": {
+          "avg_ms": 0.106144,
+          "best_ms": 0.106144,
+          "in_gibs": 135.261,
+          "out_gibs": 135.261
+        },
+        "d2h": {
+          "avg_ms": 0.283712,
+          "best_ms": 0.283712,
+          "in_gibs": 50.6048,
+          "out_gibs": 50.6048
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.019219,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.27916,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__zeros__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.57,
+      "status": "pass",
+      "throughput_in_gibs": 14.1538,
+      "throughput_out_gibs": 0.0166308,
+      "compression_fold": 851.059,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.00413088,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.248388,
+      "init_s": 0.095108,
+      "flush_s": 4.6e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.1176,
+          "best_ms": 0.698228,
+          "in_gibs": 22.1359,
+          "out_gibs": 22.1359
+        },
+        "h2d": {
+          "avg_ms": 0.890381,
+          "best_ms": 0.296416,
+          "in_gibs": 52.8864,
+          "out_gibs": 52.8864
+        },
+        "scatter": {
+          "avg_ms": 0.281714,
+          "best_ms": 0.068544,
+          "in_gibs": 167.152,
+          "out_gibs": 167.152
+        },
+        "compress": {
+          "avg_ms": 1.84535,
+          "best_ms": 1.7848,
+          "in_gibs": 76.205,
+          "out_gibs": 0.0441863
+        },
+        "aggregate": {
+          "avg_ms": 0.0346547,
+          "best_ms": 0.028672,
+          "in_gibs": 2.3529,
+          "out_gibs": 2.3529
+        },
+        "d2h": {
+          "avg_ms": 6.42015,
+          "best_ms": 5.78707,
+          "in_gibs": 0.0127005,
+          "out_gibs": 0.0127005
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 4.36628,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 1.48008,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.28753,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__zeros__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.78,
+      "status": "pass",
+      "throughput_in_gibs": 13.7925,
+      "throughput_out_gibs": 0.00417524,
+      "compression_fold": 3303.41,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.00106424,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.254893,
+      "init_s": 0.235558,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.10045,
+          "best_ms": 0.682153,
+          "in_gibs": 22.3166,
+          "out_gibs": 22.3166
+        },
+        "h2d": {
+          "avg_ms": 0.890763,
+          "best_ms": 0.296032,
+          "in_gibs": 52.8637,
+          "out_gibs": 52.8637
+        },
+        "scatter": {
+          "avg_ms": 0.200601,
+          "best_ms": 0.06848,
+          "in_gibs": 234.739,
+          "out_gibs": 234.739
+        },
+        "compress": {
+          "avg_ms": 6.875,
+          "best_ms": 4.61414,
+          "in_gibs": 73.0519,
+          "out_gibs": 0.0161629
+        },
+        "aggregate": {
+          "avg_ms": 0.049632,
+          "best_ms": 0.030688,
+          "in_gibs": 2.23888,
+          "out_gibs": 2.23888
+        },
+        "d2h": {
+          "avg_ms": 24.141,
+          "best_ms": 0.133696,
+          "in_gibs": 0.00515531,
+          "out_gibs": 0.00515531
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.577736,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 4.98992,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.2662,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__zeros__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.51,
+      "status": "pass",
+      "throughput_in_gibs": 12.932,
+      "throughput_out_gibs": 0.00264598,
+      "compression_fold": 5082.9,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.000719324,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.271856,
+      "init_s": 1.51348,
+      "flush_s": 3.245e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.4905,
+          "best_ms": 0.717507,
+          "in_gibs": 22.4065,
+          "out_gibs": 22.4065
+        },
+        "h2d": {
+          "avg_ms": 1.06569,
+          "best_ms": 0.590592,
+          "in_gibs": 52.8787,
+          "out_gibs": 52.8787
+        },
+        "scatter": {
+          "avg_ms": 0.233913,
+          "best_ms": 0.133984,
+          "in_gibs": 240.912,
+          "out_gibs": 240.912
+        },
+        "compress": {
+          "avg_ms": 30.7002,
+          "best_ms": 30.7002,
+          "in_gibs": 119.095,
+          "out_gibs": 0.0223749
+        },
+        "aggregate": {
+          "avg_ms": 0.045024,
+          "best_ms": 0.045024,
+          "in_gibs": 15.2566,
+          "out_gibs": 15.2566
+        },
+        "d2h": {
+          "avg_ms": 0.028736,
+          "best_ms": 0.028736,
+          "in_gibs": 23.9043,
+          "out_gibs": 23.9043
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 30.4917,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.26124,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__rand__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 1.05,
+      "status": "pass",
+      "throughput_in_gibs": 7.95012,
+      "throughput_out_gibs": 7.95485,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.44221,
+      "init_s": 0.0944967,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.33163,
+          "best_ms": 0.730576,
+          "in_gibs": 20.104,
+          "out_gibs": 20.104
+        },
+        "h2d": {
+          "avg_ms": 0.92875,
+          "best_ms": 0.322688,
+          "in_gibs": 50.7015,
+          "out_gibs": 50.7015
+        },
+        "scatter": {
+          "avg_ms": 0.198338,
+          "best_ms": 0.068704,
+          "in_gibs": 237.418,
+          "out_gibs": 237.418
+        },
+        "compress": {
+          "avg_ms": 0.176493,
+          "best_ms": 0.167552,
+          "in_gibs": 796.775,
+          "out_gibs": 796.775
+        },
+        "aggregate": {
+          "avg_ms": 1.94405,
+          "best_ms": 0.428032,
+          "in_gibs": 72.3362,
+          "out_gibs": 72.3362
+        },
+        "d2h": {
+          "avg_ms": 15.8363,
+          "best_ms": 2.68925,
+          "in_gibs": 8.87991,
+          "out_gibs": 8.87991
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 69.9205,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 0.027542,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.73055,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__rand__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 1.25,
+      "status": "pass",
+      "throughput_in_gibs": 7.98137,
+      "throughput_out_gibs": 7.98202,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.440479,
+      "init_s": 0.228719,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.33098,
+          "best_ms": 0.71286,
+          "in_gibs": 20.1095,
+          "out_gibs": 20.1095
+        },
+        "h2d": {
+          "avg_ms": 0.907511,
+          "best_ms": 0.306592,
+          "in_gibs": 51.8881,
+          "out_gibs": 51.8881
+        },
+        "scatter": {
+          "avg_ms": 0.199654,
+          "best_ms": 0.0688,
+          "in_gibs": 235.853,
+          "out_gibs": 235.853
+        },
+        "compress": {
+          "avg_ms": 0.725061,
+          "best_ms": 0.173184,
+          "in_gibs": 692.676,
+          "out_gibs": 692.676
+        },
+        "aggregate": {
+          "avg_ms": 7.76182,
+          "best_ms": 0.45056,
+          "in_gibs": 64.7055,
+          "out_gibs": 64.7055
+        },
+        "d2h": {
+          "avg_ms": 50.3527,
+          "best_ms": 2.68022,
+          "in_gibs": 9.97429,
+          "out_gibs": 9.97429
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 55.8114,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 0.578348,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.4181,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__rand__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.81,
+      "status": "pass",
+      "throughput_in_gibs": 7.84282,
+      "throughput_out_gibs": 8.15661,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.44826,
+      "init_s": 1.35341,
+      "flush_s": 3.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.76944,
+          "best_ms": 0.736015,
+          "in_gibs": 20.1497,
+          "out_gibs": 20.1497
+        },
+        "h2d": {
+          "avg_ms": 1.06531,
+          "best_ms": 0.589952,
+          "in_gibs": 52.8978,
+          "out_gibs": 52.8978
+        },
+        "scatter": {
+          "avg_ms": 0.235686,
+          "best_ms": 0.131968,
+          "in_gibs": 239.1,
+          "out_gibs": 239.1
+        },
+        "compress": {
+          "avg_ms": 5.32237,
+          "best_ms": 5.32237,
+          "in_gibs": 686.959,
+          "out_gibs": 686.959
+        },
+        "aggregate": {
+          "avg_ms": 7.9831,
+          "best_ms": 7.9831,
+          "in_gibs": 457.999,
+          "out_gibs": 457.999
+        },
+        "d2h": {
+          "avg_ms": 69.4831,
+          "best_ms": 69.4831,
+          "in_gibs": 52.6207,
+          "out_gibs": 52.6207
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 13.4672,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.4035,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__rand__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 1.15,
+      "status": "pass",
+      "throughput_in_gibs": 6.76427,
+      "throughput_out_gibs": 6.79401,
+      "compression_fold": 0.995622,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.53109,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.519735,
+      "init_s": 0.094942,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.31117,
+          "best_ms": 0.730226,
+          "in_gibs": 20.2819,
+          "out_gibs": 20.2819
+        },
+        "h2d": {
+          "avg_ms": 0.910195,
+          "best_ms": 0.302976,
+          "in_gibs": 51.7351,
+          "out_gibs": 51.7351
+        },
+        "scatter": {
+          "avg_ms": 0.408206,
+          "best_ms": 0.068672,
+          "in_gibs": 127.591,
+          "out_gibs": 127.591
+        },
+        "compress": {
+          "avg_ms": 18.6043,
+          "best_ms": 18.3764,
+          "in_gibs": 7.55875,
+          "out_gibs": 7.58749
+        },
+        "aggregate": {
+          "avg_ms": 0.329229,
+          "best_ms": 0.31744,
+          "in_gibs": 428.759,
+          "out_gibs": 428.759
+        },
+        "d2h": {
+          "avg_ms": 3.76671,
+          "best_ms": 2.69062,
+          "in_gibs": 37.4756,
+          "out_gibs": 37.4756
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 128.03,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 52.5082,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 13.775,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__rand__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 1.33,
+      "status": "pass",
+      "throughput_in_gibs": 7.30885,
+      "throughput_out_gibs": 7.3362,
+      "compression_fold": 0.996271,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.52878,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.48101,
+      "init_s": 0.233739,
+      "flush_s": 7.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.28815,
+          "best_ms": 0.749124,
+          "in_gibs": 20.486,
+          "out_gibs": 20.486
+        },
+        "h2d": {
+          "avg_ms": 0.912418,
+          "best_ms": 0.307392,
+          "in_gibs": 51.6091,
+          "out_gibs": 51.6091
+        },
+        "scatter": {
+          "avg_ms": 0.209365,
+          "best_ms": 0.06864,
+          "in_gibs": 222.84,
+          "out_gibs": 222.84
+        },
+        "compress": {
+          "avg_ms": 32.5381,
+          "best_ms": 11.2141,
+          "in_gibs": 15.4352,
+          "out_gibs": 15.4917
+        },
+        "aggregate": {
+          "avg_ms": 1.30976,
+          "best_ms": 0.452576,
+          "in_gibs": 384.857,
+          "out_gibs": 384.857
+        },
+        "d2h": {
+          "avg_ms": 30.6679,
+          "best_ms": 2.69053,
+          "in_gibs": 16.4365,
+          "out_gibs": 16.4365
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 54.7415,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 25.9844,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 24.145,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__rand__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.19,
+      "status": "pass",
+      "throughput_in_gibs": 5.74771,
+      "throughput_out_gibs": 5.76961,
+      "compression_fold": 1.03605,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.52902,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.611656,
+      "init_s": 1.52626,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.72541,
+          "best_ms": 0.737297,
+          "in_gibs": 20.4753,
+          "out_gibs": 20.4753
+        },
+        "h2d": {
+          "avg_ms": 1.06721,
+          "best_ms": 0.59072,
+          "in_gibs": 52.8033,
+          "out_gibs": 52.8033
+        },
+        "scatter": {
+          "avg_ms": 0.235724,
+          "best_ms": 0.134144,
+          "in_gibs": 239.062,
+          "out_gibs": 239.062
+        },
+        "compress": {
+          "avg_ms": 173.57,
+          "best_ms": 173.57,
+          "in_gibs": 21.065,
+          "out_gibs": 20.3317
+        },
+        "aggregate": {
+          "avg_ms": 8.08915,
+          "best_ms": 8.08915,
+          "in_gibs": 436.261,
+          "out_gibs": 436.261
+        },
+        "d2h": {
+          "avg_ms": 67.0661,
+          "best_ms": 67.0661,
+          "in_gibs": 52.6194,
+          "out_gibs": 52.6194
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 180.873,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.38149,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__rand__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 1.76,
+      "status": "pass",
+      "throughput_in_gibs": 3.3438,
+      "throughput_out_gibs": 2.86634,
+      "compression_fold": 1.16658,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.01363,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 1.05138,
+      "init_s": 0.094922,
+      "flush_s": 7.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.30522,
+          "best_ms": 0.723676,
+          "in_gibs": 20.3342,
+          "out_gibs": 20.3342
+        },
+        "h2d": {
+          "avg_ms": 0.908324,
+          "best_ms": 0.299488,
+          "in_gibs": 51.8417,
+          "out_gibs": 51.8417
+        },
+        "scatter": {
+          "avg_ms": 0.752947,
+          "best_ms": 0.068672,
+          "in_gibs": 67.6508,
+          "out_gibs": 67.6508
+        },
+        "compress": {
+          "avg_ms": 39.6929,
+          "best_ms": 39.1245,
+          "in_gibs": 3.54283,
+          "out_gibs": 3.03484
+        },
+        "aggregate": {
+          "avg_ms": 0.283907,
+          "best_ms": 0.274752,
+          "in_gibs": 424.3,
+          "out_gibs": 424.3
+        },
+        "d2h": {
+          "avg_ms": 2.86598,
+          "best_ms": 2.29773,
+          "in_gibs": 42.0315,
+          "out_gibs": 42.0315
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 605.794,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 582.162,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 42.8075,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__rand__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 1.94,
+      "status": "pass",
+      "throughput_in_gibs": 3.16754,
+      "throughput_out_gibs": 2.71143,
+      "compression_fold": 1.16822,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.00939,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.10989,
+      "init_s": 0.231416,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.34034,
+          "best_ms": 0.736796,
+          "in_gibs": 20.0291,
+          "out_gibs": 20.0291
+        },
+        "h2d": {
+          "avg_ms": 0.904611,
+          "best_ms": 0.304128,
+          "in_gibs": 52.0545,
+          "out_gibs": 52.0545
+        },
+        "scatter": {
+          "avg_ms": 0.630438,
+          "best_ms": 0.066784,
+          "in_gibs": 74.004,
+          "out_gibs": 74.004
+        },
+        "compress": {
+          "avg_ms": 138.988,
+          "best_ms": 15.9738,
+          "in_gibs": 3.61349,
+          "out_gibs": 3.09287
+        },
+        "aggregate": {
+          "avg_ms": 1.13114,
+          "best_ms": 0.393216,
+          "in_gibs": 380.034,
+          "out_gibs": 380.034
+        },
+        "d2h": {
+          "avg_ms": 14.0823,
+          "best_ms": 2.29562,
+          "in_gibs": 30.5257,
+          "out_gibs": 30.5257
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 429.93,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 536.469,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 147.639,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__rand__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.84,
+      "status": "pass",
+      "throughput_in_gibs": 2.38081,
+      "throughput_out_gibs": 2.0378,
+      "compression_fold": 1.21506,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.00911,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.47665,
+      "init_s": 1.36998,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.77949,
+          "best_ms": 0.724658,
+          "in_gibs": 20.0769,
+          "out_gibs": 20.0769
+        },
+        "h2d": {
+          "avg_ms": 1.06441,
+          "best_ms": 0.589984,
+          "in_gibs": 52.9424,
+          "out_gibs": 52.9424
+        },
+        "scatter": {
+          "avg_ms": 0.236015,
+          "best_ms": 0.134048,
+          "in_gibs": 238.767,
+          "out_gibs": 238.767
+        },
+        "compress": {
+          "avg_ms": 1047.01,
+          "best_ms": 1047.01,
+          "in_gibs": 3.49209,
+          "out_gibs": 2.87398
+        },
+        "aggregate": {
+          "avg_ms": 6.67955,
+          "best_ms": 6.67955,
+          "in_gibs": 450.491,
+          "out_gibs": 450.491
+        },
+        "d2h": {
+          "avg_ms": 57.1927,
+          "best_ms": 57.1927,
+          "in_gibs": 52.613,
+          "out_gibs": 52.613
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 1053.44,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.39948,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__zeros__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.71,
+      "status": "pass",
+      "throughput_in_gibs": 11.0296,
+      "throughput_out_gibs": 11.035,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.339994,
+      "init_s": 0.112186,
+      "flush_s": 3.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.81492,
+          "best_ms": 2.62854,
+          "in_gibs": 22.2031,
+          "out_gibs": 22.2031
+        },
+        "h2d": {
+          "avg_ms": 1.22193,
+          "best_ms": 1.1784,
+          "in_gibs": 51.1488,
+          "out_gibs": 51.1488
+        },
+        "scatter": {
+          "avg_ms": 0.31938,
+          "best_ms": 0.314272,
+          "in_gibs": 195.691,
+          "out_gibs": 195.691
+        },
+        "compress": {
+          "avg_ms": 0.26019,
+          "best_ms": 0.249408,
+          "in_gibs": 720.626,
+          "out_gibs": 720.626
+        },
+        "aggregate": {
+          "avg_ms": 2.28137,
+          "best_ms": 0.535552,
+          "in_gibs": 82.1875,
+          "out_gibs": 82.1875
+        },
+        "d2h": {
+          "avg_ms": 14.8491,
+          "best_ms": 3.57133,
+          "in_gibs": 12.627,
+          "out_gibs": 12.627
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 74.5686,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 0.493322,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.5794,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__zeros__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.91,
+      "status": "pass",
+      "throughput_in_gibs": 11.2082,
+      "throughput_out_gibs": 11.2089,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.334577,
+      "init_s": 0.294031,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.75198,
+          "best_ms": 2.58526,
+          "in_gibs": 22.7109,
+          "out_gibs": 22.7109
+        },
+        "h2d": {
+          "avg_ms": 1.18727,
+          "best_ms": 1.17814,
+          "in_gibs": 52.6419,
+          "out_gibs": 52.6419
+        },
+        "scatter": {
+          "avg_ms": 0.317688,
+          "best_ms": 0.313504,
+          "in_gibs": 196.734,
+          "out_gibs": 196.734
+        },
+        "compress": {
+          "avg_ms": 1.09394,
+          "best_ms": 1.06973,
+          "in_gibs": 685.596,
+          "out_gibs": 685.596
+        },
+        "aggregate": {
+          "avg_ms": 11.8264,
+          "best_ms": 2.26202,
+          "in_gibs": 63.4177,
+          "out_gibs": 63.4177
+        },
+        "d2h": {
+          "avg_ms": 51.3123,
+          "best_ms": 14.2588,
+          "in_gibs": 14.6164,
+          "out_gibs": 14.6164
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 59.4066,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 2.14167,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 17.7087,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__zeros__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.16,
+      "status": "pass",
+      "throughput_in_gibs": 11.0532,
+      "throughput_out_gibs": 11.0533,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.33927,
+      "init_s": 1.99162,
+      "flush_s": 2.794e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.76465,
+          "best_ms": 2.57453,
+          "in_gibs": 22.6069,
+          "out_gibs": 22.6069
+        },
+        "h2d": {
+          "avg_ms": 1.18432,
+          "best_ms": 1.18202,
+          "in_gibs": 52.7727,
+          "out_gibs": 52.7727
+        },
+        "scatter": {
+          "avg_ms": 0.318873,
+          "best_ms": 0.314272,
+          "in_gibs": 196.003,
+          "out_gibs": 196.003
+        },
+        "compress": {
+          "avg_ms": 5.46477,
+          "best_ms": 5.46477,
+          "in_gibs": 686.214,
+          "out_gibs": 686.214
+        },
+        "aggregate": {
+          "avg_ms": 8.09165,
+          "best_ms": 8.09165,
+          "in_gibs": 463.441,
+          "out_gibs": 463.441
+        },
+        "d2h": {
+          "avg_ms": 71.2651,
+          "best_ms": 71.2651,
+          "in_gibs": 52.6204,
+          "out_gibs": 52.6204
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 7.99095,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.29206,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__zeros__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.6,
+      "status": "pass",
+      "throughput_in_gibs": 14.1151,
+      "throughput_out_gibs": 0.0667685,
+      "compression_fold": 211.404,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0177386,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.265673,
+      "init_s": 0.110771,
+      "flush_s": 7.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.78415,
+          "best_ms": 2.6461,
+          "in_gibs": 22.4485,
+          "out_gibs": 22.4485
+        },
+        "h2d": {
+          "avg_ms": 1.18326,
+          "best_ms": 1.17811,
+          "in_gibs": 52.8202,
+          "out_gibs": 52.8202
+        },
+        "scatter": {
+          "avg_ms": 0.317593,
+          "best_ms": 0.31424,
+          "in_gibs": 196.793,
+          "out_gibs": 196.793
+        },
+        "compress": {
+          "avg_ms": 1.05679,
+          "best_ms": 1.02093,
+          "in_gibs": 177.425,
+          "out_gibs": 0.752625
+        },
+        "aggregate": {
+          "avg_ms": 0.0390944,
+          "best_ms": 0.032736,
+          "in_gibs": 20.3447,
+          "out_gibs": 20.3447
+        },
+        "d2h": {
+          "avg_ms": 9.33764,
+          "best_ms": 0.023104,
+          "in_gibs": 0.0851783,
+          "out_gibs": 0.0851783
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 4.1091,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 2.46723,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.05075,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__zeros__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.92,
+      "status": "pass",
+      "throughput_in_gibs": 14.0635,
+      "throughput_out_gibs": 0.0565462,
+      "compression_fold": 248.709,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0150779,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.266647,
+      "init_s": 0.306393,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.76718,
+          "best_ms": 2.6111,
+          "in_gibs": 22.5862,
+          "out_gibs": 22.5862
+        },
+        "h2d": {
+          "avg_ms": 1.18061,
+          "best_ms": 1.17821,
+          "in_gibs": 52.9386,
+          "out_gibs": 52.9386
+        },
+        "scatter": {
+          "avg_ms": 0.318513,
+          "best_ms": 0.314176,
+          "in_gibs": 196.225,
+          "out_gibs": 196.225
+        },
+        "compress": {
+          "avg_ms": 3.98396,
+          "best_ms": 3.92602,
+          "in_gibs": 188.255,
+          "out_gibs": 0.745424
+        },
+        "aggregate": {
+          "avg_ms": 0.045376,
+          "best_ms": 0.030688,
+          "in_gibs": 65.4474,
+          "out_gibs": 65.4474
+        },
+        "d2h": {
+          "avg_ms": 35.1006,
+          "best_ms": 0.064128,
+          "in_gibs": 0.0846066,
+          "out_gibs": 0.0846066
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.780602,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 5.21201,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.55131,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__zeros__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.15,
+      "status": "pass",
+      "throughput_in_gibs": 13.3237,
+      "throughput_out_gibs": 0.0524556,
+      "compression_fold": 254,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0147638,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.281453,
+      "init_s": 2.00521,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.76365,
+          "best_ms": 2.69666,
+          "in_gibs": 22.615,
+          "out_gibs": 22.615
+        },
+        "h2d": {
+          "avg_ms": 1.18027,
+          "best_ms": 1.17824,
+          "in_gibs": 52.9538,
+          "out_gibs": 52.9538
+        },
+        "scatter": {
+          "avg_ms": 0.31924,
+          "best_ms": 0.316384,
+          "in_gibs": 195.778,
+          "out_gibs": 195.778
+        },
+        "compress": {
+          "avg_ms": 24.2033,
+          "best_ms": 24.2033,
+          "in_gibs": 154.938,
+          "out_gibs": 0.608403
+        },
+        "aggregate": {
+          "avg_ms": 0.10208,
+          "best_ms": 0.10208,
+          "in_gibs": 144.253,
+          "out_gibs": 144.253
+        },
+        "d2h": {
+          "avg_ms": 0.289248,
+          "best_ms": 0.289248,
+          "in_gibs": 50.909,
+          "out_gibs": 50.909
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.016134,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.33172,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__zeros__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.6,
+      "status": "pass",
+      "throughput_in_gibs": 14.1685,
+      "throughput_out_gibs": 0.0151345,
+      "compression_fold": 936.173,
+      "input_gib": 3.75,
+      "compressed_gib": 0.00400567,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.264671,
+      "init_s": 0.111772,
+      "flush_s": 2.894e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.76137,
+          "best_ms": 2.63758,
+          "in_gibs": 22.6337,
+          "out_gibs": 22.6337
+        },
+        "h2d": {
+          "avg_ms": 1.18212,
+          "best_ms": 1.17811,
+          "in_gibs": 52.8709,
+          "out_gibs": 52.8709
+        },
+        "scatter": {
+          "avg_ms": 0.317805,
+          "best_ms": 0.314208,
+          "in_gibs": 196.661,
+          "out_gibs": 196.661
+        },
+        "compress": {
+          "avg_ms": 2.15074,
+          "best_ms": 2.11219,
+          "in_gibs": 87.1792,
+          "out_gibs": 0.0505495
+        },
+        "aggregate": {
+          "avg_ms": 0.038808,
+          "best_ms": 0.028672,
+          "in_gibs": 2.80145,
+          "out_gibs": 2.80145
+        },
+        "d2h": {
+          "avg_ms": 8.18062,
+          "best_ms": 0.010688,
+          "in_gibs": 0.0132898,
+          "out_gibs": 0.0132898
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 3.62787,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 3.58156,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.48151,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__zeros__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.89,
+      "status": "pass",
+      "throughput_in_gibs": 13.6882,
+      "throughput_out_gibs": 0.0038651,
+      "compression_fold": 3541.49,
+      "input_gib": 3.75,
+      "compressed_gib": 0.00105888,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.273959,
+      "init_s": 0.301401,
+      "flush_s": 6.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.77089,
+          "best_ms": 2.61619,
+          "in_gibs": 22.556,
+          "out_gibs": 22.556
+        },
+        "h2d": {
+          "avg_ms": 1.18026,
+          "best_ms": 1.17802,
+          "in_gibs": 52.9545,
+          "out_gibs": 52.9545
+        },
+        "scatter": {
+          "avg_ms": 0.327332,
+          "best_ms": 0.314368,
+          "in_gibs": 190.937,
+          "out_gibs": 190.937
+        },
+        "compress": {
+          "avg_ms": 7.99612,
+          "best_ms": 7.55677,
+          "in_gibs": 93.7955,
+          "out_gibs": 0.0207525
+        },
+        "aggregate": {
+          "avg_ms": 0.041984,
+          "best_ms": 0.028672,
+          "in_gibs": 3.95244,
+          "out_gibs": 3.95244
+        },
+        "d2h": {
+          "avg_ms": 32.6155,
+          "best_ms": 0.01088,
+          "in_gibs": 0.00508774,
+          "out_gibs": 0.00508774
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.531416,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 9.24036,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.9602,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__zeros__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.12,
+      "status": "pass",
+      "throughput_in_gibs": 13.0503,
+      "throughput_out_gibs": 0.0025856,
+      "compression_fold": 5047.3,
+      "input_gib": 3.75,
+      "compressed_gib": 0.000742972,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.28735,
+      "init_s": 1.99333,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.76656,
+          "best_ms": 2.67539,
+          "in_gibs": 22.5912,
+          "out_gibs": 22.5912
+        },
+        "h2d": {
+          "avg_ms": 1.18211,
+          "best_ms": 1.17824,
+          "in_gibs": 52.8715,
+          "out_gibs": 52.8715
+        },
+        "scatter": {
+          "avg_ms": 0.318055,
+          "best_ms": 0.316064,
+          "in_gibs": 196.507,
+          "out_gibs": 196.507
+        },
+        "compress": {
+          "avg_ms": 31.4139,
+          "best_ms": 31.4139,
+          "in_gibs": 119.374,
+          "out_gibs": 0.0224272
+        },
+        "aggregate": {
+          "avg_ms": 0.104448,
+          "best_ms": 0.104448,
+          "in_gibs": 6.74524,
+          "out_gibs": 6.74524
+        },
+        "d2h": {
+          "avg_ms": 0.024672,
+          "best_ms": 0.024672,
+          "in_gibs": 28.5557,
+          "out_gibs": 28.5557
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.003426,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.32341,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__rand__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.45,
+      "status": "pass",
+      "throughput_in_gibs": 8.002,
+      "throughput_out_gibs": 8.00591,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.468633,
+      "init_s": 0.111678,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.07796,
+          "best_ms": 3.05803,
+          "in_gibs": 20.3057,
+          "out_gibs": 20.3057
+        },
+        "h2d": {
+          "avg_ms": 1.20856,
+          "best_ms": 1.17859,
+          "in_gibs": 51.7142,
+          "out_gibs": 51.7142
+        },
+        "scatter": {
+          "avg_ms": 0.323184,
+          "best_ms": 0.318336,
+          "in_gibs": 193.388,
+          "out_gibs": 193.388
+        },
+        "compress": {
+          "avg_ms": 0.26068,
+          "best_ms": 0.249504,
+          "in_gibs": 719.273,
+          "out_gibs": 719.273
+        },
+        "aggregate": {
+          "avg_ms": 2.3365,
+          "best_ms": 0.615424,
+          "in_gibs": 80.2482,
+          "out_gibs": 80.2482
+        },
+        "d2h": {
+          "avg_ms": 21.0144,
+          "best_ms": 3.5721,
+          "in_gibs": 8.92246,
+          "out_gibs": 8.92246
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 74.6823,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 0.502955,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.83859,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__rand__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.55,
+      "status": "pass",
+      "throughput_in_gibs": 7.76565,
+      "throughput_out_gibs": 7.76613,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.482896,
+      "init_s": 0.276503,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.21431,
+          "best_ms": 3.18294,
+          "in_gibs": 19.4443,
+          "out_gibs": 19.4443
+        },
+        "h2d": {
+          "avg_ms": 1.18829,
+          "best_ms": 1.17824,
+          "in_gibs": 52.5966,
+          "out_gibs": 52.5966
+        },
+        "scatter": {
+          "avg_ms": 0.321978,
+          "best_ms": 0.320192,
+          "in_gibs": 194.112,
+          "out_gibs": 194.112
+        },
+        "compress": {
+          "avg_ms": 1.09361,
+          "best_ms": 1.06768,
+          "in_gibs": 685.8,
+          "out_gibs": 685.8
+        },
+        "aggregate": {
+          "avg_ms": 11.7865,
+          "best_ms": 2.0183,
+          "in_gibs": 63.6321,
+          "out_gibs": 63.6321
+        },
+        "d2h": {
+          "avg_ms": 75.1447,
+          "best_ms": 14.2591,
+          "in_gibs": 9.98075,
+          "out_gibs": 9.98075
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 59.4194,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 2.0808,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 18.1804,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__rand__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 5.08,
+      "status": "pass",
+      "throughput_in_gibs": 7.5529,
+      "throughput_out_gibs": 7.55298,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.496498,
+      "init_s": 1.99513,
+      "flush_s": 6.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.27078,
+          "best_ms": 3.24068,
+          "in_gibs": 19.1086,
+          "out_gibs": 19.1086
+        },
+        "h2d": {
+          "avg_ms": 1.18083,
+          "best_ms": 1.17827,
+          "in_gibs": 52.9289,
+          "out_gibs": 52.9289
+        },
+        "scatter": {
+          "avg_ms": 0.321367,
+          "best_ms": 0.318432,
+          "in_gibs": 194.482,
+          "out_gibs": 194.482
+        },
+        "compress": {
+          "avg_ms": 5.45242,
+          "best_ms": 5.45242,
+          "in_gibs": 687.769,
+          "out_gibs": 687.769
+        },
+        "aggregate": {
+          "avg_ms": 8.11418,
+          "best_ms": 8.11418,
+          "in_gibs": 462.154,
+          "out_gibs": 462.154
+        },
+        "d2h": {
+          "avg_ms": 71.2683,
+          "best_ms": 71.2683,
+          "in_gibs": 52.618,
+          "out_gibs": 52.618
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 8.00334,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.5847,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__rand__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.68,
+      "status": "pass",
+      "throughput_in_gibs": 7.14333,
+      "throughput_out_gibs": 7.17397,
+      "compression_fold": 0.995728,
+      "input_gib": 3.75,
+      "compressed_gib": 3.76609,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.524966,
+      "init_s": 0.116152,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.22956,
+          "best_ms": 3.14753,
+          "in_gibs": 19.3525,
+          "out_gibs": 19.3525
+        },
+        "h2d": {
+          "avg_ms": 1.22341,
+          "best_ms": 1.17859,
+          "in_gibs": 51.0867,
+          "out_gibs": 51.0867
+        },
+        "scatter": {
+          "avg_ms": 0.401466,
+          "best_ms": 0.316608,
+          "in_gibs": 155.679,
+          "out_gibs": 155.679
+        },
+        "compress": {
+          "avg_ms": 19.9205,
+          "best_ms": 19.5554,
+          "in_gibs": 9.41242,
+          "out_gibs": 9.44821
+        },
+        "aggregate": {
+          "avg_ms": 0.40403,
+          "best_ms": 0.393216,
+          "in_gibs": 465.838,
+          "out_gibs": 465.838
+        },
+        "d2h": {
+          "avg_ms": 6.59784,
+          "best_ms": 3.58608,
+          "in_gibs": 28.5264,
+          "out_gibs": 28.5264
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 86.6059,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 17.0917,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.763,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__rand__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.81,
+      "status": "pass",
+      "throughput_in_gibs": 6.08981,
+      "throughput_out_gibs": 6.11247,
+      "compression_fold": 0.996293,
+      "input_gib": 3.75,
+      "compressed_gib": 3.76395,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.615783,
+      "init_s": 0.27941,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.29726,
+          "best_ms": 3.21239,
+          "in_gibs": 18.9551,
+          "out_gibs": 18.9551
+        },
+        "h2d": {
+          "avg_ms": 1.18925,
+          "best_ms": 1.17821,
+          "in_gibs": 52.5542,
+          "out_gibs": 52.5542
+        },
+        "scatter": {
+          "avg_ms": 0.423628,
+          "best_ms": 0.313248,
+          "in_gibs": 147.535,
+          "out_gibs": 147.535
+        },
+        "compress": {
+          "avg_ms": 77.6196,
+          "best_ms": 75.6327,
+          "in_gibs": 9.66251,
+          "out_gibs": 9.69787
+        },
+        "aggregate": {
+          "avg_ms": 1.63862,
+          "best_ms": 1.51757,
+          "in_gibs": 459.376,
+          "out_gibs": 459.376
+        },
+        "d2h": {
+          "avg_ms": 35.1999,
+          "best_ms": 14.3115,
+          "in_gibs": 21.3848,
+          "out_gibs": 21.3848
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 58.6226,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 64.9831,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 63.102,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__rand__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 5.69,
+      "status": "pass",
+      "throughput_in_gibs": 5.4322,
+      "throughput_out_gibs": 5.45203,
+      "compression_fold": 0.996362,
+      "input_gib": 3.75,
+      "compressed_gib": 3.76369,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.690328,
+      "init_s": 2.19304,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.21909,
+          "best_ms": 3.18377,
+          "in_gibs": 19.4154,
+          "out_gibs": 19.4154
+        },
+        "h2d": {
+          "avg_ms": 1.18205,
+          "best_ms": 1.17824,
+          "in_gibs": 52.8744,
+          "out_gibs": 52.8744
+        },
+        "scatter": {
+          "avg_ms": 0.321226,
+          "best_ms": 0.31616,
+          "in_gibs": 194.567,
+          "out_gibs": 194.567
+        },
+        "compress": {
+          "avg_ms": 202.092,
+          "best_ms": 202.092,
+          "in_gibs": 18.5559,
+          "out_gibs": 18.6235
+        },
+        "aggregate": {
+          "avg_ms": 8.20189,
+          "best_ms": 8.20189,
+          "in_gibs": 458.876,
+          "out_gibs": 458.876
+        },
+        "d2h": {
+          "avg_ms": 71.5283,
+          "best_ms": 71.5283,
+          "in_gibs": 52.6177,
+          "out_gibs": 52.6177
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 209.455,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.551,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__rand__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.23,
+      "status": "pass",
+      "throughput_in_gibs": 3.69873,
+      "throughput_out_gibs": 3.17019,
+      "compression_fold": 1.16672,
+      "input_gib": 3.75,
+      "compressed_gib": 3.21413,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 1.01386,
+      "init_s": 0.123643,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.25037,
+          "best_ms": 3.09964,
+          "in_gibs": 19.2286,
+          "out_gibs": 19.2286
+        },
+        "h2d": {
+          "avg_ms": 1.18901,
+          "best_ms": 1.17872,
+          "in_gibs": 52.5648,
+          "out_gibs": 52.5648
+        },
+        "scatter": {
+          "avg_ms": 0.529126,
+          "best_ms": 0.317344,
+          "in_gibs": 118.119,
+          "out_gibs": 118.119
+        },
+        "compress": {
+          "avg_ms": 47.966,
+          "best_ms": 47.0095,
+          "in_gibs": 3.90902,
+          "out_gibs": 3.34851
+        },
+        "aggregate": {
+          "avg_ms": 0.34903,
+          "best_ms": 0.337888,
+          "in_gibs": 460.174,
+          "out_gibs": 460.174
+        },
+        "d2h": {
+          "avg_ms": 3.31388,
+          "best_ms": 3.06851,
+          "in_gibs": 48.4673,
+          "out_gibs": 48.4673
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 518.073,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 500.106,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 38.266,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__rand__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.66,
+      "status": "pass",
+      "throughput_in_gibs": 2.90477,
+      "throughput_out_gibs": 2.48643,
+      "compression_fold": 1.16825,
+      "input_gib": 3.75,
+      "compressed_gib": 3.20993,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 1.29098,
+      "init_s": 0.287166,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.32201,
+          "best_ms": 3.1903,
+          "in_gibs": 18.8139,
+          "out_gibs": 18.8139
+        },
+        "h2d": {
+          "avg_ms": 1.18777,
+          "best_ms": 1.17882,
+          "in_gibs": 52.6195,
+          "out_gibs": 52.6195
+        },
+        "scatter": {
+          "avg_ms": 3.50525,
+          "best_ms": 0.318272,
+          "in_gibs": 17.8304,
+          "out_gibs": 17.8304
+        },
+        "compress": {
+          "avg_ms": 222.262,
+          "best_ms": 220.77,
+          "in_gibs": 3.37439,
+          "out_gibs": 2.88821
+        },
+        "aggregate": {
+          "avg_ms": 1.39958,
+          "best_ms": 1.28614,
+          "in_gibs": 458.667,
+          "out_gibs": 458.667
+        },
+        "d2h": {
+          "avg_ms": 24.6485,
+          "best_ms": 12.2235,
+          "in_gibs": 26.0438,
+          "out_gibs": 26.0438
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 443.015,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 603.678,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 208.643,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__rand__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 6.56,
+      "status": "pass",
+      "throughput_in_gibs": 2.32802,
+      "throughput_out_gibs": 1.99259,
+      "compression_fold": 1.16834,
+      "input_gib": 3.75,
+      "compressed_gib": 3.2097,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 1.61081,
+      "init_s": 2.14692,
+      "flush_s": 6.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.19797,
+          "best_ms": 3.16528,
+          "in_gibs": 19.5436,
+          "out_gibs": 19.5436
+        },
+        "h2d": {
+          "avg_ms": 1.18309,
+          "best_ms": 1.17827,
+          "in_gibs": 52.8278,
+          "out_gibs": 52.8278
+        },
+        "scatter": {
+          "avg_ms": 0.321512,
+          "best_ms": 0.315744,
+          "in_gibs": 194.394,
+          "out_gibs": 194.394
+        },
+        "compress": {
+          "avg_ms": 1135.57,
+          "best_ms": 1135.57,
+          "in_gibs": 3.30232,
+          "out_gibs": 2.82648
+        },
+        "aggregate": {
+          "avg_ms": 7.01235,
+          "best_ms": 7.01235,
+          "in_gibs": 457.715,
+          "out_gibs": 457.715
+        },
+        "d2h": {
+          "avg_ms": 60.9997,
+          "best_ms": 60.9997,
+          "in_gibs": 52.6176,
+          "out_gibs": 52.6176
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 6.80106,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.73022,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 3.07,
+      "status": "pass",
+      "throughput_in_gibs": 4.17342,
+      "throughput_out_gibs": 4.17614,
+      "compression_fold": 0.999349,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51791,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.842384,
+      "init_s": 0.0896501,
+      "flush_s": 0.0410544,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.86529,
+          "best_ms": 0.902965,
+          "in_gibs": 16.3596,
+          "out_gibs": 16.3596
+        },
+        "h2d": {
+          "avg_ms": 0.898536,
+          "best_ms": 0.295904,
+          "in_gibs": 52.4064,
+          "out_gibs": 52.4064
+        },
+        "scatter": {
+          "avg_ms": 0.198978,
+          "best_ms": 0.070528,
+          "in_gibs": 236.654,
+          "out_gibs": 236.654
+        },
+        "compress": {
+          "avg_ms": 0.168306,
+          "best_ms": 0.165856,
+          "in_gibs": 835.532,
+          "out_gibs": 835.532
+        },
+        "aggregate": {
+          "avg_ms": 0.571151,
+          "best_ms": 0.333824,
+          "in_gibs": 246.213,
+          "out_gibs": 246.213
+        },
+        "d2h": {
+          "avg_ms": 29.2946,
+          "best_ms": 16.4594,
+          "in_gibs": 4.80038,
+          "out_gibs": 4.80038
+        },
+        "sink": {
+          "avg_ms": 0.00101672,
+          "best_ms": 3e-05,
+          "in_gibs": 7689.04,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 324.95,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 0.094031,
+        "kick_sync_count": 25,
+        "io_fence_ms": 250.593,
+        "io_fence_count": 25,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 48.3334,
+        "peak_pending_mib": 278.719
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 3.68,
+      "status": "pass",
+      "throughput_in_gibs": 2.05675,
+      "throughput_out_gibs": 2.05809,
+      "compression_fold": 0.999349,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51791,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 1.70931,
+      "init_s": 0.000424537,
+      "flush_s": 7.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.08396,
+          "best_ms": 0.881733,
+          "in_gibs": 9.22017,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.48934,
+          "best_ms": 4.52247,
+          "in_gibs": 21.6701,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.97911,
+          "best_ms": 3.03079,
+          "in_gibs": 20.1494,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 1.63956,
+          "best_ms": 0.000641,
+          "in_gibs": 4.7681,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 2.6,
+      "status": "pass",
+      "throughput_in_gibs": 5.87787,
+      "throughput_out_gibs": 0.762478,
+      "compression_fold": 7.70891,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.456047,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.598112,
+      "init_s": 0.0881725,
+      "flush_s": 7.5813e-05,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.54602,
+          "best_ms": 0.827381,
+          "in_gibs": 18.4111,
+          "out_gibs": 18.4111
+        },
+        "h2d": {
+          "avg_ms": 0.894229,
+          "best_ms": 0.29632,
+          "in_gibs": 52.6588,
+          "out_gibs": 52.6588
+        },
+        "scatter": {
+          "avg_ms": 0.4127,
+          "best_ms": 0.070688,
+          "in_gibs": 126.201,
+          "out_gibs": 126.201
+        },
+        "compress": {
+          "avg_ms": 22.2021,
+          "best_ms": 21.6603,
+          "in_gibs": 6.33386,
+          "out_gibs": 0.817505
+        },
+        "aggregate": {
+          "avg_ms": 0.063145,
+          "best_ms": 0.055264,
+          "in_gibs": 287.439,
+          "out_gibs": 287.439
+        },
+        "d2h": {
+          "avg_ms": 0.492676,
+          "best_ms": 0.354688,
+          "in_gibs": 36.8403,
+          "out_gibs": 36.8403
+        },
+        "sink": {
+          "avg_ms": 0.000708704,
+          "best_ms": 3e-05,
+          "in_gibs": 1429.99,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 157.408,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 164.56,
+        "kick_sync_count": 25,
+        "io_fence_ms": 0.006449,
+        "io_fence_count": 25,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.267,
+        "peak_pending_mib": 18.6328
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 2.89,
+      "status": "pass",
+      "throughput_in_gibs": 2.8335,
+      "throughput_out_gibs": 0.292543,
+      "compression_fold": 9.68576,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.362968,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 1.24074,
+      "init_s": 0.000270816,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.27552,
+          "best_ms": 2.03495,
+          "in_gibs": 8.88538,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.7567,
+          "best_ms": 8.35325,
+          "in_gibs": 11.0236,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.00836,
+          "best_ms": 0.457426,
+          "in_gibs": 2.40118,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.26747,
+          "best_ms": 0.000431,
+          "in_gibs": 3.01566,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 3.31,
+      "status": "pass",
+      "throughput_in_gibs": 2.60341,
+      "throughput_out_gibs": 1.49755,
+      "compression_fold": 1.73845,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.02228,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 1.35039,
+      "init_s": 0.000318918,
+      "flush_s": 6.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.76065,
+          "best_ms": 0.994642,
+          "in_gibs": 8.13711,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.99368,
+          "best_ms": 5.55457,
+          "in_gibs": 15.636,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.23538,
+          "best_ms": 1.69072,
+          "in_gibs": 12.9583,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.605272,
+          "best_ms": 0.000761,
+          "in_gibs": 7.42468,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 2.98,
+      "status": "pass",
+      "throughput_in_gibs": 3.30533,
+      "throughput_out_gibs": 0.0683231,
+      "compression_fold": 48.378,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.07267,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 1.06362,
+      "init_s": 0.000307211,
+      "flush_s": 8.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.5971,
+          "best_ms": 1.8809,
+          "in_gibs": 8.37488,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.03555,
+          "best_ms": 6.21647,
+          "in_gibs": 15.5635,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.11636,
+          "best_ms": 5.97321,
+          "in_gibs": 0.460282,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0415705,
+          "best_ms": 0.00035,
+          "in_gibs": 3.8847,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 3.43,
+      "status": "pass",
+      "throughput_in_gibs": 3.95768,
+      "throughput_out_gibs": 3.95802,
+      "compression_fold": 0.999913,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51593,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.888305,
+      "init_s": 0.24167,
+      "flush_s": 0.132415,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.72514,
+          "best_ms": 0.890957,
+          "in_gibs": 17.2009,
+          "out_gibs": 17.2009
+        },
+        "h2d": {
+          "avg_ms": 0.901235,
+          "best_ms": 0.2968,
+          "in_gibs": 52.2495,
+          "out_gibs": 52.2495
+        },
+        "scatter": {
+          "avg_ms": 0.198806,
+          "best_ms": 0.068512,
+          "in_gibs": 236.859,
+          "out_gibs": 236.859
+        },
+        "compress": {
+          "avg_ms": 0.719973,
+          "best_ms": 0.188416,
+          "in_gibs": 697.571,
+          "out_gibs": 697.571
+        },
+        "aggregate": {
+          "avg_ms": 5.14284,
+          "best_ms": 0.458752,
+          "in_gibs": 97.6565,
+          "out_gibs": 97.6565
+        },
+        "d2h": {
+          "avg_ms": 94.5181,
+          "best_ms": 65.8545,
+          "in_gibs": 5.31361,
+          "out_gibs": 5.31361
+        },
+        "sink": {
+          "avg_ms": 0.000677232,
+          "best_ms": 3e-05,
+          "in_gibs": 23176.9,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 137.332,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 0.041242,
+        "kick_sync_count": 7,
+        "io_fence_ms": 248.436,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 53.8936,
+        "peak_pending_mib": 1112.06
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 3.51,
+      "status": "pass",
+      "throughput_in_gibs": 2.2386,
+      "throughput_out_gibs": 2.23879,
+      "compression_fold": 0.999913,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51593,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.57046,
+      "init_s": 0.000142303,
+      "flush_s": 6.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.45925,
+          "best_ms": 1.69739,
+          "in_gibs": 8.58634,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.3411,
+          "best_ms": 8.36239,
+          "in_gibs": 35.0205,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.4062,
+          "best_ms": 7.6219,
+          "in_gibs": 34.8623,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 3.18261,
+          "best_ms": 0.000301,
+          "in_gibs": 4.93183,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.96,
+      "status": "pass",
+      "throughput_in_gibs": 5.46917,
+      "throughput_out_gibs": 0.695972,
+      "compression_fold": 7.85832,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.447376,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.642808,
+      "init_s": 0.218327,
+      "flush_s": 0.000444738,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.54726,
+          "best_ms": 0.853491,
+          "in_gibs": 18.4021,
+          "out_gibs": 18.4021
+        },
+        "h2d": {
+          "avg_ms": 0.898768,
+          "best_ms": 0.299392,
+          "in_gibs": 52.3929,
+          "out_gibs": 52.3929
+        },
+        "scatter": {
+          "avg_ms": 0.335684,
+          "best_ms": 0.066752,
+          "in_gibs": 138.985,
+          "out_gibs": 138.985
+        },
+        "compress": {
+          "avg_ms": 73.0895,
+          "best_ms": 26.3718,
+          "in_gibs": 6.87147,
+          "out_gibs": 0.873585
+        },
+        "aggregate": {
+          "avg_ms": 0.212174,
+          "best_ms": 0.05936,
+          "in_gibs": 300.932,
+          "out_gibs": 300.932
+        },
+        "d2h": {
+          "avg_ms": 7.5235,
+          "best_ms": 0.352832,
+          "in_gibs": 8.48672,
+          "out_gibs": 8.48672
+        },
+        "sink": {
+          "avg_ms": 0.0711871,
+          "best_ms": 4e-05,
+          "in_gibs": 28.0559,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 92.2512,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 136.176,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.004907,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 67.6873,
+        "peak_pending_mib": 73.2734
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 3.12,
+      "status": "pass",
+      "throughput_in_gibs": 3.08855,
+      "throughput_out_gibs": 0.311455,
+      "compression_fold": 9.9165,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.354523,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.13828,
+      "init_s": 0.000150025,
+      "flush_s": 1.041e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.92244,
+          "best_ms": 1.23254,
+          "in_gibs": 9.52272,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 61.7609,
+          "best_ms": 32.0451,
+          "in_gibs": 8.13187,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.95037,
+          "best_ms": 0.863466,
+          "in_gibs": 10.2184,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.291004,
+          "best_ms": 0.00019,
+          "in_gibs": 5.43872,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.96,
+      "status": "pass",
+      "throughput_in_gibs": 3.01953,
+      "throughput_out_gibs": 1.78814,
+      "compression_fold": 1.68865,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.08192,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.16429,
+      "init_s": 0.000137286,
+      "flush_s": 6.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.55122,
+          "best_ms": 0.604578,
+          "in_gibs": 10.2994,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.7406,
+          "best_ms": 16.7721,
+          "in_gibs": 14.4566,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.50775,
+          "best_ms": 4.68655,
+          "in_gibs": 31.2751,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 1.17724,
+          "best_ms": 0.000331,
+          "in_gibs": 7.89497,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.8,
+      "status": "pass",
+      "throughput_in_gibs": 4.26682,
+      "throughput_out_gibs": 0.0638635,
+      "compression_fold": 66.8117,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0526199,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.823944,
+      "init_s": 0.000161833,
+      "flush_s": 6.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.84094,
+          "best_ms": 0.652078,
+          "in_gibs": 9.68303,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.7001,
+          "best_ms": 12.8407,
+          "in_gibs": 20.3332,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.19428,
+          "best_ms": 0.18657,
+          "in_gibs": 1.43545,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0544563,
+          "best_ms": 0.00013,
+          "in_gibs": 4.31374,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 5.28,
+      "status": "pass",
+      "throughput_in_gibs": 2.9756,
+      "throughput_out_gibs": 3.09482,
+      "compression_fold": 0.999937,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65648,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.18148,
+      "init_s": 1.47058,
+      "flush_s": 0.70778,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.86663,
+          "best_ms": 0.79953,
+          "in_gibs": 19.4666,
+          "out_gibs": 19.4666
+        },
+        "h2d": {
+          "avg_ms": 1.06719,
+          "best_ms": 0.591072,
+          "in_gibs": 52.8046,
+          "out_gibs": 52.8046
+        },
+        "scatter": {
+          "avg_ms": 0.235613,
+          "best_ms": 0.133952,
+          "in_gibs": 239.173,
+          "out_gibs": 239.173
+        },
+        "compress": {
+          "avg_ms": 5.32886,
+          "best_ms": 5.32886,
+          "in_gibs": 686.122,
+          "out_gibs": 686.122
+        },
+        "aggregate": {
+          "avg_ms": 8.07936,
+          "best_ms": 8.07936,
+          "in_gibs": 452.542,
+          "out_gibs": 452.542
+        },
+        "d2h": {
+          "avg_ms": 69.4863,
+          "best_ms": 69.4863,
+          "in_gibs": 52.6183,
+          "out_gibs": 52.6183
+        },
+        "sink": {
+          "avg_ms": 0.00133473,
+          "best_ms": 5e-05,
+          "in_gibs": 22829.2,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 7.9453,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.00014,
+        "io_fence_count": 1,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.59737,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 3.92,
+      "status": "pass",
+      "throughput_in_gibs": 2.05189,
+      "throughput_out_gibs": 2.13409,
+      "compression_fold": 0.999937,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65648,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.71336,
+      "init_s": 0.000398688,
+      "flush_s": 7.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.93208,
+          "best_ms": 3.80006,
+          "in_gibs": 9.40709,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 81.6523,
+          "best_ms": 81.6523,
+          "in_gibs": 44.7783,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 84.4991,
+          "best_ms": 84.4991,
+          "in_gibs": 43.2697,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 7.61152,
+          "best_ms": 0.0003,
+          "in_gibs": 4.00323,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 5.27,
+      "status": "pass",
+      "throughput_in_gibs": 2.9863,
+      "throughput_out_gibs": 0.395876,
+      "compression_fold": 7.84527,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.466045,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.17725,
+      "init_s": 1.61462,
+      "flush_s": 0.0105181,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.98499,
+          "best_ms": 0.79257,
+          "in_gibs": 18.6947,
+          "out_gibs": 18.6947
+        },
+        "h2d": {
+          "avg_ms": 1.06672,
+          "best_ms": 0.58992,
+          "in_gibs": 52.8279,
+          "out_gibs": 52.8279
+        },
+        "scatter": {
+          "avg_ms": 0.235543,
+          "best_ms": 0.133888,
+          "in_gibs": 239.245,
+          "out_gibs": 239.245
+        },
+        "compress": {
+          "avg_ms": 678.338,
+          "best_ms": 678.338,
+          "in_gibs": 5.39001,
+          "out_gibs": 0.686539
+        },
+        "aggregate": {
+          "avg_ms": 1.18477,
+          "best_ms": 1.18477,
+          "in_gibs": 393.078,
+          "out_gibs": 393.078
+        },
+        "d2h": {
+          "avg_ms": 8.8617,
+          "best_ms": 8.8617,
+          "in_gibs": 52.5527,
+          "out_gibs": 52.5527
+        },
+        "sink": {
+          "avg_ms": 0.541067,
+          "best_ms": 5e-05,
+          "in_gibs": 7.17788,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 1.02178,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.00028,
+        "io_fence_count": 1,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.65685,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 2.82,
+      "status": "pass",
+      "throughput_in_gibs": 4.43572,
+      "throughput_out_gibs": 0.423521,
+      "compression_fold": 10.8924,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.33567,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.792572,
+      "init_s": 0.000129495,
+      "flush_s": 7.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.70341,
+          "best_ms": 1.29854,
+          "in_gibs": 11.8645,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 178.315,
+          "best_ms": 178.315,
+          "in_gibs": 20.5045,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.09198,
+          "best_ms": 8.09198,
+          "in_gibs": 41.4385,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.382508,
+          "best_ms": 0.00014,
+          "in_gibs": 7.31292,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 3.28,
+      "status": "pass",
+      "throughput_in_gibs": 3.06404,
+      "throughput_out_gibs": 1.63053,
+      "compression_fold": 1.95434,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.87083,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.14738,
+      "init_s": 0.000403476,
+      "flush_s": 6.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.82467,
+          "best_ms": 1.40157,
+          "in_gibs": 11.5663,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 103.173,
+          "best_ms": 103.173,
+          "in_gibs": 35.4382,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 44.1996,
+          "best_ms": 44.1996,
+          "in_gibs": 42.3191,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 3.78448,
+          "best_ms": 0.00022,
+          "in_gibs": 4.11954,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 2.59,
+      "status": "pass",
+      "throughput_in_gibs": 5.13174,
+      "throughput_out_gibs": 0.0755729,
+      "compression_fold": 70.6207,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0517731,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.685075,
+      "init_s": 0.000124206,
+      "flush_s": 7.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.73449,
+          "best_ms": 2.88715,
+          "in_gibs": 9.73121,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 58.5629,
+          "best_ms": 58.5629,
+          "in_gibs": 62.4329,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.43684,
+          "best_ms": 7.43684,
+          "in_gibs": 6.91246,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0495728,
+          "best_ms": 0.00015,
+          "in_gibs": 8.7032,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 12.36,
+      "status": "pass",
+      "throughput_in_gibs": 4.44176,
+      "throughput_out_gibs": 4.44408,
+      "compression_fold": 0.999479,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75195,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.84426,
+      "init_s": 0.107528,
+      "flush_s": 0.0583674,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.72579,
+          "best_ms": 3.2503,
+          "in_gibs": 16.775,
+          "out_gibs": 16.775
+        },
+        "h2d": {
+          "avg_ms": 1.18999,
+          "best_ms": 1.17827,
+          "in_gibs": 52.5217,
+          "out_gibs": 52.5217
+        },
+        "scatter": {
+          "avg_ms": 0.320649,
+          "best_ms": 0.315072,
+          "in_gibs": 194.917,
+          "out_gibs": 194.917
+        },
+        "compress": {
+          "avg_ms": 0.251309,
+          "best_ms": 0.247456,
+          "in_gibs": 746.094,
+          "out_gibs": 746.094
+        },
+        "aggregate": {
+          "avg_ms": 0.723518,
+          "best_ms": 0.407552,
+          "in_gibs": 259.15,
+          "out_gibs": 259.15
+        },
+        "d2h": {
+          "avg_ms": 36.4597,
+          "best_ms": 21.7653,
+          "in_gibs": 5.14266,
+          "out_gibs": 5.14266
+        },
+        "sink": {
+          "avg_ms": 0.000699553,
+          "best_ms": 3e-05,
+          "in_gibs": 13967.1,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 283.146,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 0.080517,
+        "kick_sync_count": 20,
+        "io_fence_ms": 229.451,
+        "io_fence_count": 20,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 31.9264,
+        "peak_pending_mib": 372.5
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 13.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.94002,
+      "throughput_out_gibs": 1.94103,
+      "compression_fold": 0.999479,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75195,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 1.93297,
+      "init_s": 0.000435243,
+      "flush_s": 8.52e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 10.1807,
+          "best_ms": 7.58868,
+          "in_gibs": 6.13908,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.84248,
+          "best_ms": 3.49421,
+          "in_gibs": 23.9083,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.25197,
+          "best_ms": 3.253,
+          "in_gibs": 25.8551,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 1.99193,
+          "best_ms": 0.001031,
+          "in_gibs": 4.90514,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 12.86,
+      "status": "pass",
+      "throughput_in_gibs": 7.84799,
+      "throughput_out_gibs": 0.953025,
+      "compression_fold": 8.23482,
+      "input_gib": 3.75,
+      "compressed_gib": 0.455383,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.477829,
+      "init_s": 0.103284,
+      "flush_s": 0.00213219,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.38149,
+          "best_ms": 3.25191,
+          "in_gibs": 18.483,
+          "out_gibs": 18.483
+        },
+        "h2d": {
+          "avg_ms": 1.19574,
+          "best_ms": 1.17878,
+          "in_gibs": 52.2689,
+          "out_gibs": 52.2689
+        },
+        "scatter": {
+          "avg_ms": 0.40801,
+          "best_ms": 0.316416,
+          "in_gibs": 153.183,
+          "out_gibs": 153.183
+        },
+        "compress": {
+          "avg_ms": 13.4838,
+          "best_ms": 13.2106,
+          "in_gibs": 13.9055,
+          "out_gibs": 1.68138
+        },
+        "aggregate": {
+          "avg_ms": 0.0876816,
+          "best_ms": 0.065536,
+          "in_gibs": 258.566,
+          "out_gibs": 258.566
+        },
+        "d2h": {
+          "avg_ms": 7.38071,
+          "best_ms": 0.440256,
+          "in_gibs": 3.07172,
+          "out_gibs": 3.07172
+        },
+        "sink": {
+          "avg_ms": 0.000746943,
+          "best_ms": 3e-05,
+          "in_gibs": 1587.66,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 13.5293,
+        "flush_stall_count": 19,
+        "kick_sync_ms": 14.4605,
+        "kick_sync_count": 20,
+        "io_fence_ms": 0.010777,
+        "io_fence_count": 20,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 18.6912,
+        "peak_pending_mib": 23.25
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 12.57,
+      "status": "pass",
+      "throughput_in_gibs": 2.72324,
+      "throughput_out_gibs": 0.250517,
+      "compression_fold": 10.8705,
+      "input_gib": 3.75,
+      "compressed_gib": 0.344971,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 1.37704,
+      "init_s": 0.000345088,
+      "flush_s": 8.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 9.64178,
+          "best_ms": 5.31894,
+          "in_gibs": 6.48221,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.06,
+          "best_ms": 10.3434,
+          "in_gibs": 11.675,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.85013,
+          "best_ms": 0.542474,
+          "in_gibs": 2.93171,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.268583,
+          "best_ms": 0.00027,
+          "in_gibs": 3.34481,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 13.18,
+      "status": "pass",
+      "throughput_in_gibs": 2.44863,
+      "throughput_out_gibs": 1.46515,
+      "compression_fold": 1.67125,
+      "input_gib": 3.75,
+      "compressed_gib": 2.24384,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 1.53147,
+      "init_s": 0.000377947,
+      "flush_s": 7.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 9.22166,
+          "best_ms": 7.02935,
+          "in_gibs": 6.77752,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.064,
+          "best_ms": 4.53058,
+          "in_gibs": 16.9468,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.91769,
+          "best_ms": 2.5843,
+          "in_gibs": 16.204,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.920701,
+          "best_ms": 0.001011,
+          "in_gibs": 6.3466,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 13.26,
+      "status": "pass",
+      "throughput_in_gibs": 3.08791,
+      "throughput_out_gibs": 0.0699605,
+      "compression_fold": 44.1379,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0849609,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 1.21441,
+      "init_s": 0.000407301,
+      "flush_s": 8.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 9.25294,
+          "best_ms": 6.32774,
+          "in_gibs": 6.75461,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.3139,
+          "best_ms": 10.5588,
+          "in_gibs": 14.083,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.82507,
+          "best_ms": 4.0058,
+          "in_gibs": 0.712505,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0544335,
+          "best_ms": 0.000401,
+          "in_gibs": 4.06464,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 13.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.14971,
+      "throughput_out_gibs": 4.15005,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.903678,
+      "init_s": 0.303212,
+      "flush_s": 0.243981,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.3837,
+          "best_ms": 3.0461,
+          "in_gibs": 18.4709,
+          "out_gibs": 18.4709
+        },
+        "h2d": {
+          "avg_ms": 1.18997,
+          "best_ms": 1.1783,
+          "in_gibs": 52.5223,
+          "out_gibs": 52.5223
+        },
+        "scatter": {
+          "avg_ms": 0.319825,
+          "best_ms": 0.315008,
+          "in_gibs": 195.419,
+          "out_gibs": 195.419
+        },
+        "compress": {
+          "avg_ms": 1.0879,
+          "best_ms": 1.06768,
+          "in_gibs": 689.399,
+          "out_gibs": 689.399
+        },
+        "aggregate": {
+          "avg_ms": 9.11867,
+          "best_ms": 1.51552,
+          "in_gibs": 82.2489,
+          "out_gibs": 82.2489
+        },
+        "d2h": {
+          "avg_ms": 109.83,
+          "best_ms": 84.6711,
+          "in_gibs": 6.82876,
+          "out_gibs": 6.82876
+        },
+        "sink": {
+          "avg_ms": 0.00111766,
+          "best_ms": 4e-05,
+          "in_gibs": 20971.8,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 99.6,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 0.03318,
+        "kick_sync_count": 5,
+        "io_fence_ms": 149.094,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 48.3925,
+        "peak_pending_mib": 1488.12
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 12.67,
+      "status": "pass",
+      "throughput_in_gibs": 2.37522,
+      "throughput_out_gibs": 2.37542,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 1.5788,
+      "init_s": 0.000170025,
+      "flush_s": 8.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.2165,
+          "best_ms": 4.40875,
+          "in_gibs": 11.9812,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.2345,
+          "best_ms": 12.6318,
+          "in_gibs": 56.6699,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.1124,
+          "best_ms": 12.592,
+          "in_gibs": 57.1977,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 5.5585,
+          "best_ms": 0.000291,
+          "in_gibs": 4.21686,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 12.14,
+      "status": "pass",
+      "throughput_in_gibs": 7.52565,
+      "throughput_out_gibs": 0.865989,
+      "compression_fold": 8.69024,
+      "input_gib": 3.75,
+      "compressed_gib": 0.431519,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.498296,
+      "init_s": 0.271894,
+      "flush_s": 0.0120318,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.12221,
+          "best_ms": 3.067,
+          "in_gibs": 20.0179,
+          "out_gibs": 20.0179
+        },
+        "h2d": {
+          "avg_ms": 1.1883,
+          "best_ms": 1.17824,
+          "in_gibs": 52.5959,
+          "out_gibs": 52.5959
+        },
+        "scatter": {
+          "avg_ms": 0.657314,
+          "best_ms": 0.3136,
+          "in_gibs": 95.084,
+          "out_gibs": 95.084
+        },
+        "compress": {
+          "avg_ms": 41.0909,
+          "best_ms": 40.165,
+          "in_gibs": 18.2522,
+          "out_gibs": 2.09883
+        },
+        "aggregate": {
+          "avg_ms": 0.261574,
+          "best_ms": 0.192512,
+          "in_gibs": 329.706,
+          "out_gibs": 329.706
+        },
+        "d2h": {
+          "avg_ms": 37.5725,
+          "best_ms": 1.64842,
+          "in_gibs": 2.29537,
+          "out_gibs": 2.29537
+        },
+        "sink": {
+          "avg_ms": 0.000649737,
+          "best_ms": 0.00013,
+          "in_gibs": 4150.89,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 8.26335,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 40.5458,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.002905,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 44.9125,
+        "peak_pending_mib": 88.375
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 11.7,
+      "status": "pass",
+      "throughput_in_gibs": 4.70536,
+      "throughput_out_gibs": 0.410494,
+      "compression_fold": 11.4627,
+      "input_gib": 3.75,
+      "compressed_gib": 0.327148,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.796964,
+      "init_s": 0.000170535,
+      "flush_s": 7.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.10101,
+          "best_ms": 4.39368,
+          "in_gibs": 12.2525,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.3657,
+          "best_ms": 34.1672,
+          "in_gibs": 20.6238,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.12565,
+          "best_ms": 1.12619,
+          "in_gibs": 30.7524,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.417669,
+          "best_ms": 0.00021,
+          "in_gibs": 4.89545,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 12.3,
+      "status": "pass",
+      "throughput_in_gibs": 3.20173,
+      "throughput_out_gibs": 2.08881,
+      "compression_fold": 1.5328,
+      "input_gib": 3.75,
+      "compressed_gib": 2.4465,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 1.17124,
+      "init_s": 0.000167091,
+      "flush_s": 6.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.25106,
+          "best_ms": 4.39972,
+          "in_gibs": 9.99831,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.2759,
+          "best_ms": 18.0348,
+          "in_gibs": 38.9087,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.55959,
+          "best_ms": 8.22773,
+          "in_gibs": 57.1569,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 2.41839,
+          "best_ms": 0.00032,
+          "in_gibs": 6.32266,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 12.04,
+      "status": "pass",
+      "throughput_in_gibs": 5.34852,
+      "throughput_out_gibs": 0.120133,
+      "compression_fold": 44.5217,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0842285,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.701129,
+      "init_s": 0.000161432,
+      "flush_s": 8.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.42308,
+          "best_ms": 4.39336,
+          "in_gibs": 11.5248,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.077,
+          "best_ms": 23.5045,
+          "in_gibs": 31.15,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.297635,
+          "best_ms": 0.270486,
+          "in_gibs": 56.3935,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.114434,
+          "best_ms": 0.000101,
+          "in_gibs": 4.6003,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.58,
+      "status": "pass",
+      "throughput_in_gibs": 3.4207,
+      "throughput_out_gibs": 3.42098,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 1.09627,
+      "init_s": 1.79088,
+      "flush_s": 0.611641,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.10548,
+          "best_ms": 3.08601,
+          "in_gibs": 20.1257,
+          "out_gibs": 20.1257
+        },
+        "h2d": {
+          "avg_ms": 1.18107,
+          "best_ms": 1.17818,
+          "in_gibs": 52.918,
+          "out_gibs": 52.918
+        },
+        "scatter": {
+          "avg_ms": 0.31976,
+          "best_ms": 0.314368,
+          "in_gibs": 195.459,
+          "out_gibs": 195.459
+        },
+        "compress": {
+          "avg_ms": 5.45859,
+          "best_ms": 5.45859,
+          "in_gibs": 686.99,
+          "out_gibs": 686.99
+        },
+        "aggregate": {
+          "avg_ms": 8.11008,
+          "best_ms": 8.11008,
+          "in_gibs": 462.388,
+          "out_gibs": 462.388
+        },
+        "d2h": {
+          "avg_ms": 71.2701,
+          "best_ms": 71.2701,
+          "in_gibs": 52.6167,
+          "out_gibs": 52.6167
+        },
+        "sink": {
+          "avg_ms": 0.00124058,
+          "best_ms": 4e-05,
+          "in_gibs": 18893.9,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 8.00264,
+        "kick_sync_count": 1,
+        "io_fence_ms": 5e-05,
+        "io_fence_count": 1,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.4093,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 12.8,
+      "status": "pass",
+      "throughput_in_gibs": 2.2835,
+      "throughput_out_gibs": 2.28369,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 1.64221,
+      "init_s": 0.000177527,
+      "flush_s": 7.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.55989,
+          "best_ms": 4.32981,
+          "in_gibs": 11.2412,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 78.1318,
+          "best_ms": 78.1318,
+          "in_gibs": 47.9958,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 86.314,
+          "best_ms": 86.314,
+          "in_gibs": 43.446,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 5.64995,
+          "best_ms": 0.0003,
+          "in_gibs": 4.1486,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.67,
+      "status": "pass",
+      "throughput_in_gibs": 3.89548,
+      "throughput_out_gibs": 0.456121,
+      "compression_fold": 8.54045,
+      "input_gib": 3.75,
+      "compressed_gib": 0.439087,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.962654,
+      "init_s": 1.78292,
+      "flush_s": 0.0192989,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.08251,
+          "best_ms": 3.04996,
+          "in_gibs": 20.2757,
+          "out_gibs": 20.2757
+        },
+        "h2d": {
+          "avg_ms": 1.18289,
+          "best_ms": 1.17901,
+          "in_gibs": 52.8365,
+          "out_gibs": 52.8365
+        },
+        "scatter": {
+          "avg_ms": 0.319414,
+          "best_ms": 0.318176,
+          "in_gibs": 195.671,
+          "out_gibs": 195.671
+        },
+        "compress": {
+          "avg_ms": 477.824,
+          "best_ms": 477.824,
+          "in_gibs": 7.84808,
+          "out_gibs": 0.917957
+        },
+        "aggregate": {
+          "avg_ms": 0.947232,
+          "best_ms": 0.947232,
+          "in_gibs": 463.056,
+          "out_gibs": 463.056
+        },
+        "d2h": {
+          "avg_ms": 8.35264,
+          "best_ms": 8.35264,
+          "in_gibs": 52.5129,
+          "out_gibs": 52.5129
+        },
+        "sink": {
+          "avg_ms": 0.30314,
+          "best_ms": 4e-05,
+          "in_gibs": 9.0529,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 478.52,
+        "kick_sync_count": 1,
+        "io_fence_ms": 4e-05,
+        "io_fence_count": 1,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.41634,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 11.71,
+      "status": "pass",
+      "throughput_in_gibs": 5.04518,
+      "throughput_out_gibs": 0.417131,
+      "compression_fold": 12.0949,
+      "input_gib": 3.75,
+      "compressed_gib": 0.310047,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.743284,
+      "init_s": 0.000175554,
+      "flush_s": 6.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.77305,
+          "best_ms": 4.34091,
+          "in_gibs": 13.0943,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 158.821,
+          "best_ms": 158.821,
+          "in_gibs": 23.6115,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.38981,
+          "best_ms": 6.38981,
+          "in_gibs": 48.4505,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.235434,
+          "best_ms": 0.000171,
+          "in_gibs": 8.23074,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 12.74,
+      "status": "pass",
+      "throughput_in_gibs": 3.33414,
+      "throughput_out_gibs": 1.88035,
+      "compression_fold": 1.77315,
+      "input_gib": 3.75,
+      "compressed_gib": 2.11488,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 1.12473,
+      "init_s": 0.000165268,
+      "flush_s": 6.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.67641,
+          "best_ms": 4.32253,
+          "in_gibs": 13.365,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 106.615,
+          "best_ms": 106.615,
+          "in_gibs": 35.1734,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 41.3984,
+          "best_ms": 41.3984,
+          "in_gibs": 51.0751,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 2.80312,
+          "best_ms": 0.00032,
+          "in_gibs": 4.71547,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 11.79,
+      "status": "pass",
+      "throughput_in_gibs": 6.21802,
+      "throughput_out_gibs": 0.0941141,
+      "compression_fold": 66.069,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0567589,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.603086,
+      "init_s": 0.000174102,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.75187,
+          "best_ms": 4.33077,
+          "in_gibs": 13.1527,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 73.7951,
+          "best_ms": 73.7951,
+          "in_gibs": 50.8164,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.36484,
+          "best_ms": 1.36484,
+          "in_gibs": 41.2651,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0518886,
+          "best_ms": 0.0001,
+          "in_gibs": 6.83662,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 3.1,
+      "status": "pass",
+      "throughput_in_gibs": 3.99103,
+      "throughput_out_gibs": 4.59602,
+      "compression_fold": 1.16122,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04855,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 0.880881,
+      "init_s": 0.138867,
+      "flush_s": 0.0278677,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.70436,
+          "best_ms": 0.768233,
+          "in_gibs": 17.3331,
+          "out_gibs": 17.3331
+        },
+        "h2d": {
+          "avg_ms": 0.903497,
+          "best_ms": 0.295872,
+          "in_gibs": 52.1186,
+          "out_gibs": 52.1186
+        },
+        "scatter": {
+          "avg_ms": 0.0482082,
+          "best_ms": 0.014912,
+          "in_gibs": 976.784,
+          "out_gibs": 976.784
+        },
+        "lod_gather": {
+          "avg_ms": 0.223007,
+          "best_ms": 0.216352,
+          "in_gibs": 630.586,
+          "out_gibs": 630.586
+        },
+        "lod_reduce": {
+          "avg_ms": 0.78593,
+          "best_ms": 0.75776,
+          "in_gibs": 178.928,
+          "out_gibs": 238.59
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.104112,
+          "best_ms": 0.063456,
+          "in_gibs": 450.383,
+          "out_gibs": 450.383
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.03164,
+          "best_ms": 0.229376,
+          "in_gibs": 61.8527,
+          "out_gibs": 62.0288
+        },
+        "compress": {
+          "avg_ms": 0.244593,
+          "best_ms": 0.235488,
+          "in_gibs": 768.825,
+          "out_gibs": 636.176
+        },
+        "aggregate": {
+          "avg_ms": 0.65266,
+          "best_ms": 0.292512,
+          "in_gibs": 238.416,
+          "out_gibs": 238.416
+        },
+        "d2h": {
+          "avg_ms": 30.4735,
+          "best_ms": 15.6626,
+          "in_gibs": 5.10622,
+          "out_gibs": 5.10622
+        },
+        "sink": {
+          "avg_ms": 0.00100497,
+          "best_ms": 3e-05,
+          "in_gibs": 6691.88,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 373.805,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 0.03921,
+        "kick_sync_count": 26,
+        "io_fence_ms": 324.923,
+        "io_fence_count": 26,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 32.1104,
+        "peak_pending_mib": 326.516
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 7.42,
+      "status": "pass",
+      "throughput_in_gibs": 1.48493,
+      "throughput_out_gibs": 1.71003,
+      "compression_fold": 1.16122,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04855,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 2.36753,
+      "init_s": 3.10863,
+      "flush_s": 7.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.76352,
+          "best_ms": 0.702835,
+          "in_gibs": 16.962,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.92856,
+          "best_ms": 4.69902,
+          "in_gibs": 20.2964,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 20.0405,
+          "best_ms": 11.5201,
+          "in_gibs": 9.35682,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.45193,
+          "best_ms": 0.724887,
+          "in_gibs": 10.5326,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.54524,
+          "best_ms": 3.51164,
+          "in_gibs": 33.9119,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.59783,
+          "best_ms": 3.15446,
+          "in_gibs": 52.2674,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.21019,
+          "best_ms": 0.014472,
+          "in_gibs": 34.5374,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 1.22401,
+          "best_ms": 0.000341,
+          "in_gibs": 5.49437,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 2.99,
+      "status": "pass",
+      "throughput_in_gibs": 5.17845,
+      "throughput_out_gibs": 0.748903,
+      "compression_fold": 9.24663,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.508427,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 0.678896,
+      "init_s": 0.134847,
+      "flush_s": 7.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.40677,
+          "best_ms": 0.714492,
+          "in_gibs": 19.4763,
+          "out_gibs": 19.4763
+        },
+        "h2d": {
+          "avg_ms": 0.898038,
+          "best_ms": 0.297888,
+          "in_gibs": 52.4355,
+          "out_gibs": 52.4355
+        },
+        "scatter": {
+          "avg_ms": 0.139853,
+          "best_ms": 0.017152,
+          "in_gibs": 364.222,
+          "out_gibs": 364.222
+        },
+        "lod_gather": {
+          "avg_ms": 0.388791,
+          "best_ms": 0.22016,
+          "in_gibs": 361.698,
+          "out_gibs": 361.698
+        },
+        "lod_reduce": {
+          "avg_ms": 0.819204,
+          "best_ms": 0.763936,
+          "in_gibs": 171.661,
+          "out_gibs": 228.899
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.125148,
+          "best_ms": 0.065504,
+          "in_gibs": 374.678,
+          "out_gibs": 374.678
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.36673,
+          "best_ms": 0.233472,
+          "in_gibs": 79.2296,
+          "out_gibs": 79.4553
+        },
+        "compress": {
+          "avg_ms": 24.0869,
+          "best_ms": 6.34605,
+          "in_gibs": 7.80712,
+          "out_gibs": 0.807327
+        },
+        "aggregate": {
+          "avg_ms": 0.0961969,
+          "best_ms": 0.055264,
+          "in_gibs": 202.148,
+          "out_gibs": 202.148
+        },
+        "d2h": {
+          "avg_ms": 1.00196,
+          "best_ms": 0.127584,
+          "in_gibs": 19.4081,
+          "out_gibs": 19.4081
+        },
+        "sink": {
+          "avg_ms": 0.000813529,
+          "best_ms": 4e-05,
+          "in_gibs": 1038.15,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 242.358,
+        "flush_stall_count": 24,
+        "kick_sync_ms": 252.75,
+        "kick_sync_count": 26,
+        "io_fence_ms": 0.008811,
+        "io_fence_count": 26,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 27.3501,
+        "peak_pending_mib": 22.9141
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 6.85,
+      "status": "pass",
+      "throughput_in_gibs": 2.07702,
+      "throughput_out_gibs": 0.229813,
+      "compression_fold": 12.0858,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.388988,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 1.69263,
+      "init_s": 3.15615,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.68422,
+          "best_ms": 0.777136,
+          "in_gibs": 17.4632,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.2721,
+          "best_ms": 4.80333,
+          "in_gibs": 19.3376,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 17.4173,
+          "best_ms": 11.597,
+          "in_gibs": 10.7661,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.28708,
+          "best_ms": 0.795233,
+          "in_gibs": 20.5022,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.65062,
+          "best_ms": 3.63044,
+          "in_gibs": 40.4353,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.62003,
+          "best_ms": 8.33983,
+          "in_gibs": 19.5477,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.792451,
+          "best_ms": 0.000881,
+          "in_gibs": 9.19426,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.195862,
+          "best_ms": 0.00021,
+          "in_gibs": 3.29906,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 6.88,
+      "status": "pass",
+      "throughput_in_gibs": 1.92797,
+      "throughput_out_gibs": 1.16765,
+      "compression_fold": 2.20798,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.1292,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 1.82348,
+      "init_s": 3.10176,
+      "flush_s": 0.000765468,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.77991,
+          "best_ms": 0.718689,
+          "in_gibs": 16.8621,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.6666,
+          "best_ms": 4.75254,
+          "in_gibs": 21.0939,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 18.8637,
+          "best_ms": 11.5432,
+          "in_gibs": 9.94055,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.43862,
+          "best_ms": 0.749815,
+          "in_gibs": 13.6364,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.39443,
+          "best_ms": 3.53888,
+          "in_gibs": 42.7926,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.2412,
+          "best_ms": 3.4029,
+          "in_gibs": 44.3387,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.49722,
+          "best_ms": 0.001472,
+          "in_gibs": 26.7963,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.501068,
+          "best_ms": 0.00034,
+          "in_gibs": 7.05866,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 6.41,
+      "status": "pass",
+      "throughput_in_gibs": 2.41651,
+      "throughput_out_gibs": 0.0561518,
+      "compression_fold": 57.5484,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0816917,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 1.45484,
+      "init_s": 3.11827,
+      "flush_s": 9.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.71089,
+          "best_ms": 0.763055,
+          "in_gibs": 17.2914,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.46894,
+          "best_ms": 4.72471,
+          "in_gibs": 21.7385,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 17.9195,
+          "best_ms": 11.519,
+          "in_gibs": 10.4643,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.90811,
+          "best_ms": 0.734111,
+          "in_gibs": 16.124,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.47998,
+          "best_ms": 3.52081,
+          "in_gibs": 41.9755,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.09529,
+          "best_ms": 4.28825,
+          "in_gibs": 36.9065,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.36783,
+          "best_ms": 0.000641,
+          "in_gibs": 4.04521,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0253962,
+          "best_ms": 0.00016,
+          "in_gibs": 5.34335,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 3.37,
+      "status": "pass",
+      "throughput_in_gibs": 3.79733,
+      "throughput_out_gibs": 4.38059,
+      "compression_fold": 1.17086,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.05561,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.925815,
+      "init_s": 0.273497,
+      "flush_s": 0.131822,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.61398,
+          "best_ms": 0.70033,
+          "in_gibs": 17.9324,
+          "out_gibs": 17.9324
+        },
+        "h2d": {
+          "avg_ms": 0.902892,
+          "best_ms": 0.295968,
+          "in_gibs": 52.1536,
+          "out_gibs": 52.1536
+        },
+        "scatter": {
+          "avg_ms": 0.0475906,
+          "best_ms": 0.0136,
+          "in_gibs": 989.462,
+          "out_gibs": 989.462
+        },
+        "lod_gather": {
+          "avg_ms": 0.225172,
+          "best_ms": 0.220768,
+          "in_gibs": 624.523,
+          "out_gibs": 624.523
+        },
+        "lod_reduce": {
+          "avg_ms": 0.795368,
+          "best_ms": 0.784384,
+          "in_gibs": 176.805,
+          "out_gibs": 236.124
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.128412,
+          "best_ms": 0.06144,
+          "in_gibs": 367.412,
+          "out_gibs": 367.412
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 22.7828,
+          "best_ms": 0.229376,
+          "in_gibs": 8.2433,
+          "out_gibs": 8.33707
+        },
+        "compress": {
+          "avg_ms": 0.886972,
+          "best_ms": 0.244416,
+          "in_gibs": 695.974,
+          "out_gibs": 571.491
+        },
+        "aggregate": {
+          "avg_ms": 5.88848,
+          "best_ms": 0.464928,
+          "in_gibs": 86.0829,
+          "out_gibs": 86.0829
+        },
+        "d2h": {
+          "avg_ms": 86.9277,
+          "best_ms": 9.87197,
+          "in_gibs": 5.83125,
+          "out_gibs": 5.83125
+        },
+        "sink": {
+          "avg_ms": 0.00131475,
+          "best_ms": 3e-05,
+          "in_gibs": 10015.3,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 189.663,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 0.029214,
+        "kick_sync_count": 8,
+        "io_fence_ms": 291.21,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 78.5195,
+        "peak_pending_mib": 1280.09
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 7.43,
+      "status": "pass",
+      "throughput_in_gibs": 1.47699,
+      "throughput_out_gibs": 1.70385,
+      "compression_fold": 1.17086,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.05561,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.38026,
+      "init_s": 3.09764,
+      "flush_s": 9.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.76984,
+          "best_ms": 0.711668,
+          "in_gibs": 16.9234,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.96873,
+          "best_ms": 4.85818,
+          "in_gibs": 20.1794,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 18.0966,
+          "best_ms": 11.5083,
+          "in_gibs": 10.3779,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.85574,
+          "best_ms": 0.768202,
+          "in_gibs": 6.88185,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.91704,
+          "best_ms": 3.54024,
+          "in_gibs": 38.6292,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.7799,
+          "best_ms": 9.99206,
+          "in_gibs": 48.3033,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.05753,
+          "best_ms": 0.05958,
+          "in_gibs": 35.6935,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 2.41199,
+          "best_ms": 0.00019,
+          "in_gibs": 5.45921,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 3.1,
+      "status": "pass",
+      "throughput_in_gibs": 4.60244,
+      "throughput_out_gibs": 0.653761,
+      "compression_fold": 9.50882,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.499382,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.76386,
+      "init_s": 0.277513,
+      "flush_s": 0.000257286,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.49778,
+          "best_ms": 0.751918,
+          "in_gibs": 18.7666,
+          "out_gibs": 18.7666
+        },
+        "h2d": {
+          "avg_ms": 0.900288,
+          "best_ms": 0.30736,
+          "in_gibs": 52.3044,
+          "out_gibs": 52.3044
+        },
+        "scatter": {
+          "avg_ms": 0.13263,
+          "best_ms": 0.0136,
+          "in_gibs": 351.767,
+          "out_gibs": 351.767
+        },
+        "lod_gather": {
+          "avg_ms": 1.6228,
+          "best_ms": 0.22272,
+          "in_gibs": 86.6556,
+          "out_gibs": 86.6556
+        },
+        "lod_reduce": {
+          "avg_ms": 1.7982,
+          "best_ms": 0.7944,
+          "in_gibs": 78.203,
+          "out_gibs": 104.44
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.520824,
+          "best_ms": 0.145408,
+          "in_gibs": 90.5876,
+          "out_gibs": 90.5876
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.4757,
+          "best_ms": 0.307232,
+          "in_gibs": 15.0537,
+          "out_gibs": 15.2249
+        },
+        "compress": {
+          "avg_ms": 79.8467,
+          "best_ms": 26.451,
+          "in_gibs": 7.73119,
+          "out_gibs": 0.780863
+        },
+        "aggregate": {
+          "avg_ms": 0.362304,
+          "best_ms": 0.057376,
+          "in_gibs": 172.091,
+          "out_gibs": 172.091
+        },
+        "d2h": {
+          "avg_ms": 6.69031,
+          "best_ms": 0.108192,
+          "in_gibs": 9.31935,
+          "out_gibs": 9.31935
+        },
+        "sink": {
+          "avg_ms": 0.0295656,
+          "best_ms": 5e-05,
+          "in_gibs": 54.8397,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 173.36,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 260.908,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.003816,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 77.4561,
+        "peak_pending_mib": 81.3555
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 6.86,
+      "status": "pass",
+      "throughput_in_gibs": 1.84963,
+      "throughput_out_gibs": 0.198397,
+      "compression_fold": 12.5923,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.377098,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.90072,
+      "init_s": 3.14221,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.68693,
+          "best_ms": 0.594301,
+          "in_gibs": 17.4455,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.52809,
+          "best_ms": 4.93087,
+          "in_gibs": 21.5415,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.1256,
+          "best_ms": 11.5539,
+          "in_gibs": 12.4164,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.54179,
+          "best_ms": 0.751017,
+          "in_gibs": 13.321,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.75734,
+          "best_ms": 3.59778,
+          "in_gibs": 39.926,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 74.578,
+          "best_ms": 29.5813,
+          "in_gibs": 8.27736,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.50072,
+          "best_ms": 0.001702,
+          "in_gibs": 26.855,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.189218,
+          "best_ms": 0.0001,
+          "in_gibs": 6.47054,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 7.28,
+      "status": "pass",
+      "throughput_in_gibs": 1.58333,
+      "throughput_out_gibs": 0.973317,
+      "compression_fold": 2.19722,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.16116,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.2204,
+      "init_s": 3.07242,
+      "flush_s": 6.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.81165,
+          "best_ms": 0.789364,
+          "in_gibs": 16.6717,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.33463,
+          "best_ms": 4.83321,
+          "in_gibs": 22.1994,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 19.6849,
+          "best_ms": 11.5265,
+          "in_gibs": 9.54058,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 7.9684,
+          "best_ms": 0.761212,
+          "in_gibs": 5.92091,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 6.28925,
+          "best_ms": 3.57257,
+          "in_gibs": 30.201,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 46.9198,
+          "best_ms": 13.0742,
+          "in_gibs": 13.1567,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.85499,
+          "best_ms": 0.012999,
+          "in_gibs": 41.5977,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.899461,
+          "best_ms": 0.000311,
+          "in_gibs": 7.80105,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 6.63,
+      "status": "pass",
+      "throughput_in_gibs": 2.14742,
+      "throughput_out_gibs": 0.03631,
+      "compression_fold": 79.8819,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0594444,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.63714,
+      "init_s": 3.10212,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.68694,
+          "best_ms": 0.751037,
+          "in_gibs": 17.4455,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.50705,
+          "best_ms": 4.7784,
+          "in_gibs": 21.6112,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 19.6432,
+          "best_ms": 11.5435,
+          "in_gibs": 9.56084,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.09998,
+          "best_ms": 0.815804,
+          "in_gibs": 7.73448,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.18778,
+          "best_ms": 3.57182,
+          "in_gibs": 36.6132,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.3784,
+          "best_ms": 10.888,
+          "in_gibs": 24.3242,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.0780032,
+          "best_ms": 0.000601,
+          "in_gibs": 26.948,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0329224,
+          "best_ms": 0.00013,
+          "in_gibs": 5.86231,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 5.59,
+      "status": "pass",
+      "throughput_in_gibs": 2.89981,
+      "throughput_out_gibs": 3.56062,
+      "compression_fold": 1.18814,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31677,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 1.21236,
+      "init_s": 1.63623,
+      "flush_s": 0.0152619,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.7641,
+          "best_ms": 0.728563,
+          "in_gibs": 20.1887,
+          "out_gibs": 20.1887
+        },
+        "h2d": {
+          "avg_ms": 1.06607,
+          "best_ms": 0.58992,
+          "in_gibs": 52.8602,
+          "out_gibs": 52.8602
+        },
+        "scatter": {
+          "avg_ms": 0.0581844,
+          "best_ms": 0.023712,
+          "in_gibs": 968.515,
+          "out_gibs": 968.515
+        },
+        "lod_gather": {
+          "avg_ms": 0.423584,
+          "best_ms": 0.423584,
+          "in_gibs": 663.977,
+          "out_gibs": 663.977
+        },
+        "lod_reduce": {
+          "avg_ms": 1.5575,
+          "best_ms": 1.5575,
+          "in_gibs": 180.577,
+          "out_gibs": 242.337
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.157696,
+          "best_ms": 0.157696,
+          "in_gibs": 609.98,
+          "out_gibs": 609.98
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 57.5705,
+          "best_ms": 0.45056,
+          "in_gibs": 6.55616,
+          "out_gibs": 6.85301
+        },
+        "compress": {
+          "avg_ms": 4.01662,
+          "best_ms": 0.551232,
+          "in_gibs": 687.572,
+          "out_gibs": 537.318
+        },
+        "aggregate": {
+          "avg_ms": 14.0689,
+          "best_ms": 11.5063,
+          "in_gibs": 153.402,
+          "out_gibs": 153.402
+        },
+        "d2h": {
+          "avg_ms": 392.568,
+          "best_ms": 79.8829,
+          "in_gibs": 5.49766,
+          "out_gibs": 5.49766
+        },
+        "sink": {
+          "avg_ms": 0.00108802,
+          "best_ms": 4e-05,
+          "in_gibs": 20881.8,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 26.7559,
+        "kick_sync_count": 2,
+        "io_fence_ms": 715.33,
+        "io_fence_count": 2,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.32845,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 10.83,
+      "status": "pass",
+      "throughput_in_gibs": 1.28949,
+      "throughput_out_gibs": 1.58191,
+      "compression_fold": 1.18921,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31286,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 2.72637,
+      "init_s": 5.87744,
+      "flush_s": 8.32e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.56169,
+          "best_ms": 0.783726,
+          "in_gibs": 15.6677,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.9939,
+          "best_ms": 9.36225,
+          "in_gibs": 23.4493,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 34.5527,
+          "best_ms": 23.3909,
+          "in_gibs": 10.9237,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 14.4042,
+          "best_ms": 2.00713,
+          "in_gibs": 6.67799,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.6776,
+          "best_ms": 8.27422,
+          "in_gibs": 31.1205,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 63.1337,
+          "best_ms": 23.0868,
+          "in_gibs": 43.744,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 21.5679,
+          "best_ms": 0.002604,
+          "in_gibs": 24.9937,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 5.11924,
+          "best_ms": 0.0003,
+          "in_gibs": 4.45757,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 5.82,
+      "status": "pass",
+      "throughput_in_gibs": 2.59421,
+      "throughput_out_gibs": 0.40621,
+      "compression_fold": 9.31703,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.550488,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 1.35518,
+      "init_s": 1.64475,
+      "flush_s": 8.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.7644,
+          "best_ms": 0.742684,
+          "in_gibs": 20.1865,
+          "out_gibs": 20.1865
+        },
+        "h2d": {
+          "avg_ms": 1.06677,
+          "best_ms": 0.591392,
+          "in_gibs": 52.8253,
+          "out_gibs": 52.8253
+        },
+        "scatter": {
+          "avg_ms": 0.0576121,
+          "best_ms": 0.025216,
+          "in_gibs": 978.136,
+          "out_gibs": 978.136
+        },
+        "lod_gather": {
+          "avg_ms": 0.423584,
+          "best_ms": 0.423584,
+          "in_gibs": 663.977,
+          "out_gibs": 663.977
+        },
+        "lod_reduce": {
+          "avg_ms": 1.51859,
+          "best_ms": 1.51859,
+          "in_gibs": 185.204,
+          "out_gibs": 248.547
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.16384,
+          "best_ms": 0.16384,
+          "in_gibs": 587.106,
+          "out_gibs": 587.106
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 467.36,
+          "best_ms": 0.442368,
+          "in_gibs": 0.807602,
+          "out_gibs": 0.844169
+        },
+        "compress": {
+          "avg_ms": 444.556,
+          "best_ms": 55.7664,
+          "in_gibs": 6.2123,
+          "out_gibs": 0.618576
+        },
+        "aggregate": {
+          "avg_ms": 1.19104,
+          "best_ms": 0.396928,
+          "in_gibs": 230.884,
+          "out_gibs": 230.884
+        },
+        "d2h": {
+          "avg_ms": 5.25302,
+          "best_ms": 0.214496,
+          "in_gibs": 52.3493,
+          "out_gibs": 52.3493
+        },
+        "sink": {
+          "avg_ms": 0.380238,
+          "best_ms": 5e-05,
+          "in_gibs": 7.66002,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 865.454,
+        "kick_sync_count": 2,
+        "io_fence_ms": 25.8908,
+        "io_fence_count": 2,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.3109,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 10.05,
+      "status": "pass",
+      "throughput_in_gibs": 1.74787,
+      "throughput_out_gibs": 0.19421,
+      "compression_fold": 13.1299,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.390629,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 2.01137,
+      "init_s": 5.87441,
+      "flush_s": 6.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.58418,
+          "best_ms": 0.728172,
+          "in_gibs": 15.5694,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.4346,
+          "best_ms": 9.4277,
+          "in_gibs": 24.5964,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 29.6144,
+          "best_ms": 23.3748,
+          "in_gibs": 12.7452,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 9.30302,
+          "best_ms": 1.80949,
+          "in_gibs": 10.3398,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.5928,
+          "best_ms": 8.26792,
+          "in_gibs": 31.3298,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 319.942,
+          "best_ms": 185.654,
+          "in_gibs": 8.63194,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.74203,
+          "best_ms": 0.000671,
+          "in_gibs": 27.9911,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.250851,
+          "best_ms": 0.000191,
+          "in_gibs": 8.23923,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 10.51,
+      "status": "pass",
+      "throughput_in_gibs": 1.5382,
+      "throughput_out_gibs": 0.979103,
+      "compression_fold": 2.29196,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.23778,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 2.28554,
+      "init_s": 6.02731,
+      "flush_s": 0.000900451,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.61216,
+          "best_ms": 0.765569,
+          "in_gibs": 15.4488,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.2092,
+          "best_ms": 9.41841,
+          "in_gibs": 25.091,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 29.3151,
+          "best_ms": 23.3571,
+          "in_gibs": 12.8753,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 8.54713,
+          "best_ms": 1.82697,
+          "in_gibs": 11.2542,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.5412,
+          "best_ms": 8.23864,
+          "in_gibs": 31.4589,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 212.752,
+          "best_ms": 118.697,
+          "in_gibs": 12.9809,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.1705,
+          "best_ms": 0.001312,
+          "in_gibs": 27.4967,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 2.52952,
+          "best_ms": 0.00029,
+          "in_gibs": 4.68077,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 9.33,
+      "status": "pass",
+      "throughput_in_gibs": 2.42584,
+      "throughput_out_gibs": 0.0440894,
+      "compression_fold": 80.2694,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0638962,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 1.44924,
+      "init_s": 5.87416,
+      "flush_s": 7.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.5482,
+          "best_ms": 0.767081,
+          "in_gibs": 15.7273,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.2909,
+          "best_ms": 9.33041,
+          "in_gibs": 24.9094,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 27.246,
+          "best_ms": 23.3934,
+          "in_gibs": 13.8531,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 7.91829,
+          "best_ms": 1.9648,
+          "in_gibs": 12.148,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 10.5553,
+          "best_ms": 8.25131,
+          "in_gibs": 37.3776,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 103.585,
+          "best_ms": 64.2246,
+          "in_gibs": 26.6614,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.712061,
+          "best_ms": 0.000811,
+          "in_gibs": 11.123,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0437437,
+          "best_ms": 0.00015,
+          "in_gibs": 7.72854,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 12.18,
+      "status": "pass",
+      "throughput_in_gibs": 4.5081,
+      "throughput_out_gibs": 4.81145,
+      "compression_fold": 1.07146,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00234,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.831836,
+      "init_s": 0.0939688,
+      "flush_s": 0.027505,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.78998,
+          "best_ms": 1.55899,
+          "in_gibs": 16.8012,
+          "out_gibs": 16.8012
+        },
+        "h2d": {
+          "avg_ms": 0.889929,
+          "best_ms": 0.590304,
+          "in_gibs": 52.6728,
+          "out_gibs": 52.6728
+        },
+        "scatter": {
+          "avg_ms": 0.0466622,
+          "best_ms": 0.025312,
+          "in_gibs": 1004.56,
+          "out_gibs": 1004.56
+        },
+        "lod_gather": {
+          "avg_ms": 0.423506,
+          "best_ms": 0.417344,
+          "in_gibs": 221.366,
+          "out_gibs": 221.366
+        },
+        "lod_reduce": {
+          "avg_ms": 0.409164,
+          "best_ms": 0.405504,
+          "in_gibs": 229.126,
+          "out_gibs": 262.018
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.0322162,
+          "best_ms": 0.0184,
+          "in_gibs": 417.748,
+          "out_gibs": 417.748
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.3156,
+          "best_ms": 0.219136,
+          "in_gibs": 81.4899,
+          "out_gibs": 81.4899
+        },
+        "compress": {
+          "avg_ms": 0.130507,
+          "best_ms": 0.102368,
+          "in_gibs": 821.476,
+          "out_gibs": 747.594
+        },
+        "aggregate": {
+          "avg_ms": 0.342252,
+          "best_ms": 0.045088,
+          "in_gibs": 285.071,
+          "out_gibs": 285.071
+        },
+        "d2h": {
+          "avg_ms": 18.9601,
+          "best_ms": 11.0374,
+          "in_gibs": 5.27441,
+          "out_gibs": 5.27441
+        },
+        "sink": {
+          "avg_ms": 0.000448607,
+          "best_ms": 3e-05,
+          "in_gibs": 11394.2,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 316.138,
+        "flush_stall_count": 39,
+        "kick_sync_ms": 0.253922,
+        "kick_sync_count": 41,
+        "io_fence_ms": 241.134,
+        "io_fence_count": 41,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 22.3092,
+        "peak_pending_mib": 200.031
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 16.4,
+      "status": "pass",
+      "throughput_in_gibs": 1.41471,
+      "throughput_out_gibs": 1.50991,
+      "compression_fold": 1.07146,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00234,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 2.65072,
+      "init_s": 2.08744,
+      "flush_s": 7.32e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.58938,
+          "best_ms": 1.52459,
+          "in_gibs": 18.1028,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.99789,
+          "best_ms": 6.28282,
+          "in_gibs": 11.7218,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 12.5296,
+          "best_ms": 4.80087,
+          "in_gibs": 8.5564,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 5.09148,
+          "best_ms": 0.2066,
+          "in_gibs": 2.64329,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.37036,
+          "best_ms": 2.89779,
+          "in_gibs": 24.5308,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.12665,
+          "best_ms": 1.71157,
+          "in_gibs": 50.4118,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.22745,
+          "best_ms": 0.00676,
+          "in_gibs": 41.7816,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.977824,
+          "best_ms": 0.0002,
+          "in_gibs": 5.22747,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 12.49,
+      "status": "pass",
+      "throughput_in_gibs": 7.88035,
+      "throughput_out_gibs": 1.01986,
+      "compression_fold": 8.83614,
+      "input_gib": 3.75,
+      "compressed_gib": 0.485317,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.475867,
+      "init_s": 0.104776,
+      "flush_s": 4.8e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.57202,
+          "best_ms": 1.58503,
+          "in_gibs": 18.225,
+          "out_gibs": 18.225
+        },
+        "h2d": {
+          "avg_ms": 0.900398,
+          "best_ms": 0.590336,
+          "in_gibs": 52.0603,
+          "out_gibs": 52.0603
+        },
+        "scatter": {
+          "avg_ms": 0.0566757,
+          "best_ms": 0.025216,
+          "in_gibs": 827.074,
+          "out_gibs": 827.074
+        },
+        "lod_gather": {
+          "avg_ms": 0.426114,
+          "best_ms": 0.421504,
+          "in_gibs": 220.011,
+          "out_gibs": 220.011
+        },
+        "lod_reduce": {
+          "avg_ms": 0.41313,
+          "best_ms": 0.411648,
+          "in_gibs": 226.926,
+          "out_gibs": 259.502
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.0314607,
+          "best_ms": 0.018432,
+          "in_gibs": 427.78,
+          "out_gibs": 427.78
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.658286,
+          "best_ms": 0.219136,
+          "in_gibs": 162.86,
+          "out_gibs": 162.86
+        },
+        "compress": {
+          "avg_ms": 5.75754,
+          "best_ms": 2.21382,
+          "in_gibs": 18.6205,
+          "out_gibs": 2.04691
+        },
+        "aggregate": {
+          "avg_ms": 0.0990268,
+          "best_ms": 0.028672,
+          "in_gibs": 119.01,
+          "out_gibs": 119.01
+        },
+        "d2h": {
+          "avg_ms": 3.6104,
+          "best_ms": 0.259744,
+          "in_gibs": 3.34578,
+          "out_gibs": 3.34578
+        },
+        "sink": {
+          "avg_ms": 0.000631937,
+          "best_ms": 4e-05,
+          "in_gibs": 980.823,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 18.7396,
+        "flush_stall_count": 39,
+        "kick_sync_ms": 10.2829,
+        "kick_sync_count": 41,
+        "io_fence_ms": 0.028951,
+        "io_fence_count": 41,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.97802,
+        "peak_pending_mib": 13.2734
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 18.97,
+      "status": "pass",
+      "throughput_in_gibs": 0.803797,
+      "throughput_out_gibs": 0.0791704,
+      "compression_fold": 11.6102,
+      "input_gib": 3.75,
+      "compressed_gib": 0.369358,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 4.66536,
+      "init_s": 2.55264,
+      "flush_s": 7.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.73163,
+          "best_ms": 1.59276,
+          "in_gibs": 17.1601,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.1285,
+          "best_ms": 8.35113,
+          "in_gibs": 8.42429,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 29.8654,
+          "best_ms": 8.87138,
+          "in_gibs": 3.58971,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 28.7265,
+          "best_ms": 0.252129,
+          "in_gibs": 0.468496,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.0145,
+          "best_ms": 4.77803,
+          "in_gibs": 8.23757,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.5383,
+          "best_ms": 6.12364,
+          "in_gibs": 10.1732,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.87414,
+          "best_ms": 0.001182,
+          "in_gibs": 1.63809,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.170561,
+          "best_ms": 0.00017,
+          "in_gibs": 2.7657,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 19.24,
+      "status": "pass",
+      "throughput_in_gibs": 0.798691,
+      "throughput_out_gibs": 0.53072,
+      "compression_fold": 1.72096,
+      "input_gib": 3.75,
+      "compressed_gib": 2.49183,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 4.69518,
+      "init_s": 2.6057,
+      "flush_s": 7.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.82734,
+          "best_ms": 1.5773,
+          "in_gibs": 16.5792,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.761,
+          "best_ms": 8.79168,
+          "in_gibs": 8.71199,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 30.2549,
+          "best_ms": 11.7409,
+          "in_gibs": 3.54351,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 27.0446,
+          "best_ms": 0.265268,
+          "in_gibs": 0.497632,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.8155,
+          "best_ms": 4.68098,
+          "in_gibs": 8.36549,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.67222,
+          "best_ms": 2.8908,
+          "in_gibs": 16.0679,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.04324,
+          "best_ms": 0.001272,
+          "in_gibs": 10.4886,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.47112,
+          "best_ms": 0.000151,
+          "in_gibs": 6.75499,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 19.25,
+      "status": "pass",
+      "throughput_in_gibs": 0.831473,
+      "throughput_out_gibs": 0.0235729,
+      "compression_fold": 40.3358,
+      "input_gib": 3.75,
+      "compressed_gib": 0.106316,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 4.51007,
+      "init_s": 2.52522,
+      "flush_s": 7.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.77169,
+          "best_ms": 1.58781,
+          "in_gibs": 16.9121,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.8619,
+          "best_ms": 8.95244,
+          "in_gibs": 8.6311,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 30.7251,
+          "best_ms": 7.65143,
+          "in_gibs": 3.48927,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 28.4071,
+          "best_ms": 0.24009,
+          "in_gibs": 0.473763,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.0542,
+          "best_ms": 4.46106,
+          "in_gibs": 8.21257,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.08087,
+          "best_ms": 4.15433,
+          "in_gibs": 11.8059,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.93074,
+          "best_ms": 0.00055,
+          "in_gibs": 0.455782,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0237361,
+          "best_ms": 0.00024,
+          "in_gibs": 5.72038,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 13.67,
+      "status": "pass",
+      "throughput_in_gibs": 3.76081,
+      "throughput_out_gibs": 4.01454,
+      "compression_fold": 1.07585,
+      "input_gib": 3.75,
+      "compressed_gib": 4.003,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.997126,
+      "init_s": 0.328538,
+      "flush_s": 0.266326,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.69123,
+          "best_ms": 1.59216,
+          "in_gibs": 17.4177,
+          "out_gibs": 17.4177
+        },
+        "h2d": {
+          "avg_ms": 0.891355,
+          "best_ms": 0.58992,
+          "in_gibs": 52.5885,
+          "out_gibs": 52.5885
+        },
+        "scatter": {
+          "avg_ms": 0.0447028,
+          "best_ms": 0.02352,
+          "in_gibs": 1048.59,
+          "out_gibs": 1048.59
+        },
+        "lod_gather": {
+          "avg_ms": 0.432192,
+          "best_ms": 0.41904,
+          "in_gibs": 216.917,
+          "out_gibs": 216.917
+        },
+        "lod_reduce": {
+          "avg_ms": 0.420826,
+          "best_ms": 0.4072,
+          "in_gibs": 222.776,
+          "out_gibs": 255.845
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.0545088,
+          "best_ms": 0.045056,
+          "in_gibs": 255.298,
+          "out_gibs": 255.298
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.292698,
+          "best_ms": 0.279552,
+          "in_gibs": 367.84,
+          "out_gibs": 367.84
+        },
+        "compress": {
+          "avg_ms": 1.2525,
+          "best_ms": 1.22979,
+          "in_gibs": 687.688,
+          "out_gibs": 639.152
+        },
+        "aggregate": {
+          "avg_ms": 10.3416,
+          "best_ms": 2.66346,
+          "in_gibs": 77.4091,
+          "out_gibs": 77.4091
+        },
+        "d2h": {
+          "avg_ms": 122.438,
+          "best_ms": 88.6722,
+          "in_gibs": 6.53832,
+          "out_gibs": 6.53832
+        },
+        "sink": {
+          "avg_ms": 0.00384365,
+          "best_ms": 4e-05,
+          "in_gibs": 4412.95,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 130.766,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 0.023736,
+        "kick_sync_count": 5,
+        "io_fence_ms": 191.547,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 78.8095,
+        "peak_pending_mib": 1567.66
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 18.94,
+      "status": "pass",
+      "throughput_in_gibs": 0.846874,
+      "throughput_out_gibs": 0.904009,
+      "compression_fold": 1.07585,
+      "input_gib": 3.75,
+      "compressed_gib": 4.003,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 4.42805,
+      "init_s": 2.48619,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.80845,
+          "best_ms": 1.58075,
+          "in_gibs": 16.6907,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.7311,
+          "best_ms": 7.65934,
+          "in_gibs": 8.73628,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.0858,
+          "best_ms": 5.92694,
+          "in_gibs": 4.47011,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 20.9635,
+          "best_ms": 0.00013,
+          "in_gibs": 0.663822,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.2182,
+          "best_ms": 5.0345,
+          "in_gibs": 8.1453,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.3597,
+          "best_ms": 15.9446,
+          "in_gibs": 49.6166,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.60139,
+          "best_ms": 0.037256,
+          "in_gibs": 35.7294,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 3.78531,
+          "best_ms": 0.00018,
+          "in_gibs": 4.48097,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 12.47,
+      "status": "pass",
+      "throughput_in_gibs": 5.4525,
+      "throughput_out_gibs": 0.689127,
+      "compression_fold": 9.08664,
+      "input_gib": 3.75,
+      "compressed_gib": 0.473953,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.687758,
+      "init_s": 0.312587,
+      "flush_s": 0.0156166,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.48948,
+          "best_ms": 1.61723,
+          "in_gibs": 18.8292,
+          "out_gibs": 18.8292
+        },
+        "h2d": {
+          "avg_ms": 0.889027,
+          "best_ms": 0.589856,
+          "in_gibs": 52.7262,
+          "out_gibs": 52.7262
+        },
+        "scatter": {
+          "avg_ms": 0.115927,
+          "best_ms": 0.023456,
+          "in_gibs": 404.351,
+          "out_gibs": 404.351
+        },
+        "lod_gather": {
+          "avg_ms": 2.45469,
+          "best_ms": 0.419136,
+          "in_gibs": 38.1921,
+          "out_gibs": 38.1921
+        },
+        "lod_reduce": {
+          "avg_ms": 0.558598,
+          "best_ms": 0.409248,
+          "in_gibs": 167.831,
+          "out_gibs": 192.743
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.0995136,
+          "best_ms": 0.045056,
+          "in_gibs": 139.84,
+          "out_gibs": 139.84
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.512877,
+          "best_ms": 0.283648,
+          "in_gibs": 209.926,
+          "out_gibs": 209.926
+        },
+        "compress": {
+          "avg_ms": 97.1804,
+          "best_ms": 83.7238,
+          "in_gibs": 8.86319,
+          "out_gibs": 0.974342
+        },
+        "aggregate": {
+          "avg_ms": 0.51232,
+          "best_ms": 0.38064,
+          "in_gibs": 184.82,
+          "out_gibs": 184.82
+        },
+        "d2h": {
+          "avg_ms": 18.0759,
+          "best_ms": 1.81613,
+          "in_gibs": 5.2383,
+          "out_gibs": 5.2383
+        },
+        "sink": {
+          "avg_ms": 0.0904704,
+          "best_ms": 4e-05,
+          "in_gibs": 22.1982,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 84.413,
+        "flush_stall_count": 4,
+        "kick_sync_ms": 121.717,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.002813,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 89.6443,
+        "peak_pending_mib": 96.9688
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 16.93,
+      "status": "pass",
+      "throughput_in_gibs": 1.04066,
+      "throughput_out_gibs": 0.0975522,
+      "compression_fold": 12.2512,
+      "input_gib": 3.75,
+      "compressed_gib": 0.351528,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 3.60349,
+      "init_s": 2.40613,
+      "flush_s": 7.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.81935,
+          "best_ms": 1.5489,
+          "in_gibs": 16.6262,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.1918,
+          "best_ms": 9.5992,
+          "in_gibs": 8.37669,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.5476,
+          "best_ms": 12.8901,
+          "in_gibs": 4.386,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 19.8945,
+          "best_ms": 0.00019,
+          "in_gibs": 0.699492,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.1235,
+          "best_ms": 5.64319,
+          "in_gibs": 8.20406,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 40.3635,
+          "best_ms": 37.8613,
+          "in_gibs": 21.3393,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.38071,
+          "best_ms": 0.001742,
+          "in_gibs": 12.7112,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.255763,
+          "best_ms": 0.00024,
+          "in_gibs": 5.82384,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 18.44,
+      "status": "pass",
+      "throughput_in_gibs": 0.919644,
+      "throughput_out_gibs": 0.552252,
+      "compression_fold": 1.91245,
+      "input_gib": 3.75,
+      "compressed_gib": 2.2519,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 4.07767,
+      "init_s": 2.5507,
+      "flush_s": 8.32e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.81617,
+          "best_ms": 1.56469,
+          "in_gibs": 16.6449,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.0338,
+          "best_ms": 9.33872,
+          "in_gibs": 8.4966,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 25.2088,
+          "best_ms": 16.9973,
+          "in_gibs": 4.27096,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 22.6581,
+          "best_ms": 8e-05,
+          "in_gibs": 0.614175,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.3909,
+          "best_ms": 6.98711,
+          "in_gibs": 7.48155,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.5116,
+          "best_ms": 20.963,
+          "in_gibs": 36.6341,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.84503,
+          "best_ms": 0.007171,
+          "in_gibs": 29.2765,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 1.5564,
+          "best_ms": 0.00018,
+          "in_gibs": 6.1308,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 18.07,
+      "status": "pass",
+      "throughput_in_gibs": 1.06419,
+      "throughput_out_gibs": 0.0172948,
+      "compression_fold": 70.666,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0609436,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 3.52382,
+      "init_s": 2.51149,
+      "flush_s": 7.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.78959,
+          "best_ms": 1.55376,
+          "in_gibs": 16.8035,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.9838,
+          "best_ms": 8.71752,
+          "in_gibs": 8.53533,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 23.9595,
+          "best_ms": 10.2508,
+          "in_gibs": 4.49366,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 21.1369,
+          "best_ms": 0.00015,
+          "in_gibs": 0.658376,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.144,
+          "best_ms": 6.02991,
+          "in_gibs": 7.61212,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 20.4658,
+          "best_ms": 18.5844,
+          "in_gibs": 42.0861,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.4204,
+          "best_ms": 0.001042,
+          "in_gibs": 2.12704,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0728106,
+          "best_ms": 0.000121,
+          "in_gibs": 3.54668,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 15.34,
+      "status": "pass",
+      "throughput_in_gibs": 3.05092,
+      "throughput_out_gibs": 3.28955,
+      "compression_fold": 1.10136,
+      "input_gib": 3.75,
+      "compressed_gib": 4.04331,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 1.22914,
+      "init_s": 2.15336,
+      "flush_s": 0.708705,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.43551,
+          "best_ms": 1.61174,
+          "in_gibs": 19.2465,
+          "out_gibs": 19.2465
+        },
+        "h2d": {
+          "avg_ms": 0.886639,
+          "best_ms": 0.589856,
+          "in_gibs": 52.8682,
+          "out_gibs": 52.8682
+        },
+        "scatter": {
+          "avg_ms": 0.0449116,
+          "best_ms": 0.023584,
+          "in_gibs": 1043.72,
+          "out_gibs": 1043.72
+        },
+        "lod_gather": {
+          "avg_ms": 0.413344,
+          "best_ms": 0.413344,
+          "in_gibs": 226.809,
+          "out_gibs": 226.809
+        },
+        "lod_reduce": {
+          "avg_ms": 0.417792,
+          "best_ms": 0.417792,
+          "in_gibs": 224.394,
+          "out_gibs": 266.468
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.055296,
+          "best_ms": 0.055296,
+          "in_gibs": 317.891,
+          "out_gibs": 317.891
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.316416,
+          "best_ms": 0.316416,
+          "in_gibs": 351.841,
+          "out_gibs": 351.841
+        },
+        "compress": {
+          "avg_ms": 6.48224,
+          "best_ms": 6.48224,
+          "in_gibs": 686.973,
+          "out_gibs": 623.699
+        },
+        "aggregate": {
+          "avg_ms": 13.7145,
+          "best_ms": 13.7145,
+          "in_gibs": 294.796,
+          "out_gibs": 294.796
+        },
+        "d2h": {
+          "avg_ms": 76.8388,
+          "best_ms": 76.8388,
+          "in_gibs": 52.6163,
+          "out_gibs": 52.6163
+        },
+        "sink": {
+          "avg_ms": 0.00138168,
+          "best_ms": 4e-05,
+          "in_gibs": 16257.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 13.5744,
+        "kick_sync_count": 1,
+        "io_fence_ms": 4e-05,
+        "io_fence_count": 1,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.51596,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 16.7,
+      "status": "pass",
+      "throughput_in_gibs": 1.28244,
+      "throughput_out_gibs": 1.38275,
+      "compression_fold": 1.10136,
+      "input_gib": 3.75,
+      "compressed_gib": 4.04331,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 2.92412,
+      "init_s": 1.98533,
+      "flush_s": 6.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.59593,
+          "best_ms": 1.52582,
+          "in_gibs": 18.0571,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.49347,
+          "best_ms": 6.48727,
+          "in_gibs": 12.5109,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 8.09831,
+          "best_ms": 5.92934,
+          "in_gibs": 13.7471,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.23246,
+          "best_ms": 0.000321,
+          "in_gibs": 7.87388,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.9967,
+          "best_ms": 4.42576,
+          "in_gibs": 7.95387,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 89.0221,
+          "best_ms": 89.0221,
+          "in_gibs": 50.0227,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 40.2388,
+          "best_ms": 9.67076,
+          "in_gibs": 33.4915,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 5.17244,
+          "best_ms": 0.00029,
+          "in_gibs": 4.34279,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 15.3,
+      "status": "pass",
+      "throughput_in_gibs": 2.94589,
+      "throughput_out_gibs": 0.381547,
+      "compression_fold": 9.16856,
+      "input_gib": 3.75,
+      "compressed_gib": 0.485695,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 1.27296,
+      "init_s": 1.94281,
+      "flush_s": 0.0179813,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.33064,
+          "best_ms": 1.53949,
+          "in_gibs": 20.1125,
+          "out_gibs": 20.1125
+        },
+        "h2d": {
+          "avg_ms": 0.886877,
+          "best_ms": 0.589952,
+          "in_gibs": 52.854,
+          "out_gibs": 52.854
+        },
+        "scatter": {
+          "avg_ms": 0.0449239,
+          "best_ms": 0.023712,
+          "in_gibs": 1043.43,
+          "out_gibs": 1043.43
+        },
+        "lod_gather": {
+          "avg_ms": 0.41744,
+          "best_ms": 0.41744,
+          "in_gibs": 224.583,
+          "out_gibs": 224.583
+        },
+        "lod_reduce": {
+          "avg_ms": 0.405504,
+          "best_ms": 0.405504,
+          "in_gibs": 231.194,
+          "out_gibs": 274.543
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.055296,
+          "best_ms": 0.055296,
+          "in_gibs": 317.891,
+          "out_gibs": 317.891
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.318464,
+          "best_ms": 0.318464,
+          "in_gibs": 349.578,
+          "out_gibs": 349.578
+        },
+        "compress": {
+          "avg_ms": 780.836,
+          "best_ms": 780.836,
+          "in_gibs": 5.70302,
+          "out_gibs": 0.621345
+        },
+        "aggregate": {
+          "avg_ms": 1.50387,
+          "best_ms": 1.50387,
+          "in_gibs": 322.613,
+          "out_gibs": 322.613
+        },
+        "d2h": {
+          "avg_ms": 9.23539,
+          "best_ms": 9.23539,
+          "in_gibs": 52.5336,
+          "out_gibs": 52.5336
+        },
+        "sink": {
+          "avg_ms": 0.289987,
+          "best_ms": 4e-05,
+          "in_gibs": 9.30493,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 782.036,
+        "kick_sync_count": 1,
+        "io_fence_ms": 5e-05,
+        "io_fence_count": 1,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.35909,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 15.38,
+      "status": "pass",
+      "throughput_in_gibs": 1.86093,
+      "throughput_out_gibs": 0.135691,
+      "compression_fold": 16.2859,
+      "input_gib": 3.75,
+      "compressed_gib": 0.273434,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 2.01512,
+      "init_s": 2.01328,
+      "flush_s": 9.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.60056,
+          "best_ms": 1.5185,
+          "in_gibs": 18.025,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.94083,
+          "best_ms": 6.42114,
+          "in_gibs": 11.8061,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 8.22378,
+          "best_ms": 5.8947,
+          "in_gibs": 13.5373,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.75251,
+          "best_ms": 0.000271,
+          "in_gibs": 6.38621,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.9889,
+          "best_ms": 4.47204,
+          "in_gibs": 7.95831,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 137.181,
+          "best_ms": 137.181,
+          "in_gibs": 32.4617,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.65724,
+          "best_ms": 0.143415,
+          "in_gibs": 34.2378,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.195106,
+          "best_ms": 0.00019,
+          "in_gibs": 7.78592,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 16.07,
+      "status": "pass",
+      "throughput_in_gibs": 1.45698,
+      "throughput_out_gibs": 0.92555,
+      "compression_fold": 1.86933,
+      "input_gib": 3.75,
+      "compressed_gib": 2.3822,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 2.57382,
+      "init_s": 1.97473,
+      "flush_s": 7.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.60922,
+          "best_ms": 1.50605,
+          "in_gibs": 17.9652,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.69915,
+          "best_ms": 6.56498,
+          "in_gibs": 12.1767,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 9.16049,
+          "best_ms": 5.95194,
+          "in_gibs": 12.1531,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.83962,
+          "best_ms": 0.0003,
+          "in_gibs": 6.19032,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.2451,
+          "best_ms": 4.33971,
+          "in_gibs": 7.81517,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 117.887,
+          "best_ms": 117.887,
+          "in_gibs": 37.7745,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 23.0374,
+          "best_ms": 1.41231,
+          "in_gibs": 34.4621,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 2.85337,
+          "best_ms": 0.00034,
+          "in_gibs": 4.63818,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 15.16,
+      "status": "pass",
+      "throughput_in_gibs": 1.95491,
+      "throughput_out_gibs": 0.0311281,
+      "compression_fold": 74.5774,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0597115,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 1.91825,
+      "init_s": 1.99162,
+      "flush_s": 7.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.5915,
+          "best_ms": 1.52836,
+          "in_gibs": 18.088,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.76739,
+          "best_ms": 6.49253,
+          "in_gibs": 12.0697,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 8.62298,
+          "best_ms": 5.91668,
+          "in_gibs": 12.9106,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.08612,
+          "best_ms": 0.00033,
+          "in_gibs": 5.69587,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.8833,
+          "best_ms": 4.47067,
+          "in_gibs": 8.01884,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 68.1511,
+          "best_ms": 68.1511,
+          "in_gibs": 65.342,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.636749,
+          "best_ms": 0.101172,
+          "in_gibs": 31.0009,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0519731,
+          "best_ms": 0.0001,
+          "in_gibs": 6.38273,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    }
+  ]
+}

--- a/bench/results/livescreen-kubuntu-c1ea1fe-20260504.json
+++ b/bench/results/livescreen-kubuntu-c1ea1fe-20260504.json
@@ -1,0 +1,32865 @@
+{
+  "version": 1,
+  "machine": {
+    "hostname": "livescreen-kubuntu",
+    "gpu": "NVIDIA RTX PRO 6000 Blackwell Workstation Edition",
+    "commit": "c1ea1fe",
+    "date": "2026-05-04T13:37:53"
+  },
+  "runs": [
+    {
+      "id": "orca2_single__none__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 3.05,
+      "status": "pass",
+      "throughput_in_gibs": 6.16391,
+      "throughput_out_gibs": 6.16792,
+      "compression_fold": 0.999349,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51791,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.570356,
+      "init_s": 0.223641,
+      "flush_s": 6.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.38054,
+          "best_ms": 0.753029,
+          "in_gibs": 19.6909,
+          "out_gibs": 19.6909
+        },
+        "h2d": {
+          "avg_ms": 0.910105,
+          "best_ms": 0.296224,
+          "in_gibs": 51.7403,
+          "out_gibs": 51.7403
+        },
+        "scatter": {
+          "avg_ms": 0.208706,
+          "best_ms": 0.074528,
+          "in_gibs": 225.624,
+          "out_gibs": 225.624
+        },
+        "compress": {
+          "avg_ms": 0.765029,
+          "best_ms": 0.17584,
+          "in_gibs": 656.488,
+          "out_gibs": 656.488
+        },
+        "aggregate": {
+          "avg_ms": 1.0894,
+          "best_ms": 0.335872,
+          "in_gibs": 461.018,
+          "out_gibs": 461.018
+        },
+        "d2h": {
+          "avg_ms": 9.67414,
+          "best_ms": 2.68413,
+          "in_gibs": 51.9149,
+          "out_gibs": 51.9149
+        },
+        "sink": {
+          "avg_ms": 0.00181385,
+          "best_ms": 4e-05,
+          "in_gibs": 9235.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 40.1111,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 2.68427,
+        "kick_sync_count": 7,
+        "io_fence_ms": 115.994,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 33.8339,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 2.46,
+      "status": "pass",
+      "throughput_in_gibs": 5.37629,
+      "throughput_out_gibs": 5.37979,
+      "compression_fold": 0.999349,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51791,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.653913,
+      "init_s": 0.000138929,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.53596,
+          "best_ms": 0.504877,
+          "in_gibs": 13.2567,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.60293,
+          "best_ms": 2.4547,
+          "in_gibs": 52.2999,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.40865,
+          "best_ms": 3.53397,
+          "in_gibs": 53.3863,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00661691,
+          "best_ms": 3e-05,
+          "in_gibs": 2531.69,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.012189,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 3.15,
+      "status": "pass",
+      "throughput_in_gibs": 4.50614,
+      "throughput_out_gibs": 0.584156,
+      "compression_fold": 7.71394,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.45575,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.780185,
+      "init_s": 0.200462,
+      "flush_s": 5.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.40018,
+          "best_ms": 0.694521,
+          "in_gibs": 19.5297,
+          "out_gibs": 19.5297
+        },
+        "h2d": {
+          "avg_ms": 0.902811,
+          "best_ms": 0.297888,
+          "in_gibs": 52.1583,
+          "out_gibs": 52.1583
+        },
+        "scatter": {
+          "avg_ms": 0.204715,
+          "best_ms": 0.072896,
+          "in_gibs": 223.525,
+          "out_gibs": 223.525
+        },
+        "compress": {
+          "avg_ms": 74.1135,
+          "best_ms": 22.2735,
+          "in_gibs": 6.77652,
+          "out_gibs": 0.873845
+        },
+        "aggregate": {
+          "avg_ms": 0.501376,
+          "best_ms": 0.063168,
+          "in_gibs": 129.172,
+          "out_gibs": 129.172
+        },
+        "d2h": {
+          "avg_ms": 9.64935,
+          "best_ms": 2.67728,
+          "in_gibs": 6.71172,
+          "out_gibs": 6.71172
+        },
+        "sink": {
+          "avg_ms": 0.0352245,
+          "best_ms": 3e-05,
+          "in_gibs": 61.6116,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 109.332,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 97.2871,
+        "kick_sync_count": 7,
+        "io_fence_ms": 11.0696,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 86.3033,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 2.43,
+      "status": "pass",
+      "throughput_in_gibs": 4.82283,
+      "throughput_out_gibs": 0.497773,
+      "compression_fold": 9.68881,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.362854,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.728955,
+      "init_s": 0.000137707,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.40734,
+          "best_ms": 0.511578,
+          "in_gibs": 13.7571,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.0334,
+          "best_ms": 11.7225,
+          "in_gibs": 17.2985,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.74148,
+          "best_ms": 0.96728,
+          "in_gibs": 134.971,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0508801,
+          "best_ms": 5e-05,
+          "in_gibs": 33.9598,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.01303,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 2.56,
+      "status": "pass",
+      "throughput_in_gibs": 5.26453,
+      "throughput_out_gibs": 3.02761,
+      "compression_fold": 1.73884,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.02182,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.667794,
+      "init_s": 0.000147842,
+      "flush_s": 1.172e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.2659,
+          "best_ms": 0.51383,
+          "in_gibs": 14.3528,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.688,
+          "best_ms": 2.99702,
+          "in_gibs": 34.1935,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.40744,
+          "best_ms": 1.3016,
+          "in_gibs": 78.4305,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.195871,
+          "best_ms": 4e-05,
+          "in_gibs": 49.1534,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.009906,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 2.18,
+      "status": "pass",
+      "throughput_in_gibs": 6.86876,
+      "throughput_out_gibs": 0.140997,
+      "compression_fold": 48.7155,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0721664,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.511828,
+      "init_s": 0.000134221,
+      "flush_s": 0.000550195,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.28917,
+          "best_ms": 0.511788,
+          "in_gibs": 20.4768,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.1606,
+          "best_ms": 3.43602,
+          "in_gibs": 38.1619,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.76509,
+          "best_ms": 0.080681,
+          "in_gibs": 284.709,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0134106,
+          "best_ms": 4e-05,
+          "in_gibs": 25.6253,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.010367,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.72,
+      "status": "pass",
+      "throughput_in_gibs": 6.19628,
+      "throughput_out_gibs": 6.19682,
+      "compression_fold": 0.999913,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51593,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.567377,
+      "init_s": 0.200261,
+      "flush_s": 7.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41624,
+          "best_ms": 0.74737,
+          "in_gibs": 19.4,
+          "out_gibs": 19.4
+        },
+        "h2d": {
+          "avg_ms": 0.913011,
+          "best_ms": 0.302592,
+          "in_gibs": 51.5755,
+          "out_gibs": 51.5755
+        },
+        "scatter": {
+          "avg_ms": 0.2085,
+          "best_ms": 0.0736,
+          "in_gibs": 225.847,
+          "out_gibs": 225.847
+        },
+        "compress": {
+          "avg_ms": 0.762656,
+          "best_ms": 0.176576,
+          "in_gibs": 658.53,
+          "out_gibs": 658.53
+        },
+        "aggregate": {
+          "avg_ms": 1.32432,
+          "best_ms": 0.47104,
+          "in_gibs": 379.236,
+          "out_gibs": 379.236
+        },
+        "d2h": {
+          "avg_ms": 9.66738,
+          "best_ms": 2.67757,
+          "in_gibs": 51.9512,
+          "out_gibs": 51.9512
+        },
+        "sink": {
+          "avg_ms": 0.000705276,
+          "best_ms": 4e-05,
+          "in_gibs": 22255.3,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 14.4636,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 2.68357,
+        "kick_sync_count": 7,
+        "io_fence_ms": 136.256,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 33.2086,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.38,
+      "status": "pass",
+      "throughput_in_gibs": 5.67823,
+      "throughput_out_gibs": 5.67873,
+      "compression_fold": 0.999913,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51593,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.619141,
+      "init_s": 8.046e-05,
+      "flush_s": 1.2239e-05,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.10642,
+          "best_ms": 0.504136,
+          "in_gibs": 15.0897,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.3911,
+          "best_ms": 2.73878,
+          "in_gibs": 48.3331,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.59765,
+          "best_ms": 2.78039,
+          "in_gibs": 52.3354,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00115379,
+          "best_ms": 3e-05,
+          "in_gibs": 13604,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011488,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.93,
+      "status": "pass",
+      "throughput_in_gibs": 6.06951,
+      "throughput_out_gibs": 0.66112,
+      "compression_fold": 9.18065,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.382938,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.579227,
+      "init_s": 0.201487,
+      "flush_s": 6.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.42069,
+          "best_ms": 0.756664,
+          "in_gibs": 19.3643,
+          "out_gibs": 19.3643
+        },
+        "h2d": {
+          "avg_ms": 0.908244,
+          "best_ms": 0.309728,
+          "in_gibs": 51.8463,
+          "out_gibs": 51.8463
+        },
+        "scatter": {
+          "avg_ms": 0.394681,
+          "best_ms": 0.074624,
+          "in_gibs": 118.209,
+          "out_gibs": 118.209
+        },
+        "compress": {
+          "avg_ms": 63.4317,
+          "best_ms": 27.5457,
+          "in_gibs": 7.91768,
+          "out_gibs": 0.861468
+        },
+        "aggregate": {
+          "avg_ms": 0.190985,
+          "best_ms": 0.059392,
+          "in_gibs": 286.119,
+          "out_gibs": 286.119
+        },
+        "d2h": {
+          "avg_ms": 9.72058,
+          "best_ms": 2.67642,
+          "in_gibs": 5.62152,
+          "out_gibs": 5.62152
+        },
+        "sink": {
+          "avg_ms": 0.0286035,
+          "best_ms": 4e-05,
+          "in_gibs": 59.767,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 121.279,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 112.898,
+        "kick_sync_count": 7,
+        "io_fence_ms": 11.4678,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 70.4874,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.38,
+      "status": "pass",
+      "throughput_in_gibs": 4.88268,
+      "throughput_out_gibs": 0.492379,
+      "compression_fold": 9.9165,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.354523,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.720019,
+      "init_s": 8.0661e-05,
+      "flush_s": 9.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.56663,
+          "best_ms": 0.502925,
+          "in_gibs": 13.1427,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.7035,
+          "best_ms": 13.9065,
+          "in_gibs": 18.1288,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.25311,
+          "best_ms": 0.955733,
+          "in_gibs": 223.806,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0475964,
+          "best_ms": 5e-05,
+          "in_gibs": 33.2524,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.013911,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.35,
+      "status": "pass",
+      "throughput_in_gibs": 5.15607,
+      "throughput_out_gibs": 3.05337,
+      "compression_fold": 1.68865,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.08192,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.681842,
+      "init_s": 9.9779e-05,
+      "flush_s": 8.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.42872,
+          "best_ms": 0.490275,
+          "in_gibs": 13.6713,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.8562,
+          "best_ms": 3.24036,
+          "in_gibs": 36.2459,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.32612,
+          "best_ms": 1.44132,
+          "in_gibs": 68.5668,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.203921,
+          "best_ms": 4e-05,
+          "in_gibs": 45.5778,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.009576,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.31,
+      "status": "pass",
+      "throughput_in_gibs": 5.30857,
+      "throughput_out_gibs": 0.0794557,
+      "compression_fold": 66.8117,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0526199,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.662255,
+      "init_s": 8.1652e-05,
+      "flush_s": 7.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.24962,
+          "best_ms": 0.58027,
+          "in_gibs": 11.0304,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.7962,
+          "best_ms": 4.05654,
+          "in_gibs": 39.2484,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.03275,
+          "best_ms": 0.042844,
+          "in_gibs": 99.8119,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00832479,
+          "best_ms": 4e-05,
+          "in_gibs": 28.2182,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011378,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 2.98,
+      "status": "pass",
+      "throughput_in_gibs": 6.127,
+      "throughput_out_gibs": 6.37248,
+      "compression_fold": 0.999937,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65648,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.573793,
+      "init_s": 0.200767,
+      "flush_s": 7.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.89634,
+          "best_ms": 0.762904,
+          "in_gibs": 19.2669,
+          "out_gibs": 19.2669
+        },
+        "h2d": {
+          "avg_ms": 1.08482,
+          "best_ms": 0.590048,
+          "in_gibs": 51.9465,
+          "out_gibs": 51.9465
+        },
+        "scatter": {
+          "avg_ms": 0.247089,
+          "best_ms": 0.142144,
+          "in_gibs": 228.065,
+          "out_gibs": 228.065
+        },
+        "compress": {
+          "avg_ms": 0.791781,
+          "best_ms": 0.378848,
+          "in_gibs": 659.68,
+          "out_gibs": 659.68
+        },
+        "aggregate": {
+          "avg_ms": 3.19561,
+          "best_ms": 2.9481,
+          "in_gibs": 163.45,
+          "out_gibs": 163.45
+        },
+        "d2h": {
+          "avg_ms": 10.0867,
+          "best_ms": 5.35552,
+          "in_gibs": 51.7832,
+          "out_gibs": 51.7832
+        },
+        "sink": {
+          "avg_ms": 0.00070922,
+          "best_ms": 4e-05,
+          "in_gibs": 30688.3,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 6.68305,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 5.35669,
+        "kick_sync_count": 7,
+        "io_fence_ms": 145.683,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 32.8104,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 2.38,
+      "status": "pass",
+      "throughput_in_gibs": 6.08092,
+      "throughput_out_gibs": 6.32456,
+      "compression_fold": 0.999937,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65648,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.57814,
+      "init_s": 5.3991e-05,
+      "flush_s": 3.9919e-05,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.69844,
+          "best_ms": 0.934321,
+          "in_gibs": 20.6799,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.109,
+          "best_ms": 8.465,
+          "in_gibs": 43.1351,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.7782,
+          "best_ms": 6.87656,
+          "in_gibs": 44.3507,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00124727,
+          "best_ms": 4e-05,
+          "in_gibs": 17449.9,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.006199,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 2.86,
+      "status": "pass",
+      "throughput_in_gibs": 6.05708,
+      "throughput_out_gibs": 0.77743,
+      "compression_fold": 8.1028,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.451233,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.580416,
+      "init_s": 0.202806,
+      "flush_s": 6.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.83773,
+          "best_ms": 0.955343,
+          "in_gibs": 19.6648,
+          "out_gibs": 19.6648
+        },
+        "h2d": {
+          "avg_ms": 1.08518,
+          "best_ms": 0.589952,
+          "in_gibs": 51.929,
+          "out_gibs": 51.929
+        },
+        "scatter": {
+          "avg_ms": 0.332974,
+          "best_ms": 0.14224,
+          "in_gibs": 168.932,
+          "out_gibs": 168.932
+        },
+        "compress": {
+          "avg_ms": 63.3023,
+          "best_ms": 52.7351,
+          "in_gibs": 8.25123,
+          "out_gibs": 1.01759
+        },
+        "aggregate": {
+          "avg_ms": 0.451643,
+          "best_ms": 0.120832,
+          "in_gibs": 142.626,
+          "out_gibs": 142.626
+        },
+        "d2h": {
+          "avg_ms": 10.1095,
+          "best_ms": 5.34816,
+          "in_gibs": 6.37183,
+          "out_gibs": 6.37183
+        },
+        "sink": {
+          "avg_ms": 0.0483516,
+          "best_ms": 5e-05,
+          "in_gibs": 55.5496,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 135.921,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 126.41,
+        "kick_sync_count": 7,
+        "io_fence_ms": 12.5876,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 59.8648,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 2.52,
+      "status": "pass",
+      "throughput_in_gibs": 5.83125,
+      "throughput_out_gibs": 0.576216,
+      "compression_fold": 10.5247,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.347397,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.602894,
+      "init_s": 6.2304e-05,
+      "flush_s": 7.92e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.79953,
+          "best_ms": 0.549374,
+          "in_gibs": 19.9332,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.1844,
+          "best_ms": 13.3208,
+          "in_gibs": 20.7399,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.68532,
+          "best_ms": 0.441171,
+          "in_gibs": 311.165,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0515303,
+          "best_ms": 5e-05,
+          "in_gibs": 40.1286,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.010405,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 2.26,
+      "status": "pass",
+      "throughput_in_gibs": 5.86552,
+      "throughput_out_gibs": 3.24547,
+      "compression_fold": 1.87959,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.94524,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.599372,
+      "init_s": 5.6154e-05,
+      "flush_s": 6.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.93894,
+          "best_ms": 0.910715,
+          "in_gibs": 18.9877,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.5671,
+          "best_ms": 7.36612,
+          "in_gibs": 41.5625,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.32467,
+          "best_ms": 3.29348,
+          "in_gibs": 71.3176,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.246845,
+          "best_ms": 4.1e-05,
+          "in_gibs": 46.9071,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.009385,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 2.13,
+      "status": "pass",
+      "throughput_in_gibs": 7.9027,
+      "throughput_out_gibs": 0.121113,
+      "compression_fold": 67.8607,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0538788,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.444864,
+      "init_s": 6.2534e-05,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.52309,
+          "best_ms": 0.570014,
+          "in_gibs": 22.1171,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.88951,
+          "best_ms": 3.48543,
+          "in_gibs": 66.2045,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.45416,
+          "best_ms": 0.067872,
+          "in_gibs": 359.231,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.011845,
+          "best_ms": 4e-05,
+          "in_gibs": 27.0752,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011226,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 11.95,
+      "status": "pass",
+      "throughput_in_gibs": 5.96565,
+      "throughput_out_gibs": 5.96876,
+      "compression_fold": 0.999479,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75195,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.628598,
+      "init_s": 0.201254,
+      "flush_s": 9.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.44884,
+          "best_ms": 3.32896,
+          "in_gibs": 18.122,
+          "out_gibs": 18.122
+        },
+        "h2d": {
+          "avg_ms": 1.19761,
+          "best_ms": 1.17824,
+          "in_gibs": 52.1874,
+          "out_gibs": 52.1874
+        },
+        "scatter": {
+          "avg_ms": 0.334659,
+          "best_ms": 0.331712,
+          "in_gibs": 186.757,
+          "out_gibs": 186.757
+        },
+        "compress": {
+          "avg_ms": 0.813655,
+          "best_ms": 0.530368,
+          "in_gibs": 658.405,
+          "out_gibs": 658.405
+        },
+        "aggregate": {
+          "avg_ms": 1.14288,
+          "best_ms": 0.76288,
+          "in_gibs": 468.741,
+          "out_gibs": 468.741
+        },
+        "d2h": {
+          "avg_ms": 10.3071,
+          "best_ms": 7.13315,
+          "in_gibs": 51.9753,
+          "out_gibs": 51.9753
+        },
+        "sink": {
+          "avg_ms": 0.00107137,
+          "best_ms": 3e-05,
+          "in_gibs": 16836.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 22.6352,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 7.13736,
+        "kick_sync_count": 7,
+        "io_fence_ms": 132.575,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 34.4261,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 11.72,
+      "status": "pass",
+      "throughput_in_gibs": 4.96521,
+      "throughput_out_gibs": 4.96779,
+      "compression_fold": 0.999479,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75195,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.755256,
+      "init_s": 0.000136986,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.90585,
+          "best_ms": 4.39692,
+          "in_gibs": 10.5827,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.65553,
+          "best_ms": 6.54636,
+          "in_gibs": 55.4826,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.5037,
+          "best_ms": 6.31485,
+          "in_gibs": 56.3759,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00777884,
+          "best_ms": 3e-05,
+          "in_gibs": 2318.89,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011988,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 11.85,
+      "status": "pass",
+      "throughput_in_gibs": 7.15983,
+      "throughput_out_gibs": 0.869109,
+      "compression_fold": 8.23813,
+      "input_gib": 3.75,
+      "compressed_gib": 0.4552,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.523755,
+      "init_s": 0.201622,
+      "flush_s": 7.82e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.45481,
+          "best_ms": 3.34714,
+          "in_gibs": 18.0907,
+          "out_gibs": 18.0907
+        },
+        "h2d": {
+          "avg_ms": 1.20304,
+          "best_ms": 1.17824,
+          "in_gibs": 51.9517,
+          "out_gibs": 51.9517
+        },
+        "scatter": {
+          "avg_ms": 0.51005,
+          "best_ms": 0.328192,
+          "in_gibs": 122.537,
+          "out_gibs": 122.537
+        },
+        "compress": {
+          "avg_ms": 38.4396,
+          "best_ms": 26.3465,
+          "in_gibs": 13.9365,
+          "out_gibs": 1.684
+        },
+        "aggregate": {
+          "avg_ms": 0.19925,
+          "best_ms": 0.13072,
+          "in_gibs": 324.879,
+          "out_gibs": 324.879
+        },
+        "d2h": {
+          "avg_ms": 10.379,
+          "best_ms": 7.13344,
+          "in_gibs": 6.23681,
+          "out_gibs": 6.23681
+        },
+        "sink": {
+          "avg_ms": 0.0341897,
+          "best_ms": 3e-05,
+          "in_gibs": 64.0094,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 54.7957,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 41.8502,
+        "kick_sync_count": 7,
+        "io_fence_ms": 7.97547,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 28.2626,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 11.66,
+      "status": "pass",
+      "throughput_in_gibs": 4.38362,
+      "throughput_out_gibs": 0.403401,
+      "compression_fold": 10.8666,
+      "input_gib": 3.75,
+      "compressed_gib": 0.345093,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.855458,
+      "init_s": 0.000144808,
+      "flush_s": 1.873e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.12875,
+          "best_ms": 4.51842,
+          "in_gibs": 10.1978,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.4112,
+          "best_ms": 18.5097,
+          "in_gibs": 18.2147,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.30153,
+          "best_ms": 0.622874,
+          "in_gibs": 234.043,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0567741,
+          "best_ms": 5e-05,
+          "in_gibs": 29.2228,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014162,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 11.75,
+      "status": "pass",
+      "throughput_in_gibs": 4.25473,
+      "throughput_out_gibs": 2.54522,
+      "compression_fold": 1.67165,
+      "input_gib": 3.75,
+      "compressed_gib": 2.24329,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.881372,
+      "init_s": 0.000136584,
+      "flush_s": 7.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.65623,
+          "best_ms": 4.37214,
+          "in_gibs": 9.3897,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.5905,
+          "best_ms": 8.57721,
+          "in_gibs": 32.2904,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.63313,
+          "best_ms": 4.05262,
+          "in_gibs": 80.8126,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.2865,
+          "best_ms": 4e-05,
+          "in_gibs": 37.6441,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.01321,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 11.58,
+      "status": "pass",
+      "throughput_in_gibs": 4.72198,
+      "throughput_out_gibs": 0.106598,
+      "compression_fold": 44.297,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0846558,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.794158,
+      "init_s": 0.000150004,
+      "flush_s": 1.632e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.27661,
+          "best_ms": 4.4414,
+          "in_gibs": 9.95761,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 22.1904,
+          "best_ms": 14.6806,
+          "in_gibs": 24.1417,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.06648,
+          "best_ms": 0.213791,
+          "in_gibs": 502.627,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0184462,
+          "best_ms": 5e-05,
+          "in_gibs": 22.0641,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.01346,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 11.99,
+      "status": "pass",
+      "throughput_in_gibs": 6.06106,
+      "throughput_out_gibs": 6.06155,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.618704,
+      "init_s": 0.255028,
+      "flush_s": 1.041e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.41192,
+          "best_ms": 3.3053,
+          "in_gibs": 18.3181,
+          "out_gibs": 18.3181
+        },
+        "h2d": {
+          "avg_ms": 1.19533,
+          "best_ms": 1.17821,
+          "in_gibs": 52.2867,
+          "out_gibs": 52.2867
+        },
+        "scatter": {
+          "avg_ms": 0.334553,
+          "best_ms": 0.332416,
+          "in_gibs": 186.816,
+          "out_gibs": 186.816
+        },
+        "compress": {
+          "avg_ms": 1.17016,
+          "best_ms": 1.06906,
+          "in_gibs": 640.94,
+          "out_gibs": 640.94
+        },
+        "aggregate": {
+          "avg_ms": 1.68509,
+          "best_ms": 1.53805,
+          "in_gibs": 445.079,
+          "out_gibs": 445.079
+        },
+        "d2h": {
+          "avg_ms": 14.4223,
+          "best_ms": 14.2764,
+          "in_gibs": 52.0027,
+          "out_gibs": 52.0027
+        },
+        "sink": {
+          "avg_ms": 0.00112649,
+          "best_ms": 4e-05,
+          "in_gibs": 20807.4,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 34.5715,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 13.6524,
+        "kick_sync_count": 5,
+        "io_fence_ms": 114.828,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 42.7343,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 11.93,
+      "status": "pass",
+      "throughput_in_gibs": 4.68488,
+      "throughput_out_gibs": 4.68527,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.800447,
+      "init_s": 8.3806e-05,
+      "flush_s": 9.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.10639,
+          "best_ms": 4.40411,
+          "in_gibs": 10.2352,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.3163,
+          "best_ms": 12.909,
+          "in_gibs": 48.9676,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 16.3914,
+          "best_ms": 12.5679,
+          "in_gibs": 45.7597,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00144148,
+          "best_ms": 4e-05,
+          "in_gibs": 16260.7,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011498,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 11.92,
+      "status": "pass",
+      "throughput_in_gibs": 7.05887,
+      "throughput_out_gibs": 0.812275,
+      "compression_fold": 8.69024,
+      "input_gib": 3.75,
+      "compressed_gib": 0.431519,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.531247,
+      "init_s": 0.255222,
+      "flush_s": 9.32e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.44386,
+          "best_ms": 3.34655,
+          "in_gibs": 18.1482,
+          "out_gibs": 18.1482
+        },
+        "h2d": {
+          "avg_ms": 1.20441,
+          "best_ms": 1.17824,
+          "in_gibs": 51.8925,
+          "out_gibs": 51.8925
+        },
+        "scatter": {
+          "avg_ms": 0.538887,
+          "best_ms": 0.330528,
+          "in_gibs": 115.98,
+          "out_gibs": 115.98
+        },
+        "compress": {
+          "avg_ms": 44.4251,
+          "best_ms": 43.8719,
+          "in_gibs": 16.8823,
+          "out_gibs": 1.9413
+        },
+        "aggregate": {
+          "avg_ms": 0.308102,
+          "best_ms": 0.198656,
+          "in_gibs": 279.916,
+          "out_gibs": 279.916
+        },
+        "d2h": {
+          "avg_ms": 14.4932,
+          "best_ms": 14.2567,
+          "in_gibs": 5.95058,
+          "out_gibs": 5.95058
+        },
+        "sink": {
+          "avg_ms": 0.000667925,
+          "best_ms": 0.00014,
+          "in_gibs": 4037.87,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 57.1398,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 54.3702,
+        "kick_sync_count": 5,
+        "io_fence_ms": 15.0106,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 32.252,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 11.58,
+      "status": "pass",
+      "throughput_in_gibs": 4.76915,
+      "throughput_out_gibs": 0.416059,
+      "compression_fold": 11.4627,
+      "input_gib": 3.75,
+      "compressed_gib": 0.327148,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.786304,
+      "init_s": 0.000107411,
+      "flush_s": 9.22e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.88223,
+          "best_ms": 4.38277,
+          "in_gibs": 10.6252,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 35.8255,
+          "best_ms": 33.8589,
+          "in_gibs": 20.9348,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.1591,
+          "best_ms": 1.13154,
+          "in_gibs": 348.754,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00147256,
+          "best_ms": 5e-05,
+          "in_gibs": 1388.52,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.010807,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 11.51,
+      "status": "pass",
+      "throughput_in_gibs": 5.10567,
+      "throughput_out_gibs": 3.33094,
+      "compression_fold": 1.5328,
+      "input_gib": 3.75,
+      "compressed_gib": 2.4465,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.734477,
+      "init_s": 8.0721e-05,
+      "flush_s": 8.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.48497,
+          "best_ms": 4.40049,
+          "in_gibs": 11.3948,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.359,
+          "best_ms": 18.0059,
+          "in_gibs": 38.7417,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.90491,
+          "best_ms": 8.39135,
+          "in_gibs": 84.2356,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000898456,
+          "best_ms": 6e-05,
+          "in_gibs": 17018.8,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.010676,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 11.69,
+      "status": "pass",
+      "throughput_in_gibs": 5.36576,
+      "throughput_out_gibs": 0.12052,
+      "compression_fold": 44.5217,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0842285,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.698876,
+      "init_s": 8.2484e-05,
+      "flush_s": 9.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.51967,
+          "best_ms": 4.34511,
+          "in_gibs": 11.3231,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.8673,
+          "best_ms": 23.472,
+          "in_gibs": 30.1601,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.323038,
+          "best_ms": 0.268663,
+          "in_gibs": 2322.05,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00294326,
+          "best_ms": 5e-05,
+          "in_gibs": 178.859,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.009673,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 12.2,
+      "status": "pass",
+      "throughput_in_gibs": 6.1126,
+      "throughput_out_gibs": 6.1131,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.613487,
+      "init_s": 0.256251,
+      "flush_s": 7.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.3242,
+          "best_ms": 3.19012,
+          "in_gibs": 18.8015,
+          "out_gibs": 18.8015
+        },
+        "h2d": {
+          "avg_ms": 1.19749,
+          "best_ms": 1.17827,
+          "in_gibs": 52.1924,
+          "out_gibs": 52.1924
+        },
+        "scatter": {
+          "avg_ms": 0.334586,
+          "best_ms": 0.332512,
+          "in_gibs": 186.798,
+          "out_gibs": 186.798
+        },
+        "compress": {
+          "avg_ms": 1.17261,
+          "best_ms": 1.07213,
+          "in_gibs": 639.6,
+          "out_gibs": 639.6
+        },
+        "aggregate": {
+          "avg_ms": 3.43142,
+          "best_ms": 3.29626,
+          "in_gibs": 218.568,
+          "out_gibs": 218.568
+        },
+        "d2h": {
+          "avg_ms": 14.4225,
+          "best_ms": 14.2694,
+          "in_gibs": 52.0021,
+          "out_gibs": 52.0021
+        },
+        "sink": {
+          "avg_ms": 0.00110969,
+          "best_ms": 4e-05,
+          "in_gibs": 21122.5,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 33.054,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 13.8664,
+        "kick_sync_count": 5,
+        "io_fence_ms": 116.238,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 42.7796,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 11.78,
+      "status": "pass",
+      "throughput_in_gibs": 4.66292,
+      "throughput_out_gibs": 4.6633,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.804217,
+      "init_s": 5.4712e-05,
+      "flush_s": 7.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.80555,
+          "best_ms": 3.99839,
+          "in_gibs": 10.7656,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.0345,
+          "best_ms": 15.1712,
+          "in_gibs": 41.587,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 17.6084,
+          "best_ms": 15.0973,
+          "in_gibs": 42.5971,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00893338,
+          "best_ms": 4e-05,
+          "in_gibs": 2623.8,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014011,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 12.31,
+      "status": "pass",
+      "throughput_in_gibs": 6.63173,
+      "throughput_out_gibs": 0.776583,
+      "compression_fold": 8.53963,
+      "input_gib": 3.75,
+      "compressed_gib": 0.439129,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.565463,
+      "init_s": 0.256329,
+      "flush_s": 7.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.32653,
+          "best_ms": 3.21208,
+          "in_gibs": 18.7884,
+          "out_gibs": 18.7884
+        },
+        "h2d": {
+          "avg_ms": 1.20053,
+          "best_ms": 1.17808,
+          "in_gibs": 52.0602,
+          "out_gibs": 52.0602
+        },
+        "scatter": {
+          "avg_ms": 0.696093,
+          "best_ms": 0.316352,
+          "in_gibs": 89.7869,
+          "out_gibs": 89.7869
+        },
+        "compress": {
+          "avg_ms": 66.2884,
+          "best_ms": 64.7854,
+          "in_gibs": 11.3142,
+          "out_gibs": 1.32398
+        },
+        "aggregate": {
+          "avg_ms": 0.509862,
+          "best_ms": 0.39936,
+          "in_gibs": 172.134,
+          "out_gibs": 172.134
+        },
+        "d2h": {
+          "avg_ms": 14.499,
+          "best_ms": 14.2562,
+          "in_gibs": 6.05315,
+          "out_gibs": 6.05315
+        },
+        "sink": {
+          "avg_ms": 0.00063205,
+          "best_ms": 5e-05,
+          "in_gibs": 4342.31,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 79.3346,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 77.2577,
+        "kick_sync_count": 5,
+        "io_fence_ms": 14.8139,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 56.2252,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 11.96,
+      "status": "pass",
+      "throughput_in_gibs": 4.84114,
+      "throughput_out_gibs": 0.400218,
+      "compression_fold": 12.0963,
+      "input_gib": 3.75,
+      "compressed_gib": 0.310013,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.774611,
+      "init_s": 5.4982e-05,
+      "flush_s": 1.061e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.72925,
+          "best_ms": 3.98246,
+          "in_gibs": 10.9089,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.3672,
+          "best_ms": 32.2028,
+          "in_gibs": 21.8231,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.47934,
+          "best_ms": 0.987361,
+          "in_gibs": 216.419,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00158841,
+          "best_ms": 6e-05,
+          "in_gibs": 1219.82,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.008112,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 11.51,
+      "status": "pass",
+      "throughput_in_gibs": 5.11903,
+      "throughput_out_gibs": 2.88693,
+      "compression_fold": 1.77318,
+      "input_gib": 3.75,
+      "compressed_gib": 2.11485,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.732561,
+      "init_s": 5.9009e-05,
+      "flush_s": 1.272e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.5069,
+          "best_ms": 4.0023,
+          "in_gibs": 11.3494,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.635,
+          "best_ms": 16.209,
+          "in_gibs": 40.2469,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.67116,
+          "best_ms": 8.85593,
+          "in_gibs": 77.5577,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00078035,
+          "best_ms": 5e-05,
+          "in_gibs": 16938.3,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.010717,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 11.43,
+      "status": "pass",
+      "throughput_in_gibs": 5.88916,
+      "throughput_out_gibs": 0.0890827,
+      "compression_fold": 66.1089,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0567245,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.636763,
+      "init_s": 6.1712e-05,
+      "flush_s": 8.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.22029,
+          "best_ms": 4.01607,
+          "in_gibs": 11.9725,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.1915,
+          "best_ms": 14.4909,
+          "in_gibs": 46.3205,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.22281,
+          "best_ms": 0.169554,
+          "in_gibs": 613.4,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000586138,
+          "best_ms": 5e-05,
+          "in_gibs": 604.855,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.007852,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 3.07,
+      "status": "pass",
+      "throughput_in_gibs": 5.61371,
+      "throughput_out_gibs": 6.46467,
+      "compression_fold": 1.16122,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04855,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 0.626257,
+      "init_s": 0.222406,
+      "flush_s": 7.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.45461,
+          "best_ms": 0.743675,
+          "in_gibs": 19.0968,
+          "out_gibs": 19.0968
+        },
+        "h2d": {
+          "avg_ms": 0.912498,
+          "best_ms": 0.296544,
+          "in_gibs": 51.6045,
+          "out_gibs": 51.6045
+        },
+        "scatter": {
+          "avg_ms": 0.0653028,
+          "best_ms": 0.013952,
+          "in_gibs": 721.088,
+          "out_gibs": 721.088
+        },
+        "lod_gather": {
+          "avg_ms": 0.221312,
+          "best_ms": 0.2208,
+          "in_gibs": 635.415,
+          "out_gibs": 635.415
+        },
+        "lod_reduce": {
+          "avg_ms": 0.770645,
+          "best_ms": 0.75984,
+          "in_gibs": 182.477,
+          "out_gibs": 243.322
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.091456,
+          "best_ms": 0.063456,
+          "in_gibs": 512.708,
+          "out_gibs": 512.708
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.8515,
+          "best_ms": 0.229408,
+          "in_gibs": 12.626,
+          "out_gibs": 12.6619
+        },
+        "compress": {
+          "avg_ms": 0.731901,
+          "best_ms": 0.243776,
+          "in_gibs": 668.025,
+          "out_gibs": 552.768
+        },
+        "aggregate": {
+          "avg_ms": 1.00395,
+          "best_ms": 0.301056,
+          "in_gibs": 402.979,
+          "out_gibs": 402.979
+        },
+        "d2h": {
+          "avg_ms": 7.79901,
+          "best_ms": 0.91264,
+          "in_gibs": 51.8747,
+          "out_gibs": 51.8747
+        },
+        "sink": {
+          "avg_ms": 0.00154969,
+          "best_ms": 3e-05,
+          "in_gibs": 7729.24,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 32.1024,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 3.99171,
+        "kick_sync_count": 10,
+        "io_fence_ms": 185.838,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 38.883,
+        "peak_pending_mib": 11.5117
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 6.48,
+      "status": "pass",
+      "throughput_in_gibs": 2.42278,
+      "throughput_out_gibs": 2.79004,
+      "compression_fold": 1.16122,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04855,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 1.45107,
+      "init_s": 3.15715,
+      "flush_s": 6.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.80932,
+          "best_ms": 0.810706,
+          "in_gibs": 16.6855,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.06073,
+          "best_ms": 4.68349,
+          "in_gibs": 23.2026,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 17.2131,
+          "best_ms": 11.5269,
+          "in_gibs": 10.8937,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.41809,
+          "best_ms": 0.743255,
+          "in_gibs": 13.7183,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.65128,
+          "best_ms": 3.57119,
+          "in_gibs": 40.4296,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.60721,
+          "best_ms": 3.22682,
+          "in_gibs": 56.8045,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.5351,
+          "best_ms": 0.846369,
+          "in_gibs": 53.7039,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0023299,
+          "best_ms": 3e-05,
+          "in_gibs": 5140.96,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.016914,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 3.1,
+      "status": "pass",
+      "throughput_in_gibs": 4.25966,
+      "throughput_out_gibs": 0.615567,
+      "compression_fold": 9.25357,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.508045,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 0.825329,
+      "init_s": 0.218281,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.58452,
+          "best_ms": 0.737886,
+          "in_gibs": 18.1368,
+          "out_gibs": 18.1368
+        },
+        "h2d": {
+          "avg_ms": 0.90778,
+          "best_ms": 0.2968,
+          "in_gibs": 51.8727,
+          "out_gibs": 51.8727
+        },
+        "scatter": {
+          "avg_ms": 0.0524373,
+          "best_ms": 0.013984,
+          "in_gibs": 893.924,
+          "out_gibs": 893.924
+        },
+        "lod_gather": {
+          "avg_ms": 1.13372,
+          "best_ms": 0.220992,
+          "in_gibs": 124.039,
+          "out_gibs": 124.039
+        },
+        "lod_reduce": {
+          "avg_ms": 0.981259,
+          "best_ms": 0.785952,
+          "in_gibs": 143.311,
+          "out_gibs": 191.097
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.139253,
+          "best_ms": 0.135168,
+          "in_gibs": 336.726,
+          "out_gibs": 336.726
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 15.5007,
+          "best_ms": 0.313344,
+          "in_gibs": 12.0972,
+          "out_gibs": 12.1316
+        },
+        "compress": {
+          "avg_ms": 59.4563,
+          "best_ms": 22.5093,
+          "in_gibs": 8.22332,
+          "out_gibs": 0.849724
+        },
+        "aggregate": {
+          "avg_ms": 0.594499,
+          "best_ms": 0.058944,
+          "in_gibs": 84.9816,
+          "out_gibs": 84.9816
+        },
+        "d2h": {
+          "avg_ms": 7.8283,
+          "best_ms": 0.913376,
+          "in_gibs": 6.4537,
+          "out_gibs": 6.4537
+        },
+        "sink": {
+          "avg_ms": 0.00100873,
+          "best_ms": 0.0001,
+          "in_gibs": 1490.08,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 121.837,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 114.49,
+        "kick_sync_count": 10,
+        "io_fence_ms": 18.489,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 70.5825,
+        "peak_pending_mib": 0.671875
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 6.36,
+      "status": "pass",
+      "throughput_in_gibs": 2.45543,
+      "throughput_out_gibs": 0.271554,
+      "compression_fold": 12.0915,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.388805,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 1.43178,
+      "init_s": 3.07471,
+      "flush_s": 7.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.80029,
+          "best_ms": 0.797225,
+          "in_gibs": 16.7393,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.04657,
+          "best_ms": 4.66106,
+          "in_gibs": 23.257,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.8446,
+          "best_ms": 11.5398,
+          "in_gibs": 12.6319,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.99794,
+          "best_ms": 0.762373,
+          "in_gibs": 23.4693,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.73525,
+          "best_ms": 3.61963,
+          "in_gibs": 39.7126,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.2363,
+          "best_ms": 8.74315,
+          "in_gibs": 21.0416,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.788102,
+          "best_ms": 0.100811,
+          "in_gibs": 516.231,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000865151,
+          "best_ms": 5e-05,
+          "in_gibs": 1329.61,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.012268,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 6.53,
+      "status": "pass",
+      "throughput_in_gibs": 2.15878,
+      "throughput_out_gibs": 1.30712,
+      "compression_fold": 2.20852,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.12868,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 1.62852,
+      "init_s": 3.08154,
+      "flush_s": 7.82e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.82812,
+          "best_ms": 0.78034,
+          "in_gibs": 16.5746,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.17382,
+          "best_ms": 4.63213,
+          "in_gibs": 19.6025,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 22.0137,
+          "best_ms": 11.5223,
+          "in_gibs": 8.5181,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.20824,
+          "best_ms": 0.759619,
+          "in_gibs": 11.1425,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.86148,
+          "best_ms": 3.58797,
+          "in_gibs": 38.6815,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.4637,
+          "best_ms": 3.93956,
+          "in_gibs": 39.2283,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.28205,
+          "best_ms": 0.394862,
+          "in_gibs": 94.55,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0021967,
+          "best_ms": 5e-05,
+          "in_gibs": 2866.96,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.019158,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 6.21,
+      "status": "pass",
+      "throughput_in_gibs": 2.62295,
+      "throughput_out_gibs": 0.0605619,
+      "compression_fold": 57.9163,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0811729,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 1.34033,
+      "init_s": 3.03698,
+      "flush_s": 0.000628752,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.82201,
+          "best_ms": 0.786139,
+          "in_gibs": 16.6105,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.18184,
+          "best_ms": 4.65381,
+          "in_gibs": 22.7481,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.8216,
+          "best_ms": 11.5423,
+          "in_gibs": 11.8518,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.96919,
+          "best_ms": 0.742243,
+          "in_gibs": 23.812,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.66499,
+          "best_ms": 3.61985,
+          "in_gibs": 40.3108,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.8466,
+          "best_ms": 4.31096,
+          "in_gibs": 41.2717,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.593689,
+          "best_ms": 0.058368,
+          "in_gibs": 681.952,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0010323,
+          "best_ms": 7e-05,
+          "in_gibs": 232.643,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.015053,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.85,
+      "status": "pass",
+      "throughput_in_gibs": 5.87594,
+      "throughput_out_gibs": 6.77846,
+      "compression_fold": 1.17086,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.05561,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.598309,
+      "init_s": 0.221553,
+      "flush_s": 9.52e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41831,
+          "best_ms": 0.718878,
+          "in_gibs": 19.3834,
+          "out_gibs": 19.3834
+        },
+        "h2d": {
+          "avg_ms": 0.913217,
+          "best_ms": 0.296,
+          "in_gibs": 51.5639,
+          "out_gibs": 51.5639
+        },
+        "scatter": {
+          "avg_ms": 0.0602792,
+          "best_ms": 0.01344,
+          "in_gibs": 781.182,
+          "out_gibs": 781.182
+        },
+        "lod_gather": {
+          "avg_ms": 0.222773,
+          "best_ms": 0.22256,
+          "in_gibs": 631.247,
+          "out_gibs": 631.247
+        },
+        "lod_reduce": {
+          "avg_ms": 0.773344,
+          "best_ms": 0.765952,
+          "in_gibs": 181.84,
+          "out_gibs": 242.848
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.090112,
+          "best_ms": 0.06144,
+          "in_gibs": 523.573,
+          "out_gibs": 523.573
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.9504,
+          "best_ms": 0.231424,
+          "in_gibs": 13.4623,
+          "out_gibs": 13.6155
+        },
+        "compress": {
+          "avg_ms": 0.739421,
+          "best_ms": 0.239616,
+          "in_gibs": 667.884,
+          "out_gibs": 548.426
+        },
+        "aggregate": {
+          "avg_ms": 1.66747,
+          "best_ms": 0.47104,
+          "in_gibs": 243.193,
+          "out_gibs": 243.193
+        },
+        "d2h": {
+          "avg_ms": 7.82091,
+          "best_ms": 0.947168,
+          "in_gibs": 51.8505,
+          "out_gibs": 51.8505
+        },
+        "sink": {
+          "avg_ms": 0.00105274,
+          "best_ms": 4e-05,
+          "in_gibs": 12507.9,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 25.335,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 4.75528,
+        "kick_sync_count": 10,
+        "io_fence_ms": 170.078,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 30.1849,
+        "peak_pending_mib": 13.0078
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 6.43,
+      "status": "pass",
+      "throughput_in_gibs": 2.586,
+      "throughput_out_gibs": 2.9832,
+      "compression_fold": 1.17086,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.05561,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.35948,
+      "init_s": 3.10363,
+      "flush_s": 1.5804e-05,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.816,
+          "best_ms": 0.789413,
+          "in_gibs": 16.6459,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 5.6905,
+          "best_ms": 4.70972,
+          "in_gibs": 24.7122,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.2155,
+          "best_ms": 11.5398,
+          "in_gibs": 12.343,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.21907,
+          "best_ms": 0.761351,
+          "in_gibs": 21.2613,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.90855,
+          "best_ms": 3.60432,
+          "in_gibs": 38.696,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.96501,
+          "best_ms": 3.16139,
+          "in_gibs": 55.0861,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.59282,
+          "best_ms": 0.98086,
+          "in_gibs": 53.4194,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00141102,
+          "best_ms": 4e-05,
+          "in_gibs": 9331.95,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014783,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 2.86,
+      "status": "pass",
+      "throughput_in_gibs": 6.15237,
+      "throughput_out_gibs": 0.698938,
+      "compression_fold": 11.8894,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.399391,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.571426,
+      "init_s": 0.22516,
+      "flush_s": 9.82e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41946,
+          "best_ms": 0.709704,
+          "in_gibs": 19.3742,
+          "out_gibs": 19.3742
+        },
+        "h2d": {
+          "avg_ms": 0.910175,
+          "best_ms": 0.298432,
+          "in_gibs": 51.7363,
+          "out_gibs": 51.7363
+        },
+        "scatter": {
+          "avg_ms": 0.109532,
+          "best_ms": 0.015392,
+          "in_gibs": 433.901,
+          "out_gibs": 433.901
+        },
+        "lod_gather": {
+          "avg_ms": 1.5923,
+          "best_ms": 1.3792,
+          "in_gibs": 88.3159,
+          "out_gibs": 88.3159
+        },
+        "lod_reduce": {
+          "avg_ms": 1.60345,
+          "best_ms": 1.37274,
+          "in_gibs": 87.7016,
+          "out_gibs": 117.126
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.402296,
+          "best_ms": 0.321568,
+          "in_gibs": 117.277,
+          "out_gibs": 117.277
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 23.9007,
+          "best_ms": 1.04003,
+          "in_gibs": 7.85774,
+          "out_gibs": 7.94712
+        },
+        "compress": {
+          "avg_ms": 45.9247,
+          "best_ms": 26.5697,
+          "in_gibs": 10.7534,
+          "out_gibs": 0.868719
+        },
+        "aggregate": {
+          "avg_ms": 0.251587,
+          "best_ms": 0.05936,
+          "in_gibs": 158.576,
+          "out_gibs": 158.576
+        },
+        "d2h": {
+          "avg_ms": 7.88534,
+          "best_ms": 0.94672,
+          "in_gibs": 5.05947,
+          "out_gibs": 5.05947
+        },
+        "sink": {
+          "avg_ms": 0.000741569,
+          "best_ms": 0.00013,
+          "in_gibs": 1748.62,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 127.496,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 124.422,
+        "kick_sync_count": 10,
+        "io_fence_ms": 19.9098,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 45.4536,
+        "peak_pending_mib": 0.632812
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 6.27,
+      "status": "pass",
+      "throughput_in_gibs": 2.35638,
+      "throughput_out_gibs": 0.252731,
+      "compression_fold": 12.5935,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.377064,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.49196,
+      "init_s": 3.06775,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.82494,
+          "best_ms": 0.795653,
+          "in_gibs": 16.5933,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.35241,
+          "best_ms": 4.74745,
+          "in_gibs": 22.1373,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.9944,
+          "best_ms": 11.5707,
+          "in_gibs": 11.7419,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.5487,
+          "best_ms": 0.81334,
+          "in_gibs": 13.2951,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.9731,
+          "best_ms": 3.59034,
+          "in_gibs": 38.1938,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 21.2508,
+          "best_ms": 8.489,
+          "in_gibs": 23.2391,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.10536,
+          "best_ms": 0.087721,
+          "in_gibs": 368.376,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000452812,
+          "best_ms": 6e-05,
+          "in_gibs": 2703.62,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.01336,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 6.26,
+      "status": "pass",
+      "throughput_in_gibs": 2.44709,
+      "throughput_out_gibs": 1.50428,
+      "compression_fold": 2.19725,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.16113,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.43665,
+      "init_s": 3.10547,
+      "flush_s": 0.000631837,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.84336,
+          "best_ms": 0.786649,
+          "in_gibs": 16.4858,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.81214,
+          "best_ms": 4.64671,
+          "in_gibs": 20.6433,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 17.1735,
+          "best_ms": 11.5209,
+          "in_gibs": 10.9358,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.26973,
+          "best_ms": 0.765288,
+          "in_gibs": 14.4294,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.71256,
+          "best_ms": 3.60356,
+          "in_gibs": 40.3054,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.0681,
+          "best_ms": 3.60728,
+          "in_gibs": 49.0509,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.25438,
+          "best_ms": 0.271447,
+          "in_gibs": 95.3457,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000804679,
+          "best_ms": 5e-05,
+          "in_gibs": 8719.82,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.018859,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 6.21,
+      "status": "pass",
+      "throughput_in_gibs": 2.67856,
+      "throughput_out_gibs": 0.0451803,
+      "compression_fold": 80.0772,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0592995,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.31251,
+      "init_s": 3.08628,
+      "flush_s": 8.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.83195,
+          "best_ms": 0.795613,
+          "in_gibs": 16.5522,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 5.91957,
+          "best_ms": 4.69126,
+          "in_gibs": 23.7559,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.6005,
+          "best_ms": 11.485,
+          "in_gibs": 12.0384,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.9715,
+          "best_ms": 0.795693,
+          "in_gibs": 15.8776,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.8717,
+          "best_ms": 3.58104,
+          "in_gibs": 38.9887,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.85541,
+          "best_ms": 2.86648,
+          "in_gibs": 62.8672,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.350423,
+          "best_ms": 0.044998,
+          "in_gibs": 1157.56,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00108909,
+          "best_ms": 5e-05,
+          "in_gibs": 176.782,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.019459,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 3.16,
+      "status": "pass",
+      "throughput_in_gibs": 5.77532,
+      "throughput_out_gibs": 7.09141,
+      "compression_fold": 1.18814,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31677,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 0.608732,
+      "init_s": 0.300267,
+      "flush_s": 7.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.84367,
+          "best_ms": 0.592909,
+          "in_gibs": 19.6238,
+          "out_gibs": 19.6238
+        },
+        "h2d": {
+          "avg_ms": 1.08283,
+          "best_ms": 0.589952,
+          "in_gibs": 52.0417,
+          "out_gibs": 52.0417
+        },
+        "scatter": {
+          "avg_ms": 0.0599439,
+          "best_ms": 0.025344,
+          "in_gibs": 940.087,
+          "out_gibs": 940.087
+        },
+        "lod_gather": {
+          "avg_ms": 0.430632,
+          "best_ms": 0.429696,
+          "in_gibs": 653.11,
+          "out_gibs": 653.11
+        },
+        "lod_reduce": {
+          "avg_ms": 1.54461,
+          "best_ms": 1.52986,
+          "in_gibs": 182.085,
+          "out_gibs": 244.361
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.252416,
+          "best_ms": 0.15872,
+          "in_gibs": 381.083,
+          "out_gibs": 381.083
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 8.64393,
+          "best_ms": 0.446464,
+          "in_gibs": 43.6655,
+          "out_gibs": 45.6426
+        },
+        "compress": {
+          "avg_ms": 1.05878,
+          "best_ms": 0.546784,
+          "in_gibs": 652.102,
+          "out_gibs": 509.599
+        },
+        "aggregate": {
+          "avg_ms": 7.72598,
+          "best_ms": 2.85184,
+          "in_gibs": 69.8359,
+          "out_gibs": 69.8359
+        },
+        "d2h": {
+          "avg_ms": 10.3964,
+          "best_ms": 2.16182,
+          "in_gibs": 51.898,
+          "out_gibs": 51.898
+        },
+        "sink": {
+          "avg_ms": 0.00106316,
+          "best_ms": 4e-05,
+          "in_gibs": 17060.2,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 45.5416,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 19.6038,
+        "kick_sync_count": 8,
+        "io_fence_ms": 140.187,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 37.9021,
+        "peak_pending_mib": 8.00391
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 9.28,
+      "status": "pass",
+      "throughput_in_gibs": 2.62683,
+      "throughput_out_gibs": 3.22543,
+      "compression_fold": 1.18814,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31677,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 1.33835,
+      "init_s": 5.92947,
+      "flush_s": 4.1332e-05,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.6468,
+          "best_ms": 0.801151,
+          "in_gibs": 15.3021,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.1726,
+          "best_ms": 9.34905,
+          "in_gibs": 27.6479,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 23.7362,
+          "best_ms": 23.4364,
+          "in_gibs": 15.9015,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.60911,
+          "best_ms": 1.83753,
+          "in_gibs": 20.8699,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 9.82467,
+          "best_ms": 7.58338,
+          "in_gibs": 40.1572,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.8528,
+          "best_ms": 7.95054,
+          "in_gibs": 46.4849,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.9704,
+          "best_ms": 2.89885,
+          "in_gibs": 45.0795,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00127294,
+          "best_ms": 4e-05,
+          "in_gibs": 14248.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.010094,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 2.96,
+      "status": "pass",
+      "throughput_in_gibs": 5.26696,
+      "throughput_out_gibs": 0.739175,
+      "compression_fold": 10.3953,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.493389,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 0.667486,
+      "init_s": 0.301429,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.82723,
+          "best_ms": 0.724676,
+          "in_gibs": 19.7379,
+          "out_gibs": 19.7379
+        },
+        "h2d": {
+          "avg_ms": 1.07723,
+          "best_ms": 0.590176,
+          "in_gibs": 52.3121,
+          "out_gibs": 52.3121
+        },
+        "scatter": {
+          "avg_ms": 0.110417,
+          "best_ms": 0.025344,
+          "in_gibs": 510.359,
+          "out_gibs": 510.359
+        },
+        "lod_gather": {
+          "avg_ms": 1.13486,
+          "best_ms": 0.425792,
+          "in_gibs": 247.827,
+          "out_gibs": 247.827
+        },
+        "lod_reduce": {
+          "avg_ms": 1.83965,
+          "best_ms": 1.52576,
+          "in_gibs": 152.882,
+          "out_gibs": 205.17
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.487944,
+          "best_ms": 0.160736,
+          "in_gibs": 197.136,
+          "out_gibs": 197.136
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 15.9692,
+          "best_ms": 0.444448,
+          "in_gibs": 23.6357,
+          "out_gibs": 24.7058
+        },
+        "compress": {
+          "avg_ms": 62.8497,
+          "best_ms": 53.8778,
+          "in_gibs": 10.9854,
+          "out_gibs": 0.980385
+        },
+        "aggregate": {
+          "avg_ms": 0.863728,
+          "best_ms": 0.202752,
+          "in_gibs": 71.3383,
+          "out_gibs": 71.3383
+        },
+        "d2h": {
+          "avg_ms": 10.3527,
+          "best_ms": 2.16134,
+          "in_gibs": 5.95179,
+          "out_gibs": 5.95179
+        },
+        "sink": {
+          "avg_ms": 0.0300014,
+          "best_ms": 4e-05,
+          "in_gibs": 69.0988,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 210.326,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 200.433,
+        "kick_sync_count": 8,
+        "io_fence_ms": 14.2875,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 73.249,
+        "peak_pending_mib": 0.296875
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 9.43,
+      "status": "pass",
+      "throughput_in_gibs": 2.38354,
+      "throughput_out_gibs": 0.264913,
+      "compression_fold": 13.1263,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.390736,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 1.47496,
+      "init_s": 5.99272,
+      "flush_s": 1.071e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.73374,
+          "best_ms": 0.791277,
+          "in_gibs": 14.9458,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.6016,
+          "best_ms": 9.32423,
+          "in_gibs": 26.5291,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 27.0179,
+          "best_ms": 23.3823,
+          "in_gibs": 13.9701,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.69741,
+          "best_ms": 1.81109,
+          "in_gibs": 14.3625,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 11.8676,
+          "best_ms": 7.635,
+          "in_gibs": 33.2443,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.8424,
+          "best_ms": 16.1786,
+          "in_gibs": 24.7978,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.52296,
+          "best_ms": 0.122824,
+          "in_gibs": 355.706,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0421632,
+          "best_ms": 5e-05,
+          "in_gibs": 38.9379,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.013091,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 9.19,
+      "status": "pass",
+      "throughput_in_gibs": 2.37434,
+      "throughput_out_gibs": 1.51176,
+      "compression_fold": 2.29131,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.23842,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 1.48067,
+      "init_s": 5.89972,
+      "flush_s": 1.011e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.73765,
+          "best_ms": 0.81345,
+          "in_gibs": 14.9301,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.9278,
+          "best_ms": 9.20681,
+          "in_gibs": 25.7372,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 29.8918,
+          "best_ms": 23.4051,
+          "in_gibs": 12.6269,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 7.33431,
+          "best_ms": 1.83777,
+          "in_gibs": 13.1153,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 10.7566,
+          "best_ms": 7.59097,
+          "in_gibs": 36.678,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.9099,
+          "best_ms": 6.47044,
+          "in_gibs": 49.6358,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.04912,
+          "best_ms": 1.10914,
+          "in_gibs": 89.2081,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.201625,
+          "best_ms": 5e-05,
+          "in_gibs": 46.6466,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.01378,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 9.05,
+      "status": "pass",
+      "throughput_in_gibs": 2.63476,
+      "throughput_out_gibs": 0.0479923,
+      "compression_fold": 80.0925,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0640373,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 1.33433,
+      "init_s": 5.90011,
+      "flush_s": 0.000465278,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.69158,
+          "best_ms": 0.691107,
+          "in_gibs": 15.1164,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.4281,
+          "best_ms": 9.29606,
+          "in_gibs": 24.6105,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 30.7535,
+          "best_ms": 23.4362,
+          "in_gibs": 12.2731,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.54841,
+          "best_ms": 1.81255,
+          "in_gibs": 14.6893,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 9.9087,
+          "best_ms": 7.55231,
+          "in_gibs": 39.8166,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.87148,
+          "best_ms": 4.82305,
+          "in_gibs": 77.8257,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.168827,
+          "best_ms": 0.058338,
+          "in_gibs": 3196.35,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0083216,
+          "best_ms": 5e-05,
+          "in_gibs": 32.3332,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.015382,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 11.98,
+      "status": "pass",
+      "throughput_in_gibs": 5.93534,
+      "throughput_out_gibs": 6.33473,
+      "compression_fold": 1.07146,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00234,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.631809,
+      "init_s": 0.207062,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.55104,
+          "best_ms": 1.61059,
+          "in_gibs": 18.3749,
+          "out_gibs": 18.3749
+        },
+        "h2d": {
+          "avg_ms": 0.897817,
+          "best_ms": 0.590048,
+          "in_gibs": 52.21,
+          "out_gibs": 52.21
+        },
+        "scatter": {
+          "avg_ms": 0.0462277,
+          "best_ms": 0.025152,
+          "in_gibs": 1014,
+          "out_gibs": 1014
+        },
+        "lod_gather": {
+          "avg_ms": 0.425045,
+          "best_ms": 0.421568,
+          "in_gibs": 220.565,
+          "out_gibs": 220.565
+        },
+        "lod_reduce": {
+          "avg_ms": 0.4136,
+          "best_ms": 0.413344,
+          "in_gibs": 226.668,
+          "out_gibs": 259.208
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.0300267,
+          "best_ms": 0.02048,
+          "in_gibs": 448.21,
+          "out_gibs": 448.21
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 37.2654,
+          "best_ms": 0.2232,
+          "in_gibs": 2.87688,
+          "out_gibs": 2.87688
+        },
+        "compress": {
+          "avg_ms": 0.738372,
+          "best_ms": 0.139424,
+          "in_gibs": 661.446,
+          "out_gibs": 601.957
+        },
+        "aggregate": {
+          "avg_ms": 1.09635,
+          "best_ms": 0.047104,
+          "in_gibs": 405.406,
+          "out_gibs": 405.406
+        },
+        "d2h": {
+          "avg_ms": 8.57599,
+          "best_ms": 0.011648,
+          "in_gibs": 51.827,
+          "out_gibs": 51.827
+        },
+        "sink": {
+          "avg_ms": 0.00140141,
+          "best_ms": 3e-05,
+          "in_gibs": 11609.5,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 16.4145,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 8.84968,
+        "kick_sync_count": 9,
+        "io_fence_ms": 165.124,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 30.8354,
+        "peak_pending_mib": 0.289062
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 14.87,
+      "status": "pass",
+      "throughput_in_gibs": 2.19503,
+      "throughput_out_gibs": 2.34273,
+      "compression_fold": 1.07146,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00234,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.70841,
+      "init_s": 2.05841,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.69275,
+          "best_ms": 1.54498,
+          "in_gibs": 17.4079,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.81927,
+          "best_ms": 6.62175,
+          "in_gibs": 11.9896,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 10.2111,
+          "best_ms": 4.74522,
+          "in_gibs": 10.4992,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.05628,
+          "best_ms": 0.195784,
+          "in_gibs": 4.40348,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.37169,
+          "best_ms": 2.92017,
+          "in_gibs": 24.5233,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.79744,
+          "best_ms": 1.91905,
+          "in_gibs": 55.5154,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.91627,
+          "best_ms": 0.010125,
+          "in_gibs": 56.1564,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0056612,
+          "best_ms": 3e-05,
+          "in_gibs": 2873.89,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014319,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 11.95,
+      "status": "pass",
+      "throughput_in_gibs": 6.68317,
+      "throughput_out_gibs": 0.863351,
+      "compression_fold": 8.85221,
+      "input_gib": 3.75,
+      "compressed_gib": 0.484436,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.561111,
+      "init_s": 0.21145,
+      "flush_s": 5.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.57279,
+          "best_ms": 1.58834,
+          "in_gibs": 18.2195,
+          "out_gibs": 18.2195
+        },
+        "h2d": {
+          "avg_ms": 0.901632,
+          "best_ms": 0.589888,
+          "in_gibs": 51.989,
+          "out_gibs": 51.989
+        },
+        "scatter": {
+          "avg_ms": 0.0557982,
+          "best_ms": 0.024224,
+          "in_gibs": 844.827,
+          "out_gibs": 844.827
+        },
+        "lod_gather": {
+          "avg_ms": 0.425589,
+          "best_ms": 0.421408,
+          "in_gibs": 220.283,
+          "out_gibs": 220.283
+        },
+        "lod_reduce": {
+          "avg_ms": 0.412192,
+          "best_ms": 0.411648,
+          "in_gibs": 227.443,
+          "out_gibs": 260.093
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.0293547,
+          "best_ms": 0.02048,
+          "in_gibs": 458.471,
+          "out_gibs": 458.471
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 37.6101,
+          "best_ms": 0.223232,
+          "in_gibs": 2.85052,
+          "out_gibs": 2.85052
+        },
+        "compress": {
+          "avg_ms": 36.4153,
+          "best_ms": 2.23744,
+          "in_gibs": 13.4118,
+          "out_gibs": 1.47163
+        },
+        "aggregate": {
+          "avg_ms": 0.279097,
+          "best_ms": 0.028704,
+          "in_gibs": 192.011,
+          "out_gibs": 192.011
+        },
+        "d2h": {
+          "avg_ms": 9.68271,
+          "best_ms": 9.53254,
+          "in_gibs": 6.2263,
+          "out_gibs": 6.2263
+        },
+        "sink": {
+          "avg_ms": 0.00125911,
+          "best_ms": 6e-05,
+          "in_gibs": 1564.01,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 56.3364,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 49.3354,
+        "kick_sync_count": 9,
+        "io_fence_ms": 15.1173,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 28.6796,
+        "peak_pending_mib": 0.0390625
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 15.19,
+      "status": "pass",
+      "throughput_in_gibs": 2.36621,
+      "throughput_out_gibs": 0.23275,
+      "compression_fold": 11.6257,
+      "input_gib": 3.75,
+      "compressed_gib": 0.368866,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.58481,
+      "init_s": 2.06594,
+      "flush_s": 8.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.76907,
+          "best_ms": 1.63967,
+          "in_gibs": 16.9281,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.40638,
+          "best_ms": 6.37565,
+          "in_gibs": 12.658,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 8.3022,
+          "best_ms": 4.77626,
+          "in_gibs": 12.9132,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.11782,
+          "best_ms": 0.16025,
+          "in_gibs": 12.0397,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.72,
+          "best_ms": 2.9084,
+          "in_gibs": 28.8195,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.109,
+          "best_ms": 5.79847,
+          "in_gibs": 19.4509,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.784876,
+          "best_ms": 0.004036,
+          "in_gibs": 569.445,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00127862,
+          "best_ms": 5e-05,
+          "in_gibs": 1172.71,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.013312,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 14.73,
+      "status": "pass",
+      "throughput_in_gibs": 2.12002,
+      "throughput_out_gibs": 1.40812,
+      "compression_fold": 1.7217,
+      "input_gib": 3.75,
+      "compressed_gib": 2.49075,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.76885,
+      "init_s": 2.11458,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.77955,
+          "best_ms": 1.64798,
+          "in_gibs": 16.8643,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 8.26934,
+          "best_ms": 6.34259,
+          "in_gibs": 11.3371,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 10.657,
+          "best_ms": 4.76804,
+          "in_gibs": 10.0599,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.20418,
+          "best_ms": 0.196805,
+          "in_gibs": 4.20021,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.11314,
+          "best_ms": 2.90032,
+          "in_gibs": 26.0648,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.7745,
+          "best_ms": 2.93756,
+          "in_gibs": 33.0565,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.04961,
+          "best_ms": 0.004226,
+          "in_gibs": 88.0807,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00268858,
+          "best_ms": 5e-05,
+          "in_gibs": 3765.92,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.013831,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 14.64,
+      "status": "pass",
+      "throughput_in_gibs": 2.26963,
+      "throughput_out_gibs": 0.0635817,
+      "compression_fold": 40.8207,
+      "input_gib": 3.75,
+      "compressed_gib": 0.105053,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.65225,
+      "init_s": 2.09841,
+      "flush_s": 8.62e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.7501,
+          "best_ms": 1.64619,
+          "in_gibs": 17.0448,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.70229,
+          "best_ms": 6.48275,
+          "in_gibs": 12.1717,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 9.08036,
+          "best_ms": 4.74828,
+          "in_gibs": 11.8066,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.18016,
+          "best_ms": 0.196435,
+          "in_gibs": 4.23194,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.94308,
+          "best_ms": 2.91135,
+          "in_gibs": 27.1889,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.5829,
+          "best_ms": 3.67073,
+          "in_gibs": 27.7766,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.517602,
+          "best_ms": 0.002935,
+          "in_gibs": 859.297,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0028213,
+          "best_ms": 5e-05,
+          "in_gibs": 151.364,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.01353,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 11.95,
+      "status": "pass",
+      "throughput_in_gibs": 5.91743,
+      "throughput_out_gibs": 6.31665,
+      "compression_fold": 1.07585,
+      "input_gib": 3.75,
+      "compressed_gib": 4.003,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.633721,
+      "init_s": 0.205413,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.55129,
+          "best_ms": 1.6179,
+          "in_gibs": 18.3731,
+          "out_gibs": 18.3731
+        },
+        "h2d": {
+          "avg_ms": 0.899767,
+          "best_ms": 0.589952,
+          "in_gibs": 52.0968,
+          "out_gibs": 52.0968
+        },
+        "scatter": {
+          "avg_ms": 0.0455422,
+          "best_ms": 0.025312,
+          "in_gibs": 1029.27,
+          "out_gibs": 1029.27
+        },
+        "lod_gather": {
+          "avg_ms": 0.427392,
+          "best_ms": 0.425632,
+          "in_gibs": 219.354,
+          "out_gibs": 219.354
+        },
+        "lod_reduce": {
+          "avg_ms": 0.409408,
+          "best_ms": 0.405504,
+          "in_gibs": 228.989,
+          "out_gibs": 262.98
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.03584,
+          "best_ms": 0.02048,
+          "in_gibs": 388.282,
+          "out_gibs": 388.282
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.256,
+          "best_ms": 0.229376,
+          "in_gibs": 420.57,
+          "out_gibs": 420.57
+        },
+        "compress": {
+          "avg_ms": 0.812252,
+          "best_ms": 0.759328,
+          "in_gibs": 662.762,
+          "out_gibs": 615.986
+        },
+        "aggregate": {
+          "avg_ms": 2.09276,
+          "best_ms": 1.76499,
+          "in_gibs": 239.079,
+          "out_gibs": 239.079
+        },
+        "d2h": {
+          "avg_ms": 9.66925,
+          "best_ms": 9.47894,
+          "in_gibs": 51.745,
+          "out_gibs": 51.745
+        },
+        "sink": {
+          "avg_ms": 0.00234159,
+          "best_ms": 4e-05,
+          "in_gibs": 7123,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 13.1676,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 9.15628,
+        "kick_sync_count": 8,
+        "io_fence_ms": 155.606,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 30.719,
+        "peak_pending_mib": 0.753906
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 14.75,
+      "status": "pass",
+      "throughput_in_gibs": 2.33784,
+      "throughput_out_gibs": 2.49557,
+      "compression_fold": 1.07585,
+      "input_gib": 3.75,
+      "compressed_gib": 4.003,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.60404,
+      "init_s": 2.04301,
+      "flush_s": 7.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.76639,
+          "best_ms": 1.63451,
+          "in_gibs": 16.9445,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.72718,
+          "best_ms": 6.63881,
+          "in_gibs": 12.1325,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.34937,
+          "best_ms": 4.90388,
+          "in_gibs": 14.6497,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.11731,
+          "best_ms": 0.00018,
+          "in_gibs": 6.5725,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.653,
+          "best_ms": 3.55222,
+          "in_gibs": 19.0458,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.33171,
+          "best_ms": 9.02996,
+          "in_gibs": 57.6882,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.81183,
+          "best_ms": 8.32445,
+          "in_gibs": 56.7901,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00144489,
+          "best_ms": 5e-05,
+          "in_gibs": 11543.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.016723,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 12.26,
+      "status": "pass",
+      "throughput_in_gibs": 7.05283,
+      "throughput_out_gibs": 0.891153,
+      "compression_fold": 9.08905,
+      "input_gib": 3.75,
+      "compressed_gib": 0.473827,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.531702,
+      "init_s": 0.206196,
+      "flush_s": 7.12e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.58041,
+          "best_ms": 1.65731,
+          "in_gibs": 18.1657,
+          "out_gibs": 18.1657
+        },
+        "h2d": {
+          "avg_ms": 0.902661,
+          "best_ms": 0.589856,
+          "in_gibs": 51.9298,
+          "out_gibs": 51.9298
+        },
+        "scatter": {
+          "avg_ms": 0.0752853,
+          "best_ms": 0.024224,
+          "in_gibs": 622.631,
+          "out_gibs": 622.631
+        },
+        "lod_gather": {
+          "avg_ms": 0.419088,
+          "best_ms": 0.41664,
+          "in_gibs": 223.7,
+          "out_gibs": 223.7
+        },
+        "lod_reduce": {
+          "avg_ms": 0.409408,
+          "best_ms": 0.407552,
+          "in_gibs": 228.989,
+          "out_gibs": 262.98
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.03584,
+          "best_ms": 0.02048,
+          "in_gibs": 388.282,
+          "out_gibs": 388.282
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.256512,
+          "best_ms": 0.231424,
+          "in_gibs": 419.731,
+          "out_gibs": 419.731
+        },
+        "compress": {
+          "avg_ms": 39.5235,
+          "best_ms": 34.799,
+          "in_gibs": 13.6205,
+          "out_gibs": 1.49756
+        },
+        "aggregate": {
+          "avg_ms": 0.31474,
+          "best_ms": 0.243296,
+          "in_gibs": 188.056,
+          "out_gibs": 188.056
+        },
+        "d2h": {
+          "avg_ms": 9.69785,
+          "best_ms": 9.50912,
+          "in_gibs": 6.1033,
+          "out_gibs": 6.1033
+        },
+        "sink": {
+          "avg_ms": 0.000928017,
+          "best_ms": 5e-05,
+          "in_gibs": 2127.42,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 47.1857,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 43.5403,
+        "kick_sync_count": 8,
+        "io_fence_ms": 21.5042,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 40.2169,
+        "peak_pending_mib": 0.0429688
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 14.72,
+      "status": "pass",
+      "throughput_in_gibs": 2.34845,
+      "throughput_out_gibs": 0.220053,
+      "compression_fold": 12.2564,
+      "input_gib": 3.75,
+      "compressed_gib": 0.351379,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.5968,
+      "init_s": 2.04046,
+      "flush_s": 8.72e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.78634,
+          "best_ms": 1.65455,
+          "in_gibs": 16.8232,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.68362,
+          "best_ms": 6.67851,
+          "in_gibs": 12.2013,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.85291,
+          "best_ms": 4.91878,
+          "in_gibs": 13.7103,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.45486,
+          "best_ms": 0.000211,
+          "in_gibs": 9.56519,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.9609,
+          "best_ms": 3.59813,
+          "in_gibs": 21.7029,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.2324,
+          "best_ms": 22.6369,
+          "in_gibs": 23.1715,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.37513,
+          "best_ms": 0.686078,
+          "in_gibs": 365.333,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000501842,
+          "best_ms": 6e-05,
+          "in_gibs": 2917.42,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.012619,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 15.0,
+      "status": "pass",
+      "throughput_in_gibs": 2.42119,
+      "throughput_out_gibs": 1.45391,
+      "compression_fold": 1.91248,
+      "input_gib": 3.75,
+      "compressed_gib": 2.25186,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.54883,
+      "init_s": 2.05502,
+      "flush_s": 6.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.78997,
+          "best_ms": 1.64143,
+          "in_gibs": 16.8012,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.39301,
+          "best_ms": 6.60482,
+          "in_gibs": 12.6809,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.90221,
+          "best_ms": 4.8956,
+          "in_gibs": 15.5988,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.46306,
+          "best_ms": 0.00011,
+          "in_gibs": 5.64989,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.13521,
+          "best_ms": 3.5394,
+          "in_gibs": 20.9662,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.7839,
+          "best_ms": 11.234,
+          "in_gibs": 45.6837,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.96126,
+          "best_ms": 4.66879,
+          "in_gibs": 100.875,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00167494,
+          "best_ms": 4e-05,
+          "in_gibs": 5601.83,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011606,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 14.59,
+      "status": "pass",
+      "throughput_in_gibs": 2.28626,
+      "throughput_out_gibs": 0.0372136,
+      "compression_fold": 70.5556,
+      "input_gib": 3.75,
+      "compressed_gib": 0.061039,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.64023,
+      "init_s": 2.02584,
+      "flush_s": 7.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.75757,
+          "best_ms": 1.65058,
+          "in_gibs": 16.9987,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.86319,
+          "best_ms": 6.57879,
+          "in_gibs": 11.9226,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 9.30948,
+          "best_ms": 4.88078,
+          "in_gibs": 11.5652,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.06777,
+          "best_ms": 0.00016,
+          "in_gibs": 4.53621,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.4418,
+          "best_ms": 3.56973,
+          "in_gibs": 19.785,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.7309,
+          "best_ms": 10.2014,
+          "in_gibs": 50.1664,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.886339,
+          "best_ms": 0.127351,
+          "in_gibs": 564.643,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00116625,
+          "best_ms": 5e-05,
+          "in_gibs": 218.074,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.017034,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 11.91,
+      "status": "pass",
+      "throughput_in_gibs": 5.87177,
+      "throughput_out_gibs": 6.33104,
+      "compression_fold": 1.10136,
+      "input_gib": 3.75,
+      "compressed_gib": 4.04331,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 0.638649,
+      "init_s": 0.20981,
+      "flush_s": 9.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.56801,
+          "best_ms": 1.61709,
+          "in_gibs": 18.2534,
+          "out_gibs": 18.2534
+        },
+        "h2d": {
+          "avg_ms": 0.898421,
+          "best_ms": 0.589952,
+          "in_gibs": 52.1749,
+          "out_gibs": 52.1749
+        },
+        "scatter": {
+          "avg_ms": 0.0461128,
+          "best_ms": 0.024544,
+          "in_gibs": 1016.53,
+          "out_gibs": 1016.53
+        },
+        "lod_gather": {
+          "avg_ms": 0.420512,
+          "best_ms": 0.417408,
+          "in_gibs": 222.943,
+          "out_gibs": 222.943
+        },
+        "lod_reduce": {
+          "avg_ms": 0.408576,
+          "best_ms": 0.407552,
+          "in_gibs": 229.455,
+          "out_gibs": 272.478
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.041984,
+          "best_ms": 0.026624,
+          "in_gibs": 418.686,
+          "out_gibs": 418.686
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.276976,
+          "best_ms": 0.235488,
+          "in_gibs": 401.941,
+          "out_gibs": 401.941
+        },
+        "compress": {
+          "avg_ms": 0.83758,
+          "best_ms": 0.786432,
+          "in_gibs": 664.582,
+          "out_gibs": 603.37
+        },
+        "aggregate": {
+          "avg_ms": 8.7656,
+          "best_ms": 8.67226,
+          "in_gibs": 57.6539,
+          "out_gibs": 57.6539
+        },
+        "d2h": {
+          "avg_ms": 9.74414,
+          "best_ms": 9.55507,
+          "in_gibs": 51.8641,
+          "out_gibs": 51.8641
+        },
+        "sink": {
+          "avg_ms": 0.000501955,
+          "best_ms": 4e-05,
+          "in_gibs": 30056.4,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.7381,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 9.45811,
+        "kick_sync_count": 8,
+        "io_fence_ms": 160.108,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 31.4006,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 15.02,
+      "status": "pass",
+      "throughput_in_gibs": 1.88774,
+      "throughput_out_gibs": 2.0354,
+      "compression_fold": 1.10136,
+      "input_gib": 3.75,
+      "compressed_gib": 4.04331,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 1.9865,
+      "init_s": 1.93301,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.7203,
+          "best_ms": 1.58041,
+          "in_gibs": 17.2315,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.5187,
+          "best_ms": 6.31393,
+          "in_gibs": 12.4689,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 8.26115,
+          "best_ms": 5.84857,
+          "in_gibs": 13.4761,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.30145,
+          "best_ms": 0.00016,
+          "in_gibs": 7.63784,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.2885,
+          "best_ms": 3.89584,
+          "in_gibs": 8.37778,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.1018,
+          "best_ms": 11.9695,
+          "in_gibs": 45.9965,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.0664,
+          "best_ms": 10.6609,
+          "in_gibs": 45.6759,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00131002,
+          "best_ms": 5e-05,
+          "in_gibs": 11516.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.015294,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 12.01,
+      "status": "pass",
+      "throughput_in_gibs": 6.50863,
+      "throughput_out_gibs": 0.729341,
+      "compression_fold": 10.5972,
+      "input_gib": 3.75,
+      "compressed_gib": 0.420216,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 0.576158,
+      "init_s": 0.215249,
+      "flush_s": 3.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.54937,
+          "best_ms": 1.57624,
+          "in_gibs": 18.3869,
+          "out_gibs": 18.3869
+        },
+        "h2d": {
+          "avg_ms": 0.899306,
+          "best_ms": 0.589824,
+          "in_gibs": 52.1235,
+          "out_gibs": 52.1235
+        },
+        "scatter": {
+          "avg_ms": 0.0839734,
+          "best_ms": 0.024544,
+          "in_gibs": 560.629,
+          "out_gibs": 560.629
+        },
+        "lod_gather": {
+          "avg_ms": 0.678032,
+          "best_ms": 0.677408,
+          "in_gibs": 138.268,
+          "out_gibs": 138.268
+        },
+        "lod_reduce": {
+          "avg_ms": 0.4992,
+          "best_ms": 0.498688,
+          "in_gibs": 187.8,
+          "out_gibs": 223.013
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.072832,
+          "best_ms": 0.047136,
+          "in_gibs": 241.352,
+          "out_gibs": 241.352
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.473968,
+          "best_ms": 0.421856,
+          "in_gibs": 234.885,
+          "out_gibs": 234.885
+        },
+        "compress": {
+          "avg_ms": 56.4123,
+          "best_ms": 51.13,
+          "in_gibs": 9.86736,
+          "out_gibs": 0.930348
+        },
+        "aggregate": {
+          "avg_ms": 0.949292,
+          "best_ms": 0.5208,
+          "in_gibs": 55.2866,
+          "out_gibs": 55.2866
+        },
+        "d2h": {
+          "avg_ms": 9.74332,
+          "best_ms": 9.48099,
+          "in_gibs": 5.38657,
+          "out_gibs": 5.38657
+        },
+        "sink": {
+          "avg_ms": 0.00076672,
+          "best_ms": 4e-05,
+          "in_gibs": 2045.03,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 83.5822,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 80.9962,
+        "kick_sync_count": 8,
+        "io_fence_ms": 21.7202,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 51.6918,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.91,
+      "status": "pass",
+      "throughput_in_gibs": 1.99304,
+      "throughput_out_gibs": 0.145427,
+      "compression_fold": 16.2744,
+      "input_gib": 3.75,
+      "compressed_gib": 0.273628,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 1.88155,
+      "init_s": 1.96032,
+      "flush_s": 9.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.77379,
+          "best_ms": 1.63493,
+          "in_gibs": 16.8993,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.4856,
+          "best_ms": 6.337,
+          "in_gibs": 12.5241,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.56441,
+          "best_ms": 5.99425,
+          "in_gibs": 14.7174,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.6381,
+          "best_ms": 0.000181,
+          "in_gibs": 10.7308,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.0826,
+          "best_ms": 3.85318,
+          "in_gibs": 8.50964,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.6333,
+          "best_ms": 18.3991,
+          "in_gibs": 28.3518,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.26342,
+          "best_ms": 0.524517,
+          "in_gibs": 401.641,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000596269,
+          "best_ms": 6e-05,
+          "in_gibs": 1712.32,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.012819,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.93,
+      "status": "pass",
+      "throughput_in_gibs": 1.97072,
+      "throughput_out_gibs": 1.25195,
+      "compression_fold": 1.86926,
+      "input_gib": 3.75,
+      "compressed_gib": 2.38229,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 1.90286,
+      "init_s": 1.96521,
+      "flush_s": 1.032e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.77123,
+          "best_ms": 1.64761,
+          "in_gibs": 16.9149,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.62297,
+          "best_ms": 6.45715,
+          "in_gibs": 12.2984,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.85238,
+          "best_ms": 6.07206,
+          "in_gibs": 14.1776,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.84429,
+          "best_ms": 0.000301,
+          "in_gibs": 9.53108,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.5196,
+          "best_ms": 3.85357,
+          "in_gibs": 8.89232,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.685,
+          "best_ms": 12.2228,
+          "in_gibs": 40.6752,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.84817,
+          "best_ms": 6.3398,
+          "in_gibs": 73.8121,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00368495,
+          "best_ms": 4e-05,
+          "in_gibs": 2412.28,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011736,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.55,
+      "status": "pass",
+      "throughput_in_gibs": 2.15209,
+      "throughput_out_gibs": 0.034362,
+      "compression_fold": 74.3731,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0598755,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 1.74249,
+      "init_s": 1.93396,
+      "flush_s": 7.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.77127,
+          "best_ms": 1.6571,
+          "in_gibs": 16.9146,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.44262,
+          "best_ms": 6.29955,
+          "in_gibs": 12.5964,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.65178,
+          "best_ms": 5.94655,
+          "in_gibs": 14.5493,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.29361,
+          "best_ms": 5.1e-05,
+          "in_gibs": 13.5885,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 11.8952,
+          "best_ms": 3.91464,
+          "in_gibs": 9.35904,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.80036,
+          "best_ms": 9.14735,
+          "in_gibs": 56.798,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.27412,
+          "best_ms": 0.116505,
+          "in_gibs": 396.727,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000526045,
+          "best_ms": 4e-05,
+          "in_gibs": 424.709,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.010225,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.86,
+      "status": "pass",
+      "throughput_in_gibs": 8.92897,
+      "throughput_out_gibs": 8.93944,
+      "compression_fold": 0.998829,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51975,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.393732,
+      "init_s": 0.224313,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41001,
+          "best_ms": 0.692849,
+          "in_gibs": 19.4501,
+          "out_gibs": 19.4501
+        },
+        "h2d": {
+          "avg_ms": 0.905153,
+          "best_ms": 0.303424,
+          "in_gibs": 52.0233,
+          "out_gibs": 52.0233
+        },
+        "scatter": {
+          "avg_ms": 0.208773,
+          "best_ms": 0.074656,
+          "in_gibs": 225.552,
+          "out_gibs": 225.552
+        },
+        "compress": {
+          "avg_ms": 0.868229,
+          "best_ms": 0.174272,
+          "in_gibs": 578.456,
+          "out_gibs": 578.456
+        },
+        "aggregate": {
+          "avg_ms": 1.1111,
+          "best_ms": 0.369664,
+          "in_gibs": 452.012,
+          "out_gibs": 452.012
+        },
+        "d2h": {
+          "avg_ms": 9.6676,
+          "best_ms": 2.67738,
+          "in_gibs": 51.95,
+          "out_gibs": 51.95
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 8.89245,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 2.96714,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.44776,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.58,
+      "status": "pass",
+      "throughput_in_gibs": 9.04221,
+      "throughput_out_gibs": 9.04759,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.388801,
+      "init_s": 0.204361,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.43254,
+          "best_ms": 0.714371,
+          "in_gibs": 19.27,
+          "out_gibs": 19.27
+        },
+        "h2d": {
+          "avg_ms": 0.907252,
+          "best_ms": 0.300608,
+          "in_gibs": 51.9029,
+          "out_gibs": 51.9029
+        },
+        "scatter": {
+          "avg_ms": 0.208479,
+          "best_ms": 0.074592,
+          "in_gibs": 225.87,
+          "out_gibs": 225.87
+        },
+        "compress": {
+          "avg_ms": 0.973271,
+          "best_ms": 0.173056,
+          "in_gibs": 516.025,
+          "out_gibs": 516.025
+        },
+        "aggregate": {
+          "avg_ms": 1.05946,
+          "best_ms": 0.336896,
+          "in_gibs": 474.047,
+          "out_gibs": 474.047
+        },
+        "d2h": {
+          "avg_ms": 9.66116,
+          "best_ms": 2.67629,
+          "in_gibs": 51.9847,
+          "out_gibs": 51.9847
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 6.10149,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 3.04348,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.41439,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.76,
+      "status": "pass",
+      "throughput_in_gibs": 9.11562,
+      "throughput_out_gibs": 9.11829,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51666,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.385671,
+      "init_s": 0.226769,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.4252,
+          "best_ms": 0.724026,
+          "in_gibs": 19.3283,
+          "out_gibs": 19.3283
+        },
+        "h2d": {
+          "avg_ms": 0.911118,
+          "best_ms": 0.310368,
+          "in_gibs": 51.6827,
+          "out_gibs": 51.6827
+        },
+        "scatter": {
+          "avg_ms": 0.208712,
+          "best_ms": 0.07456,
+          "in_gibs": 225.617,
+          "out_gibs": 225.617
+        },
+        "compress": {
+          "avg_ms": 0.973449,
+          "best_ms": 0.172224,
+          "in_gibs": 515.931,
+          "out_gibs": 515.931
+        },
+        "aggregate": {
+          "avg_ms": 1.09163,
+          "best_ms": 0.370688,
+          "in_gibs": 460.074,
+          "out_gibs": 460.074
+        },
+        "d2h": {
+          "avg_ms": 9.65901,
+          "best_ms": 2.67558,
+          "in_gibs": 51.9962,
+          "out_gibs": 51.9962
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 4.66304,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 3.12031,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.40508,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.86,
+      "status": "pass",
+      "throughput_in_gibs": 9.09607,
+      "throughput_out_gibs": 9.09753,
+      "compression_fold": 0.99984,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51619,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.386499,
+      "init_s": 0.226626,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.43308,
+          "best_ms": 0.719008,
+          "in_gibs": 19.2657,
+          "out_gibs": 19.2657
+        },
+        "h2d": {
+          "avg_ms": 0.904645,
+          "best_ms": 0.302976,
+          "in_gibs": 52.0525,
+          "out_gibs": 52.0525
+        },
+        "scatter": {
+          "avg_ms": 0.208377,
+          "best_ms": 0.074624,
+          "in_gibs": 225.98,
+          "out_gibs": 225.98
+        },
+        "compress": {
+          "avg_ms": 0.975845,
+          "best_ms": 0.17696,
+          "in_gibs": 514.664,
+          "out_gibs": 514.664
+        },
+        "aggregate": {
+          "avg_ms": 1.15912,
+          "best_ms": 0.34816,
+          "in_gibs": 433.288,
+          "out_gibs": 433.288
+        },
+        "d2h": {
+          "avg_ms": 9.65834,
+          "best_ms": 2.67552,
+          "in_gibs": 51.9998,
+          "out_gibs": 51.9998
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 4.0168,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 3.13099,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.42333,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.66,
+      "status": "pass",
+      "throughput_in_gibs": 9.12519,
+      "throughput_out_gibs": 9.12593,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.385266,
+      "init_s": 0.204554,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.43576,
+          "best_ms": 0.711016,
+          "in_gibs": 19.2445,
+          "out_gibs": 19.2445
+        },
+        "h2d": {
+          "avg_ms": 0.906033,
+          "best_ms": 0.304288,
+          "in_gibs": 51.9728,
+          "out_gibs": 51.9728
+        },
+        "scatter": {
+          "avg_ms": 0.208429,
+          "best_ms": 0.074592,
+          "in_gibs": 225.923,
+          "out_gibs": 225.923
+        },
+        "compress": {
+          "avg_ms": 0.974203,
+          "best_ms": 0.169984,
+          "in_gibs": 515.531,
+          "out_gibs": 515.531
+        },
+        "aggregate": {
+          "avg_ms": 1.32374,
+          "best_ms": 0.466944,
+          "in_gibs": 379.404,
+          "out_gibs": 379.404
+        },
+        "d2h": {
+          "avg_ms": 9.67127,
+          "best_ms": 2.67555,
+          "in_gibs": 51.9303,
+          "out_gibs": 51.9303
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 3.85454,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 3.38713,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.42129,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.56,
+      "status": "pass",
+      "throughput_in_gibs": 9.19844,
+      "throughput_out_gibs": 9.56675,
+      "compression_fold": 0.999961,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65639,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.382198,
+      "init_s": 0.200575,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.84874,
+          "best_ms": 0.72698,
+          "in_gibs": 19.5889,
+          "out_gibs": 19.5889
+        },
+        "h2d": {
+          "avg_ms": 1.08329,
+          "best_ms": 0.590784,
+          "in_gibs": 52.0195,
+          "out_gibs": 52.0195
+        },
+        "scatter": {
+          "avg_ms": 0.246626,
+          "best_ms": 0.142176,
+          "in_gibs": 228.493,
+          "out_gibs": 228.493
+        },
+        "compress": {
+          "avg_ms": 1.00433,
+          "best_ms": 0.380896,
+          "in_gibs": 520.07,
+          "out_gibs": 520.07
+        },
+        "aggregate": {
+          "avg_ms": 1.6207,
+          "best_ms": 0.909312,
+          "in_gibs": 322.281,
+          "out_gibs": 322.281
+        },
+        "d2h": {
+          "avg_ms": 10.0746,
+          "best_ms": 5.34765,
+          "in_gibs": 51.8451,
+          "out_gibs": 51.8451
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 7.07817,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 6.82469,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.36528,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.77,
+      "status": "pass",
+      "throughput_in_gibs": 9.11009,
+      "throughput_out_gibs": 9.47466,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65631,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.385904,
+      "init_s": 0.226033,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.86359,
+          "best_ms": 0.716875,
+          "in_gibs": 19.4872,
+          "out_gibs": 19.4872
+        },
+        "h2d": {
+          "avg_ms": 1.08764,
+          "best_ms": 0.591264,
+          "in_gibs": 51.8116,
+          "out_gibs": 51.8116
+        },
+        "scatter": {
+          "avg_ms": 0.247135,
+          "best_ms": 0.142112,
+          "in_gibs": 228.023,
+          "out_gibs": 228.023
+        },
+        "compress": {
+          "avg_ms": 1.00346,
+          "best_ms": 0.378848,
+          "in_gibs": 520.52,
+          "out_gibs": 520.52
+        },
+        "aggregate": {
+          "avg_ms": 1.83369,
+          "best_ms": 1.59334,
+          "in_gibs": 284.847,
+          "out_gibs": 284.847
+        },
+        "d2h": {
+          "avg_ms": 10.1101,
+          "best_ms": 5.34755,
+          "in_gibs": 51.6634,
+          "out_gibs": 51.6634
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 7.71917,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 7.57104,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.37682,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.79,
+      "status": "pass",
+      "throughput_in_gibs": 9.02776,
+      "throughput_out_gibs": 9.38896,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.389424,
+      "init_s": 0.223389,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.86421,
+          "best_ms": 1.03137,
+          "in_gibs": 19.483,
+          "out_gibs": 19.483
+        },
+        "h2d": {
+          "avg_ms": 1.09253,
+          "best_ms": 0.592768,
+          "in_gibs": 51.5797,
+          "out_gibs": 51.5797
+        },
+        "scatter": {
+          "avg_ms": 0.247489,
+          "best_ms": 0.14208,
+          "in_gibs": 227.697,
+          "out_gibs": 227.697
+        },
+        "compress": {
+          "avg_ms": 1.00374,
+          "best_ms": 0.380928,
+          "in_gibs": 520.373,
+          "out_gibs": 520.373
+        },
+        "aggregate": {
+          "avg_ms": 3.18713,
+          "best_ms": 2.95834,
+          "in_gibs": 163.885,
+          "out_gibs": 163.885
+        },
+        "d2h": {
+          "avg_ms": 10.1525,
+          "best_ms": 5.34749,
+          "in_gibs": 51.4476,
+          "out_gibs": 51.4476
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 9.05984,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 8.96017,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.39492,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.63,
+      "status": "pass",
+      "throughput_in_gibs": 8.14768,
+      "throughput_out_gibs": 4.12409,
+      "compression_fold": 1.97563,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.7795,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.431488,
+      "init_s": 0.203377,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.49485,
+          "best_ms": 0.727541,
+          "in_gibs": 18.7887,
+          "out_gibs": 18.7887
+        },
+        "h2d": {
+          "avg_ms": 0.911453,
+          "best_ms": 0.295808,
+          "in_gibs": 51.6637,
+          "out_gibs": 51.6637
+        },
+        "scatter": {
+          "avg_ms": 0.199873,
+          "best_ms": 0.0736,
+          "in_gibs": 221.916,
+          "out_gibs": 221.916
+        },
+        "compress": {
+          "avg_ms": 20.6044,
+          "best_ms": 7.01213,
+          "in_gibs": 24.375,
+          "out_gibs": 12.3093
+        },
+        "aggregate": {
+          "avg_ms": 0.60075,
+          "best_ms": 0.175104,
+          "in_gibs": 422.181,
+          "out_gibs": 422.181
+        },
+        "d2h": {
+          "avg_ms": 9.76832,
+          "best_ms": 2.68822,
+          "in_gibs": 25.964,
+          "out_gibs": 25.964
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 34.6286,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 28.6289,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.7549,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.54,
+      "status": "pass",
+      "throughput_in_gibs": 7.88318,
+      "throughput_out_gibs": 3.94531,
+      "compression_fold": 1.99811,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.75947,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.445965,
+      "init_s": 0.204713,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41559,
+          "best_ms": 0.725438,
+          "in_gibs": 19.4052,
+          "out_gibs": 19.4052
+        },
+        "h2d": {
+          "avg_ms": 0.902305,
+          "best_ms": 0.296288,
+          "in_gibs": 52.1875,
+          "out_gibs": 52.1875
+        },
+        "scatter": {
+          "avg_ms": 0.209374,
+          "best_ms": 0.074592,
+          "in_gibs": 223.881,
+          "out_gibs": 223.881
+        },
+        "compress": {
+          "avg_ms": 22.963,
+          "best_ms": 8.8607,
+          "in_gibs": 21.8713,
+          "out_gibs": 10.933
+        },
+        "aggregate": {
+          "avg_ms": 1.04567,
+          "best_ms": 0.173024,
+          "in_gibs": 240.09,
+          "out_gibs": 240.09
+        },
+        "d2h": {
+          "avg_ms": 9.68427,
+          "best_ms": 2.68717,
+          "in_gibs": 25.9239,
+          "out_gibs": 25.9239
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 37.4983,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 34.4224,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 30.0663,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.64,
+      "status": "pass",
+      "throughput_in_gibs": 7.93586,
+      "throughput_out_gibs": 3.98595,
+      "compression_fold": 1.99096,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.7658,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.443005,
+      "init_s": 0.211827,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.40489,
+          "best_ms": 0.752418,
+          "in_gibs": 19.4916,
+          "out_gibs": 19.4916
+        },
+        "h2d": {
+          "avg_ms": 0.913626,
+          "best_ms": 0.296192,
+          "in_gibs": 51.5408,
+          "out_gibs": 51.5408
+        },
+        "scatter": {
+          "avg_ms": 0.210829,
+          "best_ms": 0.074432,
+          "in_gibs": 219.781,
+          "out_gibs": 219.781
+        },
+        "compress": {
+          "avg_ms": 26.658,
+          "best_ms": 9.96883,
+          "in_gibs": 18.8399,
+          "out_gibs": 9.45719
+        },
+        "aggregate": {
+          "avg_ms": 0.603895,
+          "best_ms": 0.19456,
+          "in_gibs": 417.472,
+          "out_gibs": 417.472
+        },
+        "d2h": {
+          "avg_ms": 9.75018,
+          "best_ms": 2.6865,
+          "in_gibs": 25.8569,
+          "out_gibs": 25.8569
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 41.7801,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 39.9835,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 19.4422,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.81,
+      "status": "pass",
+      "throughput_in_gibs": 7.42688,
+      "throughput_out_gibs": 3.33268,
+      "compression_fold": 2.2285,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.57757,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.473365,
+      "init_s": 0.207837,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.39009,
+          "best_ms": 0.715854,
+          "in_gibs": 19.6122,
+          "out_gibs": 19.6122
+        },
+        "h2d": {
+          "avg_ms": 0.911736,
+          "best_ms": 0.296224,
+          "in_gibs": 51.6477,
+          "out_gibs": 51.6477
+        },
+        "scatter": {
+          "avg_ms": 0.20565,
+          "best_ms": 0.07456,
+          "in_gibs": 218.439,
+          "out_gibs": 218.439
+        },
+        "compress": {
+          "avg_ms": 33.7405,
+          "best_ms": 18.3166,
+          "in_gibs": 14.8852,
+          "out_gibs": 6.67706
+        },
+        "aggregate": {
+          "avg_ms": 0.595086,
+          "best_ms": 0.227328,
+          "in_gibs": 378.579,
+          "out_gibs": 378.579
+        },
+        "d2h": {
+          "avg_ms": 9.73638,
+          "best_ms": 2.68627,
+          "in_gibs": 23.1387,
+          "out_gibs": 23.1387
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 56.4981,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 55.6209,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 41.1714,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.69,
+      "status": "pass",
+      "throughput_in_gibs": 7.04275,
+      "throughput_out_gibs": 3.44677,
+      "compression_fold": 2.04329,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.72057,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.499184,
+      "init_s": 0.207566,
+      "flush_s": 5.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41305,
+          "best_ms": 0.731757,
+          "in_gibs": 19.4256,
+          "out_gibs": 19.4256
+        },
+        "h2d": {
+          "avg_ms": 0.919032,
+          "best_ms": 0.29712,
+          "in_gibs": 51.2376,
+          "out_gibs": 51.2376
+        },
+        "scatter": {
+          "avg_ms": 0.236343,
+          "best_ms": 0.074688,
+          "in_gibs": 199.24,
+          "out_gibs": 199.24
+        },
+        "compress": {
+          "avg_ms": 40.1365,
+          "best_ms": 33.4701,
+          "in_gibs": 12.5131,
+          "out_gibs": 6.12297
+        },
+        "aggregate": {
+          "avg_ms": 0.687241,
+          "best_ms": 0.249856,
+          "in_gibs": 357.596,
+          "out_gibs": 357.596
+        },
+        "d2h": {
+          "avg_ms": 9.78,
+          "best_ms": 2.68637,
+          "in_gibs": 25.1283,
+          "out_gibs": 25.1283
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 76.6066,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 76.0798,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 45.7913,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.84,
+      "status": "pass",
+      "throughput_in_gibs": 6.1599,
+      "throughput_out_gibs": 2.46854,
+      "compression_fold": 2.59517,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.40887,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.570728,
+      "init_s": 0.20684,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.85247,
+          "best_ms": 1.02504,
+          "in_gibs": 19.5632,
+          "out_gibs": 19.5632
+        },
+        "h2d": {
+          "avg_ms": 1.07464,
+          "best_ms": 0.590368,
+          "in_gibs": 52.4385,
+          "out_gibs": 52.4385
+        },
+        "scatter": {
+          "avg_ms": 0.268182,
+          "best_ms": 0.141504,
+          "in_gibs": 210.128,
+          "out_gibs": 210.128
+        },
+        "compress": {
+          "avg_ms": 59.8595,
+          "best_ms": 34.9819,
+          "in_gibs": 8.72579,
+          "out_gibs": 3.36197
+        },
+        "aggregate": {
+          "avg_ms": 0.725472,
+          "best_ms": 0.227296,
+          "in_gibs": 277.4,
+          "out_gibs": 277.4
+        },
+        "d2h": {
+          "avg_ms": 10.0648,
+          "best_ms": 5.3681,
+          "in_gibs": 19.995,
+          "out_gibs": 19.995
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 118.878,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 118.627,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 80.5072,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.05,
+      "status": "pass",
+      "throughput_in_gibs": 5.56795,
+      "throughput_out_gibs": 1.2346,
+      "compression_fold": 4.69031,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.779533,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.631404,
+      "init_s": 0.230589,
+      "flush_s": 7.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.82128,
+          "best_ms": 0.971777,
+          "in_gibs": 19.7796,
+          "out_gibs": 19.7796
+        },
+        "h2d": {
+          "avg_ms": 1.07582,
+          "best_ms": 0.590112,
+          "in_gibs": 52.3811,
+          "out_gibs": 52.3811
+        },
+        "scatter": {
+          "avg_ms": 0.256261,
+          "best_ms": 0.142304,
+          "in_gibs": 219.902,
+          "out_gibs": 219.902
+        },
+        "compress": {
+          "avg_ms": 68.7518,
+          "best_ms": 54.186,
+          "in_gibs": 7.5972,
+          "out_gibs": 1.61963
+        },
+        "aggregate": {
+          "avg_ms": 0.478153,
+          "best_ms": 0.308192,
+          "in_gibs": 232.881,
+          "out_gibs": 232.881
+        },
+        "d2h": {
+          "avg_ms": 10.077,
+          "best_ms": 5.36771,
+          "in_gibs": 11.0502,
+          "out_gibs": 11.0502
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 158.845,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 158.709,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 101.837,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.99,
+      "status": "pass",
+      "throughput_in_gibs": 4.30137,
+      "throughput_out_gibs": 0.652783,
+      "compression_fold": 6.85285,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.533537,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.817326,
+      "init_s": 0.205296,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.7903,
+          "best_ms": 0.732098,
+          "in_gibs": 19.9991,
+          "out_gibs": 19.9991
+        },
+        "h2d": {
+          "avg_ms": 1.07989,
+          "best_ms": 0.592192,
+          "in_gibs": 52.1836,
+          "out_gibs": 52.1836
+        },
+        "scatter": {
+          "avg_ms": 0.252442,
+          "best_ms": 0.142112,
+          "in_gibs": 223.23,
+          "out_gibs": 223.23
+        },
+        "compress": {
+          "avg_ms": 95.3517,
+          "best_ms": 56.2083,
+          "in_gibs": 5.47784,
+          "out_gibs": 0.799303
+        },
+        "aggregate": {
+          "avg_ms": 0.593746,
+          "best_ms": 0.233472,
+          "in_gibs": 128.363,
+          "out_gibs": 128.363
+        },
+        "d2h": {
+          "avg_ms": 10.0757,
+          "best_ms": 5.36787,
+          "in_gibs": 7.5642,
+          "out_gibs": 7.5642
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 280.656,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 280.555,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 168.971,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.71,
+      "status": "pass",
+      "throughput_in_gibs": 6.30234,
+      "throughput_out_gibs": 0.812088,
+      "compression_fold": 7.76066,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.453006,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.557829,
+      "init_s": 0.205929,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.34861,
+          "best_ms": 0.713469,
+          "in_gibs": 19.9586,
+          "out_gibs": 19.9586
+        },
+        "h2d": {
+          "avg_ms": 0.905463,
+          "best_ms": 0.295872,
+          "in_gibs": 52.0055,
+          "out_gibs": 52.0055
+        },
+        "scatter": {
+          "avg_ms": 0.225527,
+          "best_ms": 0.074752,
+          "in_gibs": 202.897,
+          "out_gibs": 202.897
+        },
+        "compress": {
+          "avg_ms": 42.2744,
+          "best_ms": 11.8745,
+          "in_gibs": 11.8803,
+          "out_gibs": 1.51691
+        },
+        "aggregate": {
+          "avg_ms": 0.288421,
+          "best_ms": 0.054976,
+          "in_gibs": 222.337,
+          "out_gibs": 222.337
+        },
+        "d2h": {
+          "avg_ms": 9.67965,
+          "best_ms": 2.67808,
+          "in_gibs": 6.62488,
+          "out_gibs": 6.62488
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 63.4589,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 57.51,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 51.5106,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.18,
+      "status": "pass",
+      "throughput_in_gibs": 4.65772,
+      "throughput_out_gibs": 0.603134,
+      "compression_fold": 7.72253,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.455243,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.754795,
+      "init_s": 0.231644,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.38253,
+          "best_ms": 0.717626,
+          "in_gibs": 19.6745,
+          "out_gibs": 19.6745
+        },
+        "h2d": {
+          "avg_ms": 0.910678,
+          "best_ms": 0.297696,
+          "in_gibs": 51.7077,
+          "out_gibs": 51.7077
+        },
+        "scatter": {
+          "avg_ms": 0.204268,
+          "best_ms": 0.070848,
+          "in_gibs": 220.978,
+          "out_gibs": 220.978
+        },
+        "compress": {
+          "avg_ms": 73.6668,
+          "best_ms": 21.9146,
+          "in_gibs": 6.81762,
+          "out_gibs": 0.878764
+        },
+        "aggregate": {
+          "avg_ms": 0.534217,
+          "best_ms": 0.052928,
+          "in_gibs": 121.179,
+          "out_gibs": 121.179
+        },
+        "d2h": {
+          "avg_ms": 9.67607,
+          "best_ms": 2.67658,
+          "in_gibs": 6.69029,
+          "out_gibs": 6.69029
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 106.946,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 103.886,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 71.5417,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.93,
+      "status": "pass",
+      "throughput_in_gibs": 4.78248,
+      "throughput_out_gibs": 0.595128,
+      "compression_fold": 8.03606,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.437481,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.735105,
+      "init_s": 0.206362,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.40561,
+          "best_ms": 0.729474,
+          "in_gibs": 19.4857,
+          "out_gibs": 19.4857
+        },
+        "h2d": {
+          "avg_ms": 0.919353,
+          "best_ms": 0.298336,
+          "in_gibs": 51.2197,
+          "out_gibs": 51.2197
+        },
+        "scatter": {
+          "avg_ms": 0.227419,
+          "best_ms": 0.074624,
+          "in_gibs": 208.662,
+          "out_gibs": 208.662
+        },
+        "compress": {
+          "avg_ms": 72.9529,
+          "best_ms": 11.1587,
+          "in_gibs": 6.88434,
+          "out_gibs": 0.854663
+        },
+        "aggregate": {
+          "avg_ms": 0.20912,
+          "best_ms": 0.053248,
+          "in_gibs": 298.155,
+          "out_gibs": 298.155
+        },
+        "d2h": {
+          "avg_ms": 9.79835,
+          "best_ms": 2.67587,
+          "in_gibs": 6.36333,
+          "out_gibs": 6.36333
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 96.0349,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 94.4929,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 72.3232,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 3.35,
+      "status": "pass",
+      "throughput_in_gibs": 3.79576,
+      "throughput_out_gibs": 0.492048,
+      "compression_fold": 7.71419,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.455735,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.926199,
+      "init_s": 0.228621,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.39935,
+          "best_ms": 0.7268,
+          "in_gibs": 19.5365,
+          "out_gibs": 19.5365
+        },
+        "h2d": {
+          "avg_ms": 0.908877,
+          "best_ms": 0.301856,
+          "in_gibs": 51.8102,
+          "out_gibs": 51.8102
+        },
+        "scatter": {
+          "avg_ms": 0.452695,
+          "best_ms": 0.069664,
+          "in_gibs": 100.409,
+          "out_gibs": 100.409
+        },
+        "compress": {
+          "avg_ms": 104.887,
+          "best_ms": 16.318,
+          "in_gibs": 4.7883,
+          "out_gibs": 0.619945
+        },
+        "aggregate": {
+          "avg_ms": 0.201819,
+          "best_ms": 0.057344,
+          "in_gibs": 322.191,
+          "out_gibs": 322.191
+        },
+        "d2h": {
+          "avg_ms": 9.67151,
+          "best_ms": 2.6753,
+          "in_gibs": 6.7233,
+          "out_gibs": 6.7233
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 136.403,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 135.523,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 107.895,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.73,
+      "status": "pass",
+      "throughput_in_gibs": 6.24436,
+      "throughput_out_gibs": 0.653788,
+      "compression_fold": 9.55106,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.368087,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.563008,
+      "init_s": 0.205428,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.40654,
+          "best_ms": 0.757446,
+          "in_gibs": 19.4782,
+          "out_gibs": 19.4782
+        },
+        "h2d": {
+          "avg_ms": 0.911624,
+          "best_ms": 0.30688,
+          "in_gibs": 51.654,
+          "out_gibs": 51.654
+        },
+        "scatter": {
+          "avg_ms": 0.449235,
+          "best_ms": 0.074752,
+          "in_gibs": 103.854,
+          "out_gibs": 103.854
+        },
+        "compress": {
+          "avg_ms": 61.4782,
+          "best_ms": 27.4862,
+          "in_gibs": 8.16927,
+          "out_gibs": 0.85466
+        },
+        "aggregate": {
+          "avg_ms": 0.182747,
+          "best_ms": 0.05936,
+          "in_gibs": 287.517,
+          "out_gibs": 287.517
+        },
+        "d2h": {
+          "avg_ms": 9.74667,
+          "best_ms": 2.6752,
+          "in_gibs": 5.39086,
+          "out_gibs": 5.39086
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 119.123,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 118.651,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 69.9581,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.94,
+      "status": "pass",
+      "throughput_in_gibs": 6.40635,
+      "throughput_out_gibs": 0.762892,
+      "compression_fold": 8.73336,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.418653,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.548772,
+      "init_s": 0.231516,
+      "flush_s": 5.8e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.81697,
+          "best_ms": 1.04211,
+          "in_gibs": 19.8098,
+          "out_gibs": 19.8098
+        },
+        "h2d": {
+          "avg_ms": 1.08046,
+          "best_ms": 0.590432,
+          "in_gibs": 52.1558,
+          "out_gibs": 52.1558
+        },
+        "scatter": {
+          "avg_ms": 0.39558,
+          "best_ms": 0.142176,
+          "in_gibs": 142.455,
+          "out_gibs": 142.455
+        },
+        "compress": {
+          "avg_ms": 57.0157,
+          "best_ms": 31.7451,
+          "in_gibs": 9.16101,
+          "out_gibs": 1.04861
+        },
+        "aggregate": {
+          "avg_ms": 0.221961,
+          "best_ms": 0.057344,
+          "in_gibs": 269.358,
+          "out_gibs": 269.358
+        },
+        "d2h": {
+          "avg_ms": 10.0801,
+          "best_ms": 5.34742,
+          "in_gibs": 5.93123,
+          "out_gibs": 5.93123
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 108.161,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 107.9,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 68.2096,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.95,
+      "status": "pass",
+      "throughput_in_gibs": 6.19925,
+      "throughput_out_gibs": 0.764897,
+      "compression_fold": 8.42886,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.433777,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.567105,
+      "init_s": 0.227381,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.83317,
+          "best_ms": 1.03904,
+          "in_gibs": 19.6965,
+          "out_gibs": 19.6965
+        },
+        "h2d": {
+          "avg_ms": 1.08449,
+          "best_ms": 0.590368,
+          "in_gibs": 51.962,
+          "out_gibs": 51.962
+        },
+        "scatter": {
+          "avg_ms": 0.445675,
+          "best_ms": 0.14208,
+          "in_gibs": 126.213,
+          "out_gibs": 126.213
+        },
+        "compress": {
+          "avg_ms": 61.5312,
+          "best_ms": 53.5868,
+          "in_gibs": 8.48872,
+          "out_gibs": 1.00695
+        },
+        "aggregate": {
+          "avg_ms": 0.281833,
+          "best_ms": 0.075776,
+          "in_gibs": 219.843,
+          "out_gibs": 219.843
+        },
+        "d2h": {
+          "avg_ms": 10.115,
+          "best_ms": 5.34723,
+          "in_gibs": 6.12545,
+          "out_gibs": 6.12545
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 135.521,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 135.376,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 57.5761,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.77,
+      "status": "pass",
+      "throughput_in_gibs": 6.09909,
+      "throughput_out_gibs": 0.747938,
+      "compression_fold": 8.48072,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.431125,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.576418,
+      "init_s": 0.206392,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.82109,
+          "best_ms": 0.996995,
+          "in_gibs": 19.7808,
+          "out_gibs": 19.7808
+        },
+        "h2d": {
+          "avg_ms": 1.07835,
+          "best_ms": 0.591424,
+          "in_gibs": 52.2579,
+          "out_gibs": 52.2579
+        },
+        "scatter": {
+          "avg_ms": 0.453278,
+          "best_ms": 0.141792,
+          "in_gibs": 124.322,
+          "out_gibs": 124.322
+        },
+        "compress": {
+          "avg_ms": 60.894,
+          "best_ms": 52.8716,
+          "in_gibs": 8.57755,
+          "out_gibs": 1.01134
+        },
+        "aggregate": {
+          "avg_ms": 0.446464,
+          "best_ms": 0.118816,
+          "in_gibs": 137.939,
+          "out_gibs": 137.939
+        },
+        "d2h": {
+          "avg_ms": 10.0753,
+          "best_ms": 5.34733,
+          "in_gibs": 6.11245,
+          "out_gibs": 6.11245
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 133.012,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 132.913,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 72.4109,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 11.72,
+      "status": "pass",
+      "throughput_in_gibs": 8.44724,
+      "throughput_out_gibs": 8.45549,
+      "compression_fold": 0.999024,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75366,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.443932,
+      "init_s": 0.206339,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.43206,
+          "best_ms": 3.34798,
+          "in_gibs": 18.2107,
+          "out_gibs": 18.2107
+        },
+        "h2d": {
+          "avg_ms": 1.19562,
+          "best_ms": 1.1783,
+          "in_gibs": 52.2742,
+          "out_gibs": 52.2742
+        },
+        "scatter": {
+          "avg_ms": 0.335094,
+          "best_ms": 0.331648,
+          "in_gibs": 186.515,
+          "out_gibs": 186.515
+        },
+        "compress": {
+          "avg_ms": 0.920169,
+          "best_ms": 0.528192,
+          "in_gibs": 582.191,
+          "out_gibs": 582.191
+        },
+        "aggregate": {
+          "avg_ms": 1.23929,
+          "best_ms": 0.918528,
+          "in_gibs": 432.275,
+          "out_gibs": 432.275
+        },
+        "d2h": {
+          "avg_ms": 10.3074,
+          "best_ms": 7.13331,
+          "in_gibs": 51.9738,
+          "out_gibs": 51.9738
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 14.4908,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 7.85574,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.2263,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 12.38,
+      "status": "pass",
+      "throughput_in_gibs": 8.61221,
+      "throughput_out_gibs": 8.61642,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.435428,
+      "init_s": 0.205822,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.44509,
+          "best_ms": 3.34218,
+          "in_gibs": 18.1418,
+          "out_gibs": 18.1418
+        },
+        "h2d": {
+          "avg_ms": 1.19797,
+          "best_ms": 1.17891,
+          "in_gibs": 52.1715,
+          "out_gibs": 52.1715
+        },
+        "scatter": {
+          "avg_ms": 0.334614,
+          "best_ms": 0.332512,
+          "in_gibs": 186.782,
+          "out_gibs": 186.782
+        },
+        "compress": {
+          "avg_ms": 1.02432,
+          "best_ms": 0.526688,
+          "in_gibs": 522.993,
+          "out_gibs": 522.993
+        },
+        "aggregate": {
+          "avg_ms": 1.11751,
+          "best_ms": 0.74512,
+          "in_gibs": 479.381,
+          "out_gibs": 479.381
+        },
+        "d2h": {
+          "avg_ms": 10.2968,
+          "best_ms": 7.13098,
+          "in_gibs": 52.0273,
+          "out_gibs": 52.0273
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 11.9813,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 8.66608,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.77269,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.31,
+      "status": "pass",
+      "throughput_in_gibs": 8.63075,
+      "throughput_out_gibs": 8.63286,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75092,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.434493,
+      "init_s": 0.205638,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.44336,
+          "best_ms": 3.33426,
+          "in_gibs": 18.1509,
+          "out_gibs": 18.1509
+        },
+        "h2d": {
+          "avg_ms": 1.19562,
+          "best_ms": 1.17814,
+          "in_gibs": 52.274,
+          "out_gibs": 52.274
+        },
+        "scatter": {
+          "avg_ms": 0.334608,
+          "best_ms": 0.332512,
+          "in_gibs": 186.786,
+          "out_gibs": 186.786
+        },
+        "compress": {
+          "avg_ms": 1.02528,
+          "best_ms": 0.524832,
+          "in_gibs": 522.508,
+          "out_gibs": 522.508
+        },
+        "aggregate": {
+          "avg_ms": 1.1552,
+          "best_ms": 0.782816,
+          "in_gibs": 463.742,
+          "out_gibs": 463.742
+        },
+        "d2h": {
+          "avg_ms": 10.2955,
+          "best_ms": 7.13014,
+          "in_gibs": 52.0339,
+          "out_gibs": 52.0339
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 10.9857,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 9.29198,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.81911,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 11.6,
+      "status": "pass",
+      "throughput_in_gibs": 8.7439,
+      "throughput_out_gibs": 8.74497,
+      "compression_fold": 0.999878,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75046,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.42887,
+      "init_s": 0.205526,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.43679,
+          "best_ms": 3.32916,
+          "in_gibs": 18.1856,
+          "out_gibs": 18.1856
+        },
+        "h2d": {
+          "avg_ms": 1.19808,
+          "best_ms": 1.17872,
+          "in_gibs": 52.1668,
+          "out_gibs": 52.1668
+        },
+        "scatter": {
+          "avg_ms": 0.334562,
+          "best_ms": 0.332384,
+          "in_gibs": 186.811,
+          "out_gibs": 186.811
+        },
+        "compress": {
+          "avg_ms": 1.02487,
+          "best_ms": 0.524288,
+          "in_gibs": 522.713,
+          "out_gibs": 522.713
+        },
+        "aggregate": {
+          "avg_ms": 1.21646,
+          "best_ms": 0.784384,
+          "in_gibs": 440.389,
+          "out_gibs": 440.389
+        },
+        "d2h": {
+          "avg_ms": 10.2949,
+          "best_ms": 7.12941,
+          "in_gibs": 52.037,
+          "out_gibs": 52.037
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 10.4692,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 9.58708,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.69428,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.8,
+      "status": "pass",
+      "throughput_in_gibs": 8.55988,
+      "throughput_out_gibs": 8.5604,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.43809,
+      "init_s": 0.259256,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.4109,
+          "best_ms": 3.33493,
+          "in_gibs": 18.3236,
+          "out_gibs": 18.3236
+        },
+        "h2d": {
+          "avg_ms": 1.2031,
+          "best_ms": 1.17907,
+          "in_gibs": 51.9493,
+          "out_gibs": 51.9493
+        },
+        "scatter": {
+          "avg_ms": 0.334663,
+          "best_ms": 0.332544,
+          "in_gibs": 186.755,
+          "out_gibs": 186.755
+        },
+        "compress": {
+          "avg_ms": 1.46645,
+          "best_ms": 1.0696,
+          "in_gibs": 511.439,
+          "out_gibs": 511.439
+        },
+        "aggregate": {
+          "avg_ms": 1.63574,
+          "best_ms": 1.52986,
+          "in_gibs": 458.509,
+          "out_gibs": 458.509
+        },
+        "d2h": {
+          "avg_ms": 14.4635,
+          "best_ms": 14.2548,
+          "in_gibs": 51.8545,
+          "out_gibs": 51.8545
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 18.9853,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 18.5424,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.67246,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 11.72,
+      "status": "pass",
+      "throughput_in_gibs": 8.51634,
+      "throughput_out_gibs": 8.5166,
+      "compression_fold": 0.999969,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75011,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.44033,
+      "init_s": 0.257468,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.41923,
+          "best_ms": 3.33825,
+          "in_gibs": 18.279,
+          "out_gibs": 18.279
+        },
+        "h2d": {
+          "avg_ms": 1.20149,
+          "best_ms": 1.17827,
+          "in_gibs": 52.0185,
+          "out_gibs": 52.0185
+        },
+        "scatter": {
+          "avg_ms": 0.334773,
+          "best_ms": 0.332544,
+          "in_gibs": 186.694,
+          "out_gibs": 186.694
+        },
+        "compress": {
+          "avg_ms": 1.46809,
+          "best_ms": 1.07373,
+          "in_gibs": 510.868,
+          "out_gibs": 510.868
+        },
+        "aggregate": {
+          "avg_ms": 2.01482,
+          "best_ms": 1.88416,
+          "in_gibs": 372.241,
+          "out_gibs": 372.241
+        },
+        "d2h": {
+          "avg_ms": 14.4625,
+          "best_ms": 14.2548,
+          "in_gibs": 51.8582,
+          "out_gibs": 51.8582
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 19.2767,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 19.0356,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.07138,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.67,
+      "status": "pass",
+      "throughput_in_gibs": 8.55391,
+      "throughput_out_gibs": 8.55404,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75006,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.438396,
+      "init_s": 0.259028,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.41387,
+          "best_ms": 3.33481,
+          "in_gibs": 18.3076,
+          "out_gibs": 18.3076
+        },
+        "h2d": {
+          "avg_ms": 1.20316,
+          "best_ms": 1.17933,
+          "in_gibs": 51.9465,
+          "out_gibs": 51.9465
+        },
+        "scatter": {
+          "avg_ms": 0.334784,
+          "best_ms": 0.330752,
+          "in_gibs": 186.688,
+          "out_gibs": 186.688
+        },
+        "compress": {
+          "avg_ms": 1.46812,
+          "best_ms": 1.07587,
+          "in_gibs": 510.857,
+          "out_gibs": 510.857
+        },
+        "aggregate": {
+          "avg_ms": 2.04247,
+          "best_ms": 1.92717,
+          "in_gibs": 367.202,
+          "out_gibs": 367.202
+        },
+        "d2h": {
+          "avg_ms": 14.462,
+          "best_ms": 14.255,
+          "in_gibs": 51.8602,
+          "out_gibs": 51.8602
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 19.2768,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 19.1448,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.66575,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 11.73,
+      "status": "pass",
+      "throughput_in_gibs": 8.53401,
+      "throughput_out_gibs": 8.5341,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.439418,
+      "init_s": 0.259665,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.41451,
+          "best_ms": 3.32776,
+          "in_gibs": 18.3043,
+          "out_gibs": 18.3043
+        },
+        "h2d": {
+          "avg_ms": 1.20127,
+          "best_ms": 1.17818,
+          "in_gibs": 52.0283,
+          "out_gibs": 52.0283
+        },
+        "scatter": {
+          "avg_ms": 0.33477,
+          "best_ms": 0.332576,
+          "in_gibs": 186.696,
+          "out_gibs": 186.696
+        },
+        "compress": {
+          "avg_ms": 1.46895,
+          "best_ms": 1.07178,
+          "in_gibs": 510.567,
+          "out_gibs": 510.567
+        },
+        "aggregate": {
+          "avg_ms": 3.41361,
+          "best_ms": 3.3024,
+          "in_gibs": 219.709,
+          "out_gibs": 219.709
+        },
+        "d2h": {
+          "avg_ms": 14.4621,
+          "best_ms": 14.2545,
+          "in_gibs": 51.8597,
+          "out_gibs": 51.8597
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 20.6444,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 20.5457,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.66711,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.28,
+      "status": "pass",
+      "throughput_in_gibs": 8.14326,
+      "throughput_out_gibs": 3.78032,
+      "compression_fold": 2.15412,
+      "input_gib": 3.75,
+      "compressed_gib": 1.74085,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.460503,
+      "init_s": 0.207135,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.43522,
+          "best_ms": 3.32921,
+          "in_gibs": 18.1939,
+          "out_gibs": 18.1939
+        },
+        "h2d": {
+          "avg_ms": 1.20374,
+          "best_ms": 1.17875,
+          "in_gibs": 51.9216,
+          "out_gibs": 51.9216
+        },
+        "scatter": {
+          "avg_ms": 0.340279,
+          "best_ms": 0.33264,
+          "in_gibs": 183.673,
+          "out_gibs": 183.673
+        },
+        "compress": {
+          "avg_ms": 19.5269,
+          "best_ms": 13.5625,
+          "in_gibs": 27.4347,
+          "out_gibs": 12.7091
+        },
+        "aggregate": {
+          "avg_ms": 0.850304,
+          "best_ms": 0.382976,
+          "in_gibs": 291.86,
+          "out_gibs": 291.86
+        },
+        "d2h": {
+          "avg_ms": 10.4026,
+          "best_ms": 7.16426,
+          "in_gibs": 23.8565,
+          "out_gibs": 23.8565
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 26.8575,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 20.2746,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.64472,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 11.95,
+      "status": "pass",
+      "throughput_in_gibs": 8.23569,
+      "throughput_out_gibs": 3.67594,
+      "compression_fold": 2.24043,
+      "input_gib": 3.75,
+      "compressed_gib": 1.67379,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.455335,
+      "init_s": 0.206393,
+      "flush_s": 7.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.4426,
+          "best_ms": 3.33123,
+          "in_gibs": 18.1549,
+          "out_gibs": 18.1549
+        },
+        "h2d": {
+          "avg_ms": 1.2002,
+          "best_ms": 1.17827,
+          "in_gibs": 52.0747,
+          "out_gibs": 52.0747
+        },
+        "scatter": {
+          "avg_ms": 0.344328,
+          "best_ms": 0.332544,
+          "in_gibs": 181.513,
+          "out_gibs": 181.513
+        },
+        "compress": {
+          "avg_ms": 20.7186,
+          "best_ms": 13.9065,
+          "in_gibs": 25.8566,
+          "out_gibs": 11.5283
+        },
+        "aggregate": {
+          "avg_ms": 0.565618,
+          "best_ms": 0.355808,
+          "in_gibs": 422.282,
+          "out_gibs": 422.282
+        },
+        "d2h": {
+          "avg_ms": 10.364,
+          "best_ms": 7.1609,
+          "in_gibs": 23.0462,
+          "out_gibs": 23.0462
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 25.0167,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 21.6841,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 9.33913,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.95,
+      "status": "pass",
+      "throughput_in_gibs": 8.05419,
+      "throughput_out_gibs": 3.79439,
+      "compression_fold": 2.12266,
+      "input_gib": 3.75,
+      "compressed_gib": 1.76666,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.465596,
+      "init_s": 0.203011,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.43981,
+          "best_ms": 3.34035,
+          "in_gibs": 18.1696,
+          "out_gibs": 18.1696
+        },
+        "h2d": {
+          "avg_ms": 1.19603,
+          "best_ms": 1.17821,
+          "in_gibs": 52.2561,
+          "out_gibs": 52.2561
+        },
+        "scatter": {
+          "avg_ms": 0.362885,
+          "best_ms": 0.329824,
+          "in_gibs": 172.231,
+          "out_gibs": 172.231
+        },
+        "compress": {
+          "avg_ms": 25.5201,
+          "best_ms": 18.6668,
+          "in_gibs": 20.9919,
+          "out_gibs": 9.88432
+        },
+        "aggregate": {
+          "avg_ms": 0.652549,
+          "best_ms": 0.385696,
+          "in_gibs": 386.559,
+          "out_gibs": 386.559
+        },
+        "d2h": {
+          "avg_ms": 10.3605,
+          "best_ms": 7.15866,
+          "in_gibs": 24.3471,
+          "out_gibs": 24.3471
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 28.7754,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 27.059,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.3907,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 12.01,
+      "status": "pass",
+      "throughput_in_gibs": 7.7759,
+      "throughput_out_gibs": 2.8736,
+      "compression_fold": 2.70598,
+      "input_gib": 3.75,
+      "compressed_gib": 1.38582,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.482259,
+      "init_s": 0.200551,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.43527,
+          "best_ms": 3.33479,
+          "in_gibs": 18.1936,
+          "out_gibs": 18.1936
+        },
+        "h2d": {
+          "avg_ms": 1.19498,
+          "best_ms": 1.1783,
+          "in_gibs": 52.3023,
+          "out_gibs": 52.3023
+        },
+        "scatter": {
+          "avg_ms": 0.342682,
+          "best_ms": 0.33248,
+          "in_gibs": 182.385,
+          "out_gibs": 182.385
+        },
+        "compress": {
+          "avg_ms": 26.9885,
+          "best_ms": 16.8387,
+          "in_gibs": 19.8497,
+          "out_gibs": 7.33309
+        },
+        "aggregate": {
+          "avg_ms": 0.509824,
+          "best_ms": 0.313344,
+          "in_gibs": 388.19,
+          "out_gibs": 388.19
+        },
+        "d2h": {
+          "avg_ms": 10.3516,
+          "best_ms": 7.15779,
+          "in_gibs": 19.1187,
+          "out_gibs": 19.1187
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 26.3713,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 25.4764,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 34.2752,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.19,
+      "status": "pass",
+      "throughput_in_gibs": 7.81741,
+      "throughput_out_gibs": 2.3539,
+      "compression_fold": 3.32105,
+      "input_gib": 3.75,
+      "compressed_gib": 1.12916,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.479698,
+      "init_s": 0.256213,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.4274,
+          "best_ms": 3.32746,
+          "in_gibs": 18.2354,
+          "out_gibs": 18.2354
+        },
+        "h2d": {
+          "avg_ms": 1.2034,
+          "best_ms": 1.17818,
+          "in_gibs": 51.9363,
+          "out_gibs": 51.9363
+        },
+        "scatter": {
+          "avg_ms": 0.362246,
+          "best_ms": 0.332608,
+          "in_gibs": 172.535,
+          "out_gibs": 172.535
+        },
+        "compress": {
+          "avg_ms": 29.501,
+          "best_ms": 28.4795,
+          "in_gibs": 25.4228,
+          "out_gibs": 7.65351
+        },
+        "aggregate": {
+          "avg_ms": 0.602662,
+          "best_ms": 0.487424,
+          "in_gibs": 374.648,
+          "out_gibs": 374.648
+        },
+        "d2h": {
+          "avg_ms": 14.5529,
+          "best_ms": 14.3111,
+          "in_gibs": 15.5148,
+          "out_gibs": 15.5148
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 44.9184,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 44.4726,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 16.7447,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.18,
+      "status": "pass",
+      "throughput_in_gibs": 6.89793,
+      "throughput_out_gibs": 2.06495,
+      "compression_fold": 3.34049,
+      "input_gib": 3.75,
+      "compressed_gib": 1.12259,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.543641,
+      "init_s": 0.259194,
+      "flush_s": 4.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.42817,
+          "best_ms": 3.3358,
+          "in_gibs": 18.2313,
+          "out_gibs": 18.2313
+        },
+        "h2d": {
+          "avg_ms": 1.19879,
+          "best_ms": 1.17846,
+          "in_gibs": 52.1359,
+          "out_gibs": 52.1359
+        },
+        "scatter": {
+          "avg_ms": 0.35806,
+          "best_ms": 0.332608,
+          "in_gibs": 174.552,
+          "out_gibs": 174.552
+        },
+        "compress": {
+          "avg_ms": 53.8392,
+          "best_ms": 53.3975,
+          "in_gibs": 13.9304,
+          "out_gibs": 4.16974
+        },
+        "aggregate": {
+          "avg_ms": 0.717338,
+          "best_ms": 0.595936,
+          "in_gibs": 312.956,
+          "out_gibs": 312.956
+        },
+        "d2h": {
+          "avg_ms": 14.4931,
+          "best_ms": 14.3105,
+          "in_gibs": 15.4898,
+          "out_gibs": 15.4898
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 69.8441,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 69.6074,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 58.4618,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.9,
+      "status": "pass",
+      "throughput_in_gibs": 6.23305,
+      "throughput_out_gibs": 1.45161,
+      "compression_fold": 4.29388,
+      "input_gib": 3.75,
+      "compressed_gib": 0.873335,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.601631,
+      "init_s": 0.261012,
+      "flush_s": 4e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.39723,
+          "best_ms": 3.32677,
+          "in_gibs": 18.3973,
+          "out_gibs": 18.3973
+        },
+        "h2d": {
+          "avg_ms": 1.19451,
+          "best_ms": 1.17894,
+          "in_gibs": 52.3228,
+          "out_gibs": 52.3228
+        },
+        "scatter": {
+          "avg_ms": 0.348086,
+          "best_ms": 0.330976,
+          "in_gibs": 179.553,
+          "out_gibs": 179.553
+        },
+        "compress": {
+          "avg_ms": 81.823,
+          "best_ms": 79.0791,
+          "in_gibs": 9.16612,
+          "out_gibs": 2.13455
+        },
+        "aggregate": {
+          "avg_ms": 0.647917,
+          "best_ms": 0.509952,
+          "in_gibs": 269.565,
+          "out_gibs": 269.565
+        },
+        "d2h": {
+          "avg_ms": 14.4427,
+          "best_ms": 14.3103,
+          "in_gibs": 12.093,
+          "out_gibs": 12.093
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 101.965,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 101.821,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 89.6347,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.09,
+      "status": "pass",
+      "throughput_in_gibs": 5.4021,
+      "throughput_out_gibs": 0.820294,
+      "compression_fold": 6.58557,
+      "input_gib": 3.75,
+      "compressed_gib": 0.569427,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.694174,
+      "init_s": 0.259551,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.39476,
+          "best_ms": 3.32602,
+          "in_gibs": 18.4107,
+          "out_gibs": 18.4107
+        },
+        "h2d": {
+          "avg_ms": 1.19312,
+          "best_ms": 1.17824,
+          "in_gibs": 52.3837,
+          "out_gibs": 52.3837
+        },
+        "scatter": {
+          "avg_ms": 0.346161,
+          "best_ms": 0.331776,
+          "in_gibs": 180.552,
+          "out_gibs": 180.552
+        },
+        "compress": {
+          "avg_ms": 100.502,
+          "best_ms": 80.2771,
+          "in_gibs": 7.46255,
+          "out_gibs": 1.13309
+        },
+        "aggregate": {
+          "avg_ms": 0.664998,
+          "best_ms": 0.407552,
+          "in_gibs": 171.245,
+          "out_gibs": 171.245
+        },
+        "d2h": {
+          "avg_ms": 14.4464,
+          "best_ms": 14.3102,
+          "in_gibs": 7.88278,
+          "out_gibs": 7.88278
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 152.441,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 152.33,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 132.525,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 11.66,
+      "status": "pass",
+      "throughput_in_gibs": 7.95558,
+      "throughput_out_gibs": 0.984125,
+      "compression_fold": 8.08391,
+      "input_gib": 3.75,
+      "compressed_gib": 0.463885,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.471367,
+      "init_s": 0.205986,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.43304,
+          "best_ms": 3.32612,
+          "in_gibs": 18.2055,
+          "out_gibs": 18.2055
+        },
+        "h2d": {
+          "avg_ms": 1.19762,
+          "best_ms": 1.17818,
+          "in_gibs": 52.1867,
+          "out_gibs": 52.1867
+        },
+        "scatter": {
+          "avg_ms": 0.689181,
+          "best_ms": 0.332608,
+          "in_gibs": 90.6874,
+          "out_gibs": 90.6874
+        },
+        "compress": {
+          "avg_ms": 27.6404,
+          "best_ms": 19.9788,
+          "in_gibs": 19.3815,
+          "out_gibs": 2.37862
+        },
+        "aggregate": {
+          "avg_ms": 0.238597,
+          "best_ms": 0.131072,
+          "in_gibs": 275.553,
+          "out_gibs": 275.553
+        },
+        "d2h": {
+          "avg_ms": 10.3365,
+          "best_ms": 7.13664,
+          "in_gibs": 6.3606,
+          "out_gibs": 6.3606
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 33.0317,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 26.4883,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 15.9172,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 12.09,
+      "status": "pass",
+      "throughput_in_gibs": 7.41335,
+      "throughput_out_gibs": 0.898821,
+      "compression_fold": 8.24786,
+      "input_gib": 3.75,
+      "compressed_gib": 0.454663,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.505844,
+      "init_s": 0.206762,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.43472,
+          "best_ms": 3.34547,
+          "in_gibs": 18.1965,
+          "out_gibs": 18.1965
+        },
+        "h2d": {
+          "avg_ms": 1.20551,
+          "best_ms": 1.17814,
+          "in_gibs": 51.8454,
+          "out_gibs": 51.8454
+        },
+        "scatter": {
+          "avg_ms": 0.33535,
+          "best_ms": 0.327904,
+          "in_gibs": 186.372,
+          "out_gibs": 186.372
+        },
+        "compress": {
+          "avg_ms": 38.0535,
+          "best_ms": 27.414,
+          "in_gibs": 14.0779,
+          "out_gibs": 1.69998
+        },
+        "aggregate": {
+          "avg_ms": 0.227264,
+          "best_ms": 0.114336,
+          "in_gibs": 284.648,
+          "out_gibs": 284.648
+        },
+        "d2h": {
+          "avg_ms": 10.4039,
+          "best_ms": 7.13251,
+          "in_gibs": 6.21787,
+          "out_gibs": 6.21787
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 46.5718,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 43.2162,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 28.0682,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.04,
+      "status": "pass",
+      "throughput_in_gibs": 7.18249,
+      "throughput_out_gibs": 0.839768,
+      "compression_fold": 8.55294,
+      "input_gib": 3.75,
+      "compressed_gib": 0.438446,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.522103,
+      "init_s": 0.205456,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.39761,
+          "best_ms": 3.31423,
+          "in_gibs": 18.3953,
+          "out_gibs": 18.3953
+        },
+        "h2d": {
+          "avg_ms": 1.19371,
+          "best_ms": 1.17818,
+          "in_gibs": 52.3576,
+          "out_gibs": 52.3576
+        },
+        "scatter": {
+          "avg_ms": 0.845929,
+          "best_ms": 0.332512,
+          "in_gibs": 73.8833,
+          "out_gibs": 73.8833
+        },
+        "compress": {
+          "avg_ms": 40.6195,
+          "best_ms": 28.2975,
+          "in_gibs": 13.1886,
+          "out_gibs": 1.53877
+        },
+        "aggregate": {
+          "avg_ms": 0.168526,
+          "best_ms": 0.1072,
+          "in_gibs": 370.889,
+          "out_gibs": 370.889
+        },
+        "d2h": {
+          "avg_ms": 10.2817,
+          "best_ms": 7.1305,
+          "in_gibs": 6.07919,
+          "out_gibs": 6.07919
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 49.7146,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 47.9936,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 47.3575,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 12.24,
+      "status": "pass",
+      "throughput_in_gibs": 7.42925,
+      "throughput_out_gibs": 0.860923,
+      "compression_fold": 8.62941,
+      "input_gib": 3.75,
+      "compressed_gib": 0.434561,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.504762,
+      "init_s": 0.229556,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.40419,
+          "best_ms": 3.33143,
+          "in_gibs": 18.3597,
+          "out_gibs": 18.3597
+        },
+        "h2d": {
+          "avg_ms": 1.20618,
+          "best_ms": 1.17808,
+          "in_gibs": 51.8163,
+          "out_gibs": 51.8163
+        },
+        "scatter": {
+          "avg_ms": 0.698582,
+          "best_ms": 0.332512,
+          "in_gibs": 89.4669,
+          "out_gibs": 89.4669
+        },
+        "compress": {
+          "avg_ms": 42.5097,
+          "best_ms": 22.9163,
+          "in_gibs": 12.6022,
+          "out_gibs": 1.45883
+        },
+        "aggregate": {
+          "avg_ms": 0.19573,
+          "best_ms": 0.088064,
+          "in_gibs": 316.837,
+          "out_gibs": 316.837
+        },
+        "d2h": {
+          "avg_ms": 10.3586,
+          "best_ms": 7.12947,
+          "in_gibs": 5.98676,
+          "out_gibs": 5.98676
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 49.8738,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 48.8409,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 32.7896,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.51,
+      "status": "pass",
+      "throughput_in_gibs": 7.17054,
+      "throughput_out_gibs": 0.824886,
+      "compression_fold": 8.69277,
+      "input_gib": 3.75,
+      "compressed_gib": 0.431393,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.522973,
+      "init_s": 0.26117,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.41932,
+          "best_ms": 3.33714,
+          "in_gibs": 18.2785,
+          "out_gibs": 18.2785
+        },
+        "h2d": {
+          "avg_ms": 1.19809,
+          "best_ms": 1.18054,
+          "in_gibs": 52.1664,
+          "out_gibs": 52.1664
+        },
+        "scatter": {
+          "avg_ms": 0.53361,
+          "best_ms": 0.330592,
+          "in_gibs": 117.127,
+          "out_gibs": 117.127
+        },
+        "compress": {
+          "avg_ms": 44.1743,
+          "best_ms": 43.8258,
+          "in_gibs": 16.9782,
+          "out_gibs": 1.9521
+        },
+        "aggregate": {
+          "avg_ms": 0.266451,
+          "best_ms": 0.19456,
+          "in_gibs": 323.634,
+          "out_gibs": 323.634
+        },
+        "d2h": {
+          "avg_ms": 14.4264,
+          "best_ms": 14.2558,
+          "in_gibs": 5.97741,
+          "out_gibs": 5.97741
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 60.2406,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 59.7899,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 48.8183,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 11.85,
+      "status": "pass",
+      "throughput_in_gibs": 6.78254,
+      "throughput_out_gibs": 0.783407,
+      "compression_fold": 8.65775,
+      "input_gib": 3.75,
+      "compressed_gib": 0.433138,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.55289,
+      "init_s": 0.260577,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.41189,
+          "best_ms": 3.31014,
+          "in_gibs": 18.3183,
+          "out_gibs": 18.3183
+        },
+        "h2d": {
+          "avg_ms": 1.20051,
+          "best_ms": 1.17859,
+          "in_gibs": 52.0612,
+          "out_gibs": 52.0612
+        },
+        "scatter": {
+          "avg_ms": 0.651675,
+          "best_ms": 0.332576,
+          "in_gibs": 95.9067,
+          "out_gibs": 95.9067
+        },
+        "compress": {
+          "avg_ms": 66.6001,
+          "best_ms": 65.8859,
+          "in_gibs": 11.2613,
+          "out_gibs": 1.30037
+        },
+        "aggregate": {
+          "avg_ms": 0.334112,
+          "best_ms": 0.223232,
+          "in_gibs": 259.209,
+          "out_gibs": 259.209
+        },
+        "d2h": {
+          "avg_ms": 14.5099,
+          "best_ms": 14.2554,
+          "in_gibs": 5.96867,
+          "out_gibs": 5.96867
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 82.2442,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 81.9735,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 54.812,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.35,
+      "status": "pass",
+      "throughput_in_gibs": 6.53943,
+      "throughput_out_gibs": 0.767247,
+      "compression_fold": 8.52324,
+      "input_gib": 3.75,
+      "compressed_gib": 0.439974,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.573445,
+      "init_s": 0.260011,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.4157,
+          "best_ms": 3.33915,
+          "in_gibs": 18.2979,
+          "out_gibs": 18.2979
+        },
+        "h2d": {
+          "avg_ms": 1.19359,
+          "best_ms": 1.17821,
+          "in_gibs": 52.3631,
+          "out_gibs": 52.3631
+        },
+        "scatter": {
+          "avg_ms": 0.787217,
+          "best_ms": 0.332608,
+          "in_gibs": 79.3937,
+          "out_gibs": 79.3937
+        },
+        "compress": {
+          "avg_ms": 69.6505,
+          "best_ms": 68.6228,
+          "in_gibs": 10.768,
+          "out_gibs": 1.26321
+        },
+        "aggregate": {
+          "avg_ms": 0.367411,
+          "best_ms": 0.239616,
+          "in_gibs": 239.468,
+          "out_gibs": 239.468
+        },
+        "d2h": {
+          "avg_ms": 14.455,
+          "best_ms": 14.2552,
+          "in_gibs": 6.08668,
+          "out_gibs": 6.08668
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 86.4853,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 86.3224,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 74.9259,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.16,
+      "status": "pass",
+      "throughput_in_gibs": 6.54667,
+      "throughput_out_gibs": 0.765829,
+      "compression_fold": 8.54847,
+      "input_gib": 3.75,
+      "compressed_gib": 0.438675,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.57281,
+      "init_s": 0.261839,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.40469,
+          "best_ms": 3.32939,
+          "in_gibs": 18.357,
+          "out_gibs": 18.357
+        },
+        "h2d": {
+          "avg_ms": 1.19153,
+          "best_ms": 1.18093,
+          "in_gibs": 52.4536,
+          "out_gibs": 52.4536
+        },
+        "scatter": {
+          "avg_ms": 0.584705,
+          "best_ms": 0.33264,
+          "in_gibs": 106.891,
+          "out_gibs": 106.891
+        },
+        "compress": {
+          "avg_ms": 71.3698,
+          "best_ms": 70.2051,
+          "in_gibs": 10.5087,
+          "out_gibs": 1.22919
+        },
+        "aggregate": {
+          "avg_ms": 0.597811,
+          "best_ms": 0.395232,
+          "in_gibs": 146.748,
+          "out_gibs": 146.748
+        },
+        "d2h": {
+          "avg_ms": 14.3868,
+          "best_ms": 14.2549,
+          "in_gibs": 6.09779,
+          "out_gibs": 6.09779
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 86.5477,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 86.4409,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 75.219,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 28.37,
+      "status": "pass",
+      "throughput_in_gibs": 8.26006,
+      "throughput_out_gibs": 8.26812,
+      "compression_fold": 0.999024,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93255,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.354681,
+      "init_s": 0.228644,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14897,
+          "best_ms": 0.375393,
+          "in_gibs": 18.2424,
+          "out_gibs": 18.2424
+        },
+        "h2d": {
+          "avg_ms": 1.10725,
+          "best_ms": 0.158144,
+          "in_gibs": 51.8383,
+          "out_gibs": 51.8383
+        },
+        "scatter": {
+          "avg_ms": 0.255191,
+          "best_ms": 0.04,
+          "in_gibs": 224.922,
+          "out_gibs": 224.922
+        },
+        "compress": {
+          "avg_ms": 0.916486,
+          "best_ms": 0.831904,
+          "in_gibs": 639.33,
+          "out_gibs": 639.33
+        },
+        "aggregate": {
+          "avg_ms": 1.37135,
+          "best_ms": 1.17965,
+          "in_gibs": 427.269,
+          "out_gibs": 427.269
+        },
+        "d2h": {
+          "avg_ms": 11.3097,
+          "best_ms": 11.1428,
+          "in_gibs": 51.8085,
+          "out_gibs": 51.8085
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 16.951,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 11.8292,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.65636,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 28.37,
+      "status": "pass",
+      "throughput_in_gibs": 8.37811,
+      "throughput_out_gibs": 8.3822,
+      "compression_fold": 0.999512,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93112,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.349684,
+      "init_s": 0.226941,
+      "flush_s": 2.543e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.13026,
+          "best_ms": 0.3729,
+          "in_gibs": 18.3515,
+          "out_gibs": 18.3515
+        },
+        "h2d": {
+          "avg_ms": 1.10644,
+          "best_ms": 0.15712,
+          "in_gibs": 51.8765,
+          "out_gibs": 51.8765
+        },
+        "scatter": {
+          "avg_ms": 0.263391,
+          "best_ms": 0.03808,
+          "in_gibs": 217.919,
+          "out_gibs": 217.919
+        },
+        "compress": {
+          "avg_ms": 0.995469,
+          "best_ms": 0.834304,
+          "in_gibs": 588.605,
+          "out_gibs": 588.605
+        },
+        "aggregate": {
+          "avg_ms": 1.39165,
+          "best_ms": 1.16531,
+          "in_gibs": 421.039,
+          "out_gibs": 421.039
+        },
+        "d2h": {
+          "avg_ms": 11.2878,
+          "best_ms": 11.1398,
+          "in_gibs": 51.9091,
+          "out_gibs": 51.9091
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.8326,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 13.2099,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.72289,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 28.36,
+      "status": "pass",
+      "throughput_in_gibs": 8.34359,
+      "throughput_out_gibs": 8.34562,
+      "compression_fold": 0.999756,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.9304,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.35113,
+      "init_s": 0.222713,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.16053,
+          "best_ms": 0.389284,
+          "in_gibs": 18.1757,
+          "out_gibs": 18.1757
+        },
+        "h2d": {
+          "avg_ms": 1.1028,
+          "best_ms": 0.148736,
+          "in_gibs": 52.0473,
+          "out_gibs": 52.0473
+        },
+        "scatter": {
+          "avg_ms": 0.272675,
+          "best_ms": 0.040096,
+          "in_gibs": 210.499,
+          "out_gibs": 210.499
+        },
+        "compress": {
+          "avg_ms": 1.07037,
+          "best_ms": 0.832864,
+          "in_gibs": 547.417,
+          "out_gibs": 547.417
+        },
+        "aggregate": {
+          "avg_ms": 1.34577,
+          "best_ms": 1.16291,
+          "in_gibs": 435.393,
+          "out_gibs": 435.393
+        },
+        "d2h": {
+          "avg_ms": 11.2815,
+          "best_ms": 11.1386,
+          "in_gibs": 51.9379,
+          "out_gibs": 51.9379
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.2766,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 13.985,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.99323,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 28.17,
+      "status": "pass",
+      "throughput_in_gibs": 8.39708,
+      "throughput_out_gibs": 8.39811,
+      "compression_fold": 0.999878,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93005,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.348893,
+      "init_s": 0.225147,
+      "flush_s": 4.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14068,
+          "best_ms": 0.384376,
+          "in_gibs": 18.2906,
+          "out_gibs": 18.2906
+        },
+        "h2d": {
+          "avg_ms": 1.10419,
+          "best_ms": 0.15248,
+          "in_gibs": 51.9817,
+          "out_gibs": 51.9817
+        },
+        "scatter": {
+          "avg_ms": 0.281704,
+          "best_ms": 0.038048,
+          "in_gibs": 203.752,
+          "out_gibs": 203.752
+        },
+        "compress": {
+          "avg_ms": 1.06778,
+          "best_ms": 0.829312,
+          "in_gibs": 548.746,
+          "out_gibs": 548.746
+        },
+        "aggregate": {
+          "avg_ms": 1.41763,
+          "best_ms": 1.24893,
+          "in_gibs": 413.321,
+          "out_gibs": 413.321
+        },
+        "d2h": {
+          "avg_ms": 11.2689,
+          "best_ms": 11.1378,
+          "in_gibs": 51.9961,
+          "out_gibs": 51.9961
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.1166,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 14.4425,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.6804,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 28.04,
+      "status": "pass",
+      "throughput_in_gibs": 8.41552,
+      "throughput_out_gibs": 8.41603,
+      "compression_fold": 0.999939,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92987,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.348129,
+      "init_s": 0.222624,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.15205,
+          "best_ms": 0.363976,
+          "in_gibs": 18.2246,
+          "out_gibs": 18.2246
+        },
+        "h2d": {
+          "avg_ms": 1.10348,
+          "best_ms": 0.154496,
+          "in_gibs": 52.0152,
+          "out_gibs": 52.0152
+        },
+        "scatter": {
+          "avg_ms": 0.283789,
+          "best_ms": 0.037952,
+          "in_gibs": 202.256,
+          "out_gibs": 202.256
+        },
+        "compress": {
+          "avg_ms": 1.06876,
+          "best_ms": 0.82896,
+          "in_gibs": 548.24,
+          "out_gibs": 548.24
+        },
+        "aggregate": {
+          "avg_ms": 1.5937,
+          "best_ms": 1.41722,
+          "in_gibs": 367.658,
+          "out_gibs": 367.658
+        },
+        "d2h": {
+          "avg_ms": 11.2654,
+          "best_ms": 11.1372,
+          "in_gibs": 52.0123,
+          "out_gibs": 52.0123
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.1551,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 14.7756,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.71046,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 27.78,
+      "status": "pass",
+      "throughput_in_gibs": 8.39919,
+      "throughput_out_gibs": 8.39947,
+      "compression_fold": 0.999967,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92978,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.348806,
+      "init_s": 0.22317,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.15257,
+          "best_ms": 0.37344,
+          "in_gibs": 18.2216,
+          "out_gibs": 18.2216
+        },
+        "h2d": {
+          "avg_ms": 1.10364,
+          "best_ms": 0.154688,
+          "in_gibs": 52.0078,
+          "out_gibs": 52.0078
+        },
+        "scatter": {
+          "avg_ms": 0.285458,
+          "best_ms": 0.04,
+          "in_gibs": 201.073,
+          "out_gibs": 201.073
+        },
+        "compress": {
+          "avg_ms": 1.14429,
+          "best_ms": 0.829088,
+          "in_gibs": 512.051,
+          "out_gibs": 512.051
+        },
+        "aggregate": {
+          "avg_ms": 1.87405,
+          "best_ms": 1.76128,
+          "in_gibs": 312.658,
+          "out_gibs": 312.658
+        },
+        "d2h": {
+          "avg_ms": 11.264,
+          "best_ms": 11.1373,
+          "in_gibs": 52.0187,
+          "out_gibs": 52.0187
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.4492,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 15.2234,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.68843,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.37,
+      "status": "pass",
+      "throughput_in_gibs": 8.38671,
+      "throughput_out_gibs": 8.38684,
+      "compression_fold": 0.999985,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92973,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.349325,
+      "init_s": 0.228091,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.15656,
+          "best_ms": 0.362895,
+          "in_gibs": 18.1986,
+          "out_gibs": 18.1986
+        },
+        "h2d": {
+          "avg_ms": 1.104,
+          "best_ms": 0.154656,
+          "in_gibs": 51.9911,
+          "out_gibs": 51.9911
+        },
+        "scatter": {
+          "avg_ms": 0.30181,
+          "best_ms": 0.04,
+          "in_gibs": 190.179,
+          "out_gibs": 190.179
+        },
+        "compress": {
+          "avg_ms": 1.14532,
+          "best_ms": 0.829088,
+          "in_gibs": 511.594,
+          "out_gibs": 511.594
+        },
+        "aggregate": {
+          "avg_ms": 1.92447,
+          "best_ms": 1.81453,
+          "in_gibs": 304.467,
+          "out_gibs": 304.467
+        },
+        "d2h": {
+          "avg_ms": 11.2652,
+          "best_ms": 11.1369,
+          "in_gibs": 52.013,
+          "out_gibs": 52.013
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.4461,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 15.3156,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.70098,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 28.68,
+      "status": "pass",
+      "throughput_in_gibs": 8.03586,
+      "throughput_out_gibs": 9.64311,
+      "compression_fold": 0.999992,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.51565,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.364577,
+      "init_s": 0.391675,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.28492,
+          "best_ms": 0.797146,
+          "in_gibs": 18.2012,
+          "out_gibs": 18.2012
+        },
+        "h2d": {
+          "avg_ms": 1.15333,
+          "best_ms": 0.374144,
+          "in_gibs": 51.8848,
+          "out_gibs": 51.8848
+        },
+        "scatter": {
+          "avg_ms": 0.346895,
+          "best_ms": 0.142144,
+          "in_gibs": 172.503,
+          "out_gibs": 172.503
+        },
+        "compress": {
+          "avg_ms": 1.95403,
+          "best_ms": 1.68413,
+          "in_gibs": 599.723,
+          "out_gibs": 599.723
+        },
+        "aggregate": {
+          "avg_ms": 4.06798,
+          "best_ms": 3.72317,
+          "in_gibs": 288.073,
+          "out_gibs": 288.073
+        },
+        "d2h": {
+          "avg_ms": 22.5321,
+          "best_ms": 22.2708,
+          "in_gibs": 52.0091,
+          "out_gibs": 52.0091
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 29.0959,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 29.0287,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.24321,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 27.85,
+      "status": "pass",
+      "throughput_in_gibs": 7.31806,
+      "throughput_out_gibs": 3.83484,
+      "compression_fold": 1.90831,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.53523,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.400337,
+      "init_s": 0.230605,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.1613,
+          "best_ms": 0.405959,
+          "in_gibs": 18.1713,
+          "out_gibs": 18.1713
+        },
+        "h2d": {
+          "avg_ms": 1.1009,
+          "best_ms": 0.152704,
+          "in_gibs": 52.1372,
+          "out_gibs": 52.1372
+        },
+        "scatter": {
+          "avg_ms": 0.265873,
+          "best_ms": 0.040096,
+          "in_gibs": 220.724,
+          "out_gibs": 220.724
+        },
+        "compress": {
+          "avg_ms": 24.5181,
+          "best_ms": 24.4132,
+          "in_gibs": 23.8982,
+          "out_gibs": 12.4999
+        },
+        "aggregate": {
+          "avg_ms": 0.898317,
+          "best_ms": 0.641056,
+          "in_gibs": 341.164,
+          "out_gibs": 341.164
+        },
+        "d2h": {
+          "avg_ms": 11.3299,
+          "best_ms": 11.1922,
+          "in_gibs": 27.05,
+          "out_gibs": 27.05
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 39.6062,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 34.5521,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 28.731,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 28.7,
+      "status": "pass",
+      "throughput_in_gibs": 7.27577,
+      "throughput_out_gibs": 3.76713,
+      "compression_fold": 1.93138,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.51688,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.402664,
+      "init_s": 0.226499,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.15356,
+          "best_ms": 0.392138,
+          "in_gibs": 18.2159,
+          "out_gibs": 18.2159
+        },
+        "h2d": {
+          "avg_ms": 1.10456,
+          "best_ms": 0.148736,
+          "in_gibs": 51.9644,
+          "out_gibs": 51.9644
+        },
+        "scatter": {
+          "avg_ms": 0.265106,
+          "best_ms": 0.038784,
+          "in_gibs": 221.363,
+          "out_gibs": 221.363
+        },
+        "compress": {
+          "avg_ms": 27.0902,
+          "best_ms": 26.8749,
+          "in_gibs": 21.6291,
+          "out_gibs": 11.1882
+        },
+        "aggregate": {
+          "avg_ms": 0.901734,
+          "best_ms": 0.62464,
+          "in_gibs": 336.12,
+          "out_gibs": 336.12
+        },
+        "d2h": {
+          "avg_ms": 11.3546,
+          "best_ms": 11.1861,
+          "in_gibs": 26.6931,
+          "out_gibs": 26.6931
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 40.9675,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 38.4261,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 31.1894,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 27.77,
+      "status": "pass",
+      "throughput_in_gibs": 7.31053,
+      "throughput_out_gibs": 3.71229,
+      "compression_fold": 1.96928,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.4877,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.400749,
+      "init_s": 0.230432,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.17008,
+          "best_ms": 0.391317,
+          "in_gibs": 18.121,
+          "out_gibs": 18.121
+        },
+        "h2d": {
+          "avg_ms": 1.10391,
+          "best_ms": 0.152736,
+          "in_gibs": 51.9952,
+          "out_gibs": 51.9952
+        },
+        "scatter": {
+          "avg_ms": 0.277252,
+          "best_ms": 0.03808,
+          "in_gibs": 213.35,
+          "out_gibs": 213.35
+        },
+        "compress": {
+          "avg_ms": 31.2753,
+          "best_ms": 30.9589,
+          "in_gibs": 18.7348,
+          "out_gibs": 9.50897
+        },
+        "aggregate": {
+          "avg_ms": 0.701907,
+          "best_ms": 0.612,
+          "in_gibs": 423.697,
+          "out_gibs": 423.697
+        },
+        "d2h": {
+          "avg_ms": 11.3408,
+          "best_ms": 11.183,
+          "in_gibs": 26.2235,
+          "out_gibs": 26.2235
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 44.5463,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 43.2126,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 23.1944,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 28.12,
+      "status": "pass",
+      "throughput_in_gibs": 7.19664,
+      "throughput_out_gibs": 3.1374,
+      "compression_fold": 2.29382,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.27721,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.407091,
+      "init_s": 0.22849,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.1492,
+          "best_ms": 0.377256,
+          "in_gibs": 18.2411,
+          "out_gibs": 18.2411
+        },
+        "h2d": {
+          "avg_ms": 1.10347,
+          "best_ms": 0.15312,
+          "in_gibs": 52.0157,
+          "out_gibs": 52.0157
+        },
+        "scatter": {
+          "avg_ms": 0.274963,
+          "best_ms": 0.039968,
+          "in_gibs": 215.126,
+          "out_gibs": 215.126
+        },
+        "compress": {
+          "avg_ms": 36.3231,
+          "best_ms": 35.2933,
+          "in_gibs": 16.1312,
+          "out_gibs": 7.0305
+        },
+        "aggregate": {
+          "avg_ms": 0.667405,
+          "best_ms": 0.562848,
+          "in_gibs": 382.631,
+          "out_gibs": 382.631
+        },
+        "d2h": {
+          "avg_ms": 11.3141,
+          "best_ms": 11.1816,
+          "in_gibs": 22.571,
+          "out_gibs": 22.571
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 49.5363,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 48.846,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 28.5282,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 28.19,
+      "status": "pass",
+      "throughput_in_gibs": 7.02805,
+      "throughput_out_gibs": 2.8457,
+      "compression_fold": 2.46971,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.18625,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.416856,
+      "init_s": 0.248263,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.12773,
+          "best_ms": 0.395383,
+          "in_gibs": 18.3663,
+          "out_gibs": 18.3663
+        },
+        "h2d": {
+          "avg_ms": 1.10314,
+          "best_ms": 0.153152,
+          "in_gibs": 52.0313,
+          "out_gibs": 52.0313
+        },
+        "scatter": {
+          "avg_ms": 0.284561,
+          "best_ms": 0.037888,
+          "in_gibs": 201.707,
+          "out_gibs": 201.707
+        },
+        "compress": {
+          "avg_ms": 35.5991,
+          "best_ms": 34.5451,
+          "in_gibs": 16.4593,
+          "out_gibs": 6.66349
+        },
+        "aggregate": {
+          "avg_ms": 0.697338,
+          "best_ms": 0.589824,
+          "in_gibs": 340.171,
+          "out_gibs": 340.171
+        },
+        "d2h": {
+          "avg_ms": 11.3071,
+          "best_ms": 11.1809,
+          "in_gibs": 20.9793,
+          "out_gibs": 20.9793
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 48.2864,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 47.8758,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 40.5937,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 28.11,
+      "status": "pass",
+      "throughput_in_gibs": 6.14278,
+      "throughput_out_gibs": 2.50215,
+      "compression_fold": 2.455,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.19336,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.476932,
+      "init_s": 0.235335,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.0887,
+          "best_ms": 0.397096,
+          "in_gibs": 18.5984,
+          "out_gibs": 18.5984
+        },
+        "h2d": {
+          "avg_ms": 1.10107,
+          "best_ms": 0.1496,
+          "in_gibs": 52.129,
+          "out_gibs": 52.129
+        },
+        "scatter": {
+          "avg_ms": 0.270465,
+          "best_ms": 0.040992,
+          "in_gibs": 212.22,
+          "out_gibs": 212.22
+        },
+        "compress": {
+          "avg_ms": 64.0568,
+          "best_ms": 63.1927,
+          "in_gibs": 9.14715,
+          "out_gibs": 3.72563
+        },
+        "aggregate": {
+          "avg_ms": 0.826746,
+          "best_ms": 0.720928,
+          "in_gibs": 288.665,
+          "out_gibs": 288.665
+        },
+        "d2h": {
+          "avg_ms": 11.3029,
+          "best_ms": 11.1804,
+          "in_gibs": 21.1143,
+          "out_gibs": 21.1143
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 78.6202,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 78.3788,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 68.812,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.23,
+      "status": "pass",
+      "throughput_in_gibs": 5.09549,
+      "throughput_out_gibs": 1.35267,
+      "compression_fold": 3.76698,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.777729,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.574957,
+      "init_s": 0.221946,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.1274,
+          "best_ms": 0.390005,
+          "in_gibs": 18.3683,
+          "out_gibs": 18.3683
+        },
+        "h2d": {
+          "avg_ms": 1.101,
+          "best_ms": 0.152,
+          "in_gibs": 52.1324,
+          "out_gibs": 52.1324
+        },
+        "scatter": {
+          "avg_ms": 0.260045,
+          "best_ms": 0.04096,
+          "in_gibs": 220.723,
+          "out_gibs": 220.723
+        },
+        "compress": {
+          "avg_ms": 84.3467,
+          "best_ms": 61.9076,
+          "in_gibs": 6.94677,
+          "out_gibs": 1.84402
+        },
+        "aggregate": {
+          "avg_ms": 0.592314,
+          "best_ms": 0.346112,
+          "in_gibs": 262.592,
+          "out_gibs": 262.592
+        },
+        "d2h": {
+          "avg_ms": 11.2955,
+          "best_ms": 11.1807,
+          "in_gibs": 13.7698,
+          "out_gibs": 13.7698
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 132.767,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 132.648,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 116.97,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 28.89,
+      "status": "pass",
+      "throughput_in_gibs": 3.4853,
+      "throughput_out_gibs": 1.12668,
+      "compression_fold": 3.7121,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.947071,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.840584,
+      "init_s": 0.439789,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.21029,
+          "best_ms": 0.834612,
+          "in_gibs": 18.6244,
+          "out_gibs": 18.6244
+        },
+        "h2d": {
+          "avg_ms": 1.14009,
+          "best_ms": 0.406016,
+          "in_gibs": 52.4875,
+          "out_gibs": 52.4875
+        },
+        "scatter": {
+          "avg_ms": 0.275619,
+          "best_ms": 0.136224,
+          "in_gibs": 217.113,
+          "out_gibs": 217.113
+        },
+        "compress": {
+          "avg_ms": 175.637,
+          "best_ms": 123.448,
+          "in_gibs": 6.67212,
+          "out_gibs": 1.79735
+        },
+        "aggregate": {
+          "avg_ms": 1.28979,
+          "best_ms": 0.647168,
+          "in_gibs": 244.754,
+          "out_gibs": 244.754
+        },
+        "d2h": {
+          "avg_ms": 22.4471,
+          "best_ms": 22.3572,
+          "in_gibs": 14.0633,
+          "out_gibs": 14.0633
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 311.251,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 311.168,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 207.381,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 28.43,
+      "status": "pass",
+      "throughput_in_gibs": 4.2183,
+      "throughput_out_gibs": 0.602093,
+      "compression_fold": 7.00606,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.418165,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.694519,
+      "init_s": 0.227422,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14726,
+          "best_ms": 0.392098,
+          "in_gibs": 18.2523,
+          "out_gibs": 18.2523
+        },
+        "h2d": {
+          "avg_ms": 1.10355,
+          "best_ms": 0.151968,
+          "in_gibs": 52.012,
+          "out_gibs": 52.012
+        },
+        "scatter": {
+          "avg_ms": 0.540303,
+          "best_ms": 0.03792,
+          "in_gibs": 107.89,
+          "out_gibs": 107.89
+        },
+        "compress": {
+          "avg_ms": 90.2186,
+          "best_ms": 89.3552,
+          "in_gibs": 6.49464,
+          "out_gibs": 0.920661
+        },
+        "aggregate": {
+          "avg_ms": 0.662419,
+          "best_ms": 0.223232,
+          "in_gibs": 125.39,
+          "out_gibs": 125.39
+        },
+        "d2h": {
+          "avg_ms": 11.3029,
+          "best_ms": 11.15,
+          "in_gibs": 7.3486,
+          "out_gibs": 7.3486
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 104.987,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 99.9199,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 93.6707,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 29.07,
+      "status": "pass",
+      "throughput_in_gibs": 3.51549,
+      "throughput_out_gibs": 0.51623,
+      "compression_fold": 6.80994,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.430208,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.833364,
+      "init_s": 0.219984,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14939,
+          "best_ms": 0.359359,
+          "in_gibs": 18.24,
+          "out_gibs": 18.24
+        },
+        "h2d": {
+          "avg_ms": 1.10579,
+          "best_ms": 0.154336,
+          "in_gibs": 51.9068,
+          "out_gibs": 51.9068
+        },
+        "scatter": {
+          "avg_ms": 0.655696,
+          "best_ms": 0.038048,
+          "in_gibs": 89.8195,
+          "out_gibs": 89.8195
+        },
+        "compress": {
+          "avg_ms": 122.469,
+          "best_ms": 120.936,
+          "in_gibs": 4.78436,
+          "out_gibs": 0.700218
+        },
+        "aggregate": {
+          "avg_ms": 0.294675,
+          "best_ms": 0.206848,
+          "in_gibs": 291.016,
+          "out_gibs": 291.016
+        },
+        "d2h": {
+          "avg_ms": 11.3045,
+          "best_ms": 11.1434,
+          "in_gibs": 7.58597,
+          "out_gibs": 7.58597
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 135.366,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 132.433,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 113.219,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 29.1,
+      "status": "pass",
+      "throughput_in_gibs": 3.54182,
+      "throughput_out_gibs": 0.480372,
+      "compression_fold": 7.37307,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.39735,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.82717,
+      "init_s": 0.22014,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.15694,
+          "best_ms": 0.383966,
+          "in_gibs": 18.1964,
+          "out_gibs": 18.1964
+        },
+        "h2d": {
+          "avg_ms": 1.11182,
+          "best_ms": 0.151872,
+          "in_gibs": 51.6253,
+          "out_gibs": 51.6253
+        },
+        "scatter": {
+          "avg_ms": 0.457446,
+          "best_ms": 0.03808,
+          "in_gibs": 128.746,
+          "out_gibs": 128.746
+        },
+        "compress": {
+          "avg_ms": 122.929,
+          "best_ms": 122.137,
+          "in_gibs": 4.76648,
+          "out_gibs": 0.645307
+        },
+        "aggregate": {
+          "avg_ms": 0.265958,
+          "best_ms": 0.173536,
+          "in_gibs": 298.268,
+          "out_gibs": 298.268
+        },
+        "d2h": {
+          "avg_ms": 11.3401,
+          "best_ms": 11.1396,
+          "in_gibs": 6.99522,
+          "out_gibs": 6.99522
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 135.201,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 133.905,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 114.704,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 28.87,
+      "status": "pass",
+      "throughput_in_gibs": 3.5152,
+      "throughput_out_gibs": 0.501191,
+      "compression_fold": 7.01371,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.417709,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.833433,
+      "init_s": 0.230327,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14668,
+          "best_ms": 0.562133,
+          "in_gibs": 18.2557,
+          "out_gibs": 18.2557
+        },
+        "h2d": {
+          "avg_ms": 1.10423,
+          "best_ms": 0.173056,
+          "in_gibs": 51.9803,
+          "out_gibs": 51.9803
+        },
+        "scatter": {
+          "avg_ms": 0.489583,
+          "best_ms": 0.044704,
+          "in_gibs": 116.888,
+          "out_gibs": 116.888
+        },
+        "compress": {
+          "avg_ms": 128.941,
+          "best_ms": 127.059,
+          "in_gibs": 4.54424,
+          "out_gibs": 0.647353
+        },
+        "aggregate": {
+          "avg_ms": 0.235149,
+          "best_ms": 0.18288,
+          "in_gibs": 354.968,
+          "out_gibs": 354.968
+        },
+        "d2h": {
+          "avg_ms": 11.3251,
+          "best_ms": 11.1386,
+          "in_gibs": 7.37038,
+          "out_gibs": 7.37038
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 139.955,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 139.273,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 131.902,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 28.25,
+      "status": "pass",
+      "throughput_in_gibs": 5.48251,
+      "throughput_out_gibs": 0.625681,
+      "compression_fold": 8.76246,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.334345,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.53437,
+      "init_s": 0.220853,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14815,
+          "best_ms": 0.384787,
+          "in_gibs": 18.2472,
+          "out_gibs": 18.2472
+        },
+        "h2d": {
+          "avg_ms": 1.09933,
+          "best_ms": 0.152,
+          "in_gibs": 52.2117,
+          "out_gibs": 52.2117
+        },
+        "scatter": {
+          "avg_ms": 0.478661,
+          "best_ms": 0.090144,
+          "in_gibs": 119.914,
+          "out_gibs": 119.914
+        },
+        "compress": {
+          "avg_ms": 76.267,
+          "best_ms": 62.8063,
+          "in_gibs": 7.68271,
+          "out_gibs": 0.876306
+        },
+        "aggregate": {
+          "avg_ms": 0.241626,
+          "best_ms": 0.115488,
+          "in_gibs": 276.598,
+          "out_gibs": 276.598
+        },
+        "d2h": {
+          "avg_ms": 11.2496,
+          "best_ms": 11.1375,
+          "in_gibs": 5.94095,
+          "out_gibs": 5.94095
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 113.003,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 112.659,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 94.1582,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 28.57,
+      "status": "pass",
+      "throughput_in_gibs": 6.15055,
+      "throughput_out_gibs": 0.848569,
+      "compression_fold": 7.24814,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.404199,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.47633,
+      "init_s": 0.223896,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14734,
+          "best_ms": 0.383255,
+          "in_gibs": 18.2519,
+          "out_gibs": 18.2519
+        },
+        "h2d": {
+          "avg_ms": 1.10066,
+          "best_ms": 0.153184,
+          "in_gibs": 52.1488,
+          "out_gibs": 52.1488
+        },
+        "scatter": {
+          "avg_ms": 0.299042,
+          "best_ms": 0.079872,
+          "in_gibs": 192.881,
+          "out_gibs": 192.881
+        },
+        "compress": {
+          "avg_ms": 66.9616,
+          "best_ms": 63.2709,
+          "in_gibs": 8.75035,
+          "out_gibs": 1.20697
+        },
+        "aggregate": {
+          "avg_ms": 0.292998,
+          "best_ms": 0.190112,
+          "in_gibs": 275.84,
+          "out_gibs": 275.84
+        },
+        "d2h": {
+          "avg_ms": 11.2511,
+          "best_ms": 11.1377,
+          "in_gibs": 7.18334,
+          "out_gibs": 7.18334
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 88.7528,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 88.5468,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 61.2309,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.21,
+      "status": "pass",
+      "throughput_in_gibs": 5.8726,
+      "throughput_out_gibs": 0.801661,
+      "compression_fold": 7.32555,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.399928,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.498874,
+      "init_s": 0.224329,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.12938,
+          "best_ms": 0.398608,
+          "in_gibs": 18.3566,
+          "out_gibs": 18.3566
+        },
+        "h2d": {
+          "avg_ms": 1.1014,
+          "best_ms": 0.149472,
+          "in_gibs": 52.1137,
+          "out_gibs": 52.1137
+        },
+        "scatter": {
+          "avg_ms": 0.410127,
+          "best_ms": 0.08848,
+          "in_gibs": 139.952,
+          "out_gibs": 139.952
+        },
+        "compress": {
+          "avg_ms": 69.0624,
+          "best_ms": 63.4665,
+          "in_gibs": 8.48417,
+          "out_gibs": 1.15803
+        },
+        "aggregate": {
+          "avg_ms": 0.367283,
+          "best_ms": 0.249504,
+          "in_gibs": 217.752,
+          "out_gibs": 217.752
+        },
+        "d2h": {
+          "avg_ms": 11.2623,
+          "best_ms": 11.1373,
+          "in_gibs": 7.10128,
+          "out_gibs": 7.10128
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 94.0067,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 93.8928,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 76.0392,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 29.09,
+      "status": "pass",
+      "throughput_in_gibs": 3.83742,
+      "throughput_out_gibs": 0.538241,
+      "compression_fold": 8.55547,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.410921,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.763452,
+      "init_s": 0.390704,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.255,
+          "best_ms": 0.838948,
+          "in_gibs": 18.3685,
+          "out_gibs": 18.3685
+        },
+        "h2d": {
+          "avg_ms": 1.14071,
+          "best_ms": 0.38608,
+          "in_gibs": 52.4589,
+          "out_gibs": 52.4589
+        },
+        "scatter": {
+          "avg_ms": 0.329787,
+          "best_ms": 0.14224,
+          "in_gibs": 181.452,
+          "out_gibs": 181.452
+        },
+        "compress": {
+          "avg_ms": 148.771,
+          "best_ms": 73.9294,
+          "in_gibs": 7.87703,
+          "out_gibs": 0.92064
+        },
+        "aggregate": {
+          "avg_ms": 0.754005,
+          "best_ms": 0.278528,
+          "in_gibs": 181.65,
+          "out_gibs": 181.65
+        },
+        "d2h": {
+          "avg_ms": 22.3594,
+          "best_ms": 22.2709,
+          "in_gibs": 6.12559,
+          "out_gibs": 6.12559
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 245.976,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 245.903,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 189.043,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.52,
+      "status": "pass",
+      "throughput_in_gibs": 0.950892,
+      "throughput_out_gibs": 0.951821,
+      "compression_fold": 0.999024,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312805,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0328639,
+      "init_s": 0.212965,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000523462,
+          "best_ms": 0.00032,
+          "in_gibs": 29.1498,
+          "out_gibs": 29.1498
+        },
+        "scatter": {
+          "avg_ms": 0.458912,
+          "best_ms": 0.458912,
+          "in_gibs": 0.0332499,
+          "out_gibs": 0.0332499
+        },
+        "compress": {
+          "avg_ms": 0.016384,
+          "best_ms": 0.016384,
+          "in_gibs": 1907.35,
+          "out_gibs": 1907.35
+        },
+        "aggregate": {
+          "avg_ms": 0.52736,
+          "best_ms": 0.52736,
+          "in_gibs": 59.2574,
+          "out_gibs": 59.2574
+        },
+        "d2h": {
+          "avg_ms": 0.603488,
+          "best_ms": 0.603488,
+          "in_gibs": 51.7823,
+          "out_gibs": 51.7823
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.697687,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.621181,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 23.5086,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.53,
+      "status": "pass",
+      "throughput_in_gibs": 1.54262,
+      "throughput_out_gibs": 1.54337,
+      "compression_fold": 0.999511,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312653,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0202577,
+      "init_s": 0.212052,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000895078,
+          "best_ms": 0.000631,
+          "in_gibs": 34.0949,
+          "out_gibs": 34.0949
+        },
+        "h2d": {
+          "avg_ms": 0.015744,
+          "best_ms": 0.015744,
+          "in_gibs": 1.93836,
+          "out_gibs": 1.93836
+        },
+        "scatter": {
+          "avg_ms": 0.077216,
+          "best_ms": 0.010112,
+          "in_gibs": 0.395223,
+          "out_gibs": 0.395223
+        },
+        "compress": {
+          "avg_ms": 0.014336,
+          "best_ms": 0.014336,
+          "in_gibs": 2179.83,
+          "out_gibs": 2179.83
+        },
+        "aggregate": {
+          "avg_ms": 0.118784,
+          "best_ms": 0.118784,
+          "in_gibs": 263.083,
+          "out_gibs": 263.083
+        },
+        "d2h": {
+          "avg_ms": 0.604576,
+          "best_ms": 0.604576,
+          "in_gibs": 51.6891,
+          "out_gibs": 51.6891
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.66695,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.621823,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.9148,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.57,
+      "status": "pass",
+      "throughput_in_gibs": 2.17661,
+      "throughput_out_gibs": 2.17714,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0143572,
+      "init_s": 0.209622,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00161829,
+          "best_ms": 0.001232,
+          "in_gibs": 37.7157,
+          "out_gibs": 37.7157
+        },
+        "h2d": {
+          "avg_ms": 0.017024,
+          "best_ms": 0.017024,
+          "in_gibs": 3.58524,
+          "out_gibs": 3.58524
+        },
+        "scatter": {
+          "avg_ms": 0.06986,
+          "best_ms": 0.01024,
+          "in_gibs": 0.873678,
+          "out_gibs": 0.873678
+        },
+        "compress": {
+          "avg_ms": 0.016384,
+          "best_ms": 0.016384,
+          "in_gibs": 1907.35,
+          "out_gibs": 1907.35
+        },
+        "aggregate": {
+          "avg_ms": 0.132096,
+          "best_ms": 0.132096,
+          "in_gibs": 236.57,
+          "out_gibs": 236.57
+        },
+        "d2h": {
+          "avg_ms": 0.59952,
+          "best_ms": 0.59952,
+          "in_gibs": 52.125,
+          "out_gibs": 52.125
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.663304,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.636314,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.97742,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.52,
+      "status": "pass",
+      "throughput_in_gibs": 2.51224,
+      "throughput_out_gibs": 2.51255,
+      "compression_fold": 0.999877,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312538,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0124391,
+      "init_s": 0.208672,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00321659,
+          "best_ms": 0.002734,
+          "in_gibs": 37.9503,
+          "out_gibs": 37.9503
+        },
+        "h2d": {
+          "avg_ms": 0.019584,
+          "best_ms": 0.019584,
+          "in_gibs": 6.23317,
+          "out_gibs": 6.23317
+        },
+        "scatter": {
+          "avg_ms": 0.0127516,
+          "best_ms": 0.010048,
+          "in_gibs": 9.57291,
+          "out_gibs": 9.57291
+        },
+        "compress": {
+          "avg_ms": 0.01536,
+          "best_ms": 0.01536,
+          "in_gibs": 2034.51,
+          "out_gibs": 2034.51
+        },
+        "aggregate": {
+          "avg_ms": 0.166912,
+          "best_ms": 0.166912,
+          "in_gibs": 187.224,
+          "out_gibs": 187.224
+        },
+        "d2h": {
+          "avg_ms": 0.598208,
+          "best_ms": 0.598208,
+          "in_gibs": 52.2394,
+          "out_gibs": 52.2394
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.693049,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.674382,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.70584,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.52,
+      "status": "pass",
+      "throughput_in_gibs": 2.81734,
+      "throughput_out_gibs": 2.81751,
+      "compression_fold": 0.999938,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312519,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.011092,
+      "init_s": 0.208773,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00635159,
+          "best_ms": 0.005509,
+          "in_gibs": 38.4377,
+          "out_gibs": 38.4377
+        },
+        "h2d": {
+          "avg_ms": 0.027584,
+          "best_ms": 0.027584,
+          "in_gibs": 8.85081,
+          "out_gibs": 8.85081
+        },
+        "scatter": {
+          "avg_ms": 0.0334094,
+          "best_ms": 0.01024,
+          "in_gibs": 7.30754,
+          "out_gibs": 7.30754
+        },
+        "compress": {
+          "avg_ms": 0.016384,
+          "best_ms": 0.016384,
+          "in_gibs": 1907.35,
+          "out_gibs": 1907.35
+        },
+        "aggregate": {
+          "avg_ms": 0.242688,
+          "best_ms": 0.242688,
+          "in_gibs": 128.766,
+          "out_gibs": 128.766
+        },
+        "d2h": {
+          "avg_ms": 0.599232,
+          "best_ms": 0.599232,
+          "in_gibs": 52.1501,
+          "out_gibs": 52.1501
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.770787,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.760651,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.56733,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.53,
+      "status": "pass",
+      "throughput_in_gibs": 2.72529,
+      "throughput_out_gibs": 2.72537,
+      "compression_fold": 0.999969,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.031251,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0114667,
+      "init_s": 0.211429,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0164619,
+          "best_ms": 0.013,
+          "in_gibs": 29.6612,
+          "out_gibs": 29.6612
+        },
+        "h2d": {
+          "avg_ms": 0.0119412,
+          "best_ms": 0.010944,
+          "in_gibs": 40.8906,
+          "out_gibs": 40.8906
+        },
+        "scatter": {
+          "avg_ms": 0.0617947,
+          "best_ms": 0.01024,
+          "in_gibs": 7.90167,
+          "out_gibs": 7.90167
+        },
+        "compress": {
+          "avg_ms": 0.014336,
+          "best_ms": 0.014336,
+          "in_gibs": 2179.83,
+          "out_gibs": 2179.83
+        },
+        "aggregate": {
+          "avg_ms": 0.816128,
+          "best_ms": 0.816128,
+          "in_gibs": 38.2906,
+          "out_gibs": 38.2906
+        },
+        "d2h": {
+          "avg_ms": 0.601312,
+          "best_ms": 0.601312,
+          "in_gibs": 51.9697,
+          "out_gibs": 51.9697
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.937406,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.928743,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.4067,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.5,
+      "status": "pass",
+      "throughput_in_gibs": 2.51918,
+      "throughput_out_gibs": 2.51922,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0124048,
+      "init_s": 0.210128,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0423867,
+          "best_ms": 0.038247,
+          "in_gibs": 23.0394,
+          "out_gibs": 23.0394
+        },
+        "h2d": {
+          "avg_ms": 0.0242091,
+          "best_ms": 0.021728,
+          "in_gibs": 40.3387,
+          "out_gibs": 40.3387
+        },
+        "scatter": {
+          "avg_ms": 0.0274155,
+          "best_ms": 0.011424,
+          "in_gibs": 35.6209,
+          "out_gibs": 35.6209
+        },
+        "compress": {
+          "avg_ms": 0.014336,
+          "best_ms": 0.014336,
+          "in_gibs": 2179.83,
+          "out_gibs": 2179.83
+        },
+        "aggregate": {
+          "avg_ms": 1.21856,
+          "best_ms": 1.21856,
+          "in_gibs": 25.645,
+          "out_gibs": 25.645
+        },
+        "d2h": {
+          "avg_ms": 0.598272,
+          "best_ms": 0.598272,
+          "in_gibs": 52.2338,
+          "out_gibs": 52.2338
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.27363,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.26138,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.29545,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.52,
+      "status": "pass",
+      "throughput_in_gibs": 2.68581,
+      "throughput_out_gibs": 2.68585,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0116352,
+      "init_s": 0.211475,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0438199,
+          "best_ms": 0.03984,
+          "in_gibs": 22.2858,
+          "out_gibs": 22.2858
+        },
+        "h2d": {
+          "avg_ms": 0.025024,
+          "best_ms": 0.021664,
+          "in_gibs": 39.025,
+          "out_gibs": 39.025
+        },
+        "scatter": {
+          "avg_ms": 0.0269131,
+          "best_ms": 0.011424,
+          "in_gibs": 36.2858,
+          "out_gibs": 36.2858
+        },
+        "compress": {
+          "avg_ms": 0.012288,
+          "best_ms": 0.012288,
+          "in_gibs": 2543.13,
+          "out_gibs": 2543.13
+        },
+        "aggregate": {
+          "avg_ms": 0.754688,
+          "best_ms": 0.754688,
+          "in_gibs": 41.4078,
+          "out_gibs": 41.4078
+        },
+        "d2h": {
+          "avg_ms": 0.60128,
+          "best_ms": 0.60128,
+          "in_gibs": 51.9725,
+          "out_gibs": 51.9725
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.26783,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.2597,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.29242,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.52,
+      "status": "pass",
+      "throughput_in_gibs": 0.927242,
+      "throughput_out_gibs": 0.228472,
+      "compression_fold": 4.05845,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00769998,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0337021,
+      "init_s": 0.213588,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000517427,
+          "best_ms": 0.00026,
+          "in_gibs": 29.4897,
+          "out_gibs": 29.4897
+        },
+        "h2d": {
+          "avg_ms": 0.011136,
+          "best_ms": 0.011136,
+          "in_gibs": 1.37022,
+          "out_gibs": 1.37022
+        },
+        "scatter": {
+          "avg_ms": 0.24448,
+          "best_ms": 0.010432,
+          "in_gibs": 0.0624132,
+          "out_gibs": 0.0624132
+        },
+        "compress": {
+          "avg_ms": 1.87597,
+          "best_ms": 1.87597,
+          "in_gibs": 16.6581,
+          "out_gibs": 4.08826
+        },
+        "aggregate": {
+          "avg_ms": 0.098304,
+          "best_ms": 0.098304,
+          "in_gibs": 78.0177,
+          "out_gibs": 78.0177
+        },
+        "d2h": {
+          "avg_ms": 0.600992,
+          "best_ms": 0.600992,
+          "in_gibs": 12.7613,
+          "out_gibs": 12.7613
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.679018,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.602063,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 23.482,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.51,
+      "status": "pass",
+      "throughput_in_gibs": 1.395,
+      "throughput_out_gibs": 0.174589,
+      "compression_fold": 7.99022,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00391103,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0224014,
+      "init_s": 0.208736,
+      "flush_s": 5.7e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000878592,
+          "best_ms": 0.000561,
+          "in_gibs": 34.7346,
+          "out_gibs": 34.7346
+        },
+        "h2d": {
+          "avg_ms": 0.016896,
+          "best_ms": 0.016896,
+          "in_gibs": 1.8062,
+          "out_gibs": 1.8062
+        },
+        "scatter": {
+          "avg_ms": 0.244256,
+          "best_ms": 0.010112,
+          "in_gibs": 0.124941,
+          "out_gibs": 0.124941
+        },
+        "compress": {
+          "avg_ms": 1.7104,
+          "best_ms": 1.7104,
+          "in_gibs": 18.2706,
+          "out_gibs": 2.27769
+        },
+        "aggregate": {
+          "avg_ms": 0.091904,
+          "best_ms": 0.091904,
+          "in_gibs": 42.3894,
+          "out_gibs": 42.3894
+        },
+        "d2h": {
+          "avg_ms": 0.601056,
+          "best_ms": 0.601056,
+          "in_gibs": 6.48153,
+          "out_gibs": 6.48153
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.639269,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.597286,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.9994,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.53,
+      "status": "pass",
+      "throughput_in_gibs": 1.98681,
+      "throughput_out_gibs": 0.128209,
+      "compression_fold": 15.4967,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00201656,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0157287,
+      "init_s": 0.209623,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00160971,
+          "best_ms": 0.001172,
+          "in_gibs": 37.9168,
+          "out_gibs": 37.9168
+        },
+        "h2d": {
+          "avg_ms": 0.016416,
+          "best_ms": 0.016416,
+          "in_gibs": 3.71803,
+          "out_gibs": 3.71803
+        },
+        "scatter": {
+          "avg_ms": 0.056704,
+          "best_ms": 0.010048,
+          "in_gibs": 1.07638,
+          "out_gibs": 1.07638
+        },
+        "compress": {
+          "avg_ms": 1.90291,
+          "best_ms": 1.90291,
+          "in_gibs": 16.4222,
+          "out_gibs": 1.05571
+        },
+        "aggregate": {
+          "avg_ms": 0.04064,
+          "best_ms": 0.04064,
+          "in_gibs": 49.432,
+          "out_gibs": 49.432
+        },
+        "d2h": {
+          "avg_ms": 0.606112,
+          "best_ms": 0.606112,
+          "in_gibs": 3.31443,
+          "out_gibs": 3.31443
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.81624,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.79384,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.96796,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.54,
+      "status": "pass",
+      "throughput_in_gibs": 2.25509,
+      "throughput_out_gibs": 0.0771825,
+      "compression_fold": 29.2176,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00106956,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0138576,
+      "init_s": 0.209943,
+      "flush_s": 5.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0031592,
+          "best_ms": 0.002634,
+          "in_gibs": 38.6397,
+          "out_gibs": 38.6397
+        },
+        "h2d": {
+          "avg_ms": 0.019584,
+          "best_ms": 0.019584,
+          "in_gibs": 6.23317,
+          "out_gibs": 6.23317
+        },
+        "scatter": {
+          "avg_ms": 0.0129586,
+          "best_ms": 0.010016,
+          "in_gibs": 9.42001,
+          "out_gibs": 9.42001
+        },
+        "compress": {
+          "avg_ms": 2.2777,
+          "best_ms": 2.2777,
+          "in_gibs": 13.72,
+          "out_gibs": 0.467899
+        },
+        "aggregate": {
+          "avg_ms": 0.090816,
+          "best_ms": 0.090816,
+          "in_gibs": 11.7351,
+          "out_gibs": 11.7351
+        },
+        "d2h": {
+          "avg_ms": 0.60112,
+          "best_ms": 0.60112,
+          "in_gibs": 1.77291,
+          "out_gibs": 1.77291
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.614411,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.598878,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.71699,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.5,
+      "status": "pass",
+      "throughput_in_gibs": 2.23599,
+      "throughput_out_gibs": 0.0426491,
+      "compression_fold": 52.4275,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000596061,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0139759,
+      "init_s": 0.21091,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00643715,
+          "best_ms": 0.005449,
+          "in_gibs": 37.9268,
+          "out_gibs": 37.9268
+        },
+        "h2d": {
+          "avg_ms": 0.0160853,
+          "best_ms": 0.011328,
+          "in_gibs": 15.1778,
+          "out_gibs": 15.1778
+        },
+        "scatter": {
+          "avg_ms": 0.0390756,
+          "best_ms": 0.01024,
+          "in_gibs": 6.24791,
+          "out_gibs": 6.24791
+        },
+        "compress": {
+          "avg_ms": 3.08355,
+          "best_ms": 3.08355,
+          "in_gibs": 10.1344,
+          "out_gibs": 0.19268
+        },
+        "aggregate": {
+          "avg_ms": 0.09392,
+          "best_ms": 0.09392,
+          "in_gibs": 6.32601,
+          "out_gibs": 6.32601
+        },
+        "d2h": {
+          "avg_ms": 0.601248,
+          "best_ms": 0.601248,
+          "in_gibs": 0.988176,
+          "out_gibs": 0.988176
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.608152,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.597917,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.59775,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.53,
+      "status": "pass",
+      "throughput_in_gibs": 2.033,
+      "throughput_out_gibs": 0.0233753,
+      "compression_fold": 86.9718,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000359312,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0153714,
+      "init_s": 0.210104,
+      "flush_s": 6.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0153715,
+          "best_ms": 0.011958,
+          "in_gibs": 31.7654,
+          "out_gibs": 31.7654
+        },
+        "h2d": {
+          "avg_ms": 0.0118601,
+          "best_ms": 0.010976,
+          "in_gibs": 41.17,
+          "out_gibs": 41.17
+        },
+        "scatter": {
+          "avg_ms": 0.033248,
+          "best_ms": 0.01024,
+          "in_gibs": 14.686,
+          "out_gibs": 14.686
+        },
+        "compress": {
+          "avg_ms": 4.69738,
+          "best_ms": 4.69738,
+          "in_gibs": 6.65265,
+          "out_gibs": 0.0762858
+        },
+        "aggregate": {
+          "avg_ms": 0.102112,
+          "best_ms": 0.102112,
+          "in_gibs": 3.50931,
+          "out_gibs": 3.50931
+        },
+        "d2h": {
+          "avg_ms": 0.604992,
+          "best_ms": 0.604992,
+          "in_gibs": 0.592311,
+          "out_gibs": 0.592311
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.605719,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.597717,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.22366,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.53,
+      "status": "pass",
+      "throughput_in_gibs": 1.62533,
+      "throughput_out_gibs": 0.0125312,
+      "compression_fold": 129.702,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000240937,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0192269,
+      "init_s": 0.206726,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.044246,
+          "best_ms": 0.039349,
+          "in_gibs": 22.0712,
+          "out_gibs": 22.0712
+        },
+        "h2d": {
+          "avg_ms": 0.0248565,
+          "best_ms": 0.02176,
+          "in_gibs": 39.288,
+          "out_gibs": 39.288
+        },
+        "scatter": {
+          "avg_ms": 0.0354069,
+          "best_ms": 0.011424,
+          "in_gibs": 27.5811,
+          "out_gibs": 27.5811
+        },
+        "compress": {
+          "avg_ms": 7.99466,
+          "best_ms": 7.99466,
+          "in_gibs": 3.90886,
+          "out_gibs": 0.0300757
+        },
+        "aggregate": {
+          "avg_ms": 0.038624,
+          "best_ms": 0.038624,
+          "in_gibs": 6.22528,
+          "out_gibs": 6.22528
+        },
+        "d2h": {
+          "avg_ms": 0.605632,
+          "best_ms": 0.605632,
+          "in_gibs": 0.397015,
+          "out_gibs": 0.397015
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 7.81402,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 7.8049,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.57003,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.54,
+      "status": "pass",
+      "throughput_in_gibs": 1.67607,
+      "throughput_out_gibs": 0.0129224,
+      "compression_fold": 129.702,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000240937,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0186448,
+      "init_s": 0.214317,
+      "flush_s": 7.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0435102,
+          "best_ms": 0.033621,
+          "in_gibs": 22.4445,
+          "out_gibs": 22.4445
+        },
+        "h2d": {
+          "avg_ms": 0.0254368,
+          "best_ms": 0.021344,
+          "in_gibs": 38.3917,
+          "out_gibs": 38.3917
+        },
+        "scatter": {
+          "avg_ms": 0.0284149,
+          "best_ms": 0.010112,
+          "in_gibs": 34.368,
+          "out_gibs": 34.368
+        },
+        "compress": {
+          "avg_ms": 7.9793,
+          "best_ms": 7.9793,
+          "in_gibs": 3.91639,
+          "out_gibs": 0.0301336
+        },
+        "aggregate": {
+          "avg_ms": 0.038624,
+          "best_ms": 0.038624,
+          "in_gibs": 6.22528,
+          "out_gibs": 6.22528
+        },
+        "d2h": {
+          "avg_ms": 0.605536,
+          "best_ms": 0.605536,
+          "in_gibs": 0.397078,
+          "out_gibs": 0.397078
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 7.81195,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 7.80259,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.30801,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.52,
+      "status": "pass",
+      "throughput_in_gibs": 0.913081,
+      "throughput_out_gibs": 0.112074,
+      "compression_fold": 8.14716,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00383569,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0342248,
+      "init_s": 0.209215,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000512478,
+          "best_ms": 0.00025,
+          "in_gibs": 29.7745,
+          "out_gibs": 29.7745
+        },
+        "h2d": {
+          "avg_ms": 0.0112,
+          "best_ms": 0.0112,
+          "in_gibs": 1.36239,
+          "out_gibs": 1.36239
+        },
+        "scatter": {
+          "avg_ms": 0.238368,
+          "best_ms": 0.010784,
+          "in_gibs": 0.0640136,
+          "out_gibs": 0.0640136
+        },
+        "compress": {
+          "avg_ms": 2.91226,
+          "best_ms": 2.91226,
+          "in_gibs": 10.7305,
+          "out_gibs": 1.3066
+        },
+        "aggregate": {
+          "avg_ms": 0.045056,
+          "best_ms": 0.045056,
+          "in_gibs": 84.454,
+          "out_gibs": 84.454
+        },
+        "d2h": {
+          "avg_ms": 0.600192,
+          "best_ms": 0.600192,
+          "in_gibs": 6.33991,
+          "out_gibs": 6.33991
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 3.37625,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 3.30409,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 23.5348,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.55,
+      "status": "pass",
+      "throughput_in_gibs": 1.24273,
+      "throughput_out_gibs": 0.146998,
+      "compression_fold": 8.45404,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00369646,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0251463,
+      "init_s": 0.210871,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.000898314,
+          "best_ms": 0.000581,
+          "in_gibs": 33.9721,
+          "out_gibs": 33.9721
+        },
+        "h2d": {
+          "avg_ms": 0.017984,
+          "best_ms": 0.017984,
+          "in_gibs": 1.69693,
+          "out_gibs": 1.69693
+        },
+        "scatter": {
+          "avg_ms": 0.247824,
+          "best_ms": 0.010112,
+          "in_gibs": 0.123142,
+          "out_gibs": 0.123142
+        },
+        "compress": {
+          "avg_ms": 4.89984,
+          "best_ms": 4.89984,
+          "in_gibs": 6.37776,
+          "out_gibs": 0.751286
+        },
+        "aggregate": {
+          "avg_ms": 0.088448,
+          "best_ms": 0.088448,
+          "in_gibs": 41.6197,
+          "out_gibs": 41.6197
+        },
+        "d2h": {
+          "avg_ms": 0.598976,
+          "best_ms": 0.598976,
+          "in_gibs": 6.14579,
+          "out_gibs": 6.14579
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.638438,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.595524,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.971,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.51,
+      "status": "pass",
+      "throughput_in_gibs": 1.33683,
+      "throughput_out_gibs": 0.155029,
+      "compression_fold": 8.62312,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00362398,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0233762,
+      "init_s": 0.210773,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00162766,
+          "best_ms": 0.001272,
+          "in_gibs": 37.4987,
+          "out_gibs": 37.4987
+        },
+        "h2d": {
+          "avg_ms": 0.017568,
+          "best_ms": 0.017568,
+          "in_gibs": 3.47422,
+          "out_gibs": 3.47422
+        },
+        "scatter": {
+          "avg_ms": 0.092176,
+          "best_ms": 0.010112,
+          "in_gibs": 0.662159,
+          "out_gibs": 0.662159
+        },
+        "compress": {
+          "avg_ms": 8.99072,
+          "best_ms": 8.99072,
+          "in_gibs": 3.47581,
+          "out_gibs": 0.40223
+        },
+        "aggregate": {
+          "avg_ms": 0.045056,
+          "best_ms": 0.045056,
+          "in_gibs": 80.2631,
+          "out_gibs": 80.2631
+        },
+        "d2h": {
+          "avg_ms": 0.598368,
+          "best_ms": 0.598368,
+          "in_gibs": 6.04366,
+          "out_gibs": 6.04366
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 9.43231,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 9.40883,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.99763,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.52,
+      "status": "pass",
+      "throughput_in_gibs": 1.15257,
+      "throughput_out_gibs": 0.132658,
+      "compression_fold": 8.68828,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0035968,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0271132,
+      "init_s": 0.212607,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0031629,
+          "best_ms": 0.002604,
+          "in_gibs": 38.5945,
+          "out_gibs": 38.5945
+        },
+        "h2d": {
+          "avg_ms": 0.021376,
+          "best_ms": 0.021376,
+          "in_gibs": 5.71062,
+          "out_gibs": 5.71062
+        },
+        "scatter": {
+          "avg_ms": 0.0129464,
+          "best_ms": 0.010016,
+          "in_gibs": 9.42888,
+          "out_gibs": 9.42888
+        },
+        "compress": {
+          "avg_ms": 15.1665,
+          "best_ms": 15.1665,
+          "in_gibs": 2.06047,
+          "out_gibs": 0.236902
+        },
+        "aggregate": {
+          "avg_ms": 0.09728,
+          "best_ms": 0.09728,
+          "in_gibs": 36.9343,
+          "out_gibs": 36.9343
+        },
+        "d2h": {
+          "avg_ms": 0.605248,
+          "best_ms": 0.605248,
+          "in_gibs": 5.93636,
+          "out_gibs": 5.93636
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.624437,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.609244,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.69448,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.53,
+      "status": "pass",
+      "throughput_in_gibs": 0.813787,
+      "throughput_out_gibs": 0.0932986,
+      "compression_fold": 8.7224,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00358273,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0384007,
+      "init_s": 0.213367,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00637523,
+          "best_ms": 0.005638,
+          "in_gibs": 38.2952,
+          "out_gibs": 38.2952
+        },
+        "h2d": {
+          "avg_ms": 0.0161813,
+          "best_ms": 0.011392,
+          "in_gibs": 15.0878,
+          "out_gibs": 15.0878
+        },
+        "scatter": {
+          "avg_ms": 0.072672,
+          "best_ms": 0.01024,
+          "in_gibs": 3.35949,
+          "out_gibs": 3.35949
+        },
+        "compress": {
+          "avg_ms": 27.388,
+          "best_ms": 27.388,
+          "in_gibs": 1.14101,
+          "out_gibs": 0.130744
+        },
+        "aggregate": {
+          "avg_ms": 0.057248,
+          "best_ms": 0.057248,
+          "in_gibs": 62.5491,
+          "out_gibs": 62.5491
+        },
+        "d2h": {
+          "avg_ms": 0.598464,
+          "best_ms": 0.598464,
+          "in_gibs": 5.98333,
+          "out_gibs": 5.98333
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 27.8401,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 27.8291,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.56824,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.55,
+      "status": "pass",
+      "throughput_in_gibs": 0.501542,
+      "throughput_out_gibs": 0.0573876,
+      "compression_fold": 8.73955,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0035757,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0623079,
+      "init_s": 0.209908,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0159792,
+          "best_ms": 0.012699,
+          "in_gibs": 30.5572,
+          "out_gibs": 30.5572
+        },
+        "h2d": {
+          "avg_ms": 0.0124201,
+          "best_ms": 0.010976,
+          "in_gibs": 39.3137,
+          "out_gibs": 39.3137
+        },
+        "scatter": {
+          "avg_ms": 0.0370987,
+          "best_ms": 0.010208,
+          "in_gibs": 13.1617,
+          "out_gibs": 13.1617
+        },
+        "compress": {
+          "avg_ms": 51.884,
+          "best_ms": 51.884,
+          "in_gibs": 0.602305,
+          "out_gibs": 0.0688984
+        },
+        "aggregate": {
+          "avg_ms": 0.123904,
+          "best_ms": 0.123904,
+          "in_gibs": 28.8508,
+          "out_gibs": 28.8508
+        },
+        "d2h": {
+          "avg_ms": 0.602496,
+          "best_ms": 0.602496,
+          "in_gibs": 5.9332,
+          "out_gibs": 5.9332
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.645379,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.63356,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.25538,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.59,
+      "status": "pass",
+      "throughput_in_gibs": 0.4945,
+      "throughput_out_gibs": 0.0565333,
+      "compression_fold": 8.74706,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00357263,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0631951,
+      "init_s": 0.215379,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0437788,
+          "best_ms": 0.036084,
+          "in_gibs": 22.3067,
+          "out_gibs": 22.3067
+        },
+        "h2d": {
+          "avg_ms": 0.02568,
+          "best_ms": 0.021696,
+          "in_gibs": 38.0281,
+          "out_gibs": 38.0281
+        },
+        "scatter": {
+          "avg_ms": 0.0297612,
+          "best_ms": 0.010112,
+          "in_gibs": 32.8132,
+          "out_gibs": 32.8132
+        },
+        "compress": {
+          "avg_ms": 51.8267,
+          "best_ms": 51.8267,
+          "in_gibs": 0.602971,
+          "out_gibs": 0.0689246
+        },
+        "aggregate": {
+          "avg_ms": 0.197632,
+          "best_ms": 0.197632,
+          "in_gibs": 18.0747,
+          "out_gibs": 18.0747
+        },
+        "d2h": {
+          "avg_ms": 0.604416,
+          "best_ms": 0.604416,
+          "in_gibs": 5.91006,
+          "out_gibs": 5.91006
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.684527,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.671437,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.33226,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.59,
+      "status": "pass",
+      "throughput_in_gibs": 0.496105,
+      "throughput_out_gibs": 0.0567167,
+      "compression_fold": 8.74706,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00357263,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0629907,
+      "init_s": 0.213239,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0426407,
+          "best_ms": 0.039469,
+          "in_gibs": 22.9021,
+          "out_gibs": 22.9021
+        },
+        "h2d": {
+          "avg_ms": 0.0235093,
+          "best_ms": 0.021408,
+          "in_gibs": 41.5394,
+          "out_gibs": 41.5394
+        },
+        "scatter": {
+          "avg_ms": 0.0265643,
+          "best_ms": 0.011424,
+          "in_gibs": 36.7622,
+          "out_gibs": 36.7622
+        },
+        "compress": {
+          "avg_ms": 51.9485,
+          "best_ms": 51.9485,
+          "in_gibs": 0.601557,
+          "out_gibs": 0.068763
+        },
+        "aggregate": {
+          "avg_ms": 0.166912,
+          "best_ms": 0.166912,
+          "in_gibs": 21.4013,
+          "out_gibs": 21.4013
+        },
+        "d2h": {
+          "avg_ms": 0.6,
+          "best_ms": 0.6,
+          "in_gibs": 5.95356,
+          "out_gibs": 5.95356
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.677356,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 0.669855,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 2.25059,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.48,
+      "status": "pass",
+      "throughput_in_gibs": 6.63522,
+      "throughput_out_gibs": 6.643,
+      "compression_fold": 0.998829,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51975,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.529843,
+      "init_s": 0.000222363,
+      "flush_s": 7.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.20737,
+          "best_ms": 0.603866,
+          "in_gibs": 21.2357,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.41031,
+          "best_ms": 2.47292,
+          "in_gibs": 53.3704,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.33674,
+          "best_ms": 2.28228,
+          "in_gibs": 53.791,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.42,
+      "status": "pass",
+      "throughput_in_gibs": 7.19539,
+      "throughput_out_gibs": 7.19967,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.488594,
+      "init_s": 0.000145638,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.78083,
+          "best_ms": 0.527741,
+          "in_gibs": 26.3219,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.13555,
+          "best_ms": 2.35166,
+          "in_gibs": 54.9756,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.57058,
+          "best_ms": 2.13403,
+          "in_gibs": 52.4767,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.41,
+      "status": "pass",
+      "throughput_in_gibs": 7.10564,
+      "throughput_out_gibs": 7.10773,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51666,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.494765,
+      "init_s": 0.000131657,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.06752,
+          "best_ms": 0.518478,
+          "in_gibs": 22.6721,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.67459,
+          "best_ms": 2.26769,
+          "in_gibs": 57.8969,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.86059,
+          "best_ms": 2.186,
+          "in_gibs": 56.6815,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.45,
+      "status": "pass",
+      "throughput_in_gibs": 7.08199,
+      "throughput_out_gibs": 7.08312,
+      "compression_fold": 0.99984,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51619,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.496418,
+      "init_s": 0.000130066,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.93085,
+          "best_ms": 0.480271,
+          "in_gibs": 24.2769,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.24881,
+          "best_ms": 4.81401,
+          "in_gibs": 54.3023,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.78921,
+          "best_ms": 2.20508,
+          "in_gibs": 57.1419,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.44,
+      "status": "pass",
+      "throughput_in_gibs": 6.95057,
+      "throughput_out_gibs": 6.95114,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.505804,
+      "init_s": 8.6931e-05,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.11752,
+          "best_ms": 0.500741,
+          "in_gibs": 22.1368,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.21223,
+          "best_ms": 2.39906,
+          "in_gibs": 54.518,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.56209,
+          "best_ms": 2.12045,
+          "in_gibs": 52.5233,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.24,
+      "status": "pass",
+      "throughput_in_gibs": 6.52743,
+      "throughput_out_gibs": 6.78879,
+      "compression_fold": 0.999961,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65639,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.538593,
+      "init_s": 8.0671e-05,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.75448,
+          "best_ms": 0.54026,
+          "in_gibs": 20.2592,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.3986,
+          "best_ms": 4.74586,
+          "in_gibs": 50.23,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.709,
+          "best_ms": 4.54981,
+          "in_gibs": 48.7743,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.21,
+      "status": "pass",
+      "throughput_in_gibs": 6.65163,
+      "throughput_out_gibs": 6.91782,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65631,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.528536,
+      "init_s": 6.8914e-05,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.29902,
+          "best_ms": 0.503445,
+          "in_gibs": 24.2728,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.0654,
+          "best_ms": 6.25022,
+          "in_gibs": 43.2909,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.5373,
+          "best_ms": 6.07983,
+          "in_gibs": 41.6614,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.25,
+      "status": "pass",
+      "throughput_in_gibs": 6.3579,
+      "throughput_out_gibs": 6.61228,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.552954,
+      "init_s": 5.5283e-05,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.38561,
+          "best_ms": 0.929354,
+          "in_gibs": 23.3918,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.6278,
+          "best_ms": 8.1639,
+          "in_gibs": 41.3629,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.875,
+          "best_ms": 9.69105,
+          "in_gibs": 40.5687,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.27,
+      "status": "pass",
+      "throughput_in_gibs": 5.73952,
+      "throughput_out_gibs": 0.334979,
+      "compression_fold": 17.134,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.205185,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.612529,
+      "init_s": 0.000194632,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.44467,
+          "best_ms": 0.59335,
+          "in_gibs": 19.1744,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.4616,
+          "best_ms": 7.43635,
+          "in_gibs": 18.2885,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.37446,
+          "best_ms": 0.190075,
+          "in_gibs": 367.188,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.31,
+      "status": "pass",
+      "throughput_in_gibs": 5.33796,
+      "throughput_out_gibs": 0.250363,
+      "compression_fold": 21.3209,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.164891,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.658608,
+      "init_s": 0.000132559,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.15355,
+          "best_ms": 0.510586,
+          "in_gibs": 14.8642,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.9853,
+          "best_ms": 6.74397,
+          "in_gibs": 19.3276,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.95986,
+          "best_ms": 0.13965,
+          "in_gibs": 257.385,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.47,
+      "status": "pass",
+      "throughput_in_gibs": 5.20198,
+      "throughput_out_gibs": 0.176385,
+      "compression_fold": 29.4922,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.119205,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.675824,
+      "init_s": 0.000150256,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.25541,
+          "best_ms": 0.521282,
+          "in_gibs": 14.3991,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.4213,
+          "best_ms": 11.7164,
+          "in_gibs": 19.0086,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.07597,
+          "best_ms": 0.341852,
+          "in_gibs": 163.957,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.48,
+      "status": "pass",
+      "throughput_in_gibs": 5.71946,
+      "throughput_out_gibs": 0.169524,
+      "compression_fold": 33.7384,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.104202,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.614678,
+      "init_s": 0.000115693,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.51504,
+          "best_ms": 0.491086,
+          "in_gibs": 18.6379,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.2398,
+          "best_ms": 11.7242,
+          "in_gibs": 19.1401,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.89815,
+          "best_ms": 0.291677,
+          "in_gibs": 173.996,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.18,
+      "status": "pass",
+      "throughput_in_gibs": 6.55295,
+      "throughput_out_gibs": 0.162098,
+      "compression_fold": 40.4259,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0869647,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.536495,
+      "init_s": 8.5038e-05,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.70296,
+          "best_ms": 0.508482,
+          "in_gibs": 27.5256,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.056,
+          "best_ms": 7.13274,
+          "in_gibs": 19.2751,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.06446,
+          "best_ms": 0.068473,
+          "in_gibs": 473.7,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.51,
+      "status": "pass",
+      "throughput_in_gibs": 5.6703,
+      "throughput_out_gibs": 0.113064,
+      "compression_fold": 52.1574,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0701003,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.620007,
+      "init_s": 7.6225e-05,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.04112,
+          "best_ms": 0.573871,
+          "in_gibs": 18.3497,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.6135,
+          "best_ms": 14.1327,
+          "in_gibs": 18.9155,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.55708,
+          "best_ms": 0.103365,
+          "in_gibs": 205.073,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.2,
+      "status": "pass",
+      "throughput_in_gibs": 6.44466,
+      "throughput_out_gibs": 0.178939,
+      "compression_fold": 37.4567,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0976128,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.54551,
+      "init_s": 6.1953e-05,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.0835,
+          "best_ms": 0.578758,
+          "in_gibs": 26.7836,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.2086,
+          "best_ms": 14.3156,
+          "in_gibs": 19.1969,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.905132,
+          "best_ms": 0.131187,
+          "in_gibs": 579.341,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.52,
+      "status": "pass",
+      "throughput_in_gibs": 5.75496,
+      "throughput_out_gibs": 0.16437,
+      "compression_fold": 36.4128,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.100411,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.610886,
+      "init_s": 7.1337e-05,
+      "flush_s": 5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.60597,
+          "best_ms": 0.950566,
+          "in_gibs": 21.4137,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 30.7765,
+          "best_ms": 18.8922,
+          "in_gibs": 16.9714,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.47688,
+          "best_ms": 0.132028,
+          "in_gibs": 355.056,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.35,
+      "status": "pass",
+      "throughput_in_gibs": 5.17069,
+      "throughput_out_gibs": 0.494888,
+      "compression_fold": 10.4482,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.336481,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.679914,
+      "init_s": 0.000205668,
+      "flush_s": 2.754e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.02713,
+          "best_ms": 0.588754,
+          "in_gibs": 15.485,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.7641,
+          "best_ms": 7.40062,
+          "in_gibs": 17.4604,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.7438,
+          "best_ms": 0.289664,
+          "in_gibs": 184.383,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.48,
+      "status": "pass",
+      "throughput_in_gibs": 5.84219,
+      "throughput_out_gibs": 0.602156,
+      "compression_fold": 9.70212,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.362356,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.601765,
+      "init_s": 0.000272709,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.2869,
+          "best_ms": 0.505949,
+          "in_gibs": 20.4972,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.1103,
+          "best_ms": 7.34864,
+          "in_gibs": 18.5255,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.83084,
+          "best_ms": 0.244717,
+          "in_gibs": 275.791,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.45,
+      "status": "pass",
+      "throughput_in_gibs": 6.06668,
+      "throughput_out_gibs": 0.588617,
+      "compression_fold": 10.3067,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.341102,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.579497,
+      "init_s": 0.00015348,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.31795,
+          "best_ms": 0.517586,
+          "in_gibs": 20.2226,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.9708,
+          "best_ms": 6.96579,
+          "in_gibs": 20.1128,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.928471,
+          "best_ms": 0.216325,
+          "in_gibs": 543.301,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.46,
+      "status": "pass",
+      "throughput_in_gibs": 6.0698,
+      "throughput_out_gibs": 0.631698,
+      "compression_fold": 9.60871,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.365879,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.579199,
+      "init_s": 0.000161643,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.23657,
+          "best_ms": 0.501473,
+          "in_gibs": 20.9584,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.3988,
+          "best_ms": 6.84639,
+          "in_gibs": 19.7738,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.179,
+          "best_ms": 0.238087,
+          "in_gibs": 231.388,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.32,
+      "status": "pass",
+      "throughput_in_gibs": 5.48338,
+      "throughput_out_gibs": 0.552411,
+      "compression_fold": 9.92626,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.354174,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.641142,
+      "init_s": 8.3365e-05,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.91531,
+          "best_ms": 0.518608,
+          "in_gibs": 16.0789,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.6473,
+          "best_ms": 6.93587,
+          "in_gibs": 19.5823,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.88991,
+          "best_ms": 0.222735,
+          "in_gibs": 174.467,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.24,
+      "status": "pass",
+      "throughput_in_gibs": 6.10836,
+      "throughput_out_gibs": 0.617782,
+      "compression_fold": 10.2831,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.35556,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.575544,
+      "init_s": 8.2664e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.30902,
+          "best_ms": 0.540191,
+          "in_gibs": 24.1677,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.3851,
+          "best_ms": 13.2572,
+          "in_gibs": 19.7961,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.59288,
+          "best_ms": 0.439159,
+          "in_gibs": 202.231,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.61,
+      "status": "pass",
+      "throughput_in_gibs": 5.0761,
+      "throughput_out_gibs": 0.530959,
+      "compression_fold": 9.94265,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.367734,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.692584,
+      "init_s": 7.0906e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.85652,
+          "best_ms": 0.527711,
+          "in_gibs": 14.4699,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.8442,
+          "best_ms": 13.1928,
+          "in_gibs": 18.7587,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.66666,
+          "best_ms": 0.463325,
+          "in_gibs": 112.363,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.4,
+      "status": "pass",
+      "throughput_in_gibs": 6.73208,
+      "throughput_out_gibs": 0.664368,
+      "compression_fold": 10.5384,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.346946,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.52222,
+      "init_s": 6.1893e-05,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.98853,
+          "best_ms": 0.546219,
+          "in_gibs": 28.0627,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.3562,
+          "best_ms": 13.1579,
+          "in_gibs": 21.4451,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.872161,
+          "best_ms": 0.42706,
+          "in_gibs": 601.221,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.33,
+      "status": "pass",
+      "throughput_in_gibs": 5.34428,
+      "throughput_out_gibs": 3.3748,
+      "compression_fold": 1.58358,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.22005,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.65783,
+      "init_s": 0.000208723,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.27909,
+          "best_ms": 0.58677,
+          "in_gibs": 14.2951,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.7908,
+          "best_ms": 3.33803,
+          "in_gibs": 26.7275,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.56773,
+          "best_ms": 1.67552,
+          "in_gibs": 76.5444,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.42,
+      "status": "pass",
+      "throughput_in_gibs": 6.71913,
+      "throughput_out_gibs": 3.86316,
+      "compression_fold": 1.73928,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.02131,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.523226,
+      "init_s": 0.000136194,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.06887,
+          "best_ms": 0.508773,
+          "in_gibs": 22.6573,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.6505,
+          "best_ms": 2.98532,
+          "in_gibs": 34.2808,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.69987,
+          "best_ms": 1.33083,
+          "in_gibs": 88.1559,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.26,
+      "status": "pass",
+      "throughput_in_gibs": 5.91461,
+      "throughput_out_gibs": 3.38217,
+      "compression_fold": 1.74876,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.01035,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.594397,
+      "init_s": 0.000133901,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.85302,
+          "best_ms": 0.518528,
+          "in_gibs": 16.43,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.3365,
+          "best_ms": 8.29944,
+          "in_gibs": 35.0317,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.46762,
+          "best_ms": 4.67344,
+          "in_gibs": 77.6723,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.38,
+      "status": "pass",
+      "throughput_in_gibs": 7.51845,
+      "throughput_out_gibs": 4.4224,
+      "compression_fold": 1.70008,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.06792,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.4676,
+      "init_s": 0.000110606,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.58589,
+          "best_ms": 0.486139,
+          "in_gibs": 29.5575,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.2894,
+          "best_ms": 8.98507,
+          "in_gibs": 40.867,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.92372,
+          "best_ms": 5.07347,
+          "in_gibs": 84.7936,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.44,
+      "status": "pass",
+      "throughput_in_gibs": 6.98055,
+      "throughput_out_gibs": 4.13305,
+      "compression_fold": 1.68896,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.08153,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.503632,
+      "init_s": 0.000106941,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.04178,
+          "best_ms": 0.542754,
+          "in_gibs": 22.958,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.4976,
+          "best_ms": 3.42781,
+          "in_gibs": 40.1863,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.95796,
+          "best_ms": 1.39256,
+          "in_gibs": 84.3013,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.27,
+      "status": "pass",
+      "throughput_in_gibs": 7.66801,
+      "throughput_out_gibs": 4.72126,
+      "compression_fold": 1.68911,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.1646,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.458479,
+      "init_s": 6.9814e-05,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.86054,
+          "best_ms": 0.52022,
+          "in_gibs": 29.9933,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.1304,
+          "best_ms": 6.25789,
+          "in_gibs": 43.0588,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.33967,
+          "best_ms": 2.84178,
+          "in_gibs": 82.3922,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.14,
+      "status": "pass",
+      "throughput_in_gibs": 7.43799,
+      "throughput_out_gibs": 4.11479,
+      "compression_fold": 1.87993,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.94489,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.472658,
+      "init_s": 5.994e-05,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.1498,
+          "best_ms": 0.514682,
+          "in_gibs": 25.9576,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.8937,
+          "best_ms": 7.20271,
+          "in_gibs": 43.9157,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.14931,
+          "best_ms": 4.96301,
+          "in_gibs": 84.9416,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.17,
+      "status": "pass",
+      "throughput_in_gibs": 6.98131,
+      "throughput_out_gibs": 3.86204,
+      "compression_fold": 1.87998,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.94483,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.503576,
+      "init_s": 6.02e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.122,
+          "best_ms": 0.922414,
+          "in_gibs": 26.2976,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.5524,
+          "best_ms": 10.0049,
+          "in_gibs": 38.541,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.459,
+          "best_ms": 3.29796,
+          "in_gibs": 70.0266,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.53,
+      "status": "pass",
+      "throughput_in_gibs": 5.66133,
+      "throughput_out_gibs": 0.188385,
+      "compression_fold": 30.052,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.116985,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.620989,
+      "init_s": 0.000226901,
+      "flush_s": 5.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.74294,
+          "best_ms": 0.583385,
+          "in_gibs": 17.0893,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.9469,
+          "best_ms": 6.58484,
+          "in_gibs": 20.1321,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.26817,
+          "best_ms": 0.12696,
+          "in_gibs": 396.416,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.37,
+      "status": "pass",
+      "throughput_in_gibs": 6.94092,
+      "throughput_out_gibs": 0.141451,
+      "compression_fold": 49.0695,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0716459,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.506507,
+      "init_s": 0.000141032,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.37259,
+          "best_ms": 0.49997,
+          "in_gibs": 19.7569,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.2973,
+          "best_ms": 8.62046,
+          "in_gibs": 37.7694,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.85163,
+          "best_ms": 0.259149,
+          "in_gibs": 271.37,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.36,
+      "status": "pass",
+      "throughput_in_gibs": 7.24857,
+      "throughput_out_gibs": 0.125698,
+      "compression_fold": 57.6665,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0609648,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.485009,
+      "init_s": 0.000139239,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.36387,
+          "best_ms": 0.508462,
+          "in_gibs": 19.8298,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.2665,
+          "best_ms": 3.20099,
+          "in_gibs": 44.5774,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.00245,
+          "best_ms": 0.062184,
+          "in_gibs": 501.128,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.45,
+      "status": "pass",
+      "throughput_in_gibs": 6.36033,
+      "throughput_out_gibs": 0.151837,
+      "compression_fold": 41.8892,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0839267,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.552743,
+      "init_s": 0.000118618,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.55674,
+          "best_ms": 0.488532,
+          "in_gibs": 18.3339,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.9486,
+          "best_ms": 4.47199,
+          "in_gibs": 29.6326,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.6525,
+          "best_ms": 0.066209,
+          "in_gibs": 189.366,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.14,
+      "status": "pass",
+      "throughput_in_gibs": 8.2461,
+      "throughput_out_gibs": 0.122441,
+      "compression_fold": 67.3474,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0522013,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.426338,
+      "init_s": 0.000100211,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.87388,
+          "best_ms": 0.506009,
+          "in_gibs": 25.0149,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.70672,
+          "best_ms": 2.38949,
+          "in_gibs": 57.6833,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.968242,
+          "best_ms": 0.043465,
+          "in_gibs": 518.737,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.2,
+      "status": "pass",
+      "throughput_in_gibs": 7.89528,
+      "throughput_out_gibs": 0.121324,
+      "compression_fold": 67.6793,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0540232,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.445282,
+      "init_s": 9.2699e-05,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.38452,
+          "best_ms": 0.577617,
+          "in_gibs": 23.4024,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.86208,
+          "best_ms": 4.64311,
+          "in_gibs": 52.9626,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.2401,
+          "best_ms": 0.073009,
+          "in_gibs": 421.207,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.36,
+      "status": "pass",
+      "throughput_in_gibs": 8.07915,
+      "throughput_out_gibs": 0.113029,
+      "compression_fold": 74.338,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0491842,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.435148,
+      "init_s": 7.5032e-05,
+      "flush_s": 2.464e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.32635,
+          "best_ms": 0.971036,
+          "in_gibs": 23.9876,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.91911,
+          "best_ms": 6.55666,
+          "in_gibs": 65.9571,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.80244,
+          "best_ms": 0.117806,
+          "in_gibs": 289.791,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.35,
+      "status": "pass",
+      "throughput_in_gibs": 8.04764,
+      "throughput_out_gibs": 0.12234,
+      "compression_fold": 68.4123,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0534443,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.436852,
+      "init_s": 5.7967e-05,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.52861,
+          "best_ms": 0.585318,
+          "in_gibs": 22.0689,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.53879,
+          "best_ms": 3.51903,
+          "in_gibs": 69.2845,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.960526,
+          "best_ms": 0.068243,
+          "in_gibs": 543.794,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 11.53,
+      "status": "pass",
+      "throughput_in_gibs": 5.49165,
+      "throughput_out_gibs": 5.49701,
+      "compression_fold": 0.999024,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75366,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.682855,
+      "init_s": 0.00021315,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.13519,
+          "best_ms": 4.51867,
+          "in_gibs": 12.1709,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.52275,
+          "best_ms": 6.69761,
+          "in_gibs": 56.2563,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.51757,
+          "best_ms": 6.29748,
+          "in_gibs": 56.2869,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 11.43,
+      "status": "pass",
+      "throughput_in_gibs": 5.66333,
+      "throughput_out_gibs": 5.66609,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.662155,
+      "init_s": 0.000143054,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.82301,
+          "best_ms": 4.38858,
+          "in_gibs": 12.9587,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.4616,
+          "best_ms": 6.50934,
+          "in_gibs": 56.6198,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.69119,
+          "best_ms": 6.20182,
+          "in_gibs": 55.2785,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.56,
+      "status": "pass",
+      "throughput_in_gibs": 5.28197,
+      "throughput_out_gibs": 5.28326,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75092,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.709962,
+      "init_s": 0.000135674,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.4016,
+          "best_ms": 4.47987,
+          "in_gibs": 11.5706,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.6079,
+          "best_ms": 6.56326,
+          "in_gibs": 50.5014,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.1771,
+          "best_ms": 6.27762,
+          "in_gibs": 52.639,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 11.79,
+      "status": "pass",
+      "throughput_in_gibs": 5.46376,
+      "throughput_out_gibs": 5.46443,
+      "compression_fold": 0.999878,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75046,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.686341,
+      "init_s": 0.000106289,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.24308,
+          "best_ms": 4.38913,
+          "in_gibs": 11.9205,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.42542,
+          "best_ms": 6.41325,
+          "in_gibs": 56.8372,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.73903,
+          "best_ms": 6.13694,
+          "in_gibs": 55.0069,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.46,
+      "status": "pass",
+      "throughput_in_gibs": 5.58318,
+      "throughput_out_gibs": 5.58352,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.671661,
+      "init_s": 8.8202e-05,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.09527,
+          "best_ms": 4.36018,
+          "in_gibs": 12.2663,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.6337,
+          "best_ms": 12.8974,
+          "in_gibs": 55.0107,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.4138,
+          "best_ms": 12.5874,
+          "in_gibs": 55.9126,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 11.96,
+      "status": "pass",
+      "throughput_in_gibs": 5.81205,
+      "throughput_out_gibs": 5.81223,
+      "compression_fold": 0.999969,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75011,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.645211,
+      "init_s": 6.7361e-05,
+      "flush_s": 6.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.51791,
+          "best_ms": 3.9612,
+          "in_gibs": 13.8338,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.2106,
+          "best_ms": 12.8299,
+          "in_gibs": 52.7773,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.9492,
+          "best_ms": 12.5192,
+          "in_gibs": 53.7666,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.55,
+      "status": "pass",
+      "throughput_in_gibs": 5.67473,
+      "throughput_out_gibs": 5.67482,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75006,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.660824,
+      "init_s": 6.5929e-05,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.347,
+          "best_ms": 3.9784,
+          "in_gibs": 14.3777,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.7531,
+          "best_ms": 14.6184,
+          "in_gibs": 44.7679,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 16.6913,
+          "best_ms": 14.5023,
+          "in_gibs": 44.9337,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.04,
+      "status": "pass",
+      "throughput_in_gibs": 5.54033,
+      "throughput_out_gibs": 5.54038,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.676855,
+      "init_s": 6.6259e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.75231,
+          "best_ms": 3.99756,
+          "in_gibs": 13.1515,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.3672,
+          "best_ms": 15.3428,
+          "in_gibs": 45.8233,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 15.8105,
+          "best_ms": 14.7182,
+          "in_gibs": 47.4367,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.18,
+      "status": "pass",
+      "throughput_in_gibs": 4.88986,
+      "throughput_out_gibs": 0.168976,
+      "compression_fold": 28.9382,
+      "input_gib": 3.75,
+      "compressed_gib": 0.129587,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.766894,
+      "init_s": 0.000221713,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.30961,
+          "best_ms": 4.56699,
+          "in_gibs": 11.7711,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.0301,
+          "best_ms": 18.5491,
+          "in_gibs": 19.1121,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.15088,
+          "best_ms": 0.327952,
+          "in_gibs": 467.756,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 11.53,
+      "status": "pass",
+      "throughput_in_gibs": 4.70962,
+      "throughput_out_gibs": 0.118614,
+      "compression_fold": 39.7053,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0944458,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.796242,
+      "init_s": 0.000141362,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.07932,
+          "best_ms": 4.48344,
+          "in_gibs": 10.2808,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.6214,
+          "best_ms": 16.8993,
+          "in_gibs": 20.9089,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.8188,
+          "best_ms": 0.237056,
+          "in_gibs": 295.837,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.45,
+      "status": "pass",
+      "throughput_in_gibs": 5.20724,
+      "throughput_out_gibs": 0.102771,
+      "compression_fold": 50.6683,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0740108,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.720151,
+      "init_s": 0.000190777,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.20569,
+          "best_ms": 4.38305,
+          "in_gibs": 12.0061,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.7064,
+          "best_ms": 15.8489,
+          "in_gibs": 22.5978,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.04595,
+          "best_ms": 0.166831,
+          "in_gibs": 514.315,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 11.44,
+      "status": "pass",
+      "throughput_in_gibs": 5.33599,
+      "throughput_out_gibs": 0.0711485,
+      "compression_fold": 74.9979,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0500014,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.702775,
+      "init_s": 0.000105098,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.98067,
+          "best_ms": 4.41586,
+          "in_gibs": 12.5485,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.5305,
+          "best_ms": 16.4567,
+          "in_gibs": 22.7668,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.990992,
+          "best_ms": 0.118287,
+          "in_gibs": 542.773,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.82,
+      "status": "pass",
+      "throughput_in_gibs": 5.34035,
+      "throughput_out_gibs": 0.052098,
+      "compression_fold": 102.506,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0365832,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.702201,
+      "init_s": 8.0671e-05,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.1254,
+          "best_ms": 4.3602,
+          "in_gibs": 12.1942,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.1005,
+          "best_ms": 31.9515,
+          "in_gibs": 23.3641,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.217102,
+          "best_ms": 0.140331,
+          "in_gibs": 3468.36,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 11.51,
+      "status": "pass",
+      "throughput_in_gibs": 4.88609,
+      "throughput_out_gibs": 0.0427811,
+      "compression_fold": 114.211,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0328338,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.767486,
+      "init_s": 7.1868e-05,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.71848,
+          "best_ms": 4.0239,
+          "in_gibs": 10.9295,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 35.0451,
+          "best_ms": 32.6065,
+          "in_gibs": 21.401,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.83597,
+          "best_ms": 0.124617,
+          "in_gibs": 265.505,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.44,
+      "status": "pass",
+      "throughput_in_gibs": 5.40071,
+      "throughput_out_gibs": 0.0542425,
+      "compression_fold": 99.566,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0376635,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.694354,
+      "init_s": 7.3561e-05,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.70766,
+          "best_ms": 4.01425,
+          "in_gibs": 13.2762,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 35.6359,
+          "best_ms": 34.2621,
+          "in_gibs": 21.0462,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.194812,
+          "best_ms": 0.136675,
+          "in_gibs": 3865.02,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.02,
+      "status": "pass",
+      "throughput_in_gibs": 5.10934,
+      "throughput_out_gibs": 0.047274,
+      "compression_fold": 108.079,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0346968,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.73395,
+      "init_s": 6.2884e-05,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.13907,
+          "best_ms": 4.08564,
+          "in_gibs": 12.1617,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 35.7713,
+          "best_ms": 34.676,
+          "in_gibs": 20.9665,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.8705,
+          "best_ms": 0.11937,
+          "in_gibs": 194.535,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 11.52,
+      "status": "pass",
+      "throughput_in_gibs": 4.83558,
+      "throughput_out_gibs": 0.430382,
+      "compression_fold": 11.2356,
+      "input_gib": 3.75,
+      "compressed_gib": 0.333762,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.775501,
+      "init_s": 0.00024673,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.16381,
+          "best_ms": 4.59352,
+          "in_gibs": 12.1035,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.8278,
+          "best_ms": 20.5804,
+          "in_gibs": 17.9602,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.80203,
+          "best_ms": 1.16576,
+          "in_gibs": 299.461,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 11.8,
+      "status": "pass",
+      "throughput_in_gibs": 4.44547,
+      "throughput_out_gibs": 0.408742,
+      "compression_fold": 10.876,
+      "input_gib": 3.75,
+      "compressed_gib": 0.344796,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.843556,
+      "init_s": 0.000136324,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.26258,
+          "best_ms": 4.48956,
+          "in_gibs": 9.97992,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.1752,
+          "best_ms": 18.608,
+          "in_gibs": 18.362,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.05732,
+          "best_ms": 0.614482,
+          "in_gibs": 176.165,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.32,
+      "status": "pass",
+      "throughput_in_gibs": 5.12131,
+      "throughput_out_gibs": 0.459014,
+      "compression_fold": 11.1572,
+      "input_gib": 3.75,
+      "compressed_gib": 0.336106,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.732235,
+      "init_s": 0.000168323,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.98793,
+          "best_ms": 4.36211,
+          "in_gibs": 12.5303,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.7558,
+          "best_ms": 17.5777,
+          "in_gibs": 20.7998,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.58736,
+          "best_ms": 0.584817,
+          "in_gibs": 207.961,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 11.79,
+      "status": "pass",
+      "throughput_in_gibs": 4.74069,
+      "throughput_out_gibs": 0.4172,
+      "compression_fold": 11.3631,
+      "input_gib": 3.75,
+      "compressed_gib": 0.330016,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.791025,
+      "init_s": 0.000108703,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.99804,
+          "best_ms": 4.56253,
+          "in_gibs": 10.4201,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.2689,
+          "best_ms": 17.0343,
+          "in_gibs": 21.2005,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.82584,
+          "best_ms": 0.579289,
+          "in_gibs": 190.317,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.93768,
+      "throughput_out_gibs": 0.430515,
+      "compression_fold": 11.4692,
+      "input_gib": 3.75,
+      "compressed_gib": 0.326962,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.759465,
+      "init_s": 8.0832e-05,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.60149,
+          "best_ms": 4.38534,
+          "in_gibs": 11.1578,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.2406,
+          "best_ms": 33.9373,
+          "in_gibs": 20.695,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.54338,
+          "best_ms": 1.12479,
+          "in_gibs": 487.846,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 11.42,
+      "status": "pass",
+      "throughput_in_gibs": 5.66309,
+      "throughput_out_gibs": 0.48433,
+      "compression_fold": 11.6926,
+      "input_gib": 3.75,
+      "compressed_gib": 0.320715,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.662183,
+      "init_s": 7.3229e-05,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.32973,
+          "best_ms": 3.97444,
+          "in_gibs": 14.4351,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.562,
+          "best_ms": 31.0785,
+          "in_gibs": 23.033,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.99891,
+          "best_ms": 1.02867,
+          "in_gibs": 376.67,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.46,
+      "status": "pass",
+      "throughput_in_gibs": 5.31614,
+      "throughput_out_gibs": 0.443694,
+      "compression_fold": 11.9815,
+      "input_gib": 3.75,
+      "compressed_gib": 0.312982,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.705399,
+      "init_s": 5.9929e-05,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.8658,
+          "best_ms": 4.00319,
+          "in_gibs": 12.8448,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 33.4137,
+          "best_ms": 31.3645,
+          "in_gibs": 22.4459,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.35877,
+          "best_ms": 1.00117,
+          "in_gibs": 319.204,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 11.42,
+      "status": "pass",
+      "throughput_in_gibs": 5.49083,
+      "throughput_out_gibs": 0.453321,
+      "compression_fold": 12.1125,
+      "input_gib": 3.75,
+      "compressed_gib": 0.309599,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.682957,
+      "init_s": 6.0131e-05,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.68201,
+          "best_ms": 3.99335,
+          "in_gibs": 13.349,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 33.5617,
+          "best_ms": 32.1805,
+          "in_gibs": 22.3469,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.06231,
+          "best_ms": 0.979639,
+          "in_gibs": 708.764,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 11.75,
+      "status": "pass",
+      "throughput_in_gibs": 4.99667,
+      "throughput_out_gibs": 3.33948,
+      "compression_fold": 1.49624,
+      "input_gib": 3.75,
+      "compressed_gib": 2.50627,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.750499,
+      "init_s": 0.000208132,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.17788,
+          "best_ms": 4.43524,
+          "in_gibs": 12.0706,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 20.3269,
+          "best_ms": 9.90877,
+          "in_gibs": 26.355,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.09365,
+          "best_ms": 4.6412,
+          "in_gibs": 75.594,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 11.66,
+      "status": "pass",
+      "throughput_in_gibs": 5.38006,
+      "throughput_out_gibs": 3.21767,
+      "compression_fold": 1.67204,
+      "input_gib": 3.75,
+      "compressed_gib": 2.24277,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.697018,
+      "init_s": 0.000144366,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.9192,
+          "best_ms": 4.36192,
+          "in_gibs": 12.7053,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.0008,
+          "best_ms": 8.70666,
+          "in_gibs": 31.5112,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.64083,
+          "best_ms": 4.06311,
+          "in_gibs": 80.7091,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.02,
+      "status": "pass",
+      "throughput_in_gibs": 5.37719,
+      "throughput_out_gibs": 3.38946,
+      "compression_fold": 1.58644,
+      "input_gib": 3.75,
+      "compressed_gib": 2.36378,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.69739,
+      "init_s": 0.000146559,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.21726,
+          "best_ms": 4.3107,
+          "in_gibs": 11.9795,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.0725,
+          "best_ms": 9.16479,
+          "in_gibs": 35.5424,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.1528,
+          "best_ms": 4.19991,
+          "in_gibs": 87.0897,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 11.55,
+      "status": "pass",
+      "throughput_in_gibs": 5.40569,
+      "throughput_out_gibs": 3.52717,
+      "compression_fold": 1.53259,
+      "input_gib": 3.75,
+      "compressed_gib": 2.44684,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.693714,
+      "init_s": 9.7947e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.31746,
+          "best_ms": 4.20063,
+          "in_gibs": 11.7537,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.8801,
+          "best_ms": 9.42597,
+          "in_gibs": 38.5959,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.26744,
+          "best_ms": 4.27451,
+          "in_gibs": 85.4862,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.68,
+      "status": "pass",
+      "throughput_in_gibs": 5.4849,
+      "throughput_out_gibs": 3.57818,
+      "compression_fold": 1.53287,
+      "input_gib": 3.75,
+      "compressed_gib": 2.44639,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.683695,
+      "init_s": 8.1432e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.96769,
+          "best_ms": 4.23292,
+          "in_gibs": 12.5813,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 20.7573,
+          "best_ms": 18.1257,
+          "in_gibs": 36.1318,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.0674,
+          "best_ms": 8.39085,
+          "in_gibs": 74.5024,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 11.41,
+      "status": "pass",
+      "throughput_in_gibs": 5.82247,
+      "throughput_out_gibs": 3.18368,
+      "compression_fold": 1.82885,
+      "input_gib": 3.75,
+      "compressed_gib": 2.05047,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.644056,
+      "init_s": 7.2979e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.60046,
+          "best_ms": 3.9746,
+          "in_gibs": 13.5856,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.5877,
+          "best_ms": 15.4995,
+          "in_gibs": 42.6435,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.33693,
+          "best_ms": 7.02036,
+          "in_gibs": 89.9639,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.74,
+      "status": "pass",
+      "throughput_in_gibs": 6.02398,
+      "throughput_out_gibs": 3.39668,
+      "compression_fold": 1.77349,
+      "input_gib": 3.75,
+      "compressed_gib": 2.11448,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.622512,
+      "init_s": 5.9319e-05,
+      "flush_s": 4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.31137,
+          "best_ms": 3.98309,
+          "in_gibs": 14.4966,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.314,
+          "best_ms": 16.0243,
+          "in_gibs": 40.9523,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.55012,
+          "best_ms": 7.19868,
+          "in_gibs": 87.7195,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 11.66,
+      "status": "pass",
+      "throughput_in_gibs": 5.72067,
+      "throughput_out_gibs": 3.22559,
+      "compression_fold": 1.77353,
+      "input_gib": 3.75,
+      "compressed_gib": 2.11443,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.655517,
+      "init_s": 6.0041e-05,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.72214,
+          "best_ms": 3.99392,
+          "in_gibs": 13.2355,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.9044,
+          "best_ms": 16.4111,
+          "in_gibs": 39.6734,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.75943,
+          "best_ms": 8.4544,
+          "in_gibs": 76.8496,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 11.75,
+      "status": "pass",
+      "throughput_in_gibs": 4.78278,
+      "throughput_out_gibs": 0.154717,
+      "compression_fold": 30.9131,
+      "input_gib": 3.75,
+      "compressed_gib": 0.121308,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.784063,
+      "init_s": 0.000210445,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.76809,
+          "best_ms": 4.54922,
+          "in_gibs": 10.8355,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.8447,
+          "best_ms": 17.3703,
+          "in_gibs": 20.7282,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.15634,
+          "best_ms": 0.341893,
+          "in_gibs": 463.737,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 11.41,
+      "status": "pass",
+      "throughput_in_gibs": 5.4865,
+      "throughput_out_gibs": 0.123357,
+      "compression_fold": 44.4765,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0843141,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.683496,
+      "init_s": 0.000141292,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.85124,
+          "best_ms": 4.39474,
+          "in_gibs": 12.8833,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 21.542,
+          "best_ms": 14.7853,
+          "in_gibs": 24.8684,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.533283,
+          "best_ms": 0.203355,
+          "in_gibs": 1005.05,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.71,
+      "status": "pass",
+      "throughput_in_gibs": 5.21677,
+      "throughput_out_gibs": 0.121479,
+      "compression_fold": 42.9439,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0873231,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.718835,
+      "init_s": 0.000138568,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.64764,
+          "best_ms": 4.36045,
+          "in_gibs": 11.0666,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.7725,
+          "best_ms": 12.6036,
+          "in_gibs": 28.5371,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.85146,
+          "best_ms": 0.177005,
+          "in_gibs": 289.418,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 11.69,
+      "status": "pass",
+      "throughput_in_gibs": 5.16572,
+      "throughput_out_gibs": 0.116291,
+      "compression_fold": 44.4205,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0844204,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.725939,
+      "init_s": 0.000109174,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.56212,
+          "best_ms": 4.3721,
+          "in_gibs": 11.2367,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.13,
+          "best_ms": 11.7655,
+          "in_gibs": 28.0038,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.30263,
+          "best_ms": 0.149184,
+          "in_gibs": 162.228,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.66,
+      "status": "pass",
+      "throughput_in_gibs": 5.722,
+      "throughput_out_gibs": 0.128116,
+      "compression_fold": 44.6627,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0839627,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.655365,
+      "init_s": 7.9639e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.05746,
+          "best_ms": 4.40125,
+          "in_gibs": 12.358,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.7906,
+          "best_ms": 23.5674,
+          "in_gibs": 31.525,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.32259,
+          "best_ms": 0.262023,
+          "in_gibs": 2325.08,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 11.61,
+      "status": "pass",
+      "throughput_in_gibs": 6.08147,
+      "throughput_out_gibs": 0.0853378,
+      "compression_fold": 71.2635,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0526216,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.616627,
+      "init_s": 7.313e-05,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.91431,
+          "best_ms": 3.96443,
+          "in_gibs": 12.7179,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.3798,
+          "best_ms": 16.8177,
+          "in_gibs": 43.1536,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.216857,
+          "best_ms": 0.164606,
+          "in_gibs": 3458.61,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.35,
+      "status": "pass",
+      "throughput_in_gibs": 6.50797,
+      "throughput_out_gibs": 0.0978441,
+      "compression_fold": 66.5137,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0563794,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.576217,
+      "init_s": 6.1311e-05,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.30848,
+          "best_ms": 3.99385,
+          "in_gibs": 14.5063,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.7834,
+          "best_ms": 14.4262,
+          "in_gibs": 47.5182,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.32214,
+          "best_ms": 0.170425,
+          "in_gibs": 567.272,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 11.35,
+      "status": "pass",
+      "throughput_in_gibs": 6.18093,
+      "throughput_out_gibs": 0.0928486,
+      "compression_fold": 66.57,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0563317,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.606705,
+      "init_s": 5.8548e-05,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.83173,
+          "best_ms": 4.03581,
+          "in_gibs": 12.9353,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.0931,
+          "best_ms": 14.5614,
+          "in_gibs": 46.6039,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.920431,
+          "best_ms": 0.170686,
+          "in_gibs": 814.844,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 27.74,
+      "status": "pass",
+      "throughput_in_gibs": 6.00236,
+      "throughput_out_gibs": 6.00823,
+      "compression_fold": 0.999024,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93255,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.488089,
+      "init_s": 0.000168192,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.43786,
+          "best_ms": 0.412779,
+          "in_gibs": 16.7095,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.387,
+          "best_ms": 9.79389,
+          "in_gibs": 51.4567,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.7529,
+          "best_ms": 9.86682,
+          "in_gibs": 54.4912,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 27.42,
+      "status": "pass",
+      "throughput_in_gibs": 6.07387,
+      "throughput_out_gibs": 6.07684,
+      "compression_fold": 0.999512,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93112,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.482342,
+      "init_s": 0.000124046,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.12223,
+          "best_ms": 0.345468,
+          "in_gibs": 18.3986,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.8413,
+          "best_ms": 9.83421,
+          "in_gibs": 45.6293,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.2043,
+          "best_ms": 9.85553,
+          "in_gibs": 48.0108,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 27.78,
+      "status": "pass",
+      "throughput_in_gibs": 6.11813,
+      "throughput_out_gibs": 6.11962,
+      "compression_fold": 0.999756,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.9304,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.478854,
+      "init_s": 0.000151267,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.00148,
+          "best_ms": 0.677296,
+          "in_gibs": 19.1389,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.3614,
+          "best_ms": 10.0077,
+          "in_gibs": 43.8529,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.909,
+          "best_ms": 9.7575,
+          "in_gibs": 49.2013,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 27.92,
+      "status": "pass",
+      "throughput_in_gibs": 6.93818,
+      "throughput_out_gibs": 6.93903,
+      "compression_fold": 0.999878,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93005,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.422256,
+      "init_s": 9.7025e-05,
+      "flush_s": 2.864e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.37201,
+          "best_ms": 0.56677,
+          "in_gibs": 24.2178,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.9689,
+          "best_ms": 9.79106,
+          "in_gibs": 53.4182,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.6389,
+          "best_ms": 9.77908,
+          "in_gibs": 55.075,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 27.83,
+      "status": "pass",
+      "throughput_in_gibs": 5.22234,
+      "throughput_out_gibs": 5.22266,
+      "compression_fold": 0.999939,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92987,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.560991,
+      "init_s": 8.9004e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.15131,
+          "best_ms": 1.76657,
+          "in_gibs": 13.8378,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.5474,
+          "best_ms": 14.8238,
+          "in_gibs": 37.6872,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.9987,
+          "best_ms": 12.8263,
+          "in_gibs": 39.0659,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 27.76,
+      "status": "pass",
+      "throughput_in_gibs": 5.79069,
+      "throughput_out_gibs": 5.79088,
+      "compression_fold": 0.999967,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92978,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.505931,
+      "init_s": 6.8784e-05,
+      "flush_s": 4.9e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.43668,
+          "best_ms": 0.50654,
+          "in_gibs": 16.7152,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.9987,
+          "best_ms": 9.83621,
+          "in_gibs": 45.0765,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.6722,
+          "best_ms": 9.80657,
+          "in_gibs": 46.2379,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.34,
+      "status": "pass",
+      "throughput_in_gibs": 5.66221,
+      "throughput_out_gibs": 5.66229,
+      "compression_fold": 0.999985,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92973,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.517411,
+      "init_s": 5.9399e-05,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.36134,
+          "best_ms": 0.51369,
+          "in_gibs": 17.0899,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.791,
+          "best_ms": 12.0441,
+          "in_gibs": 39.6144,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.8871,
+          "best_ms": 11.6853,
+          "in_gibs": 39.3589,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 27.59,
+      "status": "pass",
+      "throughput_in_gibs": 5.37777,
+      "throughput_out_gibs": 6.45338,
+      "compression_fold": 0.999992,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.51565,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.544777,
+      "init_s": 6.6309e-05,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.72621,
+          "best_ms": 0.516054,
+          "in_gibs": 16.0457,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.7844,
+          "best_ms": 25.8552,
+          "in_gibs": 42.1774,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 26.1261,
+          "best_ms": 22.9461,
+          "in_gibs": 44.8546,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 27.68,
+      "status": "pass",
+      "throughput_in_gibs": 5.4767,
+      "throughput_out_gibs": 0.544496,
+      "compression_fold": 10.0583,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.291271,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.534937,
+      "init_s": 0.000175463,
+      "flush_s": 7.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.76874,
+          "best_ms": 0.403715,
+          "in_gibs": 20.7476,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.4446,
+          "best_ms": 34.6152,
+          "in_gibs": 16.0775,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.9478,
+          "best_ms": 1.33464,
+          "in_gibs": 199.741,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 28.03,
+      "status": "pass",
+      "throughput_in_gibs": 4.7662,
+      "throughput_out_gibs": 0.434757,
+      "compression_fold": 10.9629,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.267236,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.61468,
+      "init_s": 0.000130836,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.00416,
+          "best_ms": 0.671967,
+          "in_gibs": 14.3463,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 37.4821,
+          "best_ms": 33.527,
+          "in_gibs": 15.6324,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.94805,
+          "best_ms": 0.957206,
+          "in_gibs": 199.628,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 27.8,
+      "status": "pass",
+      "throughput_in_gibs": 4.47527,
+      "throughput_out_gibs": 0.259528,
+      "compression_fold": 17.2439,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.169897,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.65464,
+      "init_s": 0.000145979,
+      "flush_s": 2.654e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.88393,
+          "best_ms": 0.68683,
+          "in_gibs": 11.762,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 37.6135,
+          "best_ms": 32.5543,
+          "in_gibs": 15.5778,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.40173,
+          "best_ms": 0.77367,
+          "in_gibs": 133.67,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 28.66,
+      "status": "pass",
+      "throughput_in_gibs": 4.92603,
+      "throughput_out_gibs": 0.299542,
+      "compression_fold": 16.4452,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.178149,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.594736,
+      "init_s": 0.00011344,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.02677,
+          "best_ms": 0.581562,
+          "in_gibs": 14.2657,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.5977,
+          "best_ms": 34.2261,
+          "in_gibs": 16.0102,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.76961,
+          "best_ms": 0.622804,
+          "in_gibs": 212.416,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 27.53,
+      "status": "pass",
+      "throughput_in_gibs": 4.7246,
+      "throughput_out_gibs": 0.206858,
+      "compression_fold": 22.8398,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.128271,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.620093,
+      "init_s": 7.4141e-05,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.21551,
+          "best_ms": 0.942864,
+          "in_gibs": 13.627,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.8557,
+          "best_ms": 35.3606,
+          "in_gibs": 15.8982,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.58816,
+          "best_ms": 4.24454,
+          "in_gibs": 105.271,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 27.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.81204,
+      "throughput_out_gibs": 0.316751,
+      "compression_fold": 15.1919,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.192846,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.608825,
+      "init_s": 7.7627e-05,
+      "flush_s": 2.674e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.62632,
+          "best_ms": 0.611246,
+          "in_gibs": 15.8411,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 40.2179,
+          "best_ms": 36.1279,
+          "in_gibs": 14.5691,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.82812,
+          "best_ms": 0.828302,
+          "in_gibs": 121.84,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 27.73,
+      "status": "pass",
+      "throughput_in_gibs": 5.08266,
+      "throughput_out_gibs": 0.297183,
+      "compression_fold": 17.1028,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.171299,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.576409,
+      "init_s": 6.3816e-05,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.19319,
+          "best_ms": 0.54696,
+          "in_gibs": 17.9898,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 40.0986,
+          "best_ms": 36.6463,
+          "in_gibs": 14.6124,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.60352,
+          "best_ms": 0.722233,
+          "in_gibs": 127.782,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 27.54,
+      "status": "pass",
+      "throughput_in_gibs": 4.90567,
+      "throughput_out_gibs": 0.322519,
+      "compression_fold": 18.2526,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.19261,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.597204,
+      "init_s": 5.8798e-05,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.30318,
+          "best_ms": 0.945367,
+          "in_gibs": 18.1006,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 75.7213,
+          "best_ms": 72.0447,
+          "in_gibs": 15.4762,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.28699,
+          "best_ms": 1.07788,
+          "in_gibs": 357.922,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 27.51,
+      "status": "pass",
+      "throughput_in_gibs": 5.03323,
+      "throughput_out_gibs": 0.526756,
+      "compression_fold": 9.55515,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.306608,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.582069,
+      "init_s": 0.000171277,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.72769,
+          "best_ms": 0.432439,
+          "in_gibs": 15.4103,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.1999,
+          "best_ms": 31.7712,
+          "in_gibs": 17.1327,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.11126,
+          "best_ms": 1.13555,
+          "in_gibs": 279.563,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 27.5,
+      "status": "pass",
+      "throughput_in_gibs": 4.97792,
+      "throughput_out_gibs": 0.564113,
+      "compression_fold": 8.82433,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.332001,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.588536,
+      "init_s": 0.000123556,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.89127,
+          "best_ms": 0.639259,
+          "in_gibs": 14.7625,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 33.619,
+          "best_ms": 31.4024,
+          "in_gibs": 17.4287,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.07712,
+          "best_ms": 1.20857,
+          "in_gibs": 144.485,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 27.58,
+      "status": "pass",
+      "throughput_in_gibs": 4.8188,
+      "throughput_out_gibs": 0.513019,
+      "compression_fold": 9.39303,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.3119,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.60797,
+      "init_s": 0.00013302,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.19854,
+          "best_ms": 1.84891,
+          "in_gibs": 13.6821,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 33.5156,
+          "best_ms": 30.0891,
+          "in_gibs": 17.4825,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.63389,
+          "best_ms": 1.0452,
+          "in_gibs": 127.002,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 27.53,
+      "status": "pass",
+      "throughput_in_gibs": 4.95979,
+      "throughput_out_gibs": 0.561031,
+      "compression_fold": 8.8405,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.331394,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.590688,
+      "init_s": 0.000116174,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.77463,
+          "best_ms": 1.10666,
+          "in_gibs": 15.2187,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.443,
+          "best_ms": 32.0814,
+          "in_gibs": 17.0118,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.255,
+          "best_ms": 1.07132,
+          "in_gibs": 138.244,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 27.49,
+      "status": "pass",
+      "throughput_in_gibs": 5.19127,
+      "throughput_out_gibs": 0.562062,
+      "compression_fold": 9.23613,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.317199,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.564348,
+      "init_s": 7.3139e-05,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.68909,
+          "best_ms": 0.930325,
+          "in_gibs": 15.5715,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.5219,
+          "best_ms": 28.6909,
+          "in_gibs": 18.0167,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.55667,
+          "best_ms": 1.01694,
+          "in_gibs": 165.387,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 27.52,
+      "status": "pass",
+      "throughput_in_gibs": 4.95652,
+      "throughput_out_gibs": 0.579979,
+      "compression_fold": 8.54603,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.342813,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.591077,
+      "init_s": 8.2173e-05,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.93352,
+          "best_ms": 0.902594,
+          "in_gibs": 14.6039,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 33.3219,
+          "best_ms": 31.1188,
+          "in_gibs": 17.5842,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.27165,
+          "best_ms": 1.11653,
+          "in_gibs": 111.583,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 27.79,
+      "status": "pass",
+      "throughput_in_gibs": 4.92614,
+      "throughput_out_gibs": 0.566882,
+      "compression_fold": 8.6899,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.337137,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.594722,
+      "init_s": 8.2614e-05,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.04,
+          "best_ms": 0.520981,
+          "in_gibs": 14.219,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.2657,
+          "best_ms": 29.8176,
+          "in_gibs": 17.0998,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.16482,
+          "best_ms": 1.12891,
+          "in_gibs": 141.237,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 27.81,
+      "status": "pass",
+      "throughput_in_gibs": 5.50035,
+      "throughput_out_gibs": 0.749706,
+      "compression_fold": 8.80401,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.399321,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.532636,
+      "init_s": 6.5509e-05,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.04637,
+          "best_ms": 0.488433,
+          "in_gibs": 19.6265,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 60.577,
+          "best_ms": 58.9644,
+          "in_gibs": 19.3452,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.49074,
+          "best_ms": 2.198,
+          "in_gibs": 472.331,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 27.5,
+      "status": "pass",
+      "throughput_in_gibs": 5.11527,
+      "throughput_out_gibs": 3.08944,
+      "compression_fold": 1.65573,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.76942,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.572734,
+      "init_s": 0.000164357,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.95081,
+          "best_ms": 1.15911,
+          "in_gibs": 14.54,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.5429,
+          "best_ms": 12.454,
+          "in_gibs": 24.8881,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.12691,
+          "best_ms": 6.2269,
+          "in_gibs": 72.1689,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 27.7,
+      "status": "pass",
+      "throughput_in_gibs": 5.44312,
+      "throughput_out_gibs": 3.49855,
+      "compression_fold": 1.55582,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.88305,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.538237,
+      "init_s": 0.000115573,
+      "flush_s": 4.597e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.57016,
+          "best_ms": 0.668122,
+          "in_gibs": 16.0903,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 21.7058,
+          "best_ms": 12.4266,
+          "in_gibs": 26.9945,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.967,
+          "best_ms": 6.64664,
+          "in_gibs": 58.8165,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 27.73,
+      "status": "pass",
+      "throughput_in_gibs": 5.40343,
+      "throughput_out_gibs": 3.32383,
+      "compression_fold": 1.62566,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.80215,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.542191,
+      "init_s": 0.000138418,
+      "flush_s": 5.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.70455,
+          "best_ms": 0.677937,
+          "in_gibs": 15.5066,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.0226,
+          "best_ms": 12.6459,
+          "in_gibs": 30.8021,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.0232,
+          "best_ms": 6.17064,
+          "in_gibs": 53.168,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 27.94,
+      "status": "pass",
+      "throughput_in_gibs": 6.37303,
+      "throughput_out_gibs": 3.3842,
+      "compression_fold": 1.88317,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.55572,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.459701,
+      "init_s": 9.998e-05,
+      "flush_s": 5.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.00968,
+          "best_ms": 0.56658,
+          "in_gibs": 19.0867,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.5924,
+          "best_ms": 11.7039,
+          "in_gibs": 40.1536,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.42099,
+          "best_ms": 5.17751,
+          "in_gibs": 78.9666,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 27.5,
+      "status": "pass",
+      "throughput_in_gibs": 5.22718,
+      "throughput_out_gibs": 2.77509,
+      "compression_fold": 1.8836,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.55536,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.560472,
+      "init_s": 7.4131e-05,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.54698,
+          "best_ms": 2.3864,
+          "in_gibs": 12.6336,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.6142,
+          "best_ms": 14.955,
+          "in_gibs": 33.2651,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.24348,
+          "best_ms": 5.14293,
+          "in_gibs": 63.3934,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 28.05,
+      "status": "pass",
+      "throughput_in_gibs": 5.74575,
+      "throughput_out_gibs": 3.22699,
+      "compression_fold": 1.78053,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.6454,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.509887,
+      "init_s": 8.0291e-05,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.55643,
+          "best_ms": 0.523094,
+          "in_gibs": 16.1524,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.1285,
+          "best_ms": 12.5289,
+          "in_gibs": 34.2084,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.01776,
+          "best_ms": 5.68569,
+          "in_gibs": 64.9781,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 27.71,
+      "status": "pass",
+      "throughput_in_gibs": 5.53737,
+      "throughput_out_gibs": 3.10978,
+      "compression_fold": 1.78063,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.64531,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.529075,
+      "init_s": 7.4061e-05,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.00148,
+          "best_ms": 0.499301,
+          "in_gibs": 14.3559,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.9353,
+          "best_ms": 16.3766,
+          "in_gibs": 32.6695,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.54825,
+          "best_ms": 6.27942,
+          "in_gibs": 68.5461,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 27.52,
+      "status": "pass",
+      "throughput_in_gibs": 5.78293,
+      "throughput_out_gibs": 3.89497,
+      "compression_fold": 1.78166,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.97323,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.506609,
+      "init_s": 5.8267e-05,
+      "flush_s": 2.634e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.45182,
+          "best_ms": 0.520963,
+          "in_gibs": 17.3212,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 30.4888,
+          "best_ms": 29.3059,
+          "in_gibs": 38.4362,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 17.1998,
+          "best_ms": 12.9254,
+          "in_gibs": 68.1338,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 27.94,
+      "status": "pass",
+      "throughput_in_gibs": 5.20034,
+      "throughput_out_gibs": 0.188302,
+      "compression_fold": 27.617,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.106083,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.563365,
+      "init_s": 0.000187952,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.83431,
+          "best_ms": 0.656206,
+          "in_gibs": 14.9818,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.624,
+          "best_ms": 26.1811,
+          "in_gibs": 19.7792,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.02447,
+          "best_ms": 0.728905,
+          "in_gibs": 145.736,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 28.66,
+      "status": "pass",
+      "throughput_in_gibs": 5.79243,
+      "throughput_out_gibs": 0.139385,
+      "compression_fold": 41.5572,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0704978,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.505778,
+      "init_s": 0.000116735,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.98367,
+          "best_ms": 1.08036,
+          "in_gibs": 14.4201,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.0671,
+          "best_ms": 11.751,
+          "in_gibs": 36.4682,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.51446,
+          "best_ms": 0.327672,
+          "in_gibs": 129.855,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 28.02,
+      "status": "pass",
+      "throughput_in_gibs": 5.38461,
+      "throughput_out_gibs": 0.0990478,
+      "compression_fold": 54.3638,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0538904,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.544085,
+      "init_s": 0.000133851,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.56998,
+          "best_ms": 1.03465,
+          "in_gibs": 12.57,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.2208,
+          "best_ms": 14.0159,
+          "in_gibs": 36.1226,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.58486,
+          "best_ms": 4.78765,
+          "in_gibs": 104.941,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 27.71,
+      "status": "pass",
+      "throughput_in_gibs": 5.64971,
+      "throughput_out_gibs": 0.0771982,
+      "compression_fold": 73.1844,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0400316,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.518556,
+      "init_s": 0.000103836,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.40145,
+          "best_ms": 0.928425,
+          "in_gibs": 13.0513,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.6864,
+          "best_ms": 10.2987,
+          "in_gibs": 46.1862,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.07866,
+          "best_ms": 5.84691,
+          "in_gibs": 96.4045,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 27.66,
+      "status": "pass",
+      "throughput_in_gibs": 6.13073,
+      "throughput_out_gibs": 0.090271,
+      "compression_fold": 67.9147,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0431377,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.47787,
+      "init_s": 7.4212e-05,
+      "flush_s": 4.8e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.86773,
+          "best_ms": 0.966192,
+          "in_gibs": 14.8524,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.465,
+          "best_ms": 8.5877,
+          "in_gibs": 51.1067,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.79557,
+          "best_ms": 0.290726,
+          "in_gibs": 122.191,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 27.65,
+      "status": "pass",
+      "throughput_in_gibs": 6.4891,
+      "throughput_out_gibs": 0.152247,
+      "compression_fold": 42.6223,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0687361,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.451479,
+      "init_s": 6.7422e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.51726,
+          "best_ms": 0.903908,
+          "in_gibs": 16.3323,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.5427,
+          "best_ms": 8.93779,
+          "in_gibs": 50.7628,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.43143,
+          "best_ms": 0.218208,
+          "in_gibs": 170.761,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 27.92,
+      "status": "pass",
+      "throughput_in_gibs": 6.70557,
+      "throughput_out_gibs": 0.157107,
+      "compression_fold": 42.6815,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0686407,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.436904,
+      "init_s": 6.7481e-05,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.2242,
+          "best_ms": 0.515083,
+          "in_gibs": 17.8168,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.7184,
+          "best_ms": 9.19958,
+          "in_gibs": 50.0013,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.4257,
+          "best_ms": 0.212559,
+          "in_gibs": 171.045,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 27.99,
+      "status": "pass",
+      "throughput_in_gibs": 6.13723,
+      "throughput_out_gibs": 0.172437,
+      "compression_fold": 42.7094,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.082315,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.477363,
+      "init_s": 6.659e-05,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.06245,
+          "best_ms": 1.70544,
+          "in_gibs": 14.7176,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 22.9988,
+          "best_ms": 21.0241,
+          "in_gibs": 50.9538,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.93454,
+          "best_ms": 4.94545,
+          "in_gibs": 197.469,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.05,
+      "status": "pass",
+      "throughput_in_gibs": 0.696258,
+      "throughput_out_gibs": 0.696939,
+      "compression_fold": 0.999024,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312805,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0448828,
+      "init_s": 6.4817e-05,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0173032,
+          "best_ms": 0.012729,
+          "in_gibs": 0.881849,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.656516,
+          "best_ms": 0.656516,
+          "in_gibs": 47.5998,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.781163,
+          "best_ms": 0.781163,
+          "in_gibs": 40.0045,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.04,
+      "status": "pass",
+      "throughput_in_gibs": 1.00588,
+      "throughput_out_gibs": 1.00637,
+      "compression_fold": 0.999511,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312653,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0310672,
+      "init_s": 0.000137907,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0210779,
+          "best_ms": 0.016975,
+          "in_gibs": 1.44785,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.65264,
+          "best_ms": 0.65264,
+          "in_gibs": 47.8824,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.76567,
+          "best_ms": 0.76567,
+          "in_gibs": 40.8139,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.47436,
+      "throughput_out_gibs": 1.47472,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0211957,
+      "init_s": 0.000107702,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0254845,
+          "best_ms": 0.019129,
+          "in_gibs": 2.39499,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.776366,
+          "best_ms": 0.776366,
+          "in_gibs": 40.2516,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.746371,
+          "best_ms": 0.746371,
+          "in_gibs": 41.8693,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.02,
+      "status": "pass",
+      "throughput_in_gibs": 1.83548,
+      "throughput_out_gibs": 1.83571,
+      "compression_fold": 0.999877,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312538,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0170255,
+      "init_s": 9.4221e-05,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0333218,
+          "best_ms": 0.022864,
+          "in_gibs": 3.66338,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.682034,
+          "best_ms": 0.682034,
+          "in_gibs": 45.8188,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.656856,
+          "best_ms": 0.656856,
+          "in_gibs": 47.5751,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.02,
+      "status": "pass",
+      "throughput_in_gibs": 2.22727,
+      "throughput_out_gibs": 2.22741,
+      "compression_fold": 0.999938,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312519,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0140306,
+      "init_s": 6.026e-05,
+      "flush_s": 4.9e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0468873,
+          "best_ms": 0.032819,
+          "in_gibs": 5.20696,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 0.661033,
+          "best_ms": 0.661033,
+          "in_gibs": 47.2745,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.620482,
+          "best_ms": 0.620482,
+          "in_gibs": 50.3641,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.26793,
+      "throughput_out_gibs": 1.26797,
+      "compression_fold": 0.999969,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.031251,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0246465,
+      "init_s": 6.5929e-05,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0909207,
+          "best_ms": 0.061793,
+          "in_gibs": 5.37041,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.05481,
+          "best_ms": 7.05481,
+          "in_gibs": 4.4296,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.29103,
+          "best_ms": 3.29103,
+          "in_gibs": 9.4955,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.56156,
+      "throughput_out_gibs": 1.56159,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.020012,
+      "init_s": 7.967e-05,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.156006,
+          "best_ms": 0.11337,
+          "in_gibs": 6.25978,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.71669,
+          "best_ms": 6.71669,
+          "in_gibs": 4.65259,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.749686,
+          "best_ms": 0.749686,
+          "in_gibs": 41.6841,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.55873,
+      "throughput_out_gibs": 1.55875,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0200484,
+      "init_s": 7.8047e-05,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.158902,
+          "best_ms": 0.1136,
+          "in_gibs": 6.14568,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.29535,
+          "best_ms": 6.29535,
+          "in_gibs": 4.96398,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.794183,
+          "best_ms": 0.794183,
+          "in_gibs": 39.3486,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.06,
+      "status": "pass",
+      "throughput_in_gibs": 0.534338,
+      "throughput_out_gibs": 0.0170245,
+      "compression_fold": 31.3865,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000995651,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0584836,
+      "init_s": 7.7827e-05,
+      "flush_s": 2.694e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.019286,
+          "best_ms": 0.014933,
+          "in_gibs": 0.791184,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.63931,
+          "best_ms": 4.63931,
+          "in_gibs": 6.73592,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.87243,
+          "best_ms": 6.87243,
+          "in_gibs": 4.56936,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.05,
+      "status": "pass",
+      "throughput_in_gibs": 0.715533,
+      "throughput_out_gibs": 0.0127964,
+      "compression_fold": 55.9166,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000558868,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0436737,
+      "init_s": 0.0001134,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0219821,
+          "best_ms": 0.017997,
+          "in_gibs": 1.38829,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.17228,
+          "best_ms": 6.17228,
+          "in_gibs": 5.06296,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.22336,
+          "best_ms": 7.22336,
+          "in_gibs": 4.34526,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.08,
+      "status": "pass",
+      "throughput_in_gibs": 0.433706,
+      "throughput_out_gibs": 0.00472534,
+      "compression_fold": 91.7831,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000340477,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0720534,
+      "init_s": 0.000215103,
+      "flush_s": 2.684e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.100433,
+          "best_ms": 0.01992,
+          "in_gibs": 0.607721,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.58035,
+          "best_ms": 5.58035,
+          "in_gibs": 5.60001,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.2356,
+          "best_ms": 7.2356,
+          "in_gibs": 4.33738,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.21507,
+      "throughput_out_gibs": 0.009002,
+      "compression_fold": 134.978,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000231519,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0257186,
+      "init_s": 0.000184838,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0353716,
+          "best_ms": 0.02664,
+          "in_gibs": 3.45108,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.77916,
+          "best_ms": 3.77916,
+          "in_gibs": 8.26904,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.8953,
+          "best_ms": 5.8953,
+          "in_gibs": 5.32283,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.02,
+      "status": "pass",
+      "throughput_in_gibs": 1.60548,
+      "throughput_out_gibs": 0.00909552,
+      "compression_fold": 176.513,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000177041,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0194646,
+      "init_s": 7.274e-05,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0510611,
+          "best_ms": 0.037065,
+          "in_gibs": 4.78134,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.27239,
+          "best_ms": 5.27239,
+          "in_gibs": 5.92711,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.657808,
+          "best_ms": 0.657808,
+          "in_gibs": 47.6976,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.02,
+      "status": "pass",
+      "throughput_in_gibs": 1.84891,
+      "throughput_out_gibs": 0.00886301,
+      "compression_fold": 208.61,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000149801,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0169019,
+      "init_s": 7.7146e-05,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0832586,
+          "best_ms": 0.058558,
+          "in_gibs": 5.86463,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.74326,
+          "best_ms": 3.74326,
+          "in_gibs": 8.34834,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.533221,
+          "best_ms": 0.533221,
+          "in_gibs": 58.8422,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.02,
+      "status": "pass",
+      "throughput_in_gibs": 2.06855,
+      "throughput_out_gibs": 0.00901435,
+      "compression_fold": 229.473,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000136182,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0151072,
+      "init_s": 6.2183e-05,
+      "flush_s": 2.554e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.154453,
+          "best_ms": 0.116585,
+          "in_gibs": 6.32271,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.20373,
+          "best_ms": 3.20373,
+          "in_gibs": 9.75425,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.024216,
+          "best_ms": 0.024216,
+          "in_gibs": 1295.67,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.02,
+      "status": "pass",
+      "throughput_in_gibs": 1.97188,
+      "throughput_out_gibs": 0.0085931,
+      "compression_fold": 229.473,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000136182,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0158478,
+      "init_s": 6.051e-05,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.172294,
+          "best_ms": 0.115623,
+          "in_gibs": 5.668,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.29362,
+          "best_ms": 3.29362,
+          "in_gibs": 9.48805,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.031527,
+          "best_ms": 0.031527,
+          "in_gibs": 995.207,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.06,
+      "status": "pass",
+      "throughput_in_gibs": 0.604489,
+      "throughput_out_gibs": 0.0536826,
+      "compression_fold": 11.2604,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00277521,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0516966,
+      "init_s": 6.9144e-05,
+      "flush_s": 5.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0199342,
+          "best_ms": 0.015183,
+          "in_gibs": 0.765459,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.99565,
+          "best_ms": 2.99565,
+          "in_gibs": 10.4318,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.221903,
+          "best_ms": 0.221903,
+          "in_gibs": 141.859,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.04,
+      "status": "pass",
+      "throughput_in_gibs": 0.874717,
+      "throughput_out_gibs": 0.0750112,
+      "compression_fold": 11.6611,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00267984,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0357258,
+      "init_s": 0.000104577,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0221733,
+          "best_ms": 0.017766,
+          "in_gibs": 1.37632,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.2738,
+          "best_ms": 4.2738,
+          "in_gibs": 7.312,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.977668,
+          "best_ms": 0.977668,
+          "in_gibs": 32.1355,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.25063,
+      "throughput_out_gibs": 0.105015,
+      "compression_fold": 11.9091,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00262405,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0249874,
+      "init_s": 0.000111868,
+      "flush_s": 3.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0270739,
+          "best_ms": 0.020811,
+          "in_gibs": 2.25439,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.67137,
+          "best_ms": 2.67137,
+          "in_gibs": 11.6981,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.255814,
+          "best_ms": 0.255814,
+          "in_gibs": 122.696,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.4417,
+      "throughput_out_gibs": 0.119893,
+      "compression_fold": 12.0249,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00259878,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0216758,
+      "init_s": 9.0005e-05,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0359692,
+          "best_ms": 0.026279,
+          "in_gibs": 3.39375,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.09796,
+          "best_ms": 5.09796,
+          "in_gibs": 6.12991,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.244397,
+          "best_ms": 0.244397,
+          "in_gibs": 128.365,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.02,
+      "status": "pass",
+      "throughput_in_gibs": 1.81265,
+      "throughput_out_gibs": 0.150009,
+      "compression_fold": 12.0836,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00258614,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.01724,
+      "init_s": 8.2063e-05,
+      "flush_s": 5.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0564096,
+          "best_ms": 0.035594,
+          "in_gibs": 4.32799,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.96087,
+          "best_ms": 2.96087,
+          "in_gibs": 10.5543,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.251528,
+          "best_ms": 0.251528,
+          "in_gibs": 124.726,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.06,
+      "status": "pass",
+      "throughput_in_gibs": 0.531672,
+      "throughput_out_gibs": 0.043901,
+      "compression_fold": 12.1107,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00258036,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0587768,
+      "init_s": 7.3711e-05,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0849204,
+          "best_ms": 0.06008,
+          "in_gibs": 5.74987,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 42.5399,
+          "best_ms": 42.5399,
+          "in_gibs": 0.734605,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.01026,
+          "best_ms": 3.01026,
+          "in_gibs": 10.4217,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.06,
+      "status": "pass",
+      "throughput_in_gibs": 0.521468,
+      "throughput_out_gibs": 0.0430071,
+      "compression_fold": 12.1251,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00257729,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.059927,
+      "init_s": 6.3997e-05,
+      "flush_s": 1.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.159294,
+          "best_ms": 0.11975,
+          "in_gibs": 6.13056,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.1685,
+          "best_ms": 43.1685,
+          "in_gibs": 0.723907,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.58305,
+          "best_ms": 3.58305,
+          "in_gibs": 8.75569,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.07,
+      "status": "pass",
+      "throughput_in_gibs": 0.511582,
+      "throughput_out_gibs": 0.0421918,
+      "compression_fold": 12.1251,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00257729,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.061085,
+      "init_s": 9.7957e-05,
+      "flush_s": 1.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.155957,
+          "best_ms": 0.114012,
+          "in_gibs": 6.26174,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 42.5307,
+          "best_ms": 42.5307,
+          "in_gibs": 0.734763,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.7521,
+          "best_ms": 4.7521,
+          "in_gibs": 6.60173,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.06,
+      "status": "pass",
+      "throughput_in_gibs": 0.548964,
+      "throughput_out_gibs": 0.366959,
+      "compression_fold": 1.49598,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0208893,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0569255,
+      "init_s": 6.9595e-05,
+      "flush_s": 3.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0186304,
+          "best_ms": 0.014352,
+          "in_gibs": 0.819024,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.67832,
+          "best_ms": 4.67832,
+          "in_gibs": 6.67975,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.0303,
+          "best_ms": 6.0303,
+          "in_gibs": 5.18723,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.04,
+      "status": "pass",
+      "throughput_in_gibs": 0.879065,
+      "throughput_out_gibs": 0.588959,
+      "compression_fold": 1.49257,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.020937,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0355492,
+      "init_s": 0.000121793,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0227784,
+          "best_ms": 0.018458,
+          "in_gibs": 1.33976,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.91879,
+          "best_ms": 2.91879,
+          "in_gibs": 10.7065,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.46587,
+          "best_ms": 0.46587,
+          "in_gibs": 67.1116,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.04,
+      "status": "pass",
+      "throughput_in_gibs": 0.910535,
+      "throughput_out_gibs": 0.610738,
+      "compression_fold": 1.49088,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209608,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0343205,
+      "init_s": 0.000156455,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0288624,
+          "best_ms": 0.021222,
+          "in_gibs": 2.11469,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.50003,
+          "best_ms": 4.50003,
+          "in_gibs": 6.9444,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.00327,
+          "best_ms": 6.00327,
+          "in_gibs": 5.20676,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.04,
+      "status": "pass",
+      "throughput_in_gibs": 1.04764,
+      "throughput_out_gibs": 0.703099,
+      "compression_fold": 1.49003,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209727,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.029829,
+      "init_s": 9.7046e-05,
+      "flush_s": 6.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.034989,
+          "best_ms": 0.025548,
+          "in_gibs": 3.48882,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.85505,
+          "best_ms": 9.85505,
+          "in_gibs": 3.17096,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.42538,
+          "best_ms": 3.42538,
+          "in_gibs": 9.12418,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.02,
+      "status": "pass",
+      "throughput_in_gibs": 1.79992,
+      "throughput_out_gibs": 1.20776,
+      "compression_fold": 1.4903,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209689,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0173619,
+      "init_s": 7.6695e-05,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0509485,
+          "best_ms": 0.037566,
+          "in_gibs": 4.79191,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.90814,
+          "best_ms": 2.90814,
+          "in_gibs": 10.7457,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.512109,
+          "best_ms": 0.512109,
+          "in_gibs": 61.0296,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.07,
+      "status": "pass",
+      "throughput_in_gibs": 0.502775,
+      "throughput_out_gibs": 0.337334,
+      "compression_fold": 1.49044,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.020967,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.062155,
+      "init_s": 0.000105699,
+      "flush_s": 3.6e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0930552,
+          "best_ms": 0.05984,
+          "in_gibs": 5.24722,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.1563,
+          "best_ms": 43.1563,
+          "in_gibs": 0.724111,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.79323,
+          "best_ms": 4.79323,
+          "in_gibs": 6.52041,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.07,
+      "status": "pass",
+      "throughput_in_gibs": 0.512246,
+      "throughput_out_gibs": 0.343673,
+      "compression_fold": 1.4905,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209661,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0610058,
+      "init_s": 6.4727e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.154413,
+          "best_ms": 0.10646,
+          "in_gibs": 6.32436,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 42.7898,
+          "best_ms": 42.7898,
+          "in_gibs": 0.730314,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.36802,
+          "best_ms": 5.36802,
+          "in_gibs": 5.82222,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.06,
+      "status": "pass",
+      "throughput_in_gibs": 0.545972,
+      "throughput_out_gibs": 0.366301,
+      "compression_fold": 1.4905,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209661,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0572373,
+      "init_s": 6.706e-05,
+      "flush_s": 3.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.156675,
+          "best_ms": 0.116114,
+          "in_gibs": 6.23305,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.2339,
+          "best_ms": 43.2339,
+          "in_gibs": 0.722812,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.69235,
+          "best_ms": 0.69235,
+          "in_gibs": 45.1416,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.06,
+      "status": "pass",
+      "throughput_in_gibs": 0.547592,
+      "throughput_out_gibs": 0.0179815,
+      "compression_fold": 30.4531,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102617,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.057068,
+      "init_s": 7.2629e-05,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0185816,
+          "best_ms": 0.014311,
+          "in_gibs": 0.821176,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.60152,
+          "best_ms": 5.60152,
+          "in_gibs": 5.57884,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.91704,
+          "best_ms": 5.91704,
+          "in_gibs": 5.28651,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.04,
+      "status": "pass",
+      "throughput_in_gibs": 0.957493,
+      "throughput_out_gibs": 0.0340422,
+      "compression_fold": 28.1267,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00111105,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0326373,
+      "init_s": 0.000105509,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.022358,
+          "best_ms": 0.017957,
+          "in_gibs": 1.36495,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.98349,
+          "best_ms": 2.98349,
+          "in_gibs": 10.4743,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.118087,
+          "best_ms": 0.118087,
+          "in_gibs": 264.765,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.28042,
+      "throughput_out_gibs": 0.0421824,
+      "compression_fold": 30.3544,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102951,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.024406,
+      "init_s": 0.000147061,
+      "flush_s": 1.753e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0274745,
+          "best_ms": 0.021332,
+          "in_gibs": 2.22152,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.31447,
+          "best_ms": 3.31447,
+          "in_gibs": 9.42836,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.116806,
+          "best_ms": 0.116806,
+          "in_gibs": 267.603,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.02,
+      "status": "pass",
+      "throughput_in_gibs": 1.6257,
+      "throughput_out_gibs": 0.0513619,
+      "compression_fold": 31.6518,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000987306,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0192225,
+      "init_s": 9.2989e-05,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0338175,
+          "best_ms": 0.025488,
+          "in_gibs": 3.60968,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 3.26592,
+          "best_ms": 3.26592,
+          "in_gibs": 9.5685,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.120591,
+          "best_ms": 0.120591,
+          "in_gibs": 259.172,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.04,
+      "status": "pass",
+      "throughput_in_gibs": 0.983996,
+      "throughput_out_gibs": 0.030968,
+      "compression_fold": 31.7745,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000983492,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0317583,
+      "init_s": 7.985e-05,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0487301,
+          "best_ms": 0.034091,
+          "in_gibs": 5.01006,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.676,
+          "best_ms": 11.676,
+          "in_gibs": 2.67643,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.99379,
+          "best_ms": 5.99379,
+          "in_gibs": 5.21437,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.07,
+      "status": "pass",
+      "throughput_in_gibs": 0.467719,
+      "throughput_out_gibs": 0.0146914,
+      "compression_fold": 31.8363,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000981584,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0668136,
+      "init_s": 6.8433e-05,
+      "flush_s": 1.743e-06,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.0847865,
+          "best_ms": 0.061152,
+          "in_gibs": 5.75895,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 50.8347,
+          "best_ms": 50.8347,
+          "in_gibs": 0.614738,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.01343,
+          "best_ms": 3.01343,
+          "in_gibs": 10.3715,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.12,
+      "status": "pass",
+      "throughput_in_gibs": 0.269449,
+      "throughput_out_gibs": 0.00845535,
+      "compression_fold": 31.8673,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000980631,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.115978,
+      "init_s": 9.1097e-05,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 1.65987,
+          "best_ms": 0.116354,
+          "in_gibs": 0.588336,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 51.572,
+          "best_ms": 51.572,
+          "in_gibs": 0.605949,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.61432,
+          "best_ms": 3.61432,
+          "in_gibs": 8.64722,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.07,
+      "status": "pass",
+      "throughput_in_gibs": 0.457558,
+      "throughput_out_gibs": 0.0143583,
+      "compression_fold": 31.8673,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000980631,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0682973,
+      "init_s": 6.5458e-05,
+      "flush_s": 2.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.157956,
+          "best_ms": 0.118268,
+          "in_gibs": 6.18248,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 51.7365,
+          "best_ms": 51.7365,
+          "in_gibs": 0.604023,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.00767,
+          "best_ms": 3.00767,
+          "in_gibs": 10.3914,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.83,
+      "status": "pass",
+      "throughput_in_gibs": 8.93803,
+      "throughput_out_gibs": 11.9597,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.70414,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.393333,
+      "init_s": 0.236535,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41603,
+          "best_ms": 0.713632,
+          "in_gibs": 19.4016,
+          "out_gibs": 19.4016
+        },
+        "h2d": {
+          "avg_ms": 0.914155,
+          "best_ms": 0.29776,
+          "in_gibs": 51.511,
+          "out_gibs": 51.511
+        },
+        "scatter": {
+          "avg_ms": 0.071783,
+          "best_ms": 0.013952,
+          "in_gibs": 655.991,
+          "out_gibs": 655.991
+        },
+        "lod_gather": {
+          "avg_ms": 0.224464,
+          "best_ms": 0.224448,
+          "in_gibs": 626.492,
+          "out_gibs": 626.492
+        },
+        "lod_reduce": {
+          "avg_ms": 0.774736,
+          "best_ms": 0.761376,
+          "in_gibs": 181.513,
+          "out_gibs": 242.116
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.31808,
+          "best_ms": 0.317056,
+          "in_gibs": 589.714,
+          "out_gibs": 591.393
+        },
+        "compress": {
+          "avg_ms": 1.04227,
+          "best_ms": 0.250336,
+          "in_gibs": 501.338,
+          "out_gibs": 501.338
+        },
+        "aggregate": {
+          "avg_ms": 1.74846,
+          "best_ms": 1.10339,
+          "in_gibs": 298.851,
+          "out_gibs": 298.851
+        },
+        "d2h": {
+          "avg_ms": 10.1102,
+          "best_ms": 3.59011,
+          "in_gibs": 51.6836,
+          "out_gibs": 51.6836
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 7.92113,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 5.77901,
+        "kick_sync_count": 9,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.35549,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 6.42,
+      "status": "pass",
+      "throughput_in_gibs": 2.84082,
+      "throughput_out_gibs": 3.8012,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.70414,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 1.23754,
+      "init_s": 3.1978,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.81957,
+          "best_ms": 0.760412,
+          "in_gibs": 16.6248,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 5.56172,
+          "best_ms": 4.67511,
+          "in_gibs": 25.2845,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 12.6891,
+          "best_ms": 11.5005,
+          "in_gibs": 14.7825,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.35194,
+          "best_ms": 4.88972,
+          "in_gibs": 35.1481,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.07264,
+          "best_ms": 3.22772,
+          "in_gibs": 57.5939,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.27028,
+          "best_ms": 3.18783,
+          "in_gibs": 56.366,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.1,
+      "status": "pass",
+      "throughput_in_gibs": 4.11288,
+      "throughput_out_gibs": 0.669367,
+      "compression_fold": 8.21924,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.572165,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.854785,
+      "init_s": 0.236953,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.42673,
+          "best_ms": 0.729566,
+          "in_gibs": 19.3161,
+          "out_gibs": 19.3161
+        },
+        "h2d": {
+          "avg_ms": 0.913214,
+          "best_ms": 0.296544,
+          "in_gibs": 51.5641,
+          "out_gibs": 51.5641
+        },
+        "scatter": {
+          "avg_ms": 0.0558876,
+          "best_ms": 0.015648,
+          "in_gibs": 832.235,
+          "out_gibs": 832.235
+        },
+        "lod_gather": {
+          "avg_ms": 3.29288,
+          "best_ms": 0.292416,
+          "in_gibs": 42.7058,
+          "out_gibs": 42.7058
+        },
+        "lod_reduce": {
+          "avg_ms": 1.58117,
+          "best_ms": 0.786016,
+          "in_gibs": 88.9374,
+          "out_gibs": 118.631
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.894352,
+          "best_ms": 0.42048,
+          "in_gibs": 209.734,
+          "out_gibs": 210.331
+        },
+        "compress": {
+          "avg_ms": 81.0022,
+          "best_ms": 18.1745,
+          "in_gibs": 6.4508,
+          "out_gibs": 0.782951
+        },
+        "aggregate": {
+          "avg_ms": 0.346631,
+          "best_ms": 0.216608,
+          "in_gibs": 182.963,
+          "out_gibs": 182.963
+        },
+        "d2h": {
+          "avg_ms": 10.1618,
+          "best_ms": 3.58896,
+          "in_gibs": 6.2411,
+          "out_gibs": 6.2411
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 107.966,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 105.826,
+        "kick_sync_count": 9,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 90.0965,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 6.41,
+      "status": "pass",
+      "throughput_in_gibs": 2.29633,
+      "throughput_out_gibs": 0.294393,
+      "compression_fold": 10.4341,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.450709,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 1.53098,
+      "init_s": 3.13516,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.79402,
+          "best_ms": 0.764919,
+          "in_gibs": 16.7769,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.38962,
+          "best_ms": 4.59121,
+          "in_gibs": 22.0083,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 17.7768,
+          "best_ms": 11.6106,
+          "in_gibs": 10.5517,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 7.27785,
+          "best_ms": 4.89951,
+          "in_gibs": 25.847,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.8448,
+          "best_ms": 14.1813,
+          "in_gibs": 19.4648,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.86595,
+          "best_ms": 0.933171,
+          "in_gibs": 281.271,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 6.42,
+      "status": "pass",
+      "throughput_in_gibs": 2.3154,
+      "throughput_out_gibs": 1.61603,
+      "compression_fold": 1.91658,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.45373,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 1.51837,
+      "init_s": 3.12705,
+      "flush_s": 4.6e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.79401,
+          "best_ms": 0.781203,
+          "in_gibs": 16.777,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.52005,
+          "best_ms": 4.66094,
+          "in_gibs": 21.5681,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 19.0789,
+          "best_ms": 11.5637,
+          "in_gibs": 9.83159,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 9.23585,
+          "best_ms": 4.87664,
+          "in_gibs": 20.3674,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.5454,
+          "best_ms": 4.08673,
+          "in_gibs": 41.651,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.64867,
+          "best_ms": 1.76786,
+          "in_gibs": 92.53,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 6.3,
+      "status": "pass",
+      "throughput_in_gibs": 2.71112,
+      "throughput_out_gibs": 0.0599976,
+      "compression_fold": 60.4457,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0778014,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 1.29674,
+      "init_s": 3.17719,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.79919,
+          "best_ms": 0.770988,
+          "in_gibs": 16.7459,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 5.76922,
+          "best_ms": 4.65894,
+          "in_gibs": 24.375,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 16.2942,
+          "best_ms": 11.5663,
+          "in_gibs": 11.5118,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 6.39309,
+          "best_ms": 4.91255,
+          "in_gibs": 29.424,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.8776,
+          "best_ms": 3.88551,
+          "in_gibs": 48.0372,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.228757,
+          "best_ms": 0.155053,
+          "in_gibs": 2284.84,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.73,
+      "status": "pass",
+      "throughput_in_gibs": 8.96921,
+      "throughput_out_gibs": 12.1156,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.74892,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.391966,
+      "init_s": 0.242169,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.44409,
+          "best_ms": 0.769696,
+          "in_gibs": 19.1789,
+          "out_gibs": 19.1789
+        },
+        "h2d": {
+          "avg_ms": 0.923646,
+          "best_ms": 0.296544,
+          "in_gibs": 50.9817,
+          "out_gibs": 50.9817
+        },
+        "scatter": {
+          "avg_ms": 0.0857771,
+          "best_ms": 0.013952,
+          "in_gibs": 548.97,
+          "out_gibs": 548.97
+        },
+        "lod_gather": {
+          "avg_ms": 0.223504,
+          "best_ms": 0.222496,
+          "in_gibs": 629.183,
+          "out_gibs": 629.183
+        },
+        "lod_reduce": {
+          "avg_ms": 0.783232,
+          "best_ms": 0.780384,
+          "in_gibs": 179.545,
+          "out_gibs": 239.782
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.315536,
+          "best_ms": 0.31504,
+          "in_gibs": 595.194,
+          "out_gibs": 601.964
+        },
+        "compress": {
+          "avg_ms": 1.05045,
+          "best_ms": 0.252288,
+          "in_gibs": 502.277,
+          "out_gibs": 502.277
+        },
+        "aggregate": {
+          "avg_ms": 3.02696,
+          "best_ms": 2.44595,
+          "in_gibs": 174.305,
+          "out_gibs": 174.305
+        },
+        "d2h": {
+          "avg_ms": 10.4522,
+          "best_ms": 3.62326,
+          "in_gibs": 50.4789,
+          "out_gibs": 50.4789
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 8.34602,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 7.64597,
+        "kick_sync_count": 9,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.09393,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 6.25,
+      "status": "pass",
+      "throughput_in_gibs": 2.60475,
+      "throughput_out_gibs": 3.5185,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.74892,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.3497,
+      "init_s": 3.16749,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.78622,
+          "best_ms": 0.762555,
+          "in_gibs": 16.8239,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.0227,
+          "best_ms": 4.71539,
+          "in_gibs": 23.3492,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.5199,
+          "best_ms": 11.5963,
+          "in_gibs": 12.9344,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 7.57165,
+          "best_ms": 5.5589,
+          "in_gibs": 25.0859,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.19007,
+          "best_ms": 3.20972,
+          "in_gibs": 57.4114,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.40783,
+          "best_ms": 3.21817,
+          "in_gibs": 56.0825,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.86,
+      "status": "pass",
+      "throughput_in_gibs": 6.10216,
+      "throughput_out_gibs": 0.63843,
+      "compression_fold": 12.91,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.367817,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.576128,
+      "init_s": 0.238362,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.42271,
+          "best_ms": 0.715834,
+          "in_gibs": 19.3481,
+          "out_gibs": 19.3481
+        },
+        "h2d": {
+          "avg_ms": 0.907247,
+          "best_ms": 0.29856,
+          "in_gibs": 51.9032,
+          "out_gibs": 51.9032
+        },
+        "scatter": {
+          "avg_ms": 0.112474,
+          "best_ms": 0.013952,
+          "in_gibs": 418.667,
+          "out_gibs": 418.667
+        },
+        "lod_gather": {
+          "avg_ms": 0.771616,
+          "best_ms": 0.238464,
+          "in_gibs": 182.247,
+          "out_gibs": 182.247
+        },
+        "lod_reduce": {
+          "avg_ms": 1.10261,
+          "best_ms": 0.769728,
+          "in_gibs": 127.538,
+          "out_gibs": 170.327
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.774528,
+          "best_ms": 0.34272,
+          "in_gibs": 242.477,
+          "out_gibs": 245.235
+        },
+        "compress": {
+          "avg_ms": 50.3114,
+          "best_ms": 29.3647,
+          "in_gibs": 10.487,
+          "out_gibs": 0.811465
+        },
+        "aggregate": {
+          "avg_ms": 0.367968,
+          "best_ms": 0.237216,
+          "in_gibs": 110.95,
+          "out_gibs": 110.95
+        },
+        "d2h": {
+          "avg_ms": 10.1665,
+          "best_ms": 3.62176,
+          "in_gibs": 4.01574,
+          "out_gibs": 4.01574
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 119.613,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 118.912,
+        "kick_sync_count": 9,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 78.7414,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 6.66,
+      "status": "pass",
+      "throughput_in_gibs": 2.30033,
+      "throughput_out_gibs": 0.300045,
+      "compression_fold": 10.3553,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.458563,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.52831,
+      "init_s": 3.19623,
+      "flush_s": 7.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.79398,
+          "best_ms": 0.787783,
+          "in_gibs": 16.7772,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.6092,
+          "best_ms": 4.80066,
+          "in_gibs": 21.2772,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 16.9603,
+          "best_ms": 11.5767,
+          "in_gibs": 11.0732,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 7.97159,
+          "best_ms": 5.52074,
+          "in_gibs": 23.8273,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.7941,
+          "best_ms": 9.07992,
+          "in_gibs": 20.4549,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.79154,
+          "best_ms": 0.924478,
+          "in_gibs": 189.744,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 6.38,
+      "status": "pass",
+      "throughput_in_gibs": 2.47201,
+      "throughput_out_gibs": 1.76118,
+      "compression_fold": 1.89585,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.5047,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.42217,
+      "init_s": 3.16808,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.79158,
+          "best_ms": 0.768805,
+          "in_gibs": 16.7916,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.55425,
+          "best_ms": 4.77454,
+          "in_gibs": 21.4555,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 17,
+          "best_ms": 11.5955,
+          "in_gibs": 11.0474,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 7.73371,
+          "best_ms": 5.58057,
+          "in_gibs": 24.5602,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.5171,
+          "best_ms": 4.19203,
+          "in_gibs": 45.8116,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.28931,
+          "best_ms": 5.20238,
+          "in_gibs": 83.8984,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 6.39,
+      "status": "pass",
+      "throughput_in_gibs": 2.28155,
+      "throughput_out_gibs": 0.0432471,
+      "compression_fold": 71.2575,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0666391,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.54089,
+      "init_s": 3.0986,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.79208,
+          "best_ms": 0.781033,
+          "in_gibs": 16.7885,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.62414,
+          "best_ms": 4.6832,
+          "in_gibs": 21.2292,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 21.7647,
+          "best_ms": 11.5634,
+          "in_gibs": 8.6289,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 10.5702,
+          "best_ms": 5.50044,
+          "in_gibs": 17.9694,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.54109,
+          "best_ms": 3.30839,
+          "in_gibs": 61.7737,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.911689,
+          "best_ms": 0.122404,
+          "in_gibs": 578.775,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.85,
+      "status": "pass",
+      "throughput_in_gibs": 8.63849,
+      "throughput_out_gibs": 12.5404,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 5.10361,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 0.406972,
+      "init_s": 0.331984,
+      "flush_s": 5.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.81472,
+          "best_ms": 0.87285,
+          "in_gibs": 19.8256,
+          "out_gibs": 19.8256
+        },
+        "h2d": {
+          "avg_ms": 1.08825,
+          "best_ms": 0.590272,
+          "in_gibs": 51.7826,
+          "out_gibs": 51.7826
+        },
+        "scatter": {
+          "avg_ms": 0.0602056,
+          "best_ms": 0.02528,
+          "in_gibs": 936,
+          "out_gibs": 936
+        },
+        "lod_gather": {
+          "avg_ms": 0.429675,
+          "best_ms": 0.4264,
+          "in_gibs": 654.565,
+          "out_gibs": 654.565
+        },
+        "lod_reduce": {
+          "avg_ms": 1.53574,
+          "best_ms": 1.52371,
+          "in_gibs": 183.136,
+          "out_gibs": 244.499
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.608555,
+          "best_ms": 0.607872,
+          "in_gibs": 617.017,
+          "out_gibs": 645.099
+        },
+        "compress": {
+          "avg_ms": 1.41022,
+          "best_ms": 0.547168,
+          "in_gibs": 516.992,
+          "out_gibs": 516.992
+        },
+        "aggregate": {
+          "avg_ms": 7.94791,
+          "best_ms": 7.57418,
+          "in_gibs": 91.7315,
+          "out_gibs": 91.7315
+        },
+        "d2h": {
+          "avg_ms": 14.1045,
+          "best_ms": 7.47216,
+          "in_gibs": 51.691,
+          "out_gibs": 51.691
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 32.5586,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 32.305,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.9163,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.4,
+      "status": "pass",
+      "throughput_in_gibs": 2.58691,
+      "throughput_out_gibs": 3.7554,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 5.10361,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.35901,
+      "init_s": 6.01554,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.71539,
+          "best_ms": 0.803506,
+          "in_gibs": 15.0196,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.7367,
+          "best_ms": 9.47745,
+          "in_gibs": 26.1952,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 26.1017,
+          "best_ms": 23.2289,
+          "in_gibs": 14.3856,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.7012,
+          "best_ms": 10.9633,
+          "in_gibs": 30.9087,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.9419,
+          "best_ms": 8.52962,
+          "in_gibs": 45.7331,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 16.0415,
+          "best_ms": 8.60844,
+          "in_gibs": 45.4492,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.95,
+      "status": "pass",
+      "throughput_in_gibs": 5.75551,
+      "throughput_out_gibs": 0.78667,
+      "compression_fold": 10.6208,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.48052,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 0.610828,
+      "init_s": 0.327221,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.74902,
+          "best_ms": 0.734453,
+          "in_gibs": 20.2994,
+          "out_gibs": 20.2994
+        },
+        "h2d": {
+          "avg_ms": 1.08468,
+          "best_ms": 0.59072,
+          "in_gibs": 51.9533,
+          "out_gibs": 51.9533
+        },
+        "scatter": {
+          "avg_ms": 0.097695,
+          "best_ms": 0.025344,
+          "in_gibs": 576.821,
+          "out_gibs": 576.821
+        },
+        "lod_gather": {
+          "avg_ms": 1.49078,
+          "best_ms": 0.436288,
+          "in_gibs": 188.659,
+          "out_gibs": 188.659
+        },
+        "lod_reduce": {
+          "avg_ms": 1.99086,
+          "best_ms": 1.51958,
+          "in_gibs": 141.271,
+          "out_gibs": 188.606
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.37745,
+          "best_ms": 0.605856,
+          "in_gibs": 272.597,
+          "out_gibs": 285.003
+        },
+        "compress": {
+          "avg_ms": 64.1968,
+          "best_ms": 56.6295,
+          "in_gibs": 11.3568,
+          "out_gibs": 1.06909
+        },
+        "aggregate": {
+          "avg_ms": 0.670871,
+          "best_ms": 0.49776,
+          "in_gibs": 102.303,
+          "out_gibs": 102.303
+        },
+        "d2h": {
+          "avg_ms": 14.0357,
+          "best_ms": 7.47146,
+          "in_gibs": 4.88985,
+          "out_gibs": 4.88985
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 167.108,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 166.856,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 81.4186,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.29,
+      "status": "pass",
+      "throughput_in_gibs": 2.68803,
+      "throughput_out_gibs": 0.335879,
+      "compression_fold": 11.6176,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.43929,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.30788,
+      "init_s": 6.0129,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.70677,
+          "best_ms": 0.795574,
+          "in_gibs": 15.0545,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.1365,
+          "best_ms": 9.33404,
+          "in_gibs": 27.7464,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 23.3953,
+          "best_ms": 23.2392,
+          "in_gibs": 16.0497,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.0865,
+          "best_ms": 11.1973,
+          "in_gibs": 32.4807,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 30.582,
+          "best_ms": 16.8909,
+          "in_gibs": 23.8399,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.66407,
+          "best_ms": 0.588433,
+          "in_gibs": 274.738,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.05,
+      "status": "pass",
+      "throughput_in_gibs": 2.66369,
+      "throughput_out_gibs": 1.9435,
+      "compression_fold": 1.9896,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.5651,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.31983,
+      "init_s": 5.97458,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.73,
+          "best_ms": 0.770477,
+          "in_gibs": 14.9608,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.6613,
+          "best_ms": 9.32559,
+          "in_gibs": 24.1183,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 28.1094,
+          "best_ms": 23.2478,
+          "in_gibs": 13.3581,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.5674,
+          "best_ms": 10.9141,
+          "in_gibs": 31.2377,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.031,
+          "best_ms": 7.83067,
+          "in_gibs": 48.5045,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.79885,
+          "best_ms": 3.61827,
+          "in_gibs": 107.239,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.07,
+      "status": "pass",
+      "throughput_in_gibs": 2.86417,
+      "throughput_out_gibs": 0.0565939,
+      "compression_fold": 73.4675,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0694663,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.22745,
+      "init_s": 6.00707,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.71469,
+          "best_ms": 0.768434,
+          "in_gibs": 15.0224,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.273,
+          "best_ms": 9.2907,
+          "in_gibs": 24.9491,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 27.9394,
+          "best_ms": 23.2731,
+          "in_gibs": 13.4394,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.1163,
+          "best_ms": 10.9606,
+          "in_gibs": 32.4008,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.79538,
+          "best_ms": 5.99202,
+          "in_gibs": 74.4304,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.999296,
+          "best_ms": 0.170105,
+          "in_gibs": 729.614,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.97,
+      "status": "pass",
+      "throughput_in_gibs": 8.56827,
+      "throughput_out_gibs": 9.80067,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28938,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.437662,
+      "init_s": 0.267505,
+      "flush_s": 5.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.39668,
+          "best_ms": 3.31453,
+          "in_gibs": 18.4003,
+          "out_gibs": 18.4003
+        },
+        "h2d": {
+          "avg_ms": 1.211,
+          "best_ms": 1.17827,
+          "in_gibs": 51.6103,
+          "out_gibs": 51.6103
+        },
+        "scatter": {
+          "avg_ms": 0.0661241,
+          "best_ms": 0.05648,
+          "in_gibs": 945.192,
+          "out_gibs": 945.192
+        },
+        "lod_gather": {
+          "avg_ms": 0.986176,
+          "best_ms": 0.986016,
+          "in_gibs": 190.128,
+          "out_gibs": 190.128
+        },
+        "lod_reduce": {
+          "avg_ms": 0.804688,
+          "best_ms": 0.80144,
+          "in_gibs": 233.01,
+          "out_gibs": 266.459
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.51776,
+          "best_ms": 0.515712,
+          "in_gibs": 414.123,
+          "out_gibs": 414.123
+        },
+        "compress": {
+          "avg_ms": 1.17459,
+          "best_ms": 0.600416,
+          "in_gibs": 521.559,
+          "out_gibs": 521.559
+        },
+        "aggregate": {
+          "avg_ms": 1.7392,
+          "best_ms": 1.28477,
+          "in_gibs": 352.243,
+          "out_gibs": 352.243
+        },
+        "d2h": {
+          "avg_ms": 11.8885,
+          "best_ms": 8.16058,
+          "in_gibs": 51.5305,
+          "out_gibs": 51.5305
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 14.7246,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 12.7386,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.32762,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 16.13,
+      "status": "pass",
+      "throughput_in_gibs": 2.76302,
+      "throughput_out_gibs": 3.16044,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28938,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.35721,
+      "init_s": 3.61444,
+      "flush_s": 4.8e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.87081,
+          "best_ms": 3.30818,
+          "in_gibs": 16.1465,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 13.3748,
+          "best_ms": 11.8252,
+          "in_gibs": 14.0189,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 11.9811,
+          "best_ms": 9.53753,
+          "in_gibs": 17.8963,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 9.62418,
+          "best_ms": 7.96053,
+          "in_gibs": 22.2789,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.6747,
+          "best_ms": 7.69858,
+          "in_gibs": 57.3899,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.9186,
+          "best_ms": 7.25641,
+          "in_gibs": 56.1079,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.07,
+      "status": "pass",
+      "throughput_in_gibs": 6.76213,
+      "throughput_out_gibs": 0.903934,
+      "compression_fold": 8.55468,
+      "input_gib": 3.75,
+      "compressed_gib": 0.501284,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.554559,
+      "init_s": 0.263202,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.38302,
+          "best_ms": 3.18628,
+          "in_gibs": 18.4746,
+          "out_gibs": 18.4746
+        },
+        "h2d": {
+          "avg_ms": 1.204,
+          "best_ms": 1.17949,
+          "in_gibs": 51.9103,
+          "out_gibs": 51.9103
+        },
+        "scatter": {
+          "avg_ms": 0.0797991,
+          "best_ms": 0.058304,
+          "in_gibs": 783.217,
+          "out_gibs": 783.217
+        },
+        "lod_gather": {
+          "avg_ms": 2.92813,
+          "best_ms": 1.02266,
+          "in_gibs": 64.0341,
+          "out_gibs": 64.0341
+        },
+        "lod_reduce": {
+          "avg_ms": 0.887792,
+          "best_ms": 0.821248,
+          "in_gibs": 211.198,
+          "out_gibs": 241.517
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.648352,
+          "best_ms": 0.51776,
+          "in_gibs": 330.71,
+          "out_gibs": 330.71
+        },
+        "compress": {
+          "avg_ms": 48.068,
+          "best_ms": 29.7049,
+          "in_gibs": 12.7448,
+          "out_gibs": 1.48669
+        },
+        "aggregate": {
+          "avg_ms": 0.360594,
+          "best_ms": 0.224768,
+          "in_gibs": 198.18,
+          "out_gibs": 198.18
+        },
+        "d2h": {
+          "avg_ms": 11.8483,
+          "best_ms": 8.16035,
+          "in_gibs": 6.03147,
+          "out_gibs": 6.03147
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 60.7286,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 58.7024,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 54.1448,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 16.39,
+      "status": "pass",
+      "throughput_in_gibs": 2.32745,
+      "throughput_out_gibs": 0.238461,
+      "compression_fold": 11.1614,
+      "input_gib": 3.75,
+      "compressed_gib": 0.38421,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.61121,
+      "init_s": 3.69374,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.85857,
+          "best_ms": 3.26,
+          "in_gibs": 16.1977,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 13.6758,
+          "best_ms": 12.2925,
+          "in_gibs": 13.7103,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 17.3069,
+          "best_ms": 9.54723,
+          "in_gibs": 12.3891,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.2431,
+          "best_ms": 8.20748,
+          "in_gibs": 16.1908,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.8981,
+          "best_ms": 20.208,
+          "in_gibs": 20.4902,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.69865,
+          "best_ms": 0.792109,
+          "in_gibs": 362.24,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 16.03,
+      "status": "pass",
+      "throughput_in_gibs": 2.78598,
+      "throughput_out_gibs": 2.00624,
+      "compression_fold": 1.58801,
+      "input_gib": 3.75,
+      "compressed_gib": 2.70044,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.34602,
+      "init_s": 3.68885,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.8353,
+          "best_ms": 3.28818,
+          "in_gibs": 16.296,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.9664,
+          "best_ms": 12.3436,
+          "in_gibs": 14.4604,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 11.4504,
+          "best_ms": 9.53408,
+          "in_gibs": 18.7257,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 8.61264,
+          "best_ms": 7.96703,
+          "in_gibs": 24.8956,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.792,
+          "best_ms": 11.0014,
+          "in_gibs": 34.4322,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.93619,
+          "best_ms": 5.32228,
+          "in_gibs": 77.2133,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 16.22,
+      "status": "pass",
+      "throughput_in_gibs": 2.63886,
+      "throughput_out_gibs": 0.070304,
+      "compression_fold": 42.9234,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0999066,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 1.42107,
+      "init_s": 3.65514,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.85434,
+          "best_ms": 3.28891,
+          "in_gibs": 16.2155,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 13.8993,
+          "best_ms": 12.152,
+          "in_gibs": 13.4899,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.7991,
+          "best_ms": 9.55429,
+          "in_gibs": 14.4885,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 9.58665,
+          "best_ms": 7.98088,
+          "in_gibs": 22.3662,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 21.1079,
+          "best_ms": 14.3123,
+          "in_gibs": 29.0233,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.332033,
+          "best_ms": 0.254072,
+          "in_gibs": 1845.54,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.93,
+      "status": "pass",
+      "throughput_in_gibs": 8.48011,
+      "throughput_out_gibs": 9.68978,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28493,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.442211,
+      "init_s": 0.359023,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.3733,
+          "best_ms": 3.27186,
+          "in_gibs": 18.5279,
+          "out_gibs": 18.5279
+        },
+        "h2d": {
+          "avg_ms": 1.20336,
+          "best_ms": 1.17926,
+          "in_gibs": 51.9379,
+          "out_gibs": 51.9379
+        },
+        "scatter": {
+          "avg_ms": 0.111499,
+          "best_ms": 0.064288,
+          "in_gibs": 560.543,
+          "out_gibs": 560.543
+        },
+        "lod_gather": {
+          "avg_ms": 1.95853,
+          "best_ms": 1.95034,
+          "in_gibs": 191.47,
+          "out_gibs": 191.47
+        },
+        "lod_reduce": {
+          "avg_ms": 1.59437,
+          "best_ms": 1.59437,
+          "in_gibs": 235.203,
+          "out_gibs": 268.738
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.07381,
+          "best_ms": 1.0728,
+          "in_gibs": 399.016,
+          "out_gibs": 399.016
+        },
+        "compress": {
+          "avg_ms": 1.7023,
+          "best_ms": 1.232,
+          "in_gibs": 503.396,
+          "out_gibs": 503.396
+        },
+        "aggregate": {
+          "avg_ms": 2.95653,
+          "best_ms": 2.7567,
+          "in_gibs": 289.844,
+          "out_gibs": 289.844
+        },
+        "d2h": {
+          "avg_ms": 16.5181,
+          "best_ms": 16.293,
+          "in_gibs": 51.8784,
+          "out_gibs": 51.8784
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 26.792,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 26.2518,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.92955,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 19.3,
+      "status": "pass",
+      "throughput_in_gibs": 2.92505,
+      "throughput_out_gibs": 3.3423,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28493,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.28203,
+      "init_s": 6.75388,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.35912,
+          "best_ms": 3.29121,
+          "in_gibs": 14.3378,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.4386,
+          "best_ms": 23.0851,
+          "in_gibs": 15.3446,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 20.8886,
+          "best_ms": 19.0292,
+          "in_gibs": 20.512,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 15.5791,
+          "best_ms": 14.6921,
+          "in_gibs": 27.5027,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.845,
+          "best_ms": 14.3288,
+          "in_gibs": 57.7254,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 15.6348,
+          "best_ms": 14.3973,
+          "in_gibs": 54.8095,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.66,
+      "status": "pass",
+      "throughput_in_gibs": 6.99142,
+      "throughput_out_gibs": 0.919176,
+      "compression_fold": 8.69066,
+      "input_gib": 3.75,
+      "compressed_gib": 0.49302,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.536371,
+      "init_s": 0.372757,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.40834,
+          "best_ms": 3.31133,
+          "in_gibs": 18.3374,
+          "out_gibs": 18.3374
+        },
+        "h2d": {
+          "avg_ms": 1.20127,
+          "best_ms": 1.17866,
+          "in_gibs": 52.0283,
+          "out_gibs": 52.0283
+        },
+        "scatter": {
+          "avg_ms": 0.0990003,
+          "best_ms": 0.064064,
+          "in_gibs": 631.311,
+          "out_gibs": 631.311
+        },
+        "lod_gather": {
+          "avg_ms": 1.95341,
+          "best_ms": 1.95238,
+          "in_gibs": 191.972,
+          "out_gibs": 191.972
+        },
+        "lod_reduce": {
+          "avg_ms": 1.59539,
+          "best_ms": 1.59437,
+          "in_gibs": 235.052,
+          "out_gibs": 268.565
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.07072,
+          "best_ms": 1.07072,
+          "in_gibs": 400.167,
+          "out_gibs": 400.167
+        },
+        "compress": {
+          "avg_ms": 48.3957,
+          "best_ms": 45.4888,
+          "in_gibs": 17.7068,
+          "out_gibs": 2.03637
+        },
+        "aggregate": {
+          "avg_ms": 0.521069,
+          "best_ms": 0.398976,
+          "in_gibs": 189.134,
+          "out_gibs": 189.134
+        },
+        "d2h": {
+          "avg_ms": 16.5142,
+          "best_ms": 16.2927,
+          "in_gibs": 5.96769,
+          "out_gibs": 5.96769
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 68.6101,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 68.065,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 54.8577,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 19.31,
+      "status": "pass",
+      "throughput_in_gibs": 2.72924,
+      "throughput_out_gibs": 0.271915,
+      "compression_fold": 11.4682,
+      "input_gib": 3.75,
+      "compressed_gib": 0.373613,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.37401,
+      "init_s": 6.76829,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.40232,
+          "best_ms": 3.28653,
+          "in_gibs": 14.1971,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.9561,
+          "best_ms": 23.98,
+          "in_gibs": 15.0264,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 21.9133,
+          "best_ms": 19.0781,
+          "in_gibs": 19.5529,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 17.228,
+          "best_ms": 15.0899,
+          "in_gibs": 24.8703,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 40.2033,
+          "best_ms": 38.9782,
+          "in_gibs": 21.315,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.37597,
+          "best_ms": 1.27121,
+          "in_gibs": 625.22,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 19.07,
+      "status": "pass",
+      "throughput_in_gibs": 2.66123,
+      "throughput_out_gibs": 1.98372,
+      "compression_fold": 1.53281,
+      "input_gib": 3.75,
+      "compressed_gib": 2.7953,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.40912,
+      "init_s": 6.78462,
+      "flush_s": 5.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.358,
+          "best_ms": 3.27206,
+          "in_gibs": 14.3415,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.6877,
+          "best_ms": 23.9581,
+          "in_gibs": 14.0514,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 26.7262,
+          "best_ms": 19.003,
+          "in_gibs": 16.0317,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 18.5236,
+          "best_ms": 14.7801,
+          "in_gibs": 23.1308,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.2631,
+          "best_ms": 20.4453,
+          "in_gibs": 36.8365,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.8421,
+          "best_ms": 9.42429,
+          "in_gibs": 79.0433,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 19.46,
+      "status": "pass",
+      "throughput_in_gibs": 2.57128,
+      "throughput_out_gibs": 0.0657837,
+      "compression_fold": 44.6598,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0959402,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.45842,
+      "init_s": 6.83488,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.34985,
+          "best_ms": 3.28075,
+          "in_gibs": 14.3683,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.0561,
+          "best_ms": 24.0867,
+          "in_gibs": 14.392,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 30.3999,
+          "best_ms": 19.8017,
+          "in_gibs": 14.0944,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 22.2405,
+          "best_ms": 15.1661,
+          "in_gibs": 19.2651,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.2076,
+          "best_ms": 28.2927,
+          "in_gibs": 29.3395,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.357114,
+          "best_ms": 0.304387,
+          "in_gibs": 2399.78,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.99,
+      "status": "pass",
+      "throughput_in_gibs": 8.23112,
+      "throughput_out_gibs": 9.45307,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 4.30671,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.455588,
+      "init_s": 0.355775,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.39536,
+          "best_ms": 3.30967,
+          "in_gibs": 18.4075,
+          "out_gibs": 18.4075
+        },
+        "h2d": {
+          "avg_ms": 1.20488,
+          "best_ms": 1.17824,
+          "in_gibs": 51.8724,
+          "out_gibs": 51.8724
+        },
+        "scatter": {
+          "avg_ms": 0.0698367,
+          "best_ms": 0.064352,
+          "in_gibs": 894.945,
+          "out_gibs": 894.945
+        },
+        "lod_gather": {
+          "avg_ms": 1.9575,
+          "best_ms": 1.95443,
+          "in_gibs": 191.57,
+          "out_gibs": 191.57
+        },
+        "lod_reduce": {
+          "avg_ms": 1.60256,
+          "best_ms": 1.60256,
+          "in_gibs": 234.001,
+          "out_gibs": 268.735
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.989824,
+          "best_ms": 0.9888,
+          "in_gibs": 435.092,
+          "out_gibs": 435.092
+        },
+        "compress": {
+          "avg_ms": 1.71382,
+          "best_ms": 1.23152,
+          "in_gibs": 502.577,
+          "out_gibs": 502.577
+        },
+        "aggregate": {
+          "avg_ms": 6.66294,
+          "best_ms": 6.47373,
+          "in_gibs": 129.271,
+          "out_gibs": 129.271
+        },
+        "d2h": {
+          "avg_ms": 16.6614,
+          "best_ms": 16.3794,
+          "in_gibs": 51.6959,
+          "out_gibs": 51.6959
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 30.4047,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 30.2163,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 10.5272,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 19.57,
+      "status": "pass",
+      "throughput_in_gibs": 2.32517,
+      "throughput_out_gibs": 2.67036,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 4.30671,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.61278,
+      "init_s": 6.78263,
+      "flush_s": 4.6e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.36764,
+          "best_ms": 3.27748,
+          "in_gibs": 14.3098,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.2576,
+          "best_ms": 23.9103,
+          "in_gibs": 14.2816,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 26.5614,
+          "best_ms": 19.5549,
+          "in_gibs": 16.2139,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 37.107,
+          "best_ms": 30.1163,
+          "in_gibs": 11.606,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.7056,
+          "best_ms": 17.8704,
+          "in_gibs": 46.0467,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 18.284,
+          "best_ms": 17.2115,
+          "in_gibs": 47.1082,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.16,
+      "status": "pass",
+      "throughput_in_gibs": 6.52075,
+      "throughput_out_gibs": 0.875093,
+      "compression_fold": 8.55758,
+      "input_gib": 3.75,
+      "compressed_gib": 0.503254,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.575087,
+      "init_s": 0.361166,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.41951,
+          "best_ms": 3.34089,
+          "in_gibs": 18.2775,
+          "out_gibs": 18.2775
+        },
+        "h2d": {
+          "avg_ms": 1.20013,
+          "best_ms": 1.17981,
+          "in_gibs": 52.0779,
+          "out_gibs": 52.0779
+        },
+        "scatter": {
+          "avg_ms": 0.101836,
+          "best_ms": 0.057344,
+          "in_gibs": 613.73,
+          "out_gibs": 613.73
+        },
+        "lod_gather": {
+          "avg_ms": 2.29544,
+          "best_ms": 2.0671,
+          "in_gibs": 163.367,
+          "out_gibs": 163.367
+        },
+        "lod_reduce": {
+          "avg_ms": 1.67731,
+          "best_ms": 1.6087,
+          "in_gibs": 223.572,
+          "out_gibs": 256.758
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.13062,
+          "best_ms": 1.00518,
+          "in_gibs": 380.908,
+          "out_gibs": 380.908
+        },
+        "compress": {
+          "avg_ms": 76.5671,
+          "best_ms": 71.0118,
+          "in_gibs": 11.2493,
+          "out_gibs": 1.31437
+        },
+        "aggregate": {
+          "avg_ms": 1.42269,
+          "best_ms": 0.693952,
+          "in_gibs": 70.7374,
+          "out_gibs": 70.7374
+        },
+        "d2h": {
+          "avg_ms": 16.5723,
+          "best_ms": 16.3762,
+          "in_gibs": 6.07265,
+          "out_gibs": 6.07265
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 95.2705,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 95.0846,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 59.5043,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 19.61,
+      "status": "pass",
+      "throughput_in_gibs": 2.26121,
+      "throughput_out_gibs": 0.213156,
+      "compression_fold": 12.1829,
+      "input_gib": 3.75,
+      "compressed_gib": 0.353498,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.6584,
+      "init_s": 6.75633,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.3728,
+          "best_ms": 3.26691,
+          "in_gibs": 14.2929,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.2959,
+          "best_ms": 23.9753,
+          "in_gibs": 14.2608,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 30.5826,
+          "best_ms": 20.3612,
+          "in_gibs": 14.082,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 37.2005,
+          "best_ms": 32.4102,
+          "in_gibs": 11.5768,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 37.658,
+          "best_ms": 36.6751,
+          "in_gibs": 22.8724,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.30153,
+          "best_ms": 1.11429,
+          "in_gibs": 664.365,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 19.79,
+      "status": "pass",
+      "throughput_in_gibs": 2.34334,
+      "throughput_out_gibs": 1.50372,
+      "compression_fold": 1.78969,
+      "input_gib": 3.75,
+      "compressed_gib": 2.40637,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.60028,
+      "init_s": 6.78929,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.3157,
+          "best_ms": 3.22967,
+          "in_gibs": 14.482,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.6296,
+          "best_ms": 24.1069,
+          "in_gibs": 14.0821,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 28.5534,
+          "best_ms": 20.1605,
+          "in_gibs": 15.0828,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 36.6735,
+          "best_ms": 30.4358,
+          "in_gibs": 11.7432,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 22.3093,
+          "best_ms": 20.9397,
+          "in_gibs": 38.6084,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.3751,
+          "best_ms": 8.08025,
+          "in_gibs": 83.021,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 19.29,
+      "status": "pass",
+      "throughput_in_gibs": 2.33953,
+      "throughput_out_gibs": 0.0402902,
+      "compression_fold": 66.6864,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0645805,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.60289,
+      "init_s": 6.74404,
+      "flush_s": 5.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.35639,
+          "best_ms": 3.26666,
+          "in_gibs": 14.3467,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.7748,
+          "best_ms": 23.5635,
+          "in_gibs": 14.0057,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 31.0316,
+          "best_ms": 19.5767,
+          "in_gibs": 13.8783,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 38.0155,
+          "best_ms": 31.2202,
+          "in_gibs": 11.3287,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.8688,
+          "best_ms": 17.8949,
+          "in_gibs": 43.3507,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.05005,
+          "best_ms": 0.205348,
+          "in_gibs": 170.563,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__gpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 28.58,
+      "status": "pass",
+      "throughput_in_gibs": 8.06662,
+      "throughput_out_gibs": 10.7642,
+      "compression_fold": 0.99974,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.9094,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 0.363187,
+      "init_s": 0.455622,
+      "flush_s": 2.144e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.17378,
+          "best_ms": 0.364898,
+          "in_gibs": 18.0998,
+          "out_gibs": 18.0998
+        },
+        "h2d": {
+          "avg_ms": 1.11282,
+          "best_ms": 0.156544,
+          "in_gibs": 51.579,
+          "out_gibs": 51.579
+        },
+        "scatter": {
+          "avg_ms": 0.140436,
+          "best_ms": 0.021248,
+          "in_gibs": 416.068,
+          "out_gibs": 416.068
+        },
+        "lod_gather": {
+          "avg_ms": 1.67139,
+          "best_ms": 1.66893,
+          "in_gibs": 350.569,
+          "out_gibs": 350.569
+        },
+        "lod_reduce": {
+          "avg_ms": 3.24029,
+          "best_ms": 3.22422,
+          "in_gibs": 180.829,
+          "out_gibs": 241.109
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.10349,
+          "best_ms": 2.10189,
+          "in_gibs": 371.413,
+          "out_gibs": 371.61
+        },
+        "compress": {
+          "avg_ms": 1.55732,
+          "best_ms": 1.11661,
+          "in_gibs": 501.938,
+          "out_gibs": 501.938
+        },
+        "aggregate": {
+          "avg_ms": 2.46518,
+          "best_ms": 2.24906,
+          "in_gibs": 317.088,
+          "out_gibs": 317.088
+        },
+        "d2h": {
+          "avg_ms": 15.1056,
+          "best_ms": 14.8716,
+          "in_gibs": 51.7476,
+          "out_gibs": 51.7476
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 27.4747,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 25.5588,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.43568,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 46.75,
+      "status": "pass",
+      "throughput_in_gibs": 2.33925,
+      "throughput_out_gibs": 3.12152,
+      "compression_fold": 0.99974,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.9094,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.25241,
+      "init_s": 18.1036,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.92608,
+          "best_ms": 0.365288,
+          "in_gibs": 11.6614,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.1288,
+          "best_ms": 23.0138,
+          "in_gibs": 23.3174,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 72.0938,
+          "best_ms": 48.891,
+          "in_gibs": 10.8368,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 32.377,
+          "best_ms": 28.586,
+          "in_gibs": 24.143,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.378,
+          "best_ms": 12.8932,
+          "in_gibs": 58.4301,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.401,
+          "best_ms": 13.1861,
+          "in_gibs": 54.2793,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__gpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 28.64,
+      "status": "pass",
+      "throughput_in_gibs": 3.08668,
+      "throughput_out_gibs": 0.554008,
+      "compression_fold": 7.43278,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.525831,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 0.949139,
+      "init_s": 0.452087,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14617,
+          "best_ms": 0.388893,
+          "in_gibs": 18.2587,
+          "out_gibs": 18.2587
+        },
+        "h2d": {
+          "avg_ms": 1.11004,
+          "best_ms": 0.153024,
+          "in_gibs": 51.7078,
+          "out_gibs": 51.7078
+        },
+        "scatter": {
+          "avg_ms": 0.178712,
+          "best_ms": 0.010592,
+          "in_gibs": 317.219,
+          "out_gibs": 317.219
+        },
+        "lod_gather": {
+          "avg_ms": 11.1089,
+          "best_ms": 4.85414,
+          "in_gibs": 52.745,
+          "out_gibs": 52.745
+        },
+        "lod_reduce": {
+          "avg_ms": 4.06053,
+          "best_ms": 3.52259,
+          "in_gibs": 144.301,
+          "out_gibs": 192.404
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.29709,
+          "best_ms": 2.21168,
+          "in_gibs": 340.11,
+          "out_gibs": 340.29
+        },
+        "compress": {
+          "avg_ms": 157.541,
+          "best_ms": 150.621,
+          "in_gibs": 4.96175,
+          "out_gibs": 0.666258
+        },
+        "aggregate": {
+          "avg_ms": 0.848832,
+          "best_ms": 0.43584,
+          "in_gibs": 123.655,
+          "out_gibs": 123.655
+        },
+        "d2h": {
+          "avg_ms": 15.1161,
+          "best_ms": 14.8724,
+          "in_gibs": 6.94376,
+          "out_gibs": 6.94376
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 204.967,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 203.078,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 145.203,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 46.77,
+      "status": "pass",
+      "throughput_in_gibs": 2.43063,
+      "throughput_out_gibs": 0.338881,
+      "compression_fold": 9.5686,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.40846,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.20532,
+      "init_s": 17.9789,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.94726,
+          "best_ms": 0.38607,
+          "in_gibs": 11.6114,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.1204,
+          "best_ms": 22.9552,
+          "in_gibs": 23.3251,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 52.8726,
+          "best_ms": 48.7487,
+          "in_gibs": 14.7763,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 28.5046,
+          "best_ms": 27.3861,
+          "in_gibs": 27.4229,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 39.2571,
+          "best_ms": 37.759,
+          "in_gibs": 19.9117,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.1538,
+          "best_ms": 1.32256,
+          "in_gibs": 364.531,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 46.16,
+      "status": "pass",
+      "throughput_in_gibs": 2.47509,
+      "throughput_out_gibs": 2.0215,
+      "compression_fold": 1.6334,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.39279,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.18367,
+      "init_s": 17.9224,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.94547,
+          "best_ms": 0.416715,
+          "in_gibs": 11.6157,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.7078,
+          "best_ms": 22.7148,
+          "in_gibs": 23.7146,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 61.7505,
+          "best_ms": 48.6461,
+          "in_gibs": 12.6519,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 29.0765,
+          "best_ms": 26.7303,
+          "in_gibs": 26.8835,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.936,
+          "best_ms": 16.6946,
+          "in_gibs": 39.2093,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.62983,
+          "best_ms": 8.08234,
+          "in_gibs": 90.6033,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 46.22,
+      "status": "pass",
+      "throughput_in_gibs": 2.64322,
+      "throughput_out_gibs": 0.0632454,
+      "compression_fold": 55.7546,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0700998,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.10838,
+      "init_s": 17.9844,
+      "flush_s": 7.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.92939,
+          "best_ms": 0.387071,
+          "in_gibs": 11.6536,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.5611,
+          "best_ms": 22.6577,
+          "in_gibs": 23.8564,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 60.1129,
+          "best_ms": 48.6689,
+          "in_gibs": 12.9966,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 29.345,
+          "best_ms": 26.7484,
+          "in_gibs": 26.6375,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.4389,
+          "best_ms": 13.8847,
+          "in_gibs": 54.1367,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.333246,
+          "best_ms": 0.277106,
+          "in_gibs": 2346.29,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__gpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 28.18,
+      "status": "pass",
+      "throughput_in_gibs": 7.88236,
+      "throughput_out_gibs": 10.5335,
+      "compression_fold": 0.999935,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.91505,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 0.371677,
+      "init_s": 0.446386,
+      "flush_s": 4.8e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.17114,
+          "best_ms": 0.385018,
+          "in_gibs": 18.1149,
+          "out_gibs": 18.1149
+        },
+        "h2d": {
+          "avg_ms": 1.11239,
+          "best_ms": 0.153088,
+          "in_gibs": 51.5988,
+          "out_gibs": 51.5988
+        },
+        "scatter": {
+          "avg_ms": 0.146143,
+          "best_ms": 0.021536,
+          "in_gibs": 399.822,
+          "out_gibs": 399.822
+        },
+        "lod_gather": {
+          "avg_ms": 1.67923,
+          "best_ms": 1.67331,
+          "in_gibs": 348.932,
+          "out_gibs": 348.932
+        },
+        "lod_reduce": {
+          "avg_ms": 3.22574,
+          "best_ms": 3.21808,
+          "in_gibs": 181.644,
+          "out_gibs": 242.209
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.10394,
+          "best_ms": 2.10189,
+          "in_gibs": 371.353,
+          "out_gibs": 372.14
+        },
+        "compress": {
+          "avg_ms": 1.55806,
+          "best_ms": 1.11651,
+          "in_gibs": 502.521,
+          "out_gibs": 502.521
+        },
+        "aggregate": {
+          "avg_ms": 4.05133,
+          "best_ms": 3.84781,
+          "in_gibs": 193.26,
+          "out_gibs": 193.26
+        },
+        "d2h": {
+          "avg_ms": 15.1201,
+          "best_ms": 14.8924,
+          "in_gibs": 51.7828,
+          "out_gibs": 51.7828
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 28.5067,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 27.9673,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 12.2351,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 46.68,
+      "status": "pass",
+      "throughput_in_gibs": 2.31564,
+      "throughput_out_gibs": 3.09447,
+      "compression_fold": 0.999935,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.91505,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.26518,
+      "init_s": 18.0075,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.92528,
+          "best_ms": 0.369484,
+          "in_gibs": 11.6633,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.2885,
+          "best_ms": 22.935,
+          "in_gibs": 23.1701,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 77.2616,
+          "best_ms": 50.3943,
+          "in_gibs": 10.1124,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 30.6837,
+          "best_ms": 28.7806,
+          "in_gibs": 25.5171,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.4345,
+          "best_ms": 12.8961,
+          "in_gibs": 58.2797,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.0502,
+          "best_ms": 13.195,
+          "in_gibs": 55.726,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__gpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 29.94,
+      "status": "pass",
+      "throughput_in_gibs": 3.4977,
+      "throughput_out_gibs": 0.48488,
+      "compression_fold": 9.63909,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.406138,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 0.837605,
+      "init_s": 0.763349,
+      "flush_s": 4.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14145,
+          "best_ms": 0.374522,
+          "in_gibs": 18.2861,
+          "out_gibs": 18.2861
+        },
+        "h2d": {
+          "avg_ms": 1.10604,
+          "best_ms": 0.157792,
+          "in_gibs": 51.8951,
+          "out_gibs": 51.8951
+        },
+        "scatter": {
+          "avg_ms": 0.142813,
+          "best_ms": 0.030464,
+          "in_gibs": 406.376,
+          "out_gibs": 406.376
+        },
+        "lod_gather": {
+          "avg_ms": 18.7148,
+          "best_ms": 18.5434,
+          "in_gibs": 31.3088,
+          "out_gibs": 31.3088
+        },
+        "lod_reduce": {
+          "avg_ms": 17.7407,
+          "best_ms": 17.5851,
+          "in_gibs": 33.0279,
+          "out_gibs": 44.0402
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.4683,
+          "best_ms": 13.3168,
+          "in_gibs": 58.0106,
+          "out_gibs": 58.1335
+        },
+        "compress": {
+          "avg_ms": 134.875,
+          "best_ms": 89.3229,
+          "in_gibs": 5.80505,
+          "out_gibs": 0.601863
+        },
+        "aggregate": {
+          "avg_ms": 0.96528,
+          "best_ms": 0.476832,
+          "in_gibs": 84.0963,
+          "out_gibs": 84.0963
+        },
+        "d2h": {
+          "avg_ms": 15.0825,
+          "best_ms": 14.8923,
+          "in_gibs": 5.38218,
+          "out_gibs": 5.38218
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 210.314,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 209.754,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 237.248,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 46.62,
+      "status": "pass",
+      "throughput_in_gibs": 2.38763,
+      "throughput_out_gibs": 0.325116,
+      "compression_fold": 9.81333,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.398926,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.22703,
+      "init_s": 17.9624,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.98341,
+          "best_ms": 0.397737,
+          "in_gibs": 11.5272,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 23.7676,
+          "best_ms": 22.7858,
+          "in_gibs": 24.6528,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 56.5535,
+          "best_ms": 48.6635,
+          "in_gibs": 13.8153,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 34.094,
+          "best_ms": 28.6755,
+          "in_gibs": 22.9647,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.5498,
+          "best_ms": 35.3942,
+          "in_gibs": 21.4217,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.40875,
+          "best_ms": 1.28472,
+          "in_gibs": 557.959,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 46.5,
+      "status": "pass",
+      "throughput_in_gibs": 2.54207,
+      "throughput_out_gibs": 1.78171,
+      "compression_fold": 1.9065,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.05339,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.15248,
+      "init_s": 18.0377,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.98128,
+          "best_ms": 0.38653,
+          "in_gibs": 11.5321,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.0375,
+          "best_ms": 23.2238,
+          "in_gibs": 22.5036,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 53.6901,
+          "best_ms": 50.4489,
+          "in_gibs": 14.5521,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 33.1315,
+          "best_ms": 26.7258,
+          "in_gibs": 23.6319,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.4615,
+          "best_ms": 15.2808,
+          "in_gibs": 44.8392,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.3006,
+          "best_ms": 6.70495,
+          "in_gibs": 107.255,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 46.19,
+      "status": "pass",
+      "throughput_in_gibs": 2.71248,
+      "throughput_out_gibs": 0.0536016,
+      "compression_fold": 67.6203,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0578937,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.08008,
+      "init_s": 17.9501,
+      "flush_s": 6.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.91669,
+          "best_ms": 0.384777,
+          "in_gibs": 11.6836,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.1497,
+          "best_ms": 22.8692,
+          "in_gibs": 23.298,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 57.7524,
+          "best_ms": 50.3841,
+          "in_gibs": 13.5285,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 28.8172,
+          "best_ms": 26.8031,
+          "in_gibs": 27.1698,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.7131,
+          "best_ms": 9.51293,
+          "in_gibs": 73.0841,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.36447,
+          "best_ms": 0.190385,
+          "in_gibs": 573.868,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__gpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.9,
+      "status": "pass",
+      "throughput_in_gibs": 7.78045,
+      "throughput_out_gibs": 10.4649,
+      "compression_fold": 0.999984,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.94049,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 0.376545,
+      "init_s": 0.450644,
+      "flush_s": 6.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.16779,
+          "best_ms": 0.391167,
+          "in_gibs": 18.134,
+          "out_gibs": 18.134
+        },
+        "h2d": {
+          "avg_ms": 1.11442,
+          "best_ms": 0.154112,
+          "in_gibs": 51.5047,
+          "out_gibs": 51.5047
+        },
+        "scatter": {
+          "avg_ms": 0.13778,
+          "best_ms": 0.021536,
+          "in_gibs": 424.089,
+          "out_gibs": 424.089
+        },
+        "lod_gather": {
+          "avg_ms": 1.68331,
+          "best_ms": 1.67126,
+          "in_gibs": 348.086,
+          "out_gibs": 348.086
+        },
+        "lod_reduce": {
+          "avg_ms": 3.21648,
+          "best_ms": 3.21603,
+          "in_gibs": 182.167,
+          "out_gibs": 242.956
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.10293,
+          "best_ms": 2.09987,
+          "in_gibs": 371.607,
+          "out_gibs": 374.756
+        },
+        "compress": {
+          "avg_ms": 1.5708,
+          "best_ms": 1.12483,
+          "in_gibs": 501.711,
+          "out_gibs": 501.711
+        },
+        "aggregate": {
+          "avg_ms": 9.53223,
+          "best_ms": 9.29389,
+          "in_gibs": 82.6759,
+          "out_gibs": 82.6759
+        },
+        "d2h": {
+          "avg_ms": 15.2284,
+          "best_ms": 14.9883,
+          "in_gibs": 51.751,
+          "out_gibs": 51.751
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 33.9239,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 33.7372,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 12.1755,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 47.09,
+      "status": "pass",
+      "throughput_in_gibs": 2.45052,
+      "throughput_out_gibs": 3.296,
+      "compression_fold": 0.999984,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.94049,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.19554,
+      "init_s": 18.0572,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.94346,
+          "best_ms": 0.369895,
+          "in_gibs": 11.6204,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.0009,
+          "best_ms": 22.6485,
+          "in_gibs": 24.4132,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 56.1762,
+          "best_ms": 48.6527,
+          "in_gibs": 13.9109,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 30.3458,
+          "best_ms": 29.2695,
+          "in_gibs": 25.9702,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.8574,
+          "best_ms": 16.0421,
+          "in_gibs": 46.75,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 16.5382,
+          "best_ms": 15.3944,
+          "in_gibs": 47.6524,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__gpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.47,
+      "status": "pass",
+      "throughput_in_gibs": 5.22698,
+      "throughput_out_gibs": 0.868927,
+      "compression_fold": 8.09078,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.487027,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 0.560493,
+      "init_s": 0.442894,
+      "flush_s": 2.413e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.1428,
+          "best_ms": 0.364967,
+          "in_gibs": 18.2783,
+          "out_gibs": 18.2783
+        },
+        "h2d": {
+          "avg_ms": 1.10159,
+          "best_ms": 0.154208,
+          "in_gibs": 52.1045,
+          "out_gibs": 52.1045
+        },
+        "scatter": {
+          "avg_ms": 0.101533,
+          "best_ms": 0.021696,
+          "in_gibs": 571.359,
+          "out_gibs": 571.359
+        },
+        "lod_gather": {
+          "avg_ms": 5.00658,
+          "best_ms": 5.0015,
+          "in_gibs": 117.034,
+          "out_gibs": 117.034
+        },
+        "lod_reduce": {
+          "avg_ms": 4.7653,
+          "best_ms": 4.76013,
+          "in_gibs": 122.959,
+          "out_gibs": 163.991
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.52426,
+          "best_ms": 4.51472,
+          "in_gibs": 172.728,
+          "out_gibs": 174.191
+        },
+        "compress": {
+          "avg_ms": 76.7864,
+          "best_ms": 62.0121,
+          "in_gibs": 10.2634,
+          "out_gibs": 1.26836
+        },
+        "aggregate": {
+          "avg_ms": 2.21276,
+          "best_ms": 1.59318,
+          "in_gibs": 44.0142,
+          "out_gibs": 44.0142
+        },
+        "d2h": {
+          "avg_ms": 15.1565,
+          "best_ms": 14.9882,
+          "in_gibs": 6.42581,
+          "out_gibs": 6.42581
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 136.65,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 136.426,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 96.2914,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 46.23,
+      "status": "pass",
+      "throughput_in_gibs": 2.29108,
+      "throughput_out_gibs": 0.315732,
+      "compression_fold": 9.75986,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.403739,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.27874,
+      "init_s": 17.8938,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.97248,
+          "best_ms": 0.386079,
+          "in_gibs": 11.5526,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.6022,
+          "best_ms": 22.9274,
+          "in_gibs": 22.8862,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 64.0209,
+          "best_ms": 50.5399,
+          "in_gibs": 12.2064,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 34.0661,
+          "best_ms": 29.1254,
+          "in_gibs": 23.134,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.7433,
+          "best_ms": 35.0718,
+          "in_gibs": 21.4484,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.72059,
+          "best_ms": 1.31652,
+          "in_gibs": 290.806,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 46.47,
+      "status": "pass",
+      "throughput_in_gibs": 2.48488,
+      "throughput_out_gibs": 1.85409,
+      "compression_fold": 1.80259,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.18599,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.17901,
+      "init_s": 18.0169,
+      "flush_s": 4.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.93686,
+          "best_ms": 0.388403,
+          "in_gibs": 11.6359,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.3213,
+          "best_ms": 23.1232,
+          "in_gibs": 24.0915,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 54.1299,
+          "best_ms": 48.9312,
+          "in_gibs": 14.4368,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 37.4377,
+          "best_ms": 29.5812,
+          "in_gibs": 21.0506,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.3733,
+          "best_ms": 16.6429,
+          "in_gibs": 40.679,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.43191,
+          "best_ms": 7.15996,
+          "in_gibs": 93.4684,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 46.76,
+      "status": "pass",
+      "throughput_in_gibs": 2.57708,
+      "throughput_out_gibs": 0.0807904,
+      "compression_fold": 42.9032,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0918446,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.13682,
+      "init_s": 17.9293,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.95411,
+          "best_ms": 0.391427,
+          "in_gibs": 11.5954,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.5272,
+          "best_ms": 22.5767,
+          "in_gibs": 23.8893,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 60.108,
+          "best_ms": 48.6532,
+          "in_gibs": 13.001,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 35.0019,
+          "best_ms": 29.6154,
+          "in_gibs": 22.5155,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.5068,
+          "best_ms": 11.953,
+          "in_gibs": 58.3472,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.78987,
+          "best_ms": 0.283986,
+          "in_gibs": 440.322,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.65,
+      "status": "pass",
+      "throughput_in_gibs": 8.99929,
+      "throughput_out_gibs": 10.3594,
+      "compression_fold": 1.16205,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04695,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.390656,
+      "init_s": 0.228301,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.40441,
+          "best_ms": 0.741312,
+          "in_gibs": 19.4954,
+          "out_gibs": 19.4954
+        },
+        "h2d": {
+          "avg_ms": 0.91495,
+          "best_ms": 0.295968,
+          "in_gibs": 51.4662,
+          "out_gibs": 51.4662
+        },
+        "scatter": {
+          "avg_ms": 0.0743711,
+          "best_ms": 0.013952,
+          "in_gibs": 633.164,
+          "out_gibs": 633.164
+        },
+        "lod_gather": {
+          "avg_ms": 0.224363,
+          "best_ms": 0.22432,
+          "in_gibs": 626.775,
+          "out_gibs": 626.775
+        },
+        "lod_reduce": {
+          "avg_ms": 0.767168,
+          "best_ms": 0.759808,
+          "in_gibs": 183.304,
+          "out_gibs": 244.505
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.0955733,
+          "best_ms": 0.065536,
+          "in_gibs": 491.259,
+          "out_gibs": 491.259
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.42656,
+          "best_ms": 0.233472,
+          "in_gibs": 131.489,
+          "out_gibs": 131.863
+        },
+        "compress": {
+          "avg_ms": 0.960922,
+          "best_ms": 0.237568,
+          "in_gibs": 508.977,
+          "out_gibs": 421.031
+        },
+        "aggregate": {
+          "avg_ms": 1.13046,
+          "best_ms": 0.37888,
+          "in_gibs": 357.886,
+          "out_gibs": 357.886
+        },
+        "d2h": {
+          "avg_ms": 7.80566,
+          "best_ms": 0.91408,
+          "in_gibs": 51.8313,
+          "out_gibs": 51.8313
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 7.74525,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 5.89011,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.29722,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 6.31,
+      "status": "pass",
+      "throughput_in_gibs": 2.41617,
+      "throughput_out_gibs": 2.78133,
+      "compression_fold": 1.16205,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04695,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 1.45504,
+      "init_s": 3.14817,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.70717,
+          "best_ms": 0.782393,
+          "in_gibs": 17.3151,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.04103,
+          "best_ms": 4.68245,
+          "in_gibs": 23.2783,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 17.7352,
+          "best_ms": 11.5422,
+          "in_gibs": 10.5765,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.51873,
+          "best_ms": 0.781663,
+          "in_gibs": 10.3904,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.55933,
+          "best_ms": 3.41435,
+          "in_gibs": 41.2583,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.60157,
+          "best_ms": 3.22519,
+          "in_gibs": 56.8602,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.38103,
+          "best_ms": 0.843296,
+          "in_gibs": 54.8132,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.94,
+      "status": "pass",
+      "throughput_in_gibs": 5.2095,
+      "throughput_out_gibs": 0.723447,
+      "compression_fold": 9.63252,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.488217,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.674848,
+      "init_s": 0.2306,
+      "flush_s": 2.755e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.37206,
+          "best_ms": 0.711717,
+          "in_gibs": 19.7613,
+          "out_gibs": 19.7613
+        },
+        "h2d": {
+          "avg_ms": 0.909735,
+          "best_ms": 0.296448,
+          "in_gibs": 51.7613,
+          "out_gibs": 51.7613
+        },
+        "scatter": {
+          "avg_ms": 0.0575328,
+          "best_ms": 0.014944,
+          "in_gibs": 814.753,
+          "out_gibs": 814.753
+        },
+        "lod_gather": {
+          "avg_ms": 9.1693,
+          "best_ms": 1.34643,
+          "in_gibs": 15.3365,
+          "out_gibs": 15.3365
+        },
+        "lod_reduce": {
+          "avg_ms": 1.82001,
+          "best_ms": 0.76864,
+          "in_gibs": 77.266,
+          "out_gibs": 103.063
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.225429,
+          "best_ms": 0.155648,
+          "in_gibs": 208.275,
+          "out_gibs": 208.275
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 12.1383,
+          "best_ms": 0.315392,
+          "in_gibs": 15.4533,
+          "out_gibs": 15.4973
+        },
+        "compress": {
+          "avg_ms": 56.4749,
+          "best_ms": 10.749,
+          "in_gibs": 8.66025,
+          "out_gibs": 0.8624
+        },
+        "aggregate": {
+          "avg_ms": 0.280826,
+          "best_ms": 0.053248,
+          "in_gibs": 173.431,
+          "out_gibs": 173.431
+        },
+        "d2h": {
+          "avg_ms": 7.86077,
+          "best_ms": 0.912992,
+          "in_gibs": 6.19583,
+          "out_gibs": 6.19583
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 99.0657,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 97.2368,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 51.613,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 6.44,
+      "status": "pass",
+      "throughput_in_gibs": 2.59201,
+      "throughput_out_gibs": 0.269089,
+      "compression_fold": 12.8852,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.364974,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 1.35633,
+      "init_s": 3.12625,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.798,
+          "best_ms": 0.790015,
+          "in_gibs": 16.7531,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 5.48537,
+          "best_ms": 4.62311,
+          "in_gibs": 25.6364,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 13.4578,
+          "best_ms": 11.5588,
+          "in_gibs": 13.9381,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.19296,
+          "best_ms": 0.751347,
+          "in_gibs": 21.4101,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.40297,
+          "best_ms": 3.4154,
+          "in_gibs": 42.7235,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 21.8516,
+          "best_ms": 8.53586,
+          "in_gibs": 22.3822,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.30897,
+          "best_ms": 0.098748,
+          "in_gibs": 310.442,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 6.16,
+      "status": "pass",
+      "throughput_in_gibs": 2.77411,
+      "throughput_out_gibs": 1.65334,
+      "compression_fold": 2.24446,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.09528,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 1.2673,
+      "init_s": 3.13761,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.81077,
+          "best_ms": 0.7534,
+          "in_gibs": 16.6769,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 5.58325,
+          "best_ms": 4.64961,
+          "in_gibs": 25.187,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 13.0931,
+          "best_ms": 11.5248,
+          "in_gibs": 14.3263,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.87267,
+          "best_ms": 0.769595,
+          "in_gibs": 25.0718,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.57974,
+          "best_ms": 3.40119,
+          "in_gibs": 41.0744,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.1122,
+          "best_ms": 3.56059,
+          "in_gibs": 44.0136,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.2298,
+          "best_ms": 0.308523,
+          "in_gibs": 95.6741,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 6.3,
+      "status": "pass",
+      "throughput_in_gibs": 2.58922,
+      "throughput_out_gibs": 0.0508522,
+      "compression_fold": 68.1096,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0690469,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 1.35779,
+      "init_s": 3.09538,
+      "flush_s": 4.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.82314,
+          "best_ms": 0.765358,
+          "in_gibs": 16.6038,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 5.79618,
+          "best_ms": 4.69291,
+          "in_gibs": 24.2617,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 16.1216,
+          "best_ms": 11.5458,
+          "in_gibs": 11.6351,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.35201,
+          "best_ms": 0.768103,
+          "in_gibs": 14.0069,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.68832,
+          "best_ms": 3.44577,
+          "in_gibs": 40.1232,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.1814,
+          "best_ms": 3.79331,
+          "in_gibs": 43.7411,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.738027,
+          "best_ms": 0.043655,
+          "in_gibs": 548.33,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.58,
+      "status": "pass",
+      "throughput_in_gibs": 9.11477,
+      "throughput_out_gibs": 10.5145,
+      "compression_fold": 1.17089,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.0555,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.385706,
+      "init_s": 0.230983,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.42998,
+          "best_ms": 0.7599,
+          "in_gibs": 19.2903,
+          "out_gibs": 19.2903
+        },
+        "h2d": {
+          "avg_ms": 0.910457,
+          "best_ms": 0.301568,
+          "in_gibs": 51.7202,
+          "out_gibs": 51.7202
+        },
+        "scatter": {
+          "avg_ms": 0.0883893,
+          "best_ms": 0.013952,
+          "in_gibs": 532.746,
+          "out_gibs": 532.746
+        },
+        "lod_gather": {
+          "avg_ms": 0.223424,
+          "best_ms": 0.22288,
+          "in_gibs": 629.409,
+          "out_gibs": 629.409
+        },
+        "lod_reduce": {
+          "avg_ms": 0.763776,
+          "best_ms": 0.755712,
+          "in_gibs": 184.118,
+          "out_gibs": 245.89
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.0959147,
+          "best_ms": 0.065536,
+          "in_gibs": 491.897,
+          "out_gibs": 491.897
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.45865,
+          "best_ms": 0.23552,
+          "in_gibs": 128.753,
+          "out_gibs": 130.218
+        },
+        "compress": {
+          "avg_ms": 0.968557,
+          "best_ms": 0.240256,
+          "in_gibs": 509.88,
+          "out_gibs": 418.682
+        },
+        "aggregate": {
+          "avg_ms": 1.71478,
+          "best_ms": 0.476544,
+          "in_gibs": 236.483,
+          "out_gibs": 236.483
+        },
+        "d2h": {
+          "avg_ms": 7.85654,
+          "best_ms": 0.946944,
+          "in_gibs": 51.6153,
+          "out_gibs": 51.6153
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 7.5753,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 6.95729,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90518,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 6.26,
+      "status": "pass",
+      "throughput_in_gibs": 2.40323,
+      "throughput_out_gibs": 2.77228,
+      "compression_fold": 1.17089,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.0555,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.46288,
+      "init_s": 3.09545,
+      "flush_s": 6.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.80359,
+          "best_ms": 0.767171,
+          "in_gibs": 16.7196,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 6.31472,
+          "best_ms": 4.66999,
+          "in_gibs": 22.2694,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.879,
+          "best_ms": 11.5402,
+          "in_gibs": 11.8272,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.40966,
+          "best_ms": 0.80638,
+          "in_gibs": 10.6993,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.54711,
+          "best_ms": 3.60828,
+          "in_gibs": 34.2415,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.2062,
+          "best_ms": 3.21444,
+          "in_gibs": 53.6429,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.05569,
+          "best_ms": 0.891908,
+          "in_gibs": 50.3393,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.84,
+      "status": "pass",
+      "throughput_in_gibs": 6.25626,
+      "throughput_out_gibs": 0.667392,
+      "compression_fold": 12.6617,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.375032,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.561937,
+      "init_s": 0.225478,
+      "flush_s": 5.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.37523,
+          "best_ms": 0.720641,
+          "in_gibs": 19.735,
+          "out_gibs": 19.735
+        },
+        "h2d": {
+          "avg_ms": 0.908838,
+          "best_ms": 0.307872,
+          "in_gibs": 51.8123,
+          "out_gibs": 51.8123
+        },
+        "scatter": {
+          "avg_ms": 0.0963248,
+          "best_ms": 0.015008,
+          "in_gibs": 488.857,
+          "out_gibs": 488.857
+        },
+        "lod_gather": {
+          "avg_ms": 0.517736,
+          "best_ms": 0.236576,
+          "in_gibs": 271.615,
+          "out_gibs": 271.615
+        },
+        "lod_reduce": {
+          "avg_ms": 0.921792,
+          "best_ms": 0.759808,
+          "in_gibs": 152.556,
+          "out_gibs": 203.739
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.214032,
+          "best_ms": 0.07168,
+          "in_gibs": 220.435,
+          "out_gibs": 220.435
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 25.4759,
+          "best_ms": 0.23552,
+          "in_gibs": 7.37187,
+          "out_gibs": 7.45572
+        },
+        "compress": {
+          "avg_ms": 43.9525,
+          "best_ms": 27.5444,
+          "in_gibs": 11.2359,
+          "out_gibs": 0.852524
+        },
+        "aggregate": {
+          "avg_ms": 0.464384,
+          "best_ms": 0.057344,
+          "in_gibs": 80.6886,
+          "out_gibs": 80.6886
+        },
+        "d2h": {
+          "avg_ms": 7.81739,
+          "best_ms": 0.945792,
+          "in_gibs": 4.79323,
+          "out_gibs": 4.79323
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 132.143,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 131.533,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 57.7409,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 6.12,
+      "status": "pass",
+      "throughput_in_gibs": 2.57497,
+      "throughput_out_gibs": 0.275784,
+      "compression_fold": 12.6113,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.376531,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.36531,
+      "init_s": 3.07878,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.80683,
+          "best_ms": 0.793971,
+          "in_gibs": 16.7004,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 5.97839,
+          "best_ms": 4.77663,
+          "in_gibs": 23.5222,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 13.5263,
+          "best_ms": 11.5375,
+          "in_gibs": 13.8845,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.91978,
+          "best_ms": 0.786019,
+          "in_gibs": 24.5759,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.91898,
+          "best_ms": 3.64414,
+          "in_gibs": 38.614,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 21.2358,
+          "best_ms": 8.4658,
+          "in_gibs": 23.2554,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.679767,
+          "best_ms": 0.088413,
+          "in_gibs": 598.884,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 6.32,
+      "status": "pass",
+      "throughput_in_gibs": 2.54144,
+      "throughput_out_gibs": 1.56192,
+      "compression_fold": 2.19775,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.16063,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.38332,
+      "init_s": 3.09894,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.81043,
+          "best_ms": 0.782453,
+          "in_gibs": 16.6789,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 5.96463,
+          "best_ms": 4.64114,
+          "in_gibs": 23.5765,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.4874,
+          "best_ms": 11.5601,
+          "in_gibs": 12.9634,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.43389,
+          "best_ms": 0.77367,
+          "in_gibs": 10.6408,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.32806,
+          "best_ms": 3.66091,
+          "in_gibs": 35.6492,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.0091,
+          "best_ms": 3.61498,
+          "in_gibs": 49.34,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.14326,
+          "best_ms": 0.269795,
+          "in_gibs": 97.8821,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 6.37,
+      "status": "pass",
+      "throughput_in_gibs": 2.53497,
+      "throughput_out_gibs": 0.0424029,
+      "compression_fold": 80.7485,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0588065,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.38685,
+      "init_s": 3.15302,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.78415,
+          "best_ms": 0.761453,
+          "in_gibs": 16.8364,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.04104,
+          "best_ms": 4.79956,
+          "in_gibs": 19.9722,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 17.122,
+          "best_ms": 11.5179,
+          "in_gibs": 10.9686,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.78455,
+          "best_ms": 0.794382,
+          "in_gibs": 12.4665,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.69513,
+          "best_ms": 3.59434,
+          "in_gibs": 40.455,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.00192,
+          "best_ms": 3.08464,
+          "in_gibs": 61.7162,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.712378,
+          "best_ms": 0.043525,
+          "in_gibs": 569.291,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.86,
+      "status": "pass",
+      "throughput_in_gibs": 8.59474,
+      "throughput_out_gibs": 10.5478,
+      "compression_fold": 1.18287,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31453,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 0.409044,
+      "init_s": 0.308634,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.87315,
+          "best_ms": 0.939559,
+          "in_gibs": 19.4224,
+          "out_gibs": 19.4224
+        },
+        "h2d": {
+          "avg_ms": 1.08633,
+          "best_ms": 0.590816,
+          "in_gibs": 51.874,
+          "out_gibs": 51.874
+        },
+        "scatter": {
+          "avg_ms": 0.0592692,
+          "best_ms": 0.024192,
+          "in_gibs": 950.787,
+          "out_gibs": 950.787
+        },
+        "lod_gather": {
+          "avg_ms": 0.428424,
+          "best_ms": 0.426496,
+          "in_gibs": 656.476,
+          "out_gibs": 656.476
+        },
+        "lod_reduce": {
+          "avg_ms": 1.53028,
+          "best_ms": 1.51962,
+          "in_gibs": 183.79,
+          "out_gibs": 245.372
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.25088,
+          "best_ms": 0.155648,
+          "in_gibs": 375.631,
+          "out_gibs": 375.631
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.48918,
+          "best_ms": 0.457728,
+          "in_gibs": 150.848,
+          "out_gibs": 157.714
+        },
+        "compress": {
+          "avg_ms": 1.29984,
+          "best_ms": 0.54272,
+          "in_gibs": 528.534,
+          "out_gibs": 414.901
+        },
+        "aggregate": {
+          "avg_ms": 4.28265,
+          "best_ms": 1.60154,
+          "in_gibs": 125.928,
+          "out_gibs": 125.928
+        },
+        "d2h": {
+          "avg_ms": 10.438,
+          "best_ms": 2.12442,
+          "in_gibs": 51.6675,
+          "out_gibs": 51.6675
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 27.3496,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 27.1213,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.49666,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.48,
+      "status": "pass",
+      "throughput_in_gibs": 2.34605,
+      "throughput_out_gibs": 2.87918,
+      "compression_fold": 1.18287,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31453,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.49853,
+      "init_s": 5.95242,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.70666,
+          "best_ms": 0.788824,
+          "in_gibs": 15.055,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.3871,
+          "best_ms": 9.41479,
+          "in_gibs": 22.7051,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 31.6442,
+          "best_ms": 23.3931,
+          "in_gibs": 11.866,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 5.72864,
+          "best_ms": 1.71644,
+          "in_gibs": 16.4504,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 9.66531,
+          "best_ms": 7.69059,
+          "in_gibs": 40.6172,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.9914,
+          "best_ms": 8.35634,
+          "in_gibs": 45.827,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.6243,
+          "best_ms": 2.57855,
+          "in_gibs": 39.5842,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.15,
+      "status": "pass",
+      "throughput_in_gibs": 5.28944,
+      "throughput_out_gibs": 0.684708,
+      "compression_fold": 11.2143,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.455091,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 0.66465,
+      "init_s": 0.308682,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.84613,
+          "best_ms": 0.737036,
+          "in_gibs": 19.6069,
+          "out_gibs": 19.6069
+        },
+        "h2d": {
+          "avg_ms": 1.07856,
+          "best_ms": 0.591136,
+          "in_gibs": 52.248,
+          "out_gibs": 52.248
+        },
+        "scatter": {
+          "avg_ms": 0.114651,
+          "best_ms": 0.024224,
+          "in_gibs": 491.512,
+          "out_gibs": 491.512
+        },
+        "lod_gather": {
+          "avg_ms": 1.11591,
+          "best_ms": 0.424416,
+          "in_gibs": 252.036,
+          "out_gibs": 252.036
+        },
+        "lod_reduce": {
+          "avg_ms": 1.81918,
+          "best_ms": 1.52371,
+          "in_gibs": 154.603,
+          "out_gibs": 206.406
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.470184,
+          "best_ms": 0.154688,
+          "in_gibs": 200.429,
+          "out_gibs": 200.429
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 17.0455,
+          "best_ms": 0.45664,
+          "in_gibs": 22.0286,
+          "out_gibs": 23.0312
+        },
+        "compress": {
+          "avg_ms": 62.946,
+          "best_ms": 57.9408,
+          "in_gibs": 10.9143,
+          "out_gibs": 0.903581
+        },
+        "aggregate": {
+          "avg_ms": 0.49124,
+          "best_ms": 0.12288,
+          "in_gibs": 115.782,
+          "out_gibs": 115.782
+        },
+        "d2h": {
+          "avg_ms": 10.3703,
+          "best_ms": 2.1232,
+          "in_gibs": 5.48457,
+          "out_gibs": 5.48457
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 216.879,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 216.667,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 77.9196,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.44,
+      "status": "pass",
+      "throughput_in_gibs": 2.38641,
+      "throughput_out_gibs": 0.272915,
+      "compression_fold": 12.6936,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.402054,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.47318,
+      "init_s": 5.98871,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.74314,
+          "best_ms": 0.78598,
+          "in_gibs": 14.9082,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 11.8006,
+          "best_ms": 9.39656,
+          "in_gibs": 23.8335,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 29.8063,
+          "best_ms": 23.1685,
+          "in_gibs": 12.5976,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.08327,
+          "best_ms": 1.86113,
+          "in_gibs": 15.4914,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 10.1607,
+          "best_ms": 7.59265,
+          "in_gibs": 38.6368,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.1572,
+          "best_ms": 14.0741,
+          "in_gibs": 25.2976,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.25765,
+          "best_ms": 0.115834,
+          "in_gibs": 430.497,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.27,
+      "status": "pass",
+      "throughput_in_gibs": 2.67398,
+      "throughput_out_gibs": 1.70212,
+      "compression_fold": 2.28052,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.23788,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.31476,
+      "init_s": 6.00986,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.7076,
+          "best_ms": 0.768994,
+          "in_gibs": 15.0511,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.9268,
+          "best_ms": 9.35251,
+          "in_gibs": 25.7396,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 26.1075,
+          "best_ms": 23.2412,
+          "in_gibs": 14.3824,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.5921,
+          "best_ms": 1.73026,
+          "in_gibs": 20.5218,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 9.70236,
+          "best_ms": 7.6,
+          "in_gibs": 40.4621,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.7921,
+          "best_ms": 6.41222,
+          "in_gibs": 49.812,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.19647,
+          "best_ms": 2.53503,
+          "in_gibs": 87.0371,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 9.03,
+      "status": "pass",
+      "throughput_in_gibs": 2.83787,
+      "throughput_out_gibs": 0.0472994,
+      "compression_fold": 87.0969,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0585958,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.23883,
+      "init_s": 5.97054,
+      "flush_s": 6.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.70678,
+          "best_ms": 0.795744,
+          "in_gibs": 15.0544,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 10.2277,
+          "best_ms": 9.24115,
+          "in_gibs": 27.4988,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 25.8473,
+          "best_ms": 23.2524,
+          "in_gibs": 14.5272,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.81258,
+          "best_ms": 1.85742,
+          "in_gibs": 19.5817,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 10.0792,
+          "best_ms": 7.63018,
+          "in_gibs": 38.9495,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.00966,
+          "best_ms": 4.29847,
+          "in_gibs": 76.2528,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.97314,
+          "best_ms": 0.056345,
+          "in_gibs": 273.333,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.0,
+      "status": "pass",
+      "throughput_in_gibs": 8.59385,
+      "throughput_out_gibs": 9.16887,
+      "compression_fold": 1.07092,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00092,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.436358,
+      "init_s": 0.211745,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.53936,
+          "best_ms": 1.62227,
+          "in_gibs": 18.4594,
+          "out_gibs": 18.4594
+        },
+        "h2d": {
+          "avg_ms": 0.90288,
+          "best_ms": 0.59008,
+          "in_gibs": 51.9172,
+          "out_gibs": 51.9172
+        },
+        "scatter": {
+          "avg_ms": 0.0531319,
+          "best_ms": 0.025184,
+          "in_gibs": 882.239,
+          "out_gibs": 882.239
+        },
+        "lod_gather": {
+          "avg_ms": 0.421392,
+          "best_ms": 0.419232,
+          "in_gibs": 222.477,
+          "out_gibs": 222.477
+        },
+        "lod_reduce": {
+          "avg_ms": 0.404256,
+          "best_ms": 0.403456,
+          "in_gibs": 231.908,
+          "out_gibs": 264.972
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.034816,
+          "best_ms": 0.02048,
+          "in_gibs": 383.924,
+          "out_gibs": 383.924
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.248832,
+          "best_ms": 0.22528,
+          "in_gibs": 430.478,
+          "out_gibs": 430.478
+        },
+        "compress": {
+          "avg_ms": 1.0901,
+          "best_ms": 0.76416,
+          "in_gibs": 491.318,
+          "out_gibs": 458.668
+        },
+        "aggregate": {
+          "avg_ms": 1.31376,
+          "best_ms": 1.18675,
+          "in_gibs": 380.58,
+          "out_gibs": 380.58
+        },
+        "d2h": {
+          "avg_ms": 9.67967,
+          "best_ms": 9.55072,
+          "in_gibs": 51.6539,
+          "out_gibs": 51.6539
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.4524,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 13.5819,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.98452,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 14.39,
+      "status": "pass",
+      "throughput_in_gibs": 2.34809,
+      "throughput_out_gibs": 2.5052,
+      "compression_fold": 1.07092,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00092,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.59704,
+      "init_s": 2.02029,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.75047,
+          "best_ms": 1.63095,
+          "in_gibs": 17.0425,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.63585,
+          "best_ms": 6.52766,
+          "in_gibs": 12.2776,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 8.4333,
+          "best_ms": 4.70095,
+          "in_gibs": 12.7016,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.02379,
+          "best_ms": 0.000261,
+          "in_gibs": 4.42051,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.25274,
+          "best_ms": 2.91599,
+          "in_gibs": 25.1877,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.46525,
+          "best_ms": 8.97034,
+          "in_gibs": 56.5842,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.84679,
+          "best_ms": 8.32488,
+          "in_gibs": 56.5168,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 11.98,
+      "status": "pass",
+      "throughput_in_gibs": 7.38881,
+      "throughput_out_gibs": 0.926369,
+      "compression_fold": 9.11332,
+      "input_gib": 3.75,
+      "compressed_gib": 0.470155,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.507524,
+      "init_s": 0.212575,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.54588,
+          "best_ms": 1.56941,
+          "in_gibs": 18.4121,
+          "out_gibs": 18.4121
+        },
+        "h2d": {
+          "avg_ms": 0.899982,
+          "best_ms": 0.590496,
+          "in_gibs": 52.0844,
+          "out_gibs": 52.0844
+        },
+        "scatter": {
+          "avg_ms": 0.0583389,
+          "best_ms": 0.025376,
+          "in_gibs": 813.061,
+          "out_gibs": 813.061
+        },
+        "lod_gather": {
+          "avg_ms": 0.425536,
+          "best_ms": 0.423424,
+          "in_gibs": 220.31,
+          "out_gibs": 220.31
+        },
+        "lod_reduce": {
+          "avg_ms": 0.407312,
+          "best_ms": 0.40704,
+          "in_gibs": 230.168,
+          "out_gibs": 262.984
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.034816,
+          "best_ms": 0.02048,
+          "in_gibs": 383.924,
+          "out_gibs": 383.924
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.247808,
+          "best_ms": 0.2232,
+          "in_gibs": 432.257,
+          "out_gibs": 432.257
+        },
+        "compress": {
+          "avg_ms": 38.836,
+          "best_ms": 33.8835,
+          "in_gibs": 13.7909,
+          "out_gibs": 1.51013
+        },
+        "aggregate": {
+          "avg_ms": 0.269908,
+          "best_ms": 0.200192,
+          "in_gibs": 217.286,
+          "out_gibs": 217.286
+        },
+        "d2h": {
+          "avg_ms": 9.66147,
+          "best_ms": 9.52048,
+          "in_gibs": 6.07022,
+          "out_gibs": 6.07022
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 47.1959,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 45.2845,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 40.8436,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 14.74,
+      "status": "pass",
+      "throughput_in_gibs": 2.34815,
+      "throughput_out_gibs": 0.224223,
+      "compression_fold": 11.9655,
+      "input_gib": 3.75,
+      "compressed_gib": 0.358085,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.597,
+      "init_s": 2.05927,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.76215,
+          "best_ms": 1.63103,
+          "in_gibs": 16.9705,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.64069,
+          "best_ms": 6.54214,
+          "in_gibs": 12.2698,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.55062,
+          "best_ms": 4.7045,
+          "in_gibs": 14.1865,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.26091,
+          "best_ms": 5e-05,
+          "in_gibs": 5.91208,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.00685,
+          "best_ms": 2.89498,
+          "in_gibs": 26.7334,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.6812,
+          "best_ms": 24.8164,
+          "in_gibs": 20.8551,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.9438,
+          "best_ms": 0.743806,
+          "in_gibs": 258.357,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 14.52,
+      "status": "pass",
+      "throughput_in_gibs": 2.49845,
+      "throughput_out_gibs": 1.67959,
+      "compression_fold": 1.69962,
+      "input_gib": 3.75,
+      "compressed_gib": 2.52095,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.50093,
+      "init_s": 2.12076,
+      "flush_s": 4.6e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.77271,
+          "best_ms": 1.63754,
+          "in_gibs": 16.9058,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.49425,
+          "best_ms": 6.58411,
+          "in_gibs": 12.5096,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.48811,
+          "best_ms": 4.71278,
+          "in_gibs": 14.3049,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.19793,
+          "best_ms": 0.000121,
+          "in_gibs": 11.1582,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.73993,
+          "best_ms": 2.86038,
+          "in_gibs": 28.6413,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.3338,
+          "best_ms": 13.4245,
+          "in_gibs": 32.7899,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.65831,
+          "best_ms": 5.38136,
+          "in_gibs": 75.1126,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 14.79,
+      "status": "pass",
+      "throughput_in_gibs": 2.06348,
+      "throughput_out_gibs": 0.0522497,
+      "compression_fold": 45.1234,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0949545,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 1.81732,
+      "init_s": 2.06752,
+      "flush_s": 4.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.75672,
+          "best_ms": 1.65154,
+          "in_gibs": 17.0039,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 8.167,
+          "best_ms": 6.56609,
+          "in_gibs": 11.4791,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 10.3049,
+          "best_ms": 4.71432,
+          "in_gibs": 10.3947,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.26268,
+          "best_ms": 0.00019,
+          "in_gibs": 3.13575,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.81935,
+          "best_ms": 2.87594,
+          "in_gibs": 18.407,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.4906,
+          "best_ms": 17.829,
+          "in_gibs": 28.9651,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.948808,
+          "best_ms": 0.225979,
+          "in_gibs": 527.106,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.81,
+      "status": "pass",
+      "throughput_in_gibs": 8.69016,
+      "throughput_out_gibs": 9.27629,
+      "compression_fold": 1.07587,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00293,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.431523,
+      "init_s": 0.216434,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.53957,
+          "best_ms": 1.56698,
+          "in_gibs": 18.4578,
+          "out_gibs": 18.4578
+        },
+        "h2d": {
+          "avg_ms": 0.905147,
+          "best_ms": 0.589984,
+          "in_gibs": 51.7872,
+          "out_gibs": 51.7872
+        },
+        "scatter": {
+          "avg_ms": 0.0629817,
+          "best_ms": 0.025216,
+          "in_gibs": 744.263,
+          "out_gibs": 744.263
+        },
+        "lod_gather": {
+          "avg_ms": 0.4224,
+          "best_ms": 0.417152,
+          "in_gibs": 221.946,
+          "out_gibs": 221.946
+        },
+        "lod_reduce": {
+          "avg_ms": 0.410352,
+          "best_ms": 0.409056,
+          "in_gibs": 228.462,
+          "out_gibs": 262.375
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.034816,
+          "best_ms": 0.02048,
+          "in_gibs": 399.702,
+          "out_gibs": 399.702
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.254464,
+          "best_ms": 0.22528,
+          "in_gibs": 423.109,
+          "out_gibs": 423.109
+        },
+        "compress": {
+          "avg_ms": 1.09331,
+          "best_ms": 0.764352,
+          "in_gibs": 492.386,
+          "out_gibs": 457.635
+        },
+        "aggregate": {
+          "avg_ms": 2.13355,
+          "best_ms": 1.82429,
+          "in_gibs": 234.508,
+          "out_gibs": 234.508
+        },
+        "d2h": {
+          "avg_ms": 9.70441,
+          "best_ms": 9.54547,
+          "in_gibs": 51.5576,
+          "out_gibs": 51.5576
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.6128,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 15.0528,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.97369,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 14.67,
+      "status": "pass",
+      "throughput_in_gibs": 2.49971,
+      "throughput_out_gibs": 2.66831,
+      "compression_fold": 1.07587,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00293,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.50017,
+      "init_s": 2.08351,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.75095,
+          "best_ms": 1.61868,
+          "in_gibs": 17.0396,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.44384,
+          "best_ms": 6.51955,
+          "in_gibs": 12.5943,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.07838,
+          "best_ms": 4.8898,
+          "in_gibs": 15.2105,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.32397,
+          "best_ms": 0.00012,
+          "in_gibs": 10.5109,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.20508,
+          "best_ms": 3.71956,
+          "in_gibs": 20.6848,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.3161,
+          "best_ms": 9.0387,
+          "in_gibs": 57.7849,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.81175,
+          "best_ms": 8.31175,
+          "in_gibs": 56.7805,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 11.87,
+      "status": "pass",
+      "throughput_in_gibs": 7.38243,
+      "throughput_out_gibs": 0.932008,
+      "compression_fold": 9.09677,
+      "input_gib": 3.75,
+      "compressed_gib": 0.473425,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.507963,
+      "init_s": 0.213301,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.54358,
+          "best_ms": 1.65588,
+          "in_gibs": 18.4288,
+          "out_gibs": 18.4288
+        },
+        "h2d": {
+          "avg_ms": 0.897503,
+          "best_ms": 0.590272,
+          "in_gibs": 52.2282,
+          "out_gibs": 52.2282
+        },
+        "scatter": {
+          "avg_ms": 0.0828997,
+          "best_ms": 0.023744,
+          "in_gibs": 565.442,
+          "out_gibs": 565.442
+        },
+        "lod_gather": {
+          "avg_ms": 0.4348,
+          "best_ms": 0.432416,
+          "in_gibs": 215.616,
+          "out_gibs": 215.616
+        },
+        "lod_reduce": {
+          "avg_ms": 0.430224,
+          "best_ms": 0.429728,
+          "in_gibs": 217.91,
+          "out_gibs": 250.256
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.045088,
+          "best_ms": 0.028544,
+          "in_gibs": 308.641,
+          "out_gibs": 308.641
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.273536,
+          "best_ms": 0.244096,
+          "in_gibs": 393.608,
+          "out_gibs": 393.608
+        },
+        "compress": {
+          "avg_ms": 43.171,
+          "best_ms": 37.697,
+          "in_gibs": 12.4697,
+          "out_gibs": 1.37008
+        },
+        "aggregate": {
+          "avg_ms": 0.337132,
+          "best_ms": 0.231072,
+          "in_gibs": 175.443,
+          "out_gibs": 175.443
+        },
+        "d2h": {
+          "avg_ms": 9.70413,
+          "best_ms": 9.54992,
+          "in_gibs": 6.09509,
+          "out_gibs": 6.09509
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 51.2842,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 50.6654,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 43.0962,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 15.31,
+      "status": "pass",
+      "throughput_in_gibs": 1.97337,
+      "throughput_out_gibs": 0.184696,
+      "compression_fold": 12.2704,
+      "input_gib": 3.75,
+      "compressed_gib": 0.350978,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.90031,
+      "init_s": 2.02072,
+      "flush_s": 4.6e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.78231,
+          "best_ms": 1.64575,
+          "in_gibs": 16.8475,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.9943,
+          "best_ms": 6.65963,
+          "in_gibs": 11.7271,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 10.6463,
+          "best_ms": 4.88512,
+          "in_gibs": 10.113,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.85855,
+          "best_ms": 0.00023,
+          "in_gibs": 2.86423,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 6.15576,
+          "best_ms": 3.57954,
+          "in_gibs": 17.4903,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.0729,
+          "best_ms": 22.5999,
+          "in_gibs": 23.3317,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.37155,
+          "best_ms": 0.68043,
+          "in_gibs": 366.221,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 14.65,
+      "status": "pass",
+      "throughput_in_gibs": 2.39731,
+      "throughput_out_gibs": 1.43932,
+      "compression_fold": 1.91282,
+      "input_gib": 3.75,
+      "compressed_gib": 2.25146,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.56425,
+      "init_s": 2.06863,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.7713,
+          "best_ms": 1.64846,
+          "in_gibs": 16.9145,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.68317,
+          "best_ms": 6.55592,
+          "in_gibs": 12.202,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.77934,
+          "best_ms": 4.89538,
+          "in_gibs": 13.84,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.10421,
+          "best_ms": 0.00014,
+          "in_gibs": 6.61343,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.34248,
+          "best_ms": 3.56607,
+          "in_gibs": 20.1528,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.7297,
+          "best_ms": 11.2214,
+          "in_gibs": 45.8945,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.96007,
+          "best_ms": 4.68989,
+          "in_gibs": 100.881,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 14.76,
+      "status": "pass",
+      "throughput_in_gibs": 2.15192,
+      "throughput_out_gibs": 0.034735,
+      "compression_fold": 71.1486,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0605302,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.74263,
+      "init_s": 2.08645,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.76365,
+          "best_ms": 1.65688,
+          "in_gibs": 16.9613,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.87396,
+          "best_ms": 6.7399,
+          "in_gibs": 11.9063,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 9.49085,
+          "best_ms": 4.89552,
+          "in_gibs": 11.3442,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.52399,
+          "best_ms": 0.0002,
+          "in_gibs": 3.07605,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 6.24186,
+          "best_ms": 3.6623,
+          "in_gibs": 17.249,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.2902,
+          "best_ms": 10.2968,
+          "in_gibs": 47.6811,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.61103,
+          "best_ms": 0.124697,
+          "in_gibs": 310.594,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.84,
+      "status": "pass",
+      "throughput_in_gibs": 8.65478,
+      "throughput_out_gibs": 9.26351,
+      "compression_fold": 1.08027,
+      "input_gib": 3.75,
+      "compressed_gib": 4.01375,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 0.433287,
+      "init_s": 0.211852,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.52613,
+          "best_ms": 1.55242,
+          "in_gibs": 18.5561,
+          "out_gibs": 18.5561
+        },
+        "h2d": {
+          "avg_ms": 0.904043,
+          "best_ms": 0.590048,
+          "in_gibs": 51.8504,
+          "out_gibs": 51.8504
+        },
+        "scatter": {
+          "avg_ms": 0.0652829,
+          "best_ms": 0.025312,
+          "in_gibs": 718.029,
+          "out_gibs": 718.029
+        },
+        "lod_gather": {
+          "avg_ms": 0.42008,
+          "best_ms": 0.416608,
+          "in_gibs": 223.172,
+          "out_gibs": 223.172
+        },
+        "lod_reduce": {
+          "avg_ms": 0.402432,
+          "best_ms": 0.401408,
+          "in_gibs": 232.959,
+          "out_gibs": 269.358
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.036864,
+          "best_ms": 0.022528,
+          "in_gibs": 397.364,
+          "out_gibs": 397.364
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.269824,
+          "best_ms": 0.237568,
+          "in_gibs": 401.738,
+          "out_gibs": 401.738
+        },
+        "compress": {
+          "avg_ms": 1.09747,
+          "best_ms": 0.768096,
+          "in_gibs": 493.855,
+          "out_gibs": 457.15
+        },
+        "aggregate": {
+          "avg_ms": 4.82054,
+          "best_ms": 4.74435,
+          "in_gibs": 104.077,
+          "out_gibs": 104.077
+        },
+        "d2h": {
+          "avg_ms": 9.73348,
+          "best_ms": 9.58214,
+          "in_gibs": 51.5447,
+          "out_gibs": 51.5447
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 18.04,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 17.789,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.92739,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 14.34,
+      "status": "pass",
+      "throughput_in_gibs": 2.39415,
+      "throughput_out_gibs": 2.56255,
+      "compression_fold": 1.08027,
+      "input_gib": 3.75,
+      "compressed_gib": 4.01375,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 1.56631,
+      "init_s": 1.99342,
+      "flush_s": 6.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.76458,
+          "best_ms": 1.63939,
+          "in_gibs": 16.9556,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.71792,
+          "best_ms": 6.48447,
+          "in_gibs": 12.1471,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.0329,
+          "best_ms": 5.31215,
+          "in_gibs": 15.413,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.62115,
+          "best_ms": 0.000321,
+          "in_gibs": 9.03581,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.25271,
+          "best_ms": 3.84178,
+          "in_gibs": 20.6367,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.823,
+          "best_ms": 11.7574,
+          "in_gibs": 45.8422,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.9831,
+          "best_ms": 10.5256,
+          "in_gibs": 45.6799,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 11.98,
+      "status": "pass",
+      "throughput_in_gibs": 6.62,
+      "throughput_out_gibs": 0.66956,
+      "compression_fold": 11.4319,
+      "input_gib": 3.75,
+      "compressed_gib": 0.379283,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 0.566465,
+      "init_s": 0.213785,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.53078,
+          "best_ms": 1.61348,
+          "in_gibs": 18.522,
+          "out_gibs": 18.522
+        },
+        "h2d": {
+          "avg_ms": 0.900859,
+          "best_ms": 0.589952,
+          "in_gibs": 52.0337,
+          "out_gibs": 52.0337
+        },
+        "scatter": {
+          "avg_ms": 0.0722585,
+          "best_ms": 0.025376,
+          "in_gibs": 648.713,
+          "out_gibs": 648.713
+        },
+        "lod_gather": {
+          "avg_ms": 0.67912,
+          "best_ms": 0.675584,
+          "in_gibs": 138.046,
+          "out_gibs": 138.046
+        },
+        "lod_reduce": {
+          "avg_ms": 0.48584,
+          "best_ms": 0.485344,
+          "in_gibs": 192.965,
+          "out_gibs": 223.116
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.052992,
+          "best_ms": 0.03616,
+          "in_gibs": 276.427,
+          "out_gibs": 276.427
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.465808,
+          "best_ms": 0.43824,
+          "in_gibs": 232.711,
+          "out_gibs": 232.711
+        },
+        "compress": {
+          "avg_ms": 54.7947,
+          "best_ms": 48.6649,
+          "in_gibs": 9.89133,
+          "out_gibs": 0.865049
+        },
+        "aggregate": {
+          "avg_ms": 0.473036,
+          "best_ms": 0.280224,
+          "in_gibs": 100.204,
+          "out_gibs": 100.204
+        },
+        "d2h": {
+          "avg_ms": 9.68597,
+          "best_ms": 9.42256,
+          "in_gibs": 4.89368,
+          "out_gibs": 4.89368
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 85.9111,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 85.6541,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 68.742,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 14.5,
+      "status": "pass",
+      "throughput_in_gibs": 2.29201,
+      "throughput_out_gibs": 0.186696,
+      "compression_fold": 14.195,
+      "input_gib": 3.75,
+      "compressed_gib": 0.305456,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 1.63612,
+      "init_s": 2.015,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.7801,
+          "best_ms": 1.65533,
+          "in_gibs": 16.8609,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.70114,
+          "best_ms": 6.54667,
+          "in_gibs": 12.1735,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.64783,
+          "best_ms": 5.29913,
+          "in_gibs": 14.1738,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.69737,
+          "best_ms": 0.000121,
+          "in_gibs": 5.43063,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.62231,
+          "best_ms": 3.77968,
+          "in_gibs": 19.28,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 20.5438,
+          "best_ms": 18.786,
+          "in_gibs": 26.3822,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.285,
+          "best_ms": 0.584867,
+          "in_gibs": 391.959,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 14.37,
+      "status": "pass",
+      "throughput_in_gibs": 2.50216,
+      "throughput_out_gibs": 1.57262,
+      "compression_fold": 1.83969,
+      "input_gib": 3.75,
+      "compressed_gib": 2.35689,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 1.4987,
+      "init_s": 1.99591,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.78115,
+          "best_ms": 1.64098,
+          "in_gibs": 16.8545,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 7.18491,
+          "best_ms": 6.59337,
+          "in_gibs": 13.0482,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.65289,
+          "best_ms": 5.32543,
+          "in_gibs": 16.2934,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.84602,
+          "best_ms": 0.000131,
+          "in_gibs": 7.93514,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.27702,
+          "best_ms": 3.82908,
+          "in_gibs": 20.5416,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.6556,
+          "best_ms": 11.6162,
+          "in_gibs": 42.8262,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.21265,
+          "best_ms": 4.92892,
+          "in_gibs": 96.2513,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 14.69,
+      "status": "pass",
+      "throughput_in_gibs": 2.05168,
+      "throughput_out_gibs": 0.0515048,
+      "compression_fold": 46.0589,
+      "input_gib": 3.75,
+      "compressed_gib": 0.094139,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 1.82777,
+      "init_s": 2.01413,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 2.75233,
+          "best_ms": 1.62883,
+          "in_gibs": 17.031,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 8.27574,
+          "best_ms": 6.5447,
+          "in_gibs": 11.3283,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 9.87506,
+          "best_ms": 5.29628,
+          "in_gibs": 10.977,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 4.67041,
+          "best_ms": 0.000221,
+          "in_gibs": 3.13643,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 6.43637,
+          "best_ms": 3.87171,
+          "in_gibs": 16.8416,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.5401,
+          "best_ms": 17.0866,
+          "in_gibs": 30.9001,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.219783,
+          "best_ms": 0.175823,
+          "in_gibs": 2282.81,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__gpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 28.22,
+      "status": "pass",
+      "throughput_in_gibs": 7.8933,
+      "throughput_out_gibs": 9.31103,
+      "compression_fold": 1.13093,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.45589,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 0.371161,
+      "init_s": 0.473811,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.155,
+          "best_ms": 0.394672,
+          "in_gibs": 18.2076,
+          "out_gibs": 18.2076
+        },
+        "h2d": {
+          "avg_ms": 1.10761,
+          "best_ms": 0.149792,
+          "in_gibs": 51.8216,
+          "out_gibs": 51.8216
+        },
+        "scatter": {
+          "avg_ms": 0.152233,
+          "best_ms": 0.021248,
+          "in_gibs": 383.827,
+          "out_gibs": 383.827
+        },
+        "lod_gather": {
+          "avg_ms": 1.67028,
+          "best_ms": 1.66864,
+          "in_gibs": 350.801,
+          "out_gibs": 350.801
+        },
+        "lod_reduce": {
+          "avg_ms": 3.24663,
+          "best_ms": 3.22816,
+          "in_gibs": 180.475,
+          "out_gibs": 240.638
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.623957,
+          "best_ms": 0.339968,
+          "in_gibs": 313.044,
+          "out_gibs": 313.044
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 28.3028,
+          "best_ms": 1.6087,
+          "in_gibs": 27.6037,
+          "out_gibs": 27.6184
+        },
+        "compress": {
+          "avg_ms": 1.48777,
+          "best_ms": 1.11651,
+          "in_gibs": 525.402,
+          "out_gibs": 387.046
+        },
+        "aggregate": {
+          "avg_ms": 1.43664,
+          "best_ms": 1.09123,
+          "in_gibs": 400.821,
+          "out_gibs": 400.821
+        },
+        "d2h": {
+          "avg_ms": 11.121,
+          "best_ms": 3.73264,
+          "in_gibs": 51.779,
+          "out_gibs": 51.779
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 29.1375,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 27.5041,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 12.0026,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 46.8,
+      "status": "pass",
+      "throughput_in_gibs": 2.1337,
+      "throughput_out_gibs": 2.51694,
+      "compression_fold": 1.13093,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.45589,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.37305,
+      "init_s": 17.973,
+      "flush_s": 5.41e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.93664,
+          "best_ms": 0.394242,
+          "in_gibs": 11.6364,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.1951,
+          "best_ms": 23.102,
+          "in_gibs": 22.3682,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 77.7225,
+          "best_ms": 50.4528,
+          "in_gibs": 10.052,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 17.5135,
+          "best_ms": 4.37307,
+          "in_gibs": 11.1528,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 25.6657,
+          "best_ms": 21.7488,
+          "in_gibs": 30.4561,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.1727,
+          "best_ms": 12.8229,
+          "in_gibs": 55.1537,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.6059,
+          "best_ms": 3.4737,
+          "in_gibs": 49.6158,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__gpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 28.99,
+      "status": "pass",
+      "throughput_in_gibs": 3.31141,
+      "throughput_out_gibs": 0.503214,
+      "compression_fold": 8.77882,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.445206,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 0.884726,
+      "init_s": 0.467511,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.1481,
+          "best_ms": 0.502023,
+          "in_gibs": 18.2475,
+          "out_gibs": 18.2475
+        },
+        "h2d": {
+          "avg_ms": 1.10304,
+          "best_ms": 0.172576,
+          "in_gibs": 52.0363,
+          "out_gibs": 52.0363
+        },
+        "scatter": {
+          "avg_ms": 0.0846843,
+          "best_ms": 0.014112,
+          "in_gibs": 669.436,
+          "out_gibs": 669.436
+        },
+        "lod_gather": {
+          "avg_ms": 1.693,
+          "best_ms": 1.6688,
+          "in_gibs": 346.094,
+          "out_gibs": 346.094
+        },
+        "lod_reduce": {
+          "avg_ms": 3.26524,
+          "best_ms": 3.2457,
+          "in_gibs": 179.447,
+          "out_gibs": 239.267
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.624128,
+          "best_ms": 0.356864,
+          "in_gibs": 312.958,
+          "out_gibs": 312.958
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 97.6868,
+          "best_ms": 1.62349,
+          "in_gibs": 7.99763,
+          "out_gibs": 8.00187
+        },
+        "compress": {
+          "avg_ms": 110.824,
+          "best_ms": 31.0563,
+          "in_gibs": 7.05331,
+          "out_gibs": 0.668221
+        },
+        "aggregate": {
+          "avg_ms": 0.305344,
+          "best_ms": 0.17472,
+          "in_gibs": 242.53,
+          "out_gibs": 242.53
+        },
+        "d2h": {
+          "avg_ms": 11.2897,
+          "best_ms": 3.73181,
+          "in_gibs": 6.5595,
+          "out_gibs": 6.5595
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 179.25,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 177.64,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 116.458,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 47.03,
+      "status": "pass",
+      "throughput_in_gibs": 2.16952,
+      "throughput_out_gibs": 0.26153,
+      "compression_fold": 11.0667,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.353166,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.35038,
+      "init_s": 17.9346,
+      "flush_s": 6.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.93694,
+          "best_ms": 0.391337,
+          "in_gibs": 11.6357,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.0865,
+          "best_ms": 22.7616,
+          "in_gibs": 23.3567,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 62.0393,
+          "best_ms": 48.7117,
+          "in_gibs": 12.593,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 13.5918,
+          "best_ms": 4.09475,
+          "in_gibs": 14.3709,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 26.331,
+          "best_ms": 20.159,
+          "in_gibs": 29.6866,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 37.3474,
+          "best_ms": 35.0147,
+          "in_gibs": 20.9299,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.04056,
+          "best_ms": 0.409314,
+          "in_gibs": 283.437,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 46.25,
+      "status": "pass",
+      "throughput_in_gibs": 2.4469,
+      "throughput_out_gibs": 1.69447,
+      "compression_fold": 1.92645,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.0288,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.19731,
+      "init_s": 17.9551,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.96366,
+          "best_ms": 0.376835,
+          "in_gibs": 11.5731,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.0847,
+          "best_ms": 22.8708,
+          "in_gibs": 24.3282,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 53.0586,
+          "best_ms": 48.6206,
+          "in_gibs": 14.7245,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 8.82454,
+          "best_ms": 4.41866,
+          "in_gibs": 22.1344,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 27.8637,
+          "best_ms": 20.6423,
+          "in_gibs": 28.0536,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.3402,
+          "best_ms": 14.5852,
+          "in_gibs": 40.4173,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.34656,
+          "best_ms": 1.86226,
+          "in_gibs": 90.7551,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 46.52,
+      "status": "pass",
+      "throughput_in_gibs": 2.37857,
+      "throughput_out_gibs": 0.0556572,
+      "compression_fold": 57.0125,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0685531,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.2317,
+      "init_s": 18.0217,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.94205,
+          "best_ms": 0.415072,
+          "in_gibs": 11.6237,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.5493,
+          "best_ms": 22.5342,
+          "in_gibs": 22.9336,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 58.359,
+          "best_ms": 48.6504,
+          "in_gibs": 13.3872,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 13.1696,
+          "best_ms": 4.12539,
+          "in_gibs": 14.8315,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 24.7195,
+          "best_ms": 20.2513,
+          "in_gibs": 31.6219,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 22.5089,
+          "best_ms": 14.7266,
+          "in_gibs": 34.7276,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.48218,
+          "best_ms": 0.111107,
+          "in_gibs": 388.607,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__gpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 28.14,
+      "status": "pass",
+      "throughput_in_gibs": 7.92162,
+      "throughput_out_gibs": 9.34612,
+      "compression_fold": 1.13258,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.45652,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 0.369835,
+      "init_s": 0.464364,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14069,
+          "best_ms": 0.362303,
+          "in_gibs": 18.2905,
+          "out_gibs": 18.2905
+        },
+        "h2d": {
+          "avg_ms": 1.10754,
+          "best_ms": 0.155456,
+          "in_gibs": 51.8247,
+          "out_gibs": 51.8247
+        },
+        "scatter": {
+          "avg_ms": 0.136063,
+          "best_ms": 0.021248,
+          "in_gibs": 429.44,
+          "out_gibs": 429.44
+        },
+        "lod_gather": {
+          "avg_ms": 1.68669,
+          "best_ms": 1.6735,
+          "in_gibs": 347.389,
+          "out_gibs": 347.389
+        },
+        "lod_reduce": {
+          "avg_ms": 3.22199,
+          "best_ms": 3.21638,
+          "in_gibs": 181.856,
+          "out_gibs": 242.491
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.623275,
+          "best_ms": 0.342016,
+          "in_gibs": 313.451,
+          "out_gibs": 313.451
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 28.0734,
+          "best_ms": 1.60666,
+          "in_gibs": 27.8307,
+          "out_gibs": 27.8897
+        },
+        "compress": {
+          "avg_ms": 1.48789,
+          "best_ms": 1.11856,
+          "in_gibs": 526.22,
+          "out_gibs": 387.158
+        },
+        "aggregate": {
+          "avg_ms": 1.93822,
+          "best_ms": 1.4105,
+          "in_gibs": 297.205,
+          "out_gibs": 297.205
+        },
+        "d2h": {
+          "avg_ms": 11.1267,
+          "best_ms": 3.75552,
+          "in_gibs": 51.7719,
+          "out_gibs": 51.7719
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 30.3514,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 29.8604,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.974,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 46.71,
+      "status": "pass",
+      "throughput_in_gibs": 2.25768,
+      "throughput_out_gibs": 2.66367,
+      "compression_fold": 1.13258,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.45652,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.29765,
+      "init_s": 18.0452,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.96957,
+          "best_ms": 0.394571,
+          "in_gibs": 11.5593,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.0737,
+          "best_ms": 22.9827,
+          "in_gibs": 23.3686,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 67.4552,
+          "best_ms": 48.8469,
+          "in_gibs": 11.5826,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 16.8362,
+          "best_ms": 4.08287,
+          "in_gibs": 11.6039,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 24.9849,
+          "best_ms": 19.7989,
+          "in_gibs": 31.3373,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.4341,
+          "best_ms": 12.8662,
+          "in_gibs": 58.2812,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.7037,
+          "best_ms": 3.38406,
+          "in_gibs": 53.8178,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__gpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 28.66,
+      "status": "pass",
+      "throughput_in_gibs": 4.70781,
+      "throughput_out_gibs": 0.571984,
+      "compression_fold": 10.9982,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.355948,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 0.622304,
+      "init_s": 0.472406,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.13283,
+          "best_ms": 0.394021,
+          "in_gibs": 18.3364,
+          "out_gibs": 18.3364
+        },
+        "h2d": {
+          "avg_ms": 1.10314,
+          "best_ms": 0.15312,
+          "in_gibs": 52.0313,
+          "out_gibs": 52.0313
+        },
+        "scatter": {
+          "avg_ms": 0.127947,
+          "best_ms": 0.021248,
+          "in_gibs": 453.593,
+          "out_gibs": 453.593
+        },
+        "lod_gather": {
+          "avg_ms": 11.6243,
+          "best_ms": 9.46352,
+          "in_gibs": 50.4063,
+          "out_gibs": 50.4063
+        },
+        "lod_reduce": {
+          "avg_ms": 10.6113,
+          "best_ms": 8.11216,
+          "in_gibs": 55.2183,
+          "out_gibs": 73.6294
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.95573,
+          "best_ms": 2.11693,
+          "in_gibs": 66.0973,
+          "out_gibs": 66.0973
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 74.8684,
+          "best_ms": 7.93987,
+          "in_gibs": 10.4357,
+          "out_gibs": 10.4578
+        },
+        "compress": {
+          "avg_ms": 77.282,
+          "best_ms": 29.4055,
+          "in_gibs": 10.1312,
+          "out_gibs": 0.767164
+        },
+        "aggregate": {
+          "avg_ms": 0.290795,
+          "best_ms": 0.108544,
+          "in_gibs": 203.883,
+          "out_gibs": 203.883
+        },
+        "d2h": {
+          "avg_ms": 11.104,
+          "best_ms": 3.75504,
+          "in_gibs": 5.33935,
+          "out_gibs": 5.33935
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 193.309,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 192.867,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 84.1083,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 47.56,
+      "status": "pass",
+      "throughput_in_gibs": 2.30726,
+      "throughput_out_gibs": 0.278335,
+      "compression_fold": 11.0769,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.35342,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.26977,
+      "init_s": 17.9824,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.96342,
+          "best_ms": 0.385588,
+          "in_gibs": 11.5736,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.5371,
+          "best_ms": 22.6837,
+          "in_gibs": 23.8797,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 57.2527,
+          "best_ms": 48.6407,
+          "in_gibs": 13.6466,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 9.54716,
+          "best_ms": 4.12982,
+          "in_gibs": 20.4633,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 24.562,
+          "best_ms": 20.3321,
+          "in_gibs": 31.8769,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.8882,
+          "best_ms": 32.4262,
+          "in_gibs": 22.442,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.07333,
+          "best_ms": 0.33367,
+          "in_gibs": 538.79,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 47.29,
+      "status": "pass",
+      "throughput_in_gibs": 2.51178,
+      "throughput_out_gibs": 1.49645,
+      "compression_fold": 2.24289,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.74543,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.16638,
+      "init_s": 18.0472,
+      "flush_s": 5.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.98879,
+          "best_ms": 0.396985,
+          "in_gibs": 11.5148,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.6481,
+          "best_ms": 22.907,
+          "in_gibs": 22.8453,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 54.4433,
+          "best_ms": 49.1016,
+          "in_gibs": 14.3508,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 8.93249,
+          "best_ms": 4.08751,
+          "in_gibs": 21.8714,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 24.35,
+          "best_ms": 19.6284,
+          "in_gibs": 32.1544,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.2183,
+          "best_ms": 14.1615,
+          "in_gibs": 51.4486,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.64542,
+          "best_ms": 1.50348,
+          "in_gibs": 102.046,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 46.46,
+      "status": "pass",
+      "throughput_in_gibs": 2.24997,
+      "throughput_out_gibs": 0.0386767,
+      "compression_fold": 77.7348,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0503609,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.3021,
+      "init_s": 18.0778,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.02177,
+          "best_ms": 0.397847,
+          "in_gibs": 11.4392,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 27.9032,
+          "best_ms": 26.1054,
+          "in_gibs": 20.9989,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 74.8938,
+          "best_ms": 52.3522,
+          "in_gibs": 10.4321,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 18.0661,
+          "best_ms": 4.12933,
+          "in_gibs": 10.8139,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 27.0026,
+          "best_ms": 20.1297,
+          "in_gibs": 28.9956,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.7709,
+          "best_ms": 9.58808,
+          "in_gibs": 72.6917,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.08567,
+          "best_ms": 0.103225,
+          "in_gibs": 276.214,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__gpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.51,
+      "status": "pass",
+      "throughput_in_gibs": 8.01672,
+      "throughput_out_gibs": 9.47858,
+      "compression_fold": 1.13756,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.46392,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 0.365447,
+      "init_s": 0.470606,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14539,
+          "best_ms": 0.388603,
+          "in_gibs": 18.2632,
+          "out_gibs": 18.2632
+        },
+        "h2d": {
+          "avg_ms": 1.1054,
+          "best_ms": 0.15328,
+          "in_gibs": 51.9253,
+          "out_gibs": 51.9253
+        },
+        "scatter": {
+          "avg_ms": 0.136947,
+          "best_ms": 0.020832,
+          "in_gibs": 426.67,
+          "out_gibs": 426.67
+        },
+        "lod_gather": {
+          "avg_ms": 1.6887,
+          "best_ms": 1.67181,
+          "in_gibs": 346.975,
+          "out_gibs": 346.975
+        },
+        "lod_reduce": {
+          "avg_ms": 3.21321,
+          "best_ms": 3.21059,
+          "in_gibs": 182.353,
+          "out_gibs": 243.204
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.626005,
+          "best_ms": 0.342016,
+          "in_gibs": 312.339,
+          "out_gibs": 312.339
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 28.0222,
+          "best_ms": 1.60669,
+          "in_gibs": 27.8873,
+          "out_gibs": 28.1236
+        },
+        "compress": {
+          "avg_ms": 1.49849,
+          "best_ms": 1.12266,
+          "in_gibs": 525.922,
+          "out_gibs": 385.263
+        },
+        "aggregate": {
+          "avg_ms": 3.67262,
+          "best_ms": 1.83296,
+          "in_gibs": 157.193,
+          "out_gibs": 157.193
+        },
+        "d2h": {
+          "avg_ms": 11.1227,
+          "best_ms": 3.85171,
+          "in_gibs": 51.9037,
+          "out_gibs": 51.9037
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 35.7785,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 35.5981,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.9642,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 46.5,
+      "status": "pass",
+      "throughput_in_gibs": 2.07966,
+      "throughput_out_gibs": 2.45889,
+      "compression_fold": 1.13756,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.46392,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.40873,
+      "init_s": 17.938,
+      "flush_s": 6.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.9695,
+          "best_ms": 0.381923,
+          "in_gibs": 11.5595,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.7864,
+          "best_ms": 22.9599,
+          "in_gibs": 22.7227,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 64.3812,
+          "best_ms": 48.6131,
+          "in_gibs": 12.1381,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 26.1551,
+          "best_ms": 4.06114,
+          "in_gibs": 7.47563,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 26.9816,
+          "best_ms": 21.3821,
+          "in_gibs": 29.2083,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.165,
+          "best_ms": 16.1755,
+          "in_gibs": 43.3848,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.6956,
+          "best_ms": 8.90885,
+          "in_gibs": 42.153,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__gpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 28.8,
+      "status": "pass",
+      "throughput_in_gibs": 5.19262,
+      "throughput_out_gibs": 0.765447,
+      "compression_fold": 9.12418,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.431867,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 0.564202,
+      "init_s": 0.47311,
+      "flush_s": 4e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.14868,
+          "best_ms": 0.376294,
+          "in_gibs": 18.2441,
+          "out_gibs": 18.2441
+        },
+        "h2d": {
+          "avg_ms": 1.1003,
+          "best_ms": 0.149888,
+          "in_gibs": 52.1657,
+          "out_gibs": 52.1657
+        },
+        "scatter": {
+          "avg_ms": 0.0935763,
+          "best_ms": 0.0192,
+          "in_gibs": 635.235,
+          "out_gibs": 635.235
+        },
+        "lod_gather": {
+          "avg_ms": 3.56284,
+          "best_ms": 3.44086,
+          "in_gibs": 164.458,
+          "out_gibs": 164.458
+        },
+        "lod_reduce": {
+          "avg_ms": 4.19664,
+          "best_ms": 4.15235,
+          "in_gibs": 139.621,
+          "out_gibs": 186.212
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.30844,
+          "best_ms": 0.783296,
+          "in_gibs": 149.435,
+          "out_gibs": 149.435
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 56.0301,
+          "best_ms": 2.68896,
+          "in_gibs": 13.9472,
+          "out_gibs": 14.0654
+        },
+        "compress": {
+          "avg_ms": 67.3516,
+          "best_ms": 53.4828,
+          "in_gibs": 11.7011,
+          "out_gibs": 1.06855
+        },
+        "aggregate": {
+          "avg_ms": 0.493957,
+          "best_ms": 0.220832,
+          "in_gibs": 145.698,
+          "out_gibs": 145.698
+        },
+        "d2h": {
+          "avg_ms": 11.0934,
+          "best_ms": 3.85085,
+          "in_gibs": 6.48749,
+          "out_gibs": 6.48749
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 167.055,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 166.889,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 65.2205,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 46.43,
+      "status": "pass",
+      "throughput_in_gibs": 2.13265,
+      "throughput_out_gibs": 0.270392,
+      "compression_fold": 10.6083,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.371447,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.37373,
+      "init_s": 17.9879,
+      "flush_s": 6.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.04292,
+          "best_ms": 0.39991,
+          "in_gibs": 11.3912,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.6049,
+          "best_ms": 22.8159,
+          "in_gibs": 23.8139,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 64.5179,
+          "best_ms": 50.2725,
+          "in_gibs": 12.1124,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 14.1876,
+          "best_ms": 4.4097,
+          "in_gibs": 13.7814,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 29.86,
+          "best_ms": 21.6115,
+          "in_gibs": 26.3927,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.3103,
+          "best_ms": 33.7498,
+          "in_gibs": 21.7042,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.49724,
+          "best_ms": 0.251487,
+          "in_gibs": 387.089,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 47.17,
+      "status": "pass",
+      "throughput_in_gibs": 2.13169,
+      "throughput_out_gibs": 1.34292,
+      "compression_fold": 2.13499,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.84564,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.37435,
+      "init_s": 17.9695,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.98846,
+          "best_ms": 0.424597,
+          "in_gibs": 11.5155,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 26.6755,
+          "best_ms": 22.771,
+          "in_gibs": 21.9654,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 79.4953,
+          "best_ms": 73.0516,
+          "in_gibs": 9.83031,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 18.1031,
+          "best_ms": 4.13442,
+          "in_gibs": 10.8007,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 26.2255,
+          "best_ms": 21.0967,
+          "in_gibs": 30.0503,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.0188,
+          "best_ms": 14.2032,
+          "in_gibs": 46.3069,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.15077,
+          "best_ms": 1.67196,
+          "in_gibs": 93.8623,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 46.53,
+      "status": "pass",
+      "throughput_in_gibs": 2.55368,
+      "throughput_out_gibs": 0.0687848,
+      "compression_fold": 49.934,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0789127,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.14724,
+      "init_s": 17.998,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.92715,
+          "best_ms": 0.405027,
+          "in_gibs": 11.6588,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.9933,
+          "best_ms": 22.7763,
+          "in_gibs": 22.5418,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 61.1165,
+          "best_ms": 50.8253,
+          "in_gibs": 12.7865,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 8.83681,
+          "best_ms": 4.15064,
+          "in_gibs": 22.1263,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 25.2805,
+          "best_ms": 21.3935,
+          "in_gibs": 31.1737,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.8013,
+          "best_ms": 10.8866,
+          "in_gibs": 66.7798,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.253842,
+          "best_ms": 0.143154,
+          "in_gibs": 2274.35,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__zeros__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.88,
+      "status": "pass",
+      "throughput_in_gibs": 13.3677,
+      "throughput_out_gibs": 13.3757,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.262993,
+      "init_s": 0.232853,
+      "flush_s": 6.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.24035,
+          "best_ms": 0.759789,
+          "in_gibs": 20.923,
+          "out_gibs": 20.923
+        },
+        "h2d": {
+          "avg_ms": 0.922694,
+          "best_ms": 0.296032,
+          "in_gibs": 51.0343,
+          "out_gibs": 51.0343
+        },
+        "scatter": {
+          "avg_ms": 0.208702,
+          "best_ms": 0.074816,
+          "in_gibs": 225.628,
+          "out_gibs": 225.628
+        },
+        "compress": {
+          "avg_ms": 0.974857,
+          "best_ms": 0.172256,
+          "in_gibs": 515.185,
+          "out_gibs": 515.185
+        },
+        "aggregate": {
+          "avg_ms": 1.06096,
+          "best_ms": 0.336896,
+          "in_gibs": 473.377,
+          "out_gibs": 473.377
+        },
+        "d2h": {
+          "avg_ms": 9.85853,
+          "best_ms": 2.67622,
+          "in_gibs": 50.9439,
+          "out_gibs": 50.9439
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 10.2035,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 6.64275,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.29129,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__zeros__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.8,
+      "status": "pass",
+      "throughput_in_gibs": 13.705,
+      "throughput_out_gibs": 13.7061,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.256522,
+      "init_s": 0.232253,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.28963,
+          "best_ms": 0.512018,
+          "in_gibs": 20.4728,
+          "out_gibs": 20.4728
+        },
+        "h2d": {
+          "avg_ms": 0.928253,
+          "best_ms": 0.295904,
+          "in_gibs": 50.7287,
+          "out_gibs": 50.7287
+        },
+        "scatter": {
+          "avg_ms": 0.208481,
+          "best_ms": 0.074752,
+          "in_gibs": 225.867,
+          "out_gibs": 225.867
+        },
+        "compress": {
+          "avg_ms": 0.974094,
+          "best_ms": 0.175328,
+          "in_gibs": 515.589,
+          "out_gibs": 515.589
+        },
+        "aggregate": {
+          "avg_ms": 1.32384,
+          "best_ms": 0.468992,
+          "in_gibs": 379.377,
+          "out_gibs": 379.377
+        },
+        "d2h": {
+          "avg_ms": 9.91681,
+          "best_ms": 2.67546,
+          "in_gibs": 50.6445,
+          "out_gibs": 50.6445
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 8.54535,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 7.9856,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.39456,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__zeros__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.86,
+      "status": "pass",
+      "throughput_in_gibs": 13.2026,
+      "throughput_out_gibs": 13.7308,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.266282,
+      "init_s": 0.231652,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.67567,
+          "best_ms": 1.16351,
+          "in_gibs": 20.8559,
+          "out_gibs": 20.8559
+        },
+        "h2d": {
+          "avg_ms": 1.09496,
+          "best_ms": 0.590016,
+          "in_gibs": 51.4654,
+          "out_gibs": 51.4654
+        },
+        "scatter": {
+          "avg_ms": 0.294732,
+          "best_ms": 0.14032,
+          "in_gibs": 191.199,
+          "out_gibs": 191.199
+        },
+        "compress": {
+          "avg_ms": 1.00505,
+          "best_ms": 0.38592,
+          "in_gibs": 519.699,
+          "out_gibs": 519.699
+        },
+        "aggregate": {
+          "avg_ms": 3.22779,
+          "best_ms": 2.95936,
+          "in_gibs": 161.82,
+          "out_gibs": 161.82
+        },
+        "d2h": {
+          "avg_ms": 10.1813,
+          "best_ms": 5.34752,
+          "in_gibs": 51.3022,
+          "out_gibs": 51.3022
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.4968,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 15.4019,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.20395,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__zeros__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.77,
+      "status": "pass",
+      "throughput_in_gibs": 13.123,
+      "throughput_out_gibs": 0.0634772,
+      "compression_fold": 206.735,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0170055,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.267899,
+      "init_s": 0.232994,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.29207,
+          "best_ms": 0.601983,
+          "in_gibs": 20.451,
+          "out_gibs": 20.451
+        },
+        "h2d": {
+          "avg_ms": 0.923874,
+          "best_ms": 0.296,
+          "in_gibs": 50.9691,
+          "out_gibs": 50.9691
+        },
+        "scatter": {
+          "avg_ms": 0.208406,
+          "best_ms": 0.074656,
+          "in_gibs": 225.948,
+          "out_gibs": 225.948
+        },
+        "compress": {
+          "avg_ms": 2.60832,
+          "best_ms": 0.942752,
+          "in_gibs": 192.55,
+          "out_gibs": 0.816788
+        },
+        "aggregate": {
+          "avg_ms": 0.107177,
+          "best_ms": 0.033792,
+          "in_gibs": 19.8777,
+          "out_gibs": 19.8777
+        },
+        "d2h": {
+          "avg_ms": 9.90301,
+          "best_ms": 2.68675,
+          "in_gibs": 0.215131,
+          "out_gibs": 0.215131
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 10.4276,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 6.80796,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.83691,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__zeros__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.78,
+      "status": "pass",
+      "throughput_in_gibs": 13.2973,
+      "throughput_out_gibs": 0.0537359,
+      "compression_fold": 247.456,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0142071,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.264387,
+      "init_s": 0.230959,
+      "flush_s": 6.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.30214,
+          "best_ms": 0.618587,
+          "in_gibs": 20.3615,
+          "out_gibs": 20.3615
+        },
+        "h2d": {
+          "avg_ms": 0.917949,
+          "best_ms": 0.297152,
+          "in_gibs": 51.2981,
+          "out_gibs": 51.2981
+        },
+        "scatter": {
+          "avg_ms": 0.208409,
+          "best_ms": 0.07472,
+          "in_gibs": 225.946,
+          "out_gibs": 225.946
+        },
+        "compress": {
+          "avg_ms": 3.72414,
+          "best_ms": 3.12461,
+          "in_gibs": 134.859,
+          "out_gibs": 0.533994
+        },
+        "aggregate": {
+          "avg_ms": 0.138322,
+          "best_ms": 0.03072,
+          "in_gibs": 14.377,
+          "out_gibs": 14.377
+        },
+        "d2h": {
+          "avg_ms": 9.84697,
+          "best_ms": 2.6857,
+          "in_gibs": 0.201957,
+          "out_gibs": 0.201957
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.4417,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 11.8818,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.09277,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__zeros__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.84,
+      "status": "pass",
+      "throughput_in_gibs": 10.7484,
+      "throughput_out_gibs": 0.0439938,
+      "compression_fold": 254.09,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0143896,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.327083,
+      "init_s": 0.232308,
+      "flush_s": 4.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.71479,
+          "best_ms": 0.908423,
+          "in_gibs": 20.5554,
+          "out_gibs": 20.5554
+        },
+        "h2d": {
+          "avg_ms": 1.10476,
+          "best_ms": 0.59264,
+          "in_gibs": 51.009,
+          "out_gibs": 51.009
+        },
+        "scatter": {
+          "avg_ms": 0.248727,
+          "best_ms": 0.140288,
+          "in_gibs": 226.151,
+          "out_gibs": 226.151
+        },
+        "compress": {
+          "avg_ms": 25.5528,
+          "best_ms": 25.0194,
+          "in_gibs": 20.4408,
+          "out_gibs": 0.0802662
+        },
+        "aggregate": {
+          "avg_ms": 0.0845623,
+          "best_ms": 0.028672,
+          "in_gibs": 24.2546,
+          "out_gibs": 24.2546
+        },
+        "d2h": {
+          "avg_ms": 10.2683,
+          "best_ms": 5.36784,
+          "in_gibs": 0.199745,
+          "out_gibs": 0.199745
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 59.2131,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 59.0999,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 21.1693,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__zeros__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.81,
+      "status": "pass",
+      "throughput_in_gibs": 13.0458,
+      "throughput_out_gibs": 0.0153288,
+      "compression_fold": 851.059,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.00413088,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.269484,
+      "init_s": 0.231146,
+      "flush_s": 6.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.25286,
+          "best_ms": 0.700521,
+          "in_gibs": 20.8069,
+          "out_gibs": 20.8069
+        },
+        "h2d": {
+          "avg_ms": 0.920164,
+          "best_ms": 0.296256,
+          "in_gibs": 51.1746,
+          "out_gibs": 51.1746
+        },
+        "scatter": {
+          "avg_ms": 0.278668,
+          "best_ms": 0.074656,
+          "in_gibs": 168.979,
+          "out_gibs": 168.979
+        },
+        "compress": {
+          "avg_ms": 5.49117,
+          "best_ms": 1.80362,
+          "in_gibs": 91.4617,
+          "out_gibs": 0.0530326
+        },
+        "aggregate": {
+          "avg_ms": 0.108037,
+          "best_ms": 0.034464,
+          "in_gibs": 2.69549,
+          "out_gibs": 2.69549
+        },
+        "d2h": {
+          "avg_ms": 9.8471,
+          "best_ms": 2.67654,
+          "in_gibs": 0.0295733,
+          "out_gibs": 0.0295733
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.308,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 11.7126,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.0771,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__zeros__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.82,
+      "status": "pass",
+      "throughput_in_gibs": 12.6987,
+      "throughput_out_gibs": 0.00384413,
+      "compression_fold": 3303.41,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.00106424,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.276848,
+      "init_s": 0.232909,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.21612,
+          "best_ms": 0.726229,
+          "in_gibs": 21.1518,
+          "out_gibs": 21.1518
+        },
+        "h2d": {
+          "avg_ms": 0.916454,
+          "best_ms": 0.295968,
+          "in_gibs": 51.3818,
+          "out_gibs": 51.3818
+        },
+        "scatter": {
+          "avg_ms": 0.212814,
+          "best_ms": 0.074592,
+          "in_gibs": 221.269,
+          "out_gibs": 221.269
+        },
+        "compress": {
+          "avg_ms": 7.11781,
+          "best_ms": 4.89078,
+          "in_gibs": 70.56,
+          "out_gibs": 0.0156116
+        },
+        "aggregate": {
+          "avg_ms": 0.0555703,
+          "best_ms": 0.03072,
+          "in_gibs": 1.99963,
+          "out_gibs": 1.99963
+        },
+        "d2h": {
+          "avg_ms": 9.78627,
+          "best_ms": 2.67526,
+          "in_gibs": 0.0113547,
+          "out_gibs": 0.0113547
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 18.704,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 18.1743,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.4169,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__zeros__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.84,
+      "status": "pass",
+      "throughput_in_gibs": 12.0603,
+      "throughput_out_gibs": 0.00246763,
+      "compression_fold": 5082.9,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.000719324,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.291504,
+      "init_s": 0.230069,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.64,
+          "best_ms": 0.545658,
+          "in_gibs": 21.1377,
+          "out_gibs": 21.1377
+        },
+        "h2d": {
+          "avg_ms": 1.0994,
+          "best_ms": 0.59392,
+          "in_gibs": 51.2575,
+          "out_gibs": 51.2575
+        },
+        "scatter": {
+          "avg_ms": 0.250706,
+          "best_ms": 0.140096,
+          "in_gibs": 224.775,
+          "out_gibs": 224.775
+        },
+        "compress": {
+          "avg_ms": 10.9579,
+          "best_ms": 9.62998,
+          "in_gibs": 47.6661,
+          "out_gibs": 0.00895522
+        },
+        "aggregate": {
+          "avg_ms": 0.0484343,
+          "best_ms": 0.026624,
+          "in_gibs": 2.02606,
+          "out_gibs": 2.02606
+        },
+        "d2h": {
+          "avg_ms": 10.1699,
+          "best_ms": 5.34736,
+          "in_gibs": 0.00964907,
+          "out_gibs": 0.00964907
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 29.6532,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 29.5584,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.7231,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__rand__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 1.22,
+      "status": "pass",
+      "throughput_in_gibs": 8.93714,
+      "throughput_out_gibs": 8.94246,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.393372,
+      "init_s": 0.230112,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.43146,
+          "best_ms": 0.712649,
+          "in_gibs": 19.2785,
+          "out_gibs": 19.2785
+        },
+        "h2d": {
+          "avg_ms": 0.908812,
+          "best_ms": 0.304576,
+          "in_gibs": 51.8138,
+          "out_gibs": 51.8138
+        },
+        "scatter": {
+          "avg_ms": 0.209011,
+          "best_ms": 0.074656,
+          "in_gibs": 225.295,
+          "out_gibs": 225.295
+        },
+        "compress": {
+          "avg_ms": 0.923104,
+          "best_ms": 0.172704,
+          "in_gibs": 544.069,
+          "out_gibs": 544.069
+        },
+        "aggregate": {
+          "avg_ms": 1.1062,
+          "best_ms": 0.33792,
+          "in_gibs": 454.014,
+          "out_gibs": 454.014
+        },
+        "d2h": {
+          "avg_ms": 9.6623,
+          "best_ms": 2.67603,
+          "in_gibs": 51.9785,
+          "out_gibs": 51.9785
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 6.58627,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 3.01868,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.49409,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__rand__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 1.22,
+      "status": "pass",
+      "throughput_in_gibs": 9.1996,
+      "throughput_out_gibs": 9.20035,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.38215,
+      "init_s": 0.231115,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.38965,
+          "best_ms": 0.752398,
+          "in_gibs": 19.6159,
+          "out_gibs": 19.6159
+        },
+        "h2d": {
+          "avg_ms": 0.91205,
+          "best_ms": 0.309248,
+          "in_gibs": 51.6299,
+          "out_gibs": 51.6299
+        },
+        "scatter": {
+          "avg_ms": 0.208526,
+          "best_ms": 0.073632,
+          "in_gibs": 225.819,
+          "out_gibs": 225.819
+        },
+        "compress": {
+          "avg_ms": 0.974784,
+          "best_ms": 0.172,
+          "in_gibs": 515.224,
+          "out_gibs": 515.224
+        },
+        "aggregate": {
+          "avg_ms": 1.32564,
+          "best_ms": 0.468992,
+          "in_gibs": 378.86,
+          "out_gibs": 378.86
+        },
+        "d2h": {
+          "avg_ms": 9.67512,
+          "best_ms": 2.67546,
+          "in_gibs": 51.9096,
+          "out_gibs": 51.9096
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 3.9011,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 3.36256,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.37843,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__rand__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 1.19,
+      "status": "pass",
+      "throughput_in_gibs": 9.11737,
+      "throughput_out_gibs": 9.48215,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.385596,
+      "init_s": 0.232291,
+      "flush_s": 4.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.8055,
+          "best_ms": 0.985168,
+          "in_gibs": 19.8908,
+          "out_gibs": 19.8908
+        },
+        "h2d": {
+          "avg_ms": 1.09267,
+          "best_ms": 0.591104,
+          "in_gibs": 51.5734,
+          "out_gibs": 51.5734
+        },
+        "scatter": {
+          "avg_ms": 0.248012,
+          "best_ms": 0.142144,
+          "in_gibs": 227.217,
+          "out_gibs": 227.217
+        },
+        "compress": {
+          "avg_ms": 1.00433,
+          "best_ms": 0.382944,
+          "in_gibs": 520.07,
+          "out_gibs": 520.07
+        },
+        "aggregate": {
+          "avg_ms": 3.19297,
+          "best_ms": 2.98291,
+          "in_gibs": 163.585,
+          "out_gibs": 163.585
+        },
+        "d2h": {
+          "avg_ms": 10.1515,
+          "best_ms": 5.34752,
+          "in_gibs": 51.4525,
+          "out_gibs": 51.4525
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 9.07927,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 8.98554,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.37266,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__rand__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 1.56,
+      "status": "pass",
+      "throughput_in_gibs": 4.81131,
+      "throughput_out_gibs": 4.83247,
+      "compression_fold": 0.995622,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.53109,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.730699,
+      "init_s": 0.232144,
+      "flush_s": 4.9e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.41187,
+          "best_ms": 0.729194,
+          "in_gibs": 19.4351,
+          "out_gibs": 19.4351
+        },
+        "h2d": {
+          "avg_ms": 0.910522,
+          "best_ms": 0.307232,
+          "in_gibs": 51.7165,
+          "out_gibs": 51.7165
+        },
+        "scatter": {
+          "avg_ms": 0.216781,
+          "best_ms": 0.072896,
+          "in_gibs": 216.232,
+          "out_gibs": 216.232
+        },
+        "compress": {
+          "avg_ms": 63.4215,
+          "best_ms": 18.2758,
+          "in_gibs": 7.91896,
+          "out_gibs": 7.94907
+        },
+        "aggregate": {
+          "avg_ms": 1.61801,
+          "best_ms": 0.326656,
+          "in_gibs": 311.582,
+          "out_gibs": 311.582
+        },
+        "d2h": {
+          "avg_ms": 9.6836,
+          "best_ms": 2.68707,
+          "in_gibs": 52.0614,
+          "out_gibs": 52.0614
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 92.8755,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 89.8143,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 75.4568,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__rand__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 1.32,
+      "status": "error"
+    },
+    {
+      "id": "orca2_single__lz4__rand__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 1.47,
+      "status": "pass",
+      "throughput_in_gibs": 5.55329,
+      "throughput_out_gibs": 3.81392,
+      "compression_fold": 1.5143,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.41448,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.63307,
+      "init_s": 0.233885,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.8049,
+          "best_ms": 0.739589,
+          "in_gibs": 19.895,
+          "out_gibs": 19.895
+        },
+        "h2d": {
+          "avg_ms": 1.07685,
+          "best_ms": 0.589952,
+          "in_gibs": 52.3309,
+          "out_gibs": 52.3309
+        },
+        "scatter": {
+          "avg_ms": 0.260216,
+          "best_ms": 0.142176,
+          "in_gibs": 216.56,
+          "out_gibs": 216.56
+        },
+        "compress": {
+          "avg_ms": 67.5904,
+          "best_ms": 51.0281,
+          "in_gibs": 7.72774,
+          "out_gibs": 5.10311
+        },
+        "aggregate": {
+          "avg_ms": 2.18002,
+          "best_ms": 1.44794,
+          "in_gibs": 158.219,
+          "out_gibs": 158.219
+        },
+        "d2h": {
+          "avg_ms": 10.0685,
+          "best_ms": 5.36838,
+          "in_gibs": 34.2573,
+          "out_gibs": 34.2573
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 167.817,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 167.719,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 97.2249,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__rand__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.05,
+      "status": "pass",
+      "throughput_in_gibs": 2.88933,
+      "throughput_out_gibs": 2.47676,
+      "compression_fold": 1.16658,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.01363,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 1.21676,
+      "init_s": 0.233338,
+      "flush_s": 4.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.4118,
+          "best_ms": 0.705669,
+          "in_gibs": 19.4357,
+          "out_gibs": 19.4357
+        },
+        "h2d": {
+          "avg_ms": 0.915366,
+          "best_ms": 0.302048,
+          "in_gibs": 51.4429,
+          "out_gibs": 51.4429
+        },
+        "scatter": {
+          "avg_ms": 0.259045,
+          "best_ms": 0.070848,
+          "in_gibs": 177.722,
+          "out_gibs": 177.722
+        },
+        "compress": {
+          "avg_ms": 139.267,
+          "best_ms": 39.0569,
+          "in_gibs": 3.60625,
+          "out_gibs": 3.08917
+        },
+        "aggregate": {
+          "avg_ms": 0.972462,
+          "best_ms": 0.282304,
+          "in_gibs": 442.402,
+          "out_gibs": 442.402
+        },
+        "d2h": {
+          "avg_ms": 9.74049,
+          "best_ms": 2.67722,
+          "in_gibs": 44.1682,
+          "out_gibs": 44.1682
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 198.664,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 195.093,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 144.402,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__rand__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 1.57,
+      "status": "pass",
+      "throughput_in_gibs": 4.88282,
+      "throughput_out_gibs": 2.43062,
+      "compression_fold": 2.00888,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.75004,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.719999,
+      "init_s": 0.23358,
+      "flush_s": 2.474e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.33869,
+          "best_ms": 0.744407,
+          "in_gibs": 20.0433,
+          "out_gibs": 20.0433
+        },
+        "h2d": {
+          "avg_ms": 0.914956,
+          "best_ms": 0.309728,
+          "in_gibs": 51.4659,
+          "out_gibs": 51.4659
+        },
+        "scatter": {
+          "avg_ms": 0.530081,
+          "best_ms": 0.074528,
+          "in_gibs": 88.8337,
+          "out_gibs": 88.8337
+        },
+        "compress": {
+          "avg_ms": 81.505,
+          "best_ms": 16.5079,
+          "in_gibs": 6.16198,
+          "out_gibs": 3.06687
+        },
+        "aggregate": {
+          "avg_ms": 0.704603,
+          "best_ms": 0.395264,
+          "in_gibs": 354.76,
+          "out_gibs": 354.76
+        },
+        "d2h": {
+          "avg_ms": 9.72223,
+          "best_ms": 2.67581,
+          "in_gibs": 25.7107,
+          "out_gibs": 25.7107
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 186.769,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 186.22,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 162.816,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__rand__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 1.48,
+      "status": "pass",
+      "throughput_in_gibs": 5.23338,
+      "throughput_out_gibs": 2.7508,
+      "compression_fold": 1.97859,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.8479,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.671769,
+      "init_s": 0.232477,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.81123,
+          "best_ms": 0.716544,
+          "in_gibs": 19.8502,
+          "out_gibs": 19.8502
+        },
+        "h2d": {
+          "avg_ms": 1.07602,
+          "best_ms": 0.59328,
+          "in_gibs": 52.371,
+          "out_gibs": 52.371
+        },
+        "scatter": {
+          "avg_ms": 0.312189,
+          "best_ms": 0.14208,
+          "in_gibs": 180.508,
+          "out_gibs": 180.508
+        },
+        "compress": {
+          "avg_ms": 73.6036,
+          "best_ms": 24.512,
+          "in_gibs": 7.09641,
+          "out_gibs": 3.58653
+        },
+        "aggregate": {
+          "avg_ms": 1.69588,
+          "best_ms": 1.10659,
+          "in_gibs": 155.661,
+          "out_gibs": 155.661
+        },
+        "d2h": {
+          "avg_ms": 10.0121,
+          "best_ms": 5.34762,
+          "in_gibs": 26.3663,
+          "out_gibs": 26.3663
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 172.099,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 171.996,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 131.667,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__zeros__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.78,
+      "status": "pass",
+      "throughput_in_gibs": 13.2402,
+      "throughput_out_gibs": 13.2467,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.283228,
+      "init_s": 0.234835,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.97239,
+          "best_ms": 2.53066,
+          "in_gibs": 21.0269,
+          "out_gibs": 21.0269
+        },
+        "h2d": {
+          "avg_ms": 1.22258,
+          "best_ms": 1.17901,
+          "in_gibs": 51.1214,
+          "out_gibs": 51.1214
+        },
+        "scatter": {
+          "avg_ms": 0.334788,
+          "best_ms": 0.330752,
+          "in_gibs": 186.685,
+          "out_gibs": 186.685
+        },
+        "compress": {
+          "avg_ms": 1.02433,
+          "best_ms": 0.524736,
+          "in_gibs": 522.99,
+          "out_gibs": 522.99
+        },
+        "aggregate": {
+          "avg_ms": 1.11883,
+          "best_ms": 0.741952,
+          "in_gibs": 478.819,
+          "out_gibs": 478.819
+        },
+        "d2h": {
+          "avg_ms": 10.4747,
+          "best_ms": 7.13107,
+          "in_gibs": 51.1434,
+          "out_gibs": 51.1434
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.0238,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 8.67609,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.29924,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__zeros__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.88,
+      "status": "pass",
+      "throughput_in_gibs": 12.9979,
+      "throughput_out_gibs": 12.9986,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.288509,
+      "init_s": 0.293022,
+      "flush_s": 6.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.95543,
+          "best_ms": 2.61313,
+          "in_gibs": 21.1475,
+          "out_gibs": 21.1475
+        },
+        "h2d": {
+          "avg_ms": 1.21553,
+          "best_ms": 1.17827,
+          "in_gibs": 51.4179,
+          "out_gibs": 51.4179
+        },
+        "scatter": {
+          "avg_ms": 0.334542,
+          "best_ms": 0.330624,
+          "in_gibs": 186.823,
+          "out_gibs": 186.823
+        },
+        "compress": {
+          "avg_ms": 1.46525,
+          "best_ms": 1.06768,
+          "in_gibs": 511.856,
+          "out_gibs": 511.856
+        },
+        "aggregate": {
+          "avg_ms": 1.69389,
+          "best_ms": 1.53805,
+          "in_gibs": 442.768,
+          "out_gibs": 442.768
+        },
+        "d2h": {
+          "avg_ms": 14.5952,
+          "best_ms": 14.255,
+          "in_gibs": 51.3868,
+          "out_gibs": 51.3868
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 18.9952,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 18.4897,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.43335,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__zeros__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.91,
+      "status": "pass",
+      "throughput_in_gibs": 13.1532,
+      "throughput_out_gibs": 13.1534,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.285101,
+      "init_s": 0.294572,
+      "flush_s": 5.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.9372,
+          "best_ms": 2.6142,
+          "in_gibs": 21.2787,
+          "out_gibs": 21.2787
+        },
+        "h2d": {
+          "avg_ms": 1.21838,
+          "best_ms": 1.17882,
+          "in_gibs": 51.2975,
+          "out_gibs": 51.2975
+        },
+        "scatter": {
+          "avg_ms": 0.395032,
+          "best_ms": 0.330592,
+          "in_gibs": 158.215,
+          "out_gibs": 158.215
+        },
+        "compress": {
+          "avg_ms": 1.46935,
+          "best_ms": 1.06976,
+          "in_gibs": 510.43,
+          "out_gibs": 510.43
+        },
+        "aggregate": {
+          "avg_ms": 3.45272,
+          "best_ms": 3.32083,
+          "in_gibs": 217.22,
+          "out_gibs": 217.22
+        },
+        "d2h": {
+          "avg_ms": 14.6094,
+          "best_ms": 14.2546,
+          "in_gibs": 51.3369,
+          "out_gibs": 51.3369
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 20.6544,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 20.5332,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.47536,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__zeros__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.8,
+      "status": "pass",
+      "throughput_in_gibs": 13.1294,
+      "throughput_out_gibs": 0.062106,
+      "compression_fold": 211.404,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0177386,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.285618,
+      "init_s": 0.235736,
+      "flush_s": 5.4e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.96686,
+          "best_ms": 2.64202,
+          "in_gibs": 21.066,
+          "out_gibs": 21.066
+        },
+        "h2d": {
+          "avg_ms": 1.22053,
+          "best_ms": 1.17818,
+          "in_gibs": 51.2073,
+          "out_gibs": 51.2073
+        },
+        "scatter": {
+          "avg_ms": 0.33471,
+          "best_ms": 0.330752,
+          "in_gibs": 186.729,
+          "out_gibs": 186.729
+        },
+        "compress": {
+          "avg_ms": 2.66949,
+          "best_ms": 1.56925,
+          "in_gibs": 200.681,
+          "out_gibs": 0.851276
+        },
+        "aggregate": {
+          "avg_ms": 0.107986,
+          "best_ms": 0.043552,
+          "in_gibs": 21.0441,
+          "out_gibs": 21.0441
+        },
+        "d2h": {
+          "avg_ms": 10.5061,
+          "best_ms": 7.15987,
+          "in_gibs": 0.216301,
+          "out_gibs": 0.216301
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 12.7307,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 8.83977,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.79214,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__zeros__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.92,
+      "status": "pass",
+      "throughput_in_gibs": 12.9272,
+      "throughput_out_gibs": 0.0519773,
+      "compression_fold": 248.709,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0150779,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.290086,
+      "init_s": 0.297944,
+      "flush_s": 4.5e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.95622,
+          "best_ms": 2.62361,
+          "in_gibs": 21.1419,
+          "out_gibs": 21.1419
+        },
+        "h2d": {
+          "avg_ms": 1.21831,
+          "best_ms": 1.17814,
+          "in_gibs": 51.3004,
+          "out_gibs": 51.3004
+        },
+        "scatter": {
+          "avg_ms": 0.33664,
+          "best_ms": 0.330624,
+          "in_gibs": 185.658,
+          "out_gibs": 185.658
+        },
+        "compress": {
+          "avg_ms": 4.13316,
+          "best_ms": 4.06122,
+          "in_gibs": 181.459,
+          "out_gibs": 0.718515
+        },
+        "aggregate": {
+          "avg_ms": 0.132154,
+          "best_ms": 0.032768,
+          "in_gibs": 22.4719,
+          "out_gibs": 22.4719
+        },
+        "d2h": {
+          "avg_ms": 14.6657,
+          "best_ms": 14.3103,
+          "in_gibs": 0.202496,
+          "out_gibs": 0.202496
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 20.0668,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 19.5626,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.24175,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__zeros__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.92,
+      "status": "pass",
+      "throughput_in_gibs": 11.5039,
+      "throughput_out_gibs": 0.0452911,
+      "compression_fold": 254,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0147638,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.325975,
+      "init_s": 0.295507,
+      "flush_s": 4.31e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.96269,
+          "best_ms": 2.66032,
+          "in_gibs": 21.0957,
+          "out_gibs": 21.0957
+        },
+        "h2d": {
+          "avg_ms": 1.22428,
+          "best_ms": 1.17814,
+          "in_gibs": 51.0506,
+          "out_gibs": 51.0506
+        },
+        "scatter": {
+          "avg_ms": 0.337524,
+          "best_ms": 0.330624,
+          "in_gibs": 185.172,
+          "out_gibs": 185.172
+        },
+        "compress": {
+          "avg_ms": 25.6141,
+          "best_ms": 25.3399,
+          "in_gibs": 29.2808,
+          "out_gibs": 0.114978
+        },
+        "aggregate": {
+          "avg_ms": 0.13273,
+          "best_ms": 0.032768,
+          "in_gibs": 22.1885,
+          "out_gibs": 22.1885
+        },
+        "d2h": {
+          "avg_ms": 14.7343,
+          "best_ms": 14.3097,
+          "in_gibs": 0.199878,
+          "out_gibs": 0.199878
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 41.1963,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 41.0785,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 21.385,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__zeros__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.8,
+      "status": "pass",
+      "throughput_in_gibs": 13.0224,
+      "throughput_out_gibs": 0.0139102,
+      "compression_fold": 936.173,
+      "input_gib": 3.75,
+      "compressed_gib": 0.00400567,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.287966,
+      "init_s": 0.233106,
+      "flush_s": 4.21e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.97564,
+          "best_ms": 2.62072,
+          "in_gibs": 21.0039,
+          "out_gibs": 21.0039
+        },
+        "h2d": {
+          "avg_ms": 1.22101,
+          "best_ms": 1.17814,
+          "in_gibs": 51.1871,
+          "out_gibs": 51.1871
+        },
+        "scatter": {
+          "avg_ms": 0.39008,
+          "best_ms": 0.33056,
+          "in_gibs": 160.224,
+          "out_gibs": 160.224
+        },
+        "compress": {
+          "avg_ms": 5.79559,
+          "best_ms": 3.70928,
+          "in_gibs": 92.4348,
+          "out_gibs": 0.0535968
+        },
+        "aggregate": {
+          "avg_ms": 0.1096,
+          "best_ms": 0.03856,
+          "in_gibs": 2.83417,
+          "out_gibs": 2.83417
+        },
+        "d2h": {
+          "avg_ms": 10.4651,
+          "best_ms": 7.13254,
+          "in_gibs": 0.0296821,
+          "out_gibs": 0.0296821
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 14.7779,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 10.9052,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.11878,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__zeros__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.92,
+      "status": "pass",
+      "throughput_in_gibs": 12.9048,
+      "throughput_out_gibs": 0.00364388,
+      "compression_fold": 3541.49,
+      "input_gib": 3.75,
+      "compressed_gib": 0.00105888,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.290591,
+      "init_s": 0.293943,
+      "flush_s": 4.4e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.94063,
+          "best_ms": 2.54864,
+          "in_gibs": 21.254,
+          "out_gibs": 21.254
+        },
+        "h2d": {
+          "avg_ms": 1.22328,
+          "best_ms": 1.17824,
+          "in_gibs": 51.0921,
+          "out_gibs": 51.0921
+        },
+        "scatter": {
+          "avg_ms": 0.351331,
+          "best_ms": 0.330624,
+          "in_gibs": 177.895,
+          "out_gibs": 177.895
+        },
+        "compress": {
+          "avg_ms": 8.26033,
+          "best_ms": 7.79434,
+          "in_gibs": 90.7954,
+          "out_gibs": 0.0200887
+        },
+        "aggregate": {
+          "avg_ms": 0.131379,
+          "best_ms": 0.032768,
+          "in_gibs": 1.26306,
+          "out_gibs": 1.26306
+        },
+        "d2h": {
+          "avg_ms": 14.662,
+          "best_ms": 14.2556,
+          "in_gibs": 0.0113176,
+          "out_gibs": 0.0113176
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 24.0582,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 23.5575,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.64395,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__zeros__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "zeros",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.93,
+      "status": "pass",
+      "throughput_in_gibs": 12.6407,
+      "throughput_out_gibs": 0.00250444,
+      "compression_fold": 5047.3,
+      "input_gib": 3.75,
+      "compressed_gib": 0.000742972,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.296662,
+      "init_s": 0.293456,
+      "flush_s": 5.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.92212,
+          "best_ms": 2.50542,
+          "in_gibs": 21.3886,
+          "out_gibs": 21.3886
+        },
+        "h2d": {
+          "avg_ms": 1.2189,
+          "best_ms": 1.17824,
+          "in_gibs": 51.2759,
+          "out_gibs": 51.2759
+        },
+        "scatter": {
+          "avg_ms": 0.342165,
+          "best_ms": 0.33056,
+          "in_gibs": 182.66,
+          "out_gibs": 182.66
+        },
+        "compress": {
+          "avg_ms": 12.2437,
+          "best_ms": 11.5011,
+          "in_gibs": 61.2561,
+          "out_gibs": 0.0115084
+        },
+        "aggregate": {
+          "avg_ms": 0.127661,
+          "best_ms": 0.028672,
+          "in_gibs": 1.10375,
+          "out_gibs": 1.10375
+        },
+        "d2h": {
+          "avg_ms": 14.6255,
+          "best_ms": 14.2546,
+          "in_gibs": 0.00963425,
+          "out_gibs": 0.00963425
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 27.6808,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 27.5726,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.37299,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__rand__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.47,
+      "status": "pass",
+      "throughput_in_gibs": 8.59247,
+      "throughput_out_gibs": 8.59667,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.436429,
+      "init_s": 0.210292,
+      "flush_s": 5.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.41892,
+          "best_ms": 3.32425,
+          "in_gibs": 18.2806,
+          "out_gibs": 18.2806
+        },
+        "h2d": {
+          "avg_ms": 1.19762,
+          "best_ms": 1.17926,
+          "in_gibs": 52.1867,
+          "out_gibs": 52.1867
+        },
+        "scatter": {
+          "avg_ms": 0.335197,
+          "best_ms": 0.33248,
+          "in_gibs": 186.458,
+          "out_gibs": 186.458
+        },
+        "compress": {
+          "avg_ms": 1.02491,
+          "best_ms": 0.52464,
+          "in_gibs": 522.696,
+          "out_gibs": 522.696
+        },
+        "aggregate": {
+          "avg_ms": 1.11879,
+          "best_ms": 0.744096,
+          "in_gibs": 478.834,
+          "out_gibs": 478.834
+        },
+        "d2h": {
+          "avg_ms": 10.2971,
+          "best_ms": 7.13107,
+          "in_gibs": 52.026,
+          "out_gibs": 52.026
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 11.974,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 8.66754,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.83788,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__rand__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.45,
+      "status": "pass",
+      "throughput_in_gibs": 8.58541,
+      "throughput_out_gibs": 8.58593,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.436788,
+      "init_s": 0.264048,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.39084,
+          "best_ms": 3.3019,
+          "in_gibs": 18.432,
+          "out_gibs": 18.432
+        },
+        "h2d": {
+          "avg_ms": 1.20295,
+          "best_ms": 1.17885,
+          "in_gibs": 51.9557,
+          "out_gibs": 51.9557
+        },
+        "scatter": {
+          "avg_ms": 0.334935,
+          "best_ms": 0.332512,
+          "in_gibs": 186.603,
+          "out_gibs": 186.603
+        },
+        "compress": {
+          "avg_ms": 1.46568,
+          "best_ms": 1.07178,
+          "in_gibs": 511.709,
+          "out_gibs": 511.709
+        },
+        "aggregate": {
+          "avg_ms": 1.63574,
+          "best_ms": 1.53395,
+          "in_gibs": 458.509,
+          "out_gibs": 458.509
+        },
+        "d2h": {
+          "avg_ms": 14.4627,
+          "best_ms": 14.2548,
+          "in_gibs": 51.8575,
+          "out_gibs": 51.8575
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 18.9875,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 18.5417,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.65846,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__rand__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.44,
+      "status": "pass",
+      "throughput_in_gibs": 8.50636,
+      "throughput_out_gibs": 8.50645,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.440847,
+      "init_s": 0.260369,
+      "flush_s": 4.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.40166,
+          "best_ms": 3.31754,
+          "in_gibs": 18.3734,
+          "out_gibs": 18.3734
+        },
+        "h2d": {
+          "avg_ms": 1.20225,
+          "best_ms": 1.17888,
+          "in_gibs": 51.9857,
+          "out_gibs": 51.9857
+        },
+        "scatter": {
+          "avg_ms": 0.334888,
+          "best_ms": 0.332544,
+          "in_gibs": 186.629,
+          "out_gibs": 186.629
+        },
+        "compress": {
+          "avg_ms": 1.4673,
+          "best_ms": 1.06973,
+          "in_gibs": 511.144,
+          "out_gibs": 511.144
+        },
+        "aggregate": {
+          "avg_ms": 3.42733,
+          "best_ms": 3.28602,
+          "in_gibs": 218.829,
+          "out_gibs": 218.829
+        },
+        "d2h": {
+          "avg_ms": 14.4617,
+          "best_ms": 14.2545,
+          "in_gibs": 51.8613,
+          "out_gibs": 51.8613
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 20.6366,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 20.5381,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.04252,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__rand__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.65,
+      "status": "pass",
+      "throughput_in_gibs": 5.12599,
+      "throughput_out_gibs": 5.14798,
+      "compression_fold": 0.995728,
+      "input_gib": 3.75,
+      "compressed_gib": 3.76609,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.731566,
+      "init_s": 0.210957,
+      "flush_s": 4.11e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.40516,
+          "best_ms": 3.30222,
+          "in_gibs": 18.3545,
+          "out_gibs": 18.3545
+        },
+        "h2d": {
+          "avg_ms": 1.20167,
+          "best_ms": 1.17824,
+          "in_gibs": 52.0108,
+          "out_gibs": 52.0108
+        },
+        "scatter": {
+          "avg_ms": 0.352682,
+          "best_ms": 0.328096,
+          "in_gibs": 177.214,
+          "out_gibs": 177.214
+        },
+        "compress": {
+          "avg_ms": 66.8932,
+          "best_ms": 41.7994,
+          "in_gibs": 8.0085,
+          "out_gibs": 8.03895
+        },
+        "aggregate": {
+          "avg_ms": 1.34313,
+          "best_ms": 0.742368,
+          "in_gibs": 400.372,
+          "out_gibs": 400.372
+        },
+        "d2h": {
+          "avg_ms": 10.4003,
+          "best_ms": 7.16029,
+          "in_gibs": 51.7052,
+          "out_gibs": 51.7052
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 55.391,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 52.0478,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 58.4699,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__rand__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.06,
+      "status": "error"
+    },
+    {
+      "id": "256cube_single__lz4__rand__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.76,
+      "status": "pass",
+      "throughput_in_gibs": 6.04437,
+      "throughput_out_gibs": 5.26265,
+      "compression_fold": 1.14854,
+      "input_gib": 3.75,
+      "compressed_gib": 3.26501,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.620412,
+      "init_s": 0.288506,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.36706,
+          "best_ms": 3.26269,
+          "in_gibs": 18.5622,
+          "out_gibs": 18.5622
+        },
+        "h2d": {
+          "avg_ms": 1.19381,
+          "best_ms": 1.17811,
+          "in_gibs": 52.3535,
+          "out_gibs": 52.3535
+        },
+        "scatter": {
+          "avg_ms": 0.376405,
+          "best_ms": 0.332576,
+          "in_gibs": 166.045,
+          "out_gibs": 166.045
+        },
+        "compress": {
+          "avg_ms": 86.6934,
+          "best_ms": 74.9533,
+          "in_gibs": 8.65118,
+          "out_gibs": 7.53223
+        },
+        "aggregate": {
+          "avg_ms": 3.01391,
+          "best_ms": 2.47706,
+          "in_gibs": 216.661,
+          "out_gibs": 216.661
+        },
+        "d2h": {
+          "avg_ms": 14.4517,
+          "best_ms": 14.3102,
+          "in_gibs": 45.1848,
+          "out_gibs": 45.1848
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 124.5,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 124.388,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 83.6359,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__rand__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.31,
+      "status": "pass",
+      "throughput_in_gibs": 2.91523,
+      "throughput_out_gibs": 2.49864,
+      "compression_fold": 1.16672,
+      "input_gib": 3.75,
+      "compressed_gib": 3.21413,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 1.28635,
+      "init_s": 0.20415,
+      "flush_s": 4.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.38153,
+          "best_ms": 3.14866,
+          "in_gibs": 18.4827,
+          "out_gibs": 18.4827
+        },
+        "h2d": {
+          "avg_ms": 1.19649,
+          "best_ms": 1.17818,
+          "in_gibs": 52.2362,
+          "out_gibs": 52.2362
+        },
+        "scatter": {
+          "avg_ms": 0.454565,
+          "best_ms": 0.318368,
+          "in_gibs": 137.494,
+          "out_gibs": 137.494
+        },
+        "compress": {
+          "avg_ms": 148.319,
+          "best_ms": 101.709,
+          "in_gibs": 3.6119,
+          "out_gibs": 3.094
+        },
+        "aggregate": {
+          "avg_ms": 1.28388,
+          "best_ms": 0.626368,
+          "in_gibs": 357.431,
+          "out_gibs": 357.431
+        },
+        "d2h": {
+          "avg_ms": 10.3195,
+          "best_ms": 7.1329,
+          "in_gibs": 44.4693,
+          "out_gibs": 44.4693
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 122.039,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 118.712,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 160.503,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__rand__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.04,
+      "status": "pass",
+      "throughput_in_gibs": 4.05807,
+      "throughput_out_gibs": 2.25376,
+      "compression_fold": 1.80058,
+      "input_gib": 3.75,
+      "compressed_gib": 2.08266,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.924085,
+      "init_s": 0.291079,
+      "flush_s": 4.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.35799,
+          "best_ms": 3.23388,
+          "in_gibs": 18.6123,
+          "out_gibs": 18.6123
+        },
+        "h2d": {
+          "avg_ms": 1.19796,
+          "best_ms": 1.17968,
+          "in_gibs": 52.1719,
+          "out_gibs": 52.1719
+        },
+        "scatter": {
+          "avg_ms": 2.46354,
+          "best_ms": 0.318336,
+          "in_gibs": 25.37,
+          "out_gibs": 25.37
+        },
+        "compress": {
+          "avg_ms": 146.132,
+          "best_ms": 81.6193,
+          "in_gibs": 5.13235,
+          "out_gibs": 2.85007
+        },
+        "aggregate": {
+          "avg_ms": 1.00575,
+          "best_ms": 0.484288,
+          "in_gibs": 414.107,
+          "out_gibs": 414.107
+        },
+        "d2h": {
+          "avg_ms": 14.4279,
+          "best_ms": 14.2555,
+          "in_gibs": 28.8667,
+          "out_gibs": 28.8667
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 282.026,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 281.576,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 225.231,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__rand__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "rand",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.94,
+      "status": "pass",
+      "throughput_in_gibs": 4.61078,
+      "throughput_out_gibs": 2.48878,
+      "compression_fold": 1.85262,
+      "input_gib": 3.75,
+      "compressed_gib": 2.02416,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.813312,
+      "init_s": 0.294182,
+      "flush_s": 4.81e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.36603,
+          "best_ms": 3.27506,
+          "in_gibs": 18.5679,
+          "out_gibs": 18.5679
+        },
+        "h2d": {
+          "avg_ms": 1.19793,
+          "best_ms": 1.17853,
+          "in_gibs": 52.1732,
+          "out_gibs": 52.1732
+        },
+        "scatter": {
+          "avg_ms": 0.492569,
+          "best_ms": 0.328544,
+          "in_gibs": 126.886,
+          "out_gibs": 126.886
+        },
+        "compress": {
+          "avg_ms": 126.433,
+          "best_ms": 78.1077,
+          "in_gibs": 5.932,
+          "out_gibs": 3.20188
+        },
+        "aggregate": {
+          "avg_ms": 1.95912,
+          "best_ms": 1.07069,
+          "in_gibs": 206.636,
+          "out_gibs": 206.636
+        },
+        "d2h": {
+          "avg_ms": 14.426,
+          "best_ms": 14.255,
+          "in_gibs": 28.062,
+          "out_gibs": 28.062
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 221.944,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 221.833,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 180.408,
+        "peak_pending_mib": 0.0
+      }
+    }
+  ]
+}

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -297,7 +297,8 @@ def gpu_name() -> str:
 # ---------------------------------------------------------------------------
 
 def run_one(spec: RunSpec, build_dir: Path, s3_bucket: str | None = None,
-            s3_region: str | None = None, s3_endpoint: str | None = None) -> dict | None:
+            s3_region: str | None = None, s3_endpoint: str | None = None,
+            tmpdir_root: Path | None = None) -> dict | None:
     """Execute a single benchmark run, return result dict or None if exe missing."""
     exe = build_dir / "bench" / f"bench_stream_{spec.scenario}"
     if sys.platform == "win32":
@@ -319,7 +320,8 @@ def run_one(spec: RunSpec, build_dir: Path, s3_bucket: str | None = None,
 
     tmpdir = None
     if spec.sink == "fs":
-        tmpdir = tempfile.mkdtemp(prefix="chucky_io_")
+        tmpdir = tempfile.mkdtemp(prefix="chucky_io_",
+                                  dir=str(tmpdir_root) if tmpdir_root else None)
         cmd.extend(["-o", tmpdir])
     elif spec.sink == "s3":
         if not s3_bucket or not s3_region or not s3_endpoint:
@@ -406,8 +408,10 @@ def status_style(status: str) -> str:
 @click.option("--s3-region", default="us-east-1", show_default=True, help="S3 region.")
 @click.option("--s3-endpoint", default="http://localhost:9000", show_default=True,
               help="S3 endpoint URL.")
+@click.option("--tmpdir", "tmpdir_root", type=click.Path(path_type=Path), default=None,
+              help="Parent directory for fs-sink scratch dirs (default: system temp).")
 def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
-         s3_bucket, s3_region, s3_endpoint):
+         s3_bucket, s3_region, s3_endpoint, tmpdir_root):
     """Benchmark sweep runner for chucky."""
     commit = git_commit()
     hostname = platform.node()
@@ -529,7 +533,8 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
                 result = run_one(spec, build_dir,
                                  s3_bucket=s3_bucket,
                                  s3_region=s3_region,
-                                 s3_endpoint=s3_endpoint)
+                                 s3_endpoint=s3_endpoint,
+                                 tmpdir_root=tmpdir_root)
             except subprocess.TimeoutExpired:
                 result = {**spec.base_result(), "status": "timeout"}
             except Exception as e:


### PR DESCRIPTION
## Summary
- Raise `target_chunk_bytes` from 256 KiB to 1 MiB across all `bench_stream_*` scenarios
- Add `--tmpdir` CLI option to `scripts/sweep/sweep.py`.
- Check in two livescreen sweep result sets
