### PR TITLE
CUDA 13 build (and dual-target with CUDA 12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,20 @@ jobs:
 
   gpu-tests:
     runs-on: [self-hosted, Linux, gpu]
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda:
+          - { major: 13, version: 13.2.1 }
+          - { major: 12, version: 12.8.1 }
+    name: gpu-tests (cuda${{ matrix.cuda.major }})
+    env:
+      CUDA_VERSION: ${{ matrix.cuda.version }}
+      CUDA_MAJOR: ${{ matrix.cuda.major }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build and test (GPU)
+      - name: Build and test (GPU, CUDA ${{ matrix.cuda.version }})
         run: docker compose run --rm test
 
       - name: Cleanup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.24)
 project(chucky VERSION 0.1.0 LANGUAGES C CXX)
 include(GNUInstallDirs)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 # syntax=docker/dockerfile:1
 
-# CUDA 12.8 required for SM 100 (Blackwell) target
-FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
+# CUDA major.minor.patch tag of the nvidia/cuda base image. SM 100 (Blackwell)
+# requires CUDA 12.8+; default is 13.2.1. Override with --build-arg to target
+# CUDA 12 (e.g. CUDA_VERSION=12.8.1 CUDA_MAJOR=12).
+ARG CUDA_VERSION=13.2.1
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu24.04
+# Re-declare ARGs needed in subsequent layers; they are reset by FROM.
+ARG CUDA_MAJOR=13
+ARG NVCOMP_VERSION=5.1.0.21
 
 # Avoid interactive prompts during package install
 ENV DEBIAN_FRONTEND=noninteractive
@@ -48,7 +54,7 @@ RUN wget -qO /tmp/awscliv2.zip \
     && rm -rf /tmp/awscliv2.zip /tmp/aws
 
 RUN wget -qO /tmp/nvcomp.tar.xz \
-        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-5.1.0.21_cuda12-archive.tar.xz" \
+        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-${NVCOMP_VERSION}_cuda${CUDA_MAJOR}-archive.tar.xz" \
     && mkdir -p /opt/nvcomp \
     && tar -xJf /tmp/nvcomp.tar.xz -C /opt/nvcomp --strip-components=1 \
     && rm /tmp/nvcomp.tar.xz

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -720,7 +720,7 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
     CUdevice dev;
     CU(Fail, cuInit(0));
     CU(Fail, cuDeviceGet(&dev, 0));
-    CU(Fail, cuCtxCreate(&ctx, 0, dev));
+    CU(Fail, cu_ctx_create(&ctx, 0, dev));
   }
 
   struct bench_config cfg = {
@@ -1098,7 +1098,7 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
   CUcontext ctx = 0;
   CU(Fail, cuInit(0));
   CU(Fail, cuDeviceGet(&dev, 0));
-  CU(Fail, cuCtxCreate(&ctx, 0, dev));
+  CU(Fail, cu_ctx_create(&ctx, 0, dev));
 
   struct bench_config cfg = {
     .label = spec.label,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,14 @@ services:
       retries: 5
 
   test:
-    build: .
+    build:
+      context: .
+      args:
+        # Defaults match the Dockerfile (CUDA 13.2). CI overrides via env vars
+        # to exercise the CUDA 12 build path on the same self-hosted runner.
+        CUDA_VERSION: ${CUDA_VERSION:-13.2.1}
+        CUDA_MAJOR: ${CUDA_MAJOR:-13}
+        NVCOMP_VERSION: ${NVCOMP_VERSION:-5.1.0.21}
     devices:
       - nvidia.com/gpu=all
     depends_on:

--- a/flake.nix
+++ b/flake.nix
@@ -69,12 +69,17 @@
           aws-checksums
           s2n-tls
         ];
-        gpuBuildInputs = with pkgs; [
-          cudaPackages.cudatoolkit
-          cudaPackages.nvcomp
-          cudaPackages.nvcomp.static
-          llvmPackages.openmp
-        ];
+        # GPU build inputs are parameterized by CUDA version. The devshell and
+        # the default `chucky` package use CUDA 13.2 (Blackwell-era). A
+        # CUDA 12.9 variant (`chucky-cuda12`) is also emitted for downstream
+        # consumers that pin the older toolkit.
+        mkGpuBuildInputs =
+          cudaPackages: with pkgs; [
+            cudaPackages.cudatoolkit
+            cudaPackages.nvcomp
+            cudaPackages.nvcomp.static
+            llvmPackages.openmp
+          ];
 
         commonNativeBuildInputs = with pkgs; [
           cmake
@@ -85,18 +90,26 @@
         mkChucky =
           {
             variant, # "gpu" | "cpu"
+            cudaPackages ? pkgs.cudaPackages_13_2,
+            pname ? null,
           }:
           let
             isGpu = variant == "gpu";
-            pname = if isGpu then "chucky" else "chucky-cpu";
+            resolvedPname =
+              if pname != null then
+                pname
+              else if isGpu then
+                "chucky"
+              else
+                "chucky-cpu";
           in
           pkgs.stdenv.mkDerivation {
-            inherit pname;
+            pname = resolvedPname;
             version = "0.1.0";
             src = self;
 
             nativeBuildInputs = commonNativeBuildInputs;
-            buildInputs = commonBuildInputs ++ pkgs.lib.optionals isGpu gpuBuildInputs;
+            buildInputs = commonBuildInputs ++ pkgs.lib.optionals isGpu (mkGpuBuildInputs cudaPackages);
 
             cmakeFlags = [
               "-DCHUCKY_ENABLE_GPU=${if isGpu then "ON" else "OFF"}"
@@ -118,7 +131,19 @@
         formatter = pkgs.nixfmt-tree;
 
         packages = {
+          # Default GPU package is CUDA 13.2.
           chucky = mkChucky { variant = "gpu"; };
+          # Explicit per-CUDA aliases for downstream consumers.
+          chucky-cuda13 = mkChucky {
+            variant = "gpu";
+            cudaPackages = pkgs.cudaPackages_13_2;
+            pname = "chucky-cuda13";
+          };
+          chucky-cuda12 = mkChucky {
+            variant = "gpu";
+            cudaPackages = pkgs.cudaPackages_12;
+            pname = "chucky-cuda12";
+          };
           chucky-cpu = mkChucky { variant = "cpu"; };
           default = mkChucky { variant = "gpu"; };
         };
@@ -152,7 +177,7 @@
               uv
             ]);
 
-          buildInputs = commonBuildInputs ++ gpuBuildInputs;
+          buildInputs = commonBuildInputs ++ (mkGpuBuildInputs pkgs.cudaPackages_13_2);
         };
       }
     );

--- a/src/gpu/prelude.cuda.h
+++ b/src/gpu/prelude.cuda.h
@@ -47,6 +47,19 @@ extern "C"
     return 1;
   }
 
+  // CUDA 13 added a CUctxCreateParams* argument in position 2; pass NULL to
+  // preserve the CUDA 12 behaviour. Wrap so call sites stay portable.
+  static inline CUresult cu_ctx_create(CUcontext* pctx,
+                                       unsigned int flags,
+                                       CUdevice dev)
+  {
+#if CUDA_VERSION >= 13000
+    return cuCtxCreate(pctx, NULL, flags, dev);
+#else
+    return cuCtxCreate(pctx, flags, dev);
+#endif
+  }
+
   static inline void cu_event_destroy(CUevent e)
   {
     if (e)

--- a/tests/experiments/index.ops.cuda.c
+++ b/tests/experiments/index.ops.cuda.c
@@ -410,7 +410,7 @@ main(int ac, char* av[])
 
   CU(Fail, cuInit(0));
   CU(Fail, cuDeviceGet(&dev, 0));
-  CU(Fail, cuCtxCreate(&ctx, 0, dev));
+  CU(Fail, cu_ctx_create(&ctx, 0, dev));
 
   printf("=== Test 0: CPU hit count verification ===\n");
   ecode |= test_transpose_hit_count_cpu();

--- a/tests/test_destroy_drain.c
+++ b/tests/test_destroy_drain.c
@@ -181,7 +181,7 @@ main(int ac, char* av[])
   CUdevice dev;
   CU(Cleanup, cuInit(0));
   CU(Cleanup, cuDeviceGet(&dev, 0));
-  CU(Cleanup, cuCtxCreate(&ctx, 0, dev));
+  CU(Cleanup, cu_ctx_create(&ctx, 0, dev));
 
   {
     char sub[4200];

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -188,7 +188,7 @@ main(int ac, char* av[])
   CUdevice dev;
   CU(Cleanup, cuInit(0));
   CU(Cleanup, cuDeviceGet(&dev, 0));
-  CU(Cleanup, cuCtxCreate(&ctx, 0, dev));
+  CU(Cleanup, cu_ctx_create(&ctx, 0, dev));
 
   {
     char sub[4200];

--- a/tests/test_lod.c
+++ b/tests/test_lod.c
@@ -1019,7 +1019,7 @@ main(void)
   CUdevice dev;
   CUcontext ctx;
   if (cuInit(0) != CUDA_SUCCESS || cuDeviceGet(&dev, 0) != CUDA_SUCCESS ||
-      cuCtxCreate(&ctx, 0, dev) != CUDA_SUCCESS) {
+      cu_ctx_create(&ctx, 0, dev) != CUDA_SUCCESS) {
     log_error("CUDA init failed");
     return 1;
   }

--- a/tests/test_lod_dtypes.cu
+++ b/tests/test_lod_dtypes.cu
@@ -496,7 +496,7 @@ main(void)
   CUdevice dev;
   CUcontext ctx;
   if (cuInit(0) != CUDA_SUCCESS || cuDeviceGet(&dev, 0) != CUDA_SUCCESS ||
-      cuCtxCreate(&ctx, 0, dev) != CUDA_SUCCESS) {
+      cu_ctx_create(&ctx, 0, dev) != CUDA_SUCCESS) {
     log_error("CUDA init failed");
     return 1;
   }

--- a/tests/test_multiarray_flush_mock.c
+++ b/tests/test_multiarray_flush_mock.c
@@ -10,6 +10,7 @@
 // prior sink stamped on the shared delivery pipeline.
 
 #include "dimension.h"
+#include "gpu/prelude.cuda.h"
 #include "multiarray.gpu.h"
 #include "stream.gpu.h"
 #include "util/prelude.h"
@@ -215,7 +216,7 @@ main(int ac, char* av[])
   CUdevice dev;
   CUcontext ctx;
   if (cuDeviceGet(&dev, 0) != CUDA_SUCCESS ||
-      cuCtxCreate(&ctx, 0, dev) != CUDA_SUCCESS) {
+      cu_ctx_create(&ctx, 0, dev) != CUDA_SUCCESS) {
     log_error("Failed to create CUDA context");
     return 1;
   }

--- a/tests/test_multiarray_gpu.c
+++ b/tests/test_multiarray_gpu.c
@@ -1,4 +1,5 @@
 #include "dimension.h"
+#include "gpu/prelude.cuda.h"
 #include "multiarray.gpu.h"
 #include "stream.gpu.h"
 #include "test_shard_sink.h"
@@ -1095,7 +1096,7 @@ main(int ac, char* av[])
   CUdevice dev;
   CUcontext ctx;
   if (cuDeviceGet(&dev, 0) != CUDA_SUCCESS ||
-      cuCtxCreate(&ctx, 0, dev) != CUDA_SUCCESS) {
+      cu_ctx_create(&ctx, 0, dev) != CUDA_SUCCESS) {
     log_error("Failed to create CUDA context");
     return 1;
   }

--- a/tests/test_runner.h
+++ b/tests/test_runner.h
@@ -20,7 +20,7 @@
                                                                                \
     CU(RunGpuFail_, cuInit(0));                                                \
     CU(RunGpuFail_, cuDeviceGet(&dev_, 0));                                    \
-    CU(RunGpuFail_, cuCtxCreate(&ctx_, 0, dev_));                              \
+    CU(RunGpuFail_, cu_ctx_create(&ctx_, 0, dev_));                              \
                                                                                \
     int rc_ = 0;                                                               \
     struct                                                                     \

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -2311,7 +2311,7 @@ main(int ac, char* av[])
 
     CU(Cleanup, cuInit(0));
     CU(Cleanup, cuDeviceGet(&dev, 0));
-    CU(Cleanup, cuCtxCreate(&ctx, 0, dev));
+    CU(Cleanup, cu_ctx_create(&ctx, 0, dev));
 
     {
       char sub[4200];


### PR DESCRIPTION
Closes #127.

## What

- Source compiles cleanly under both CUDA 12 (12.8/12.9) and CUDA 13 (13.2). The only API break the codebase touches is `cuCtxCreate`, which gained a `CUctxCreateParams *` argument in CUDA 13. Hidden behind a thin `cu_ctx_create()` shim in `src/gpu/prelude.cuda.h` (12 call sites updated).
- `Dockerfile` parameterized via build args (`CUDA_VERSION`, `CUDA_MAJOR`, `NVCOMP_VERSION`); `docker-compose.yml` plumbs them through env vars.
- `gpu-tests` CI job now runs as a matrix over `{cuda-12.8.1, cuda-13.2.1}` on the self-hosted runner.
- `cmake_minimum_required` bumped 3.18 → 3.24 for cleaner CUDA architecture handling.

## Versions in play

- **CUDA**: 12.9 (Nix `cudaPackages_12`) and 13.2.1 (Nix `cudaPackages_13_2`, Docker default).
- **nvcomp**: 5.0.0.6 via Nix (current nixpkgs floor across all CUDA variants), 5.1.0.21 via Docker (downloaded direct from NVIDIA). nvcomp 5.1 will roll into Nix automatically once nixpkgs bumps it.
- **`CMAKE_CUDA_ARCHITECTURES`**: `100` (sm_100 / Blackwell) — already above CUDA 13's new floor (Maxwell/Pascal/Volta dropped in 13.0).

## Not in this PR (and why)

- **VS 2026 + CUDA 13 on Windows CI**: the source-side compat changes are forward-compatible with VS 2026 + CUDA 13.2 (CUDA 13.2 supports VS 2026 / MSVC v195 officially), but Windows CI stays CPU-only because GitHub-hosted Windows GPU runners aren't a thing and self-hosted Windows GPU runners aren't set up.
