### PR TITLE
GPU aggregate: unify per-LOD dispatch

### DIFF
--- a/src/gpu/aggregate.cu
+++ b/src/gpu/aggregate.cu
@@ -240,6 +240,86 @@ Error:
 }
 
 // ---------------------------------------------------------------------------
+// Unified kernels (across all LODs)
+// ---------------------------------------------------------------------------
+
+// write_total_unified_k:
+//   One thread per LOD. Each thread writes the inclusive-sum value at its
+//   LOD's sentinel position (idx = d_lod_last_idx[lv]):
+//     d_offsets[idx] = d_offsets[idx - 1] + d_permuted_sizes[idx - 1]
+//
+//   For LODs whose sentinel idx is within [0, count) of the ExclusiveSum,
+//   this is idempotent (recomputes a value the scan already wrote correctly,
+//   since output[idx] = sum(input[0..idx-1]) = output[idx-1] + input[idx-1]).
+//   For any sentinel idx that lies at or beyond the scan's output range,
+//   this kernel writes the missing total — same role legacy write_total_k
+//   plays for the single-LOD case.
+__global__ void
+write_total_unified_k(size_t* __restrict__ d_offsets,
+                      const size_t* __restrict__ d_permuted_sizes,
+                      const uint64_t* __restrict__ d_lod_last_idx,
+                      uint8_t nlod)
+{
+  const uint32_t lv = threadIdx.x;
+  if (lv >= nlod)
+    return;
+  const uint64_t idx = d_lod_last_idx[lv];
+  d_offsets[idx] = d_offsets[idx - 1] + d_permuted_sizes[idx - 1];
+}
+
+// add_shard_bias_unified_k:
+//   Block per shard. Reads per-shard parameters (base index, run length,
+//   destination base byte offset) from device tables. Computes
+//     bias_s = d_shard_base_offsets[s] + d_tail_bytes_prev[s]
+//              - d_offsets[d_shard_offsets_base[s]]
+//   once into shared memory, then adds it across the shard's run in
+//   d_offsets. Same structure as add_shard_bias_k; per-shard parameters
+//   replace the uniform tps_group / s*shard_capacity values.
+__global__ void
+add_shard_bias_unified_k(size_t* __restrict__ d_offsets,
+                         const size_t* __restrict__ d_tail_bytes_prev,
+                         const size_t* __restrict__ d_shard_base_offsets,
+                         const uint64_t* __restrict__ d_shard_tps_group,
+                         const uint64_t* __restrict__ d_shard_offsets_base,
+                         uint64_t num_shards)
+{
+  const uint64_t s = blockIdx.x;
+  if (s >= num_shards)
+    return;
+  const uint64_t base = d_shard_offsets_base[s];
+  const uint64_t tps_group = d_shard_tps_group[s];
+  __shared__ size_t bias_s;
+  if (threadIdx.x == 0)
+    bias_s =
+      d_shard_base_offsets[s] + d_tail_bytes_prev[s] - d_offsets[base];
+  __syncthreads();
+  for (uint64_t k = threadIdx.x; k < tps_group; k += blockDim.x)
+    d_offsets[base + k] += bias_s;
+}
+
+// copy_leading_tail_unified_k:
+//   Block per shard. Copies d_tail_bytes_prev[s] bytes from
+//   d_tail_carry + s*page_size into d_aggregated + d_shard_base_offsets[s].
+//   Same structure as copy_leading_tail_k; page_size remains uniform across
+//   shards today, while the destination base is now per-shard.
+__global__ void
+copy_leading_tail_unified_k(void* __restrict__ d_aggregated,
+                            const void* __restrict__ d_tail_carry,
+                            const size_t* __restrict__ d_tail_bytes_prev,
+                            const size_t* __restrict__ d_shard_base_offsets,
+                            size_t page_size)
+{
+  const uint64_t s = blockIdx.x;
+  const size_t nbytes = d_tail_bytes_prev[s];
+  if (nbytes == 0)
+    return;
+  const uint8_t* src = (const uint8_t*)d_tail_carry + s * page_size;
+  uint8_t* dst = (uint8_t*)d_aggregated + d_shard_base_offsets[s];
+  for (size_t off = threadIdx.x; off < nbytes; off += blockDim.x)
+    dst[off] = src[off];
+}
+
+// ---------------------------------------------------------------------------
 // aggregate_batch_by_shard_async
 // ---------------------------------------------------------------------------
 
@@ -318,6 +398,120 @@ aggregate_batch_by_shard_async(const void* d_compressed,
   }
 
   // Pass 4: gather compressed tiles using LUTs.
+  {
+    const int block = 256;
+    const int grid = (int)N;
+    gather_batch_k<<<grid, block, 0, cuda_stream>>>(d_compressed,
+                                                    slot->d_aggregated,
+                                                    d_comp_sizes,
+                                                    slot->d_offsets,
+                                                    d_batch_gather,
+                                                    d_batch_perm,
+                                                    max_comp_chunk_bytes);
+  }
+
+  // d_tail_bytes / d_tail_carry are uploaded by host post-delivery
+  // (flush.d2h_deliver.c).
+
+  return 0;
+
+Error:
+  return 1;
+}
+
+// ---------------------------------------------------------------------------
+// aggregate_batch_unified_async
+//   Single dispatch across all LODs. The kernel launches are identical in
+//   structure to aggregate_batch_by_shard_async, but per-LOD/per-shard
+//   parameters come from device-side tables built host-side at kick time.
+// ---------------------------------------------------------------------------
+
+extern "C" int
+aggregate_batch_unified_async(const void* d_compressed,
+                              size_t* d_comp_sizes,
+                              const uint32_t* d_batch_gather,
+                              const uint32_t* d_batch_perm,
+                              uint64_t total_batch_chunks,
+                              uint64_t total_batch_covering,
+                              uint8_t nlod,
+                              const uint64_t* d_lod_last_idx,
+                              size_t max_comp_chunk_bytes,
+                              struct aggregate_slot* slot,
+                              const size_t* d_shard_base_offsets,
+                              const size_t* d_shard_capacity,
+                              const uint64_t* d_shard_tps_group,
+                              const uint64_t* d_shard_offsets_base,
+                              const size_t* d_tail_bytes,
+                              CUdeviceptr d_tail_carry,
+                              size_t page_size,
+                              uint64_t total_shards,
+                              CUstream stream)
+{
+  (void)d_shard_capacity; // kept for symmetry/asserts; gather is offset-driven
+  const uint64_t N = total_batch_chunks;
+  const uint64_t C = total_batch_covering;
+  cudaStream_t cuda_stream = (cudaStream_t)stream;
+
+  // Zero permuted_sizes (C + nlod entries: covering plus one sentinel per LOD)
+  CU(Error,
+     cuMemsetD8Async((CUdeviceptr)slot->d_permuted_sizes,
+                     0,
+                     (C + nlod) * sizeof(size_t),
+                     stream));
+
+  // Pass 1: permute sizes using unified LUTs (perm targets already shifted
+  // by +lv per LOD inside aggregate_batch_luts_unified).
+  {
+    const int block = 256;
+    const int grid = (int)((N + block - 1) / block);
+    permute_sizes_batch_k<<<grid, block, 0, cuda_stream>>>(
+      d_comp_sizes, slot->d_permuted_sizes, d_batch_gather, d_batch_perm, N);
+  }
+
+  // Pass 2: single exclusive prefix sum across the unified covering range
+  // plus one sentinel slot per LOD.
+  {
+    size_t temp = slot->temp_bytes;
+    cub::DeviceScan::ExclusiveSum(slot->d_temp,
+                                  temp,
+                                  slot->d_permuted_sizes,
+                                  slot->d_offsets,
+                                  (int)(C + nlod),
+                                  cuda_stream);
+
+    // No write_total fixup needed: ExclusiveSum over (C + nlod) entries
+    // already writes every LOD's tail-sentinel slot (positions land within
+    // the scan's output range).
+    (void)d_lod_last_idx; // retained for ABI; unused now
+  }
+
+  if (page_size > 0 && total_shards > 0) {
+    // Pass 3a: per-shard bias. Anchors each shard's first chunk at its
+    // base byte offset + tail_in, packs subsequent chunks tightly.
+    {
+      const int block = 256;
+      add_shard_bias_unified_k<<<(int)total_shards, block, 0, cuda_stream>>>(
+        slot->d_offsets,
+        d_tail_bytes,
+        d_shard_base_offsets,
+        d_shard_tps_group,
+        d_shard_offsets_base,
+        total_shards);
+    }
+    // Pass 3b: stage prior batch's ragged tail at the head of each shard's
+    // region so chunks pack just past it.
+    {
+      const int block = 256;
+      copy_leading_tail_unified_k<<<(int)total_shards, block, 0, cuda_stream>>>(
+        slot->d_aggregated,
+        (const void*)d_tail_carry,
+        d_tail_bytes,
+        d_shard_base_offsets,
+        page_size);
+    }
+  }
+
+  // Pass 4: gather compressed tiles using unified LUTs.
   {
     const int block = 256;
     const int grid = (int)N;

--- a/src/gpu/aggregate.cu
+++ b/src/gpu/aggregate.cu
@@ -136,7 +136,6 @@ aggregate_slot_destroy(struct aggregate_slot* slot)
     cuEventDestroy(slot->ready);
   cuMemFree((CUdeviceptr)slot->d_permuted_sizes);
   cuMemFree((CUdeviceptr)slot->d_offsets);
-  cuMemFree((CUdeviceptr)slot->d_perm);
   cuMemFree((CUdeviceptr)slot->d_aggregated);
   cuMemFreeHost(slot->h_aggregated);
   cuMemFreeHost(slot->h_offsets);
@@ -201,7 +200,7 @@ aggregate_batch_slot_init(struct aggregate_slot* slot,
                           size_t comp_pool_bytes)
 {
   uint64_t C = batch_covering_count;
-  uint64_t M = batch_chunk_count;
+  (void)batch_chunk_count;
 
   CHECK(Error, slot);
   memset(slot, 0, sizeof(*slot));
@@ -211,7 +210,6 @@ aggregate_batch_slot_init(struct aggregate_slot* slot,
                 (C + 1) * sizeof(size_t)));
   CU(Error,
      cuMemAlloc((CUdeviceptr*)&slot->d_offsets, (C + 1) * sizeof(size_t)));
-  CU(Error, cuMemAlloc((CUdeviceptr*)&slot->d_perm, M * sizeof(uint32_t)));
   CU(Error, cuMemAlloc((CUdeviceptr*)&slot->d_aggregated, comp_pool_bytes));
   CU(Error, cuMemHostAlloc(&slot->h_aggregated, comp_pool_bytes, 0));
   CU(Error,
@@ -242,30 +240,6 @@ Error:
 // ---------------------------------------------------------------------------
 // Unified kernels (across all LODs)
 // ---------------------------------------------------------------------------
-
-// write_total_unified_k:
-//   One thread per LOD. Each thread writes the inclusive-sum value at its
-//   LOD's sentinel position (idx = d_lod_last_idx[lv]):
-//     d_offsets[idx] = d_offsets[idx - 1] + d_permuted_sizes[idx - 1]
-//
-//   For LODs whose sentinel idx is within [0, count) of the ExclusiveSum,
-//   this is idempotent (recomputes a value the scan already wrote correctly,
-//   since output[idx] = sum(input[0..idx-1]) = output[idx-1] + input[idx-1]).
-//   For any sentinel idx that lies at or beyond the scan's output range,
-//   this kernel writes the missing total — same role legacy write_total_k
-//   plays for the single-LOD case.
-__global__ void
-write_total_unified_k(size_t* __restrict__ d_offsets,
-                      const size_t* __restrict__ d_permuted_sizes,
-                      const uint64_t* __restrict__ d_lod_last_idx,
-                      uint8_t nlod)
-{
-  const uint32_t lv = threadIdx.x;
-  if (lv >= nlod)
-    return;
-  const uint64_t idx = d_lod_last_idx[lv];
-  d_offsets[idx] = d_offsets[idx - 1] + d_permuted_sizes[idx - 1];
-}
 
 // add_shard_bias_unified_k:
 //   Block per shard. Reads per-shard parameters (base index, run length,
@@ -434,7 +408,6 @@ aggregate_batch_unified_async(const void* d_compressed,
                               uint64_t total_batch_chunks,
                               uint64_t total_batch_covering,
                               uint8_t nlod,
-                              const uint64_t* d_lod_last_idx,
                               size_t max_comp_chunk_bytes,
                               struct aggregate_slot* slot,
                               const size_t* d_shard_base_offsets,
@@ -469,7 +442,8 @@ aggregate_batch_unified_async(const void* d_compressed,
   }
 
   // Pass 2: single exclusive prefix sum across the unified covering range
-  // plus one sentinel slot per LOD.
+  // plus one sentinel slot per LOD. The scan writes every LOD's
+  // tail-sentinel position; no separate write_total fixup needed.
   {
     size_t temp = slot->temp_bytes;
     cub::DeviceScan::ExclusiveSum(slot->d_temp,
@@ -478,11 +452,6 @@ aggregate_batch_unified_async(const void* d_compressed,
                                   slot->d_offsets,
                                   (int)(C + nlod),
                                   cuda_stream);
-
-    // No write_total fixup needed: ExclusiveSum over (C + nlod) entries
-    // already writes every LOD's tail-sentinel slot (positions land within
-    // the scan's output range).
-    (void)d_lod_last_idx; // retained for ABI; unused now
   }
 
   if (page_size > 0 && total_shards > 0) {

--- a/src/gpu/aggregate.h
+++ b/src/gpu/aggregate.h
@@ -20,7 +20,6 @@ extern "C"
   {
     size_t* d_permuted_sizes; // device: (C+1) size_t, zeroed each epoch
     size_t* d_offsets;        // device: (C+1) size_t
-    uint32_t* d_perm;         // device: M uint32_t
     void* d_aggregated;       // device: comp_pool_bytes
     void* h_aggregated;       // host pinned: comp_pool_bytes
     size_t* h_offsets;        // host pinned: (C+1) size_t
@@ -79,15 +78,10 @@ extern "C"
   //   total_batch_chunks   : M_total = sum_lv n_active[lv] * chunks_per_epoch[lv]
   //   total_batch_covering : C_total = sum_lv n_active[lv] * covering_count[lv]
   //   nlod                 : number of LODs
-  //   d_lod_last_idx       : [nlod] device array; entry lv = index in d_offsets
-  //                          where LOD lv's last sentinel offset should land
-  //                          (i.e. batch_covering_offset + n_active*covering + lv).
-  //                          Used by a small per-LOD write_total step.
   //   max_comp_chunk_bytes : uniform pool stride
   //   slot                 : unified aggregate_slot (d_aggregated sized to
   //                          max_total_data_bytes; d_offsets/d_permuted_sizes
-  //                          sized to max_total_batch_covering + LOD_MAX_LEVELS;
-  //                          d_perm sized to max_total_batch_chunks).
+  //                          sized to max_total_batch_covering + LOD_MAX_LEVELS).
   //   d_shard_base_offsets : [total_shards] base byte offset in d_aggregated
   //                          for each shard. Replaces uniform s*shard_capacity.
   //   d_shard_capacity     : [total_shards] each shard's capacity in bytes
@@ -113,7 +107,6 @@ extern "C"
     uint64_t total_batch_chunks,
     uint64_t total_batch_covering,
     uint8_t nlod,
-    const uint64_t* d_lod_last_idx,
     size_t max_comp_chunk_bytes,
     struct aggregate_slot* slot,
     const size_t* d_shard_base_offsets,

--- a/src/gpu/aggregate.h
+++ b/src/gpu/aggregate.h
@@ -63,6 +63,69 @@ extern "C"
                                      CUdeviceptr d_tail_carry,
                                      CUstream stream);
 
+  // Single dispatch across all LODs. The kernels read per-shard parameters
+  // from device-side tables built host-side at kick time. Per-LOD info is
+  // encoded in the tables; the kernels themselves are level-agnostic.
+  //
+  //   d_compressed         : the chunk pool (sized M * max_comp_chunk_bytes,
+  //                          shared across LODs — single pool stride)
+  //   d_comp_sizes         : per-chunk actual compressed sizes [M]
+  //   d_batch_gather       : unified gather LUT, length total_batch_chunks.
+  //                          Maps unified output position -> chunk-pool index.
+  //   d_batch_perm         : unified perm LUT, length total_batch_chunks.
+  //                          Maps unified output position -> permuted index in
+  //                          d_offsets/d_permuted_sizes (already LOD-shifted
+  //                          by +lv inside aggregate_batch_luts_unified).
+  //   total_batch_chunks   : M_total = sum_lv n_active[lv] * chunks_per_epoch[lv]
+  //   total_batch_covering : C_total = sum_lv n_active[lv] * covering_count[lv]
+  //   nlod                 : number of LODs
+  //   d_lod_last_idx       : [nlod] device array; entry lv = index in d_offsets
+  //                          where LOD lv's last sentinel offset should land
+  //                          (i.e. batch_covering_offset + n_active*covering + lv).
+  //                          Used by a small per-LOD write_total step.
+  //   max_comp_chunk_bytes : uniform pool stride
+  //   slot                 : unified aggregate_slot (d_aggregated sized to
+  //                          max_total_data_bytes; d_offsets/d_permuted_sizes
+  //                          sized to max_total_batch_covering + LOD_MAX_LEVELS;
+  //                          d_perm sized to max_total_batch_chunks).
+  //   d_shard_base_offsets : [total_shards] base byte offset in d_aggregated
+  //                          for each shard. Replaces uniform s*shard_capacity.
+  //   d_shard_capacity     : [total_shards] each shard's capacity in bytes
+  //                          (unused by gather_batch_k but kept for symmetry/asserts).
+  //   d_shard_tps_group    : [total_shards] chunks-per-shard within this batch.
+  //                          Replaces uniform tps_group.
+  //   d_shard_offsets_base : [total_shards] base index in d_offsets for each
+  //                          shard's run. Replaces uniform s*tps_group.
+  //   d_tail_bytes         : [total_shards] persistent per-shard tail-bytes
+  //                          carried from prior batch. Uploaded by host
+  //                          post-delivery.
+  //   d_tail_carry         : [total_shards * page_size] persistent tail bytes
+  //                          carry buffer. Uploaded post-delivery.
+  //   page_size            : uniform sink page size (one for all shards today).
+  //                          0 = no carry-over path.
+  //   total_shards         : sum_lv num_shards[lv]
+  //   stream               : compress stream
+  int aggregate_batch_unified_async(
+    const void* d_compressed,
+    size_t* d_comp_sizes,
+    const uint32_t* d_batch_gather,
+    const uint32_t* d_batch_perm,
+    uint64_t total_batch_chunks,
+    uint64_t total_batch_covering,
+    uint8_t nlod,
+    const uint64_t* d_lod_last_idx,
+    size_t max_comp_chunk_bytes,
+    struct aggregate_slot* slot,
+    const size_t* d_shard_base_offsets,
+    const size_t* d_shard_capacity,
+    const uint64_t* d_shard_tps_group,
+    const uint64_t* d_shard_offsets_base,
+    const size_t* d_tail_bytes,
+    CUdeviceptr d_tail_carry,
+    size_t page_size,
+    uint64_t total_shards,
+    CUstream stream);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -60,11 +60,16 @@ compress_agg_init(struct compress_agg_stage* stage,
   // Codec
   CHECK(Fail, codec_init(&stage->codec, config->codec.id, chunk_bytes, M) == 0);
 
-  // Per-LOD scratch for mask-scan results. Sized at LOD_MAX_LEVELS * K so the
-  // unified kick can carve a per-LOD slice without thrashing one buffer.
+  // Per-LOD scratch for mask-scan results, plus the previous-kick cache used
+  // for steady-state LUT-cache validation. Both are sized to
+  // LOD_MAX_LEVELS * K with stride K so each LOD's slice lives at a stable
+  // offset and the cache comparison can match by stride.
+  stage->pool_epochs_stride = K;
   stage->pool_epochs_scratch =
     (uint32_t*)malloc((size_t)LOD_MAX_LEVELS * K * sizeof(uint32_t));
-  CHECK(Fail, stage->pool_epochs_scratch);
+  stage->cached_pool_epochs =
+    (uint32_t*)malloc((size_t)LOD_MAX_LEVELS * K * sizeof(uint32_t));
+  CHECK(Fail, stage->pool_epochs_scratch && stage->cached_pool_epochs);
 
   CHECK_MUL_OVERFLOW(Fail, M, stage->codec.max_output_size, SIZE_MAX);
   // Compressed buffers + events. CODEC_NONE aggregates directly from pool_buf
@@ -118,7 +123,6 @@ compress_agg_init(struct compress_agg_stage* stage,
   //     entries each (one sentinel slot per LOD for the +lv shift in
   //     aggregate_batch_luts_unified). The CUB exclusive scan fills all
   //     sentinel positions, so no per-LOD write_total fixup is needed.
-  //   d_perm: max_total_batch_chunks
   if (stage->max_total_batch_chunks > 0) {
     // aggregate_batch_slot_init allocates (C+1) entries for d_offsets /
     // d_permuted_sizes / h_offsets and C entries for h_permuted_sizes. We
@@ -152,14 +156,6 @@ compress_agg_init(struct compress_agg_stage* stage,
     CHECK(Fail, stage->h_lut_gather_scratch && stage->h_lut_perm_scratch);
   }
 
-  // Per-LOD sentinel index buffer for write_total_unified_k.
-  CU(Fail,
-     cuMemAlloc((CUdeviceptr*)&stage->d_lod_last_idx,
-                LOD_MAX_LEVELS * sizeof(uint64_t)));
-  stage->h_lod_last_idx_scratch =
-    (uint64_t*)malloc(LOD_MAX_LEVELS * sizeof(uint64_t));
-  CHECK(Fail, stage->h_lod_last_idx_scratch);
-
   // Per-shard tables. total_shards = sum_lv num_shards[lv].
   {
     uint64_t total_shards = 0;
@@ -181,19 +177,16 @@ compress_agg_init(struct compress_agg_stage* stage,
         (uint64_t*)malloc(total_shards * sizeof(uint64_t));
       stage->shards.h_offsets_base =
         (uint64_t*)malloc(total_shards * sizeof(uint64_t));
-      stage->shards.h_shard_lod =
-        (uint8_t*)malloc(total_shards * sizeof(uint8_t));
       stage->shards.h_tail_bytes =
         (size_t*)calloc(total_shards, sizeof(size_t));
       CHECK(Fail,
             stage->shards.h_base_offsets && stage->shards.h_shard_capacity &&
               stage->shards.h_tps_group && stage->shards.h_offsets_base &&
-              stage->shards.h_shard_lod && stage->shards.h_tail_bytes);
+              stage->shards.h_tail_bytes);
       for (uint64_t i = 0; i < total_shards; ++i) {
         for (int lv = 0; lv < cl->levels.nlod; ++lv) {
           if (i >= stage->shards.shards_begin[lv] &&
               i < stage->shards.shards_begin[lv] + stage->shards.n_shards[lv]) {
-            stage->shards.h_shard_lod[i] = (uint8_t)lv;
             stage->shards.h_shard_capacity[i] =
               cl->per_level[lv].agg_layout.shard_capacity;
             break;
@@ -272,7 +265,9 @@ compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
     return;
   codec_free(&stage->codec);
   free(stage->pool_epochs_scratch);
+  free(stage->cached_pool_epochs);
   stage->pool_epochs_scratch = NULL;
+  stage->cached_pool_epochs = NULL;
   for (int fc = 0; fc < 2; ++fc) {
     cu_mem_free(stage->d_compressed[fc]);
     cu_event_destroy(stage->t_compress_start[fc]);
@@ -291,13 +286,10 @@ compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
     aggregate_slot_destroy(&stage->agg[fc]);
   cu_mem_free(stage->d_batch_gather);
   cu_mem_free(stage->d_batch_perm);
-  cu_mem_free((CUdeviceptr)stage->d_lod_last_idx);
   free(stage->h_lut_gather_scratch);
   free(stage->h_lut_perm_scratch);
-  free(stage->h_lod_last_idx_scratch);
   stage->h_lut_gather_scratch = NULL;
   stage->h_lut_perm_scratch = NULL;
-  stage->h_lod_last_idx_scratch = NULL;
   for (int lv = 0; lv < nlod; ++lv) {
     aggregate_layout_destroy(&stage->per_lod_agg_layouts[lv]);
     shard_state_destroy(&stage->shard[lv]);
@@ -306,7 +298,6 @@ compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
   free(stage->shards.h_shard_capacity);
   free(stage->shards.h_tps_group);
   free(stage->shards.h_offsets_base);
-  free(stage->shards.h_shard_lod);
   free(stage->shards.h_tail_bytes);
   cu_mem_free((CUdeviceptr)stage->shards.d_base_offsets);
   cu_mem_free((CUdeviceptr)stage->shards.d_shard_capacity);
@@ -349,9 +340,6 @@ build_and_upload_shard_tables(struct compress_agg_stage* stage,
       t->h_base_offsets[s] =
         seg->data_segment_offset + (size_t)si * al->shard_capacity;
     }
-    // Sentinel index for this LOD's tail offset slot.
-    stage->h_lod_last_idx_scratch[lv] =
-      lod_offsets_base + (uint64_t)seg->n_active * seg->covering_count;
   }
 
   CU(Error,
@@ -368,11 +356,6 @@ build_and_upload_shard_tables(struct compress_agg_stage* stage,
      cuMemcpyHtoDAsync((CUdeviceptr)t->d_offsets_base,
                        t->h_offsets_base,
                        t->total_shards * sizeof(uint64_t),
-                       stream));
-  CU(Error,
-     cuMemcpyHtoDAsync((CUdeviceptr)stage->d_lod_last_idx,
-                       stage->h_lod_last_idx_scratch,
-                       (size_t)layout->nlod * sizeof(uint64_t),
                        stream));
 
   return 0;
@@ -398,10 +381,13 @@ compress_agg_kick(struct compress_agg_stage* stage,
 
   // --- Phase 1: mask scan (LOD-aware ends here) ----------------------------
   // Per-LOD pool_epochs slices from the [LOD_MAX_LEVELS * K] scratch.
+  // Stride is the configured K (pool_epochs_stride), so the cache (same
+  // layout) can compare each LOD's slice at a stable offset.
+  const uint32_t stride = stage->pool_epochs_stride;
   uint32_t per_lod_n_active[LOD_MAX_LEVELS] = { 0 };
   const uint32_t* per_lod_pool_epochs[LOD_MAX_LEVELS] = { 0 };
   for (uint8_t lv = 0; lv < nlod; ++lv) {
-    uint32_t* dst = stage->pool_epochs_scratch + (size_t)lv * n_epochs;
+    uint32_t* dst = stage->pool_epochs_scratch + (size_t)lv * stride;
     uint32_t k = 0;
     for (uint32_t e = 0; e < n_epochs; ++e)
       if (in->batch_active_masks[e] & (1u << lv))
@@ -427,11 +413,24 @@ compress_agg_kick(struct compress_agg_stage* stage,
         layout.total_batch_covering <= stage->max_total_batch_covering);
 
   // --- Phase 3: build & upload unified LUTs (cached in steady state) -------
-  const int lut_steady =
-    stage->lut_cache_valid &&
-    memcmp(stage->cached_per_lod_n_active,
-           per_lod_n_active,
-           (size_t)nlod * sizeof(uint32_t)) == 0;
+  // Cache key: per-LOD active count AND each LOD's pool_epoch values. Counts
+  // alone are insufficient — the gather LUT encodes the actual epoch indices,
+  // so two batches with identical counts but different active-epoch positions
+  // (mid-stream phase shifts when K doesn't divide an LOD's append period)
+  // would mis-hit and reuse stale gather indices. See [[ok-let-s-make-a-curious-prism]].
+  int lut_steady = stage->lut_cache_valid &&
+                   memcmp(stage->cached_per_lod_n_active,
+                          per_lod_n_active,
+                          (size_t)nlod * sizeof(uint32_t)) == 0;
+  for (uint8_t lv = 0; lut_steady && lv < nlod; ++lv) {
+    const uint32_t n_lv = per_lod_n_active[lv];
+    if (n_lv == 0)
+      continue;
+    if (memcmp(stage->cached_pool_epochs + (size_t)lv * stride,
+               per_lod_pool_epochs[lv],
+               (size_t)n_lv * sizeof(uint32_t)) != 0)
+      lut_steady = 0;
+  }
   if (lut_steady) {
     stage->lut_steady_count++;
   } else {
@@ -457,6 +456,13 @@ compress_agg_kick(struct compress_agg_stage* stage,
     memcpy(stage->cached_per_lod_n_active,
            per_lod_n_active,
            (size_t)nlod * sizeof(uint32_t));
+    for (uint8_t lv = 0; lv < nlod; ++lv) {
+      const uint32_t n_lv = per_lod_n_active[lv];
+      if (n_lv > 0)
+        memcpy(stage->cached_pool_epochs + (size_t)lv * stride,
+               per_lod_pool_epochs[lv],
+               (size_t)n_lv * sizeof(uint32_t));
+    }
     stage->lut_cache_valid = 1;
   }
 
@@ -509,7 +515,6 @@ compress_agg_kick(struct compress_agg_stage* stage,
             layout.total_batch_chunks,
             layout.total_batch_covering,
             nlod,
-            stage->d_lod_last_idx,
             stage->codec.max_output_size,
             &stage->agg[fc],
             stage->shards.d_base_offsets,

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -40,26 +40,6 @@ Error:
 
 // --- Init / Destroy ---
 
-// Mirrors the old init_compression + init_aggregate_and_shards +
-// init_batch_luts from stream_init.c, but scoped to this stage.
-
-static void
-destroy_level_state(struct level_flush_state* lls)
-{
-  aggregate_layout_destroy(&lls->agg_layout);
-  for (int i = 0; i < 2; ++i)
-    aggregate_slot_destroy(&lls->agg[i]);
-  cu_mem_free(lls->d_batch_gather);
-  cu_mem_free(lls->d_batch_perm);
-  cu_mem_free(lls->d_tail_carry);
-  cu_mem_free((CUdeviceptr)lls->d_tail_bytes);
-  lls->d_tail_bytes = NULL;
-  free(lls->h_tail_bytes);
-  lls->h_tail_bytes = NULL;
-  free(lls->steady_pool_epochs);
-  lls->steady_pool_epochs = NULL;
-  shard_state_destroy(&lls->shard);
-}
 
 int
 compress_agg_init(struct compress_agg_stage* stage,
@@ -80,8 +60,10 @@ compress_agg_init(struct compress_agg_stage* stage,
   // Codec
   CHECK(Fail, codec_init(&stage->codec, config->codec.id, chunk_bytes, M) == 0);
 
-  // Per-level scratch for mask-scan results. Sized at K (max active_count).
-  stage->pool_epochs_scratch = (uint32_t*)malloc((size_t)K * sizeof(uint32_t));
+  // Per-LOD scratch for mask-scan results. Sized at LOD_MAX_LEVELS * K so the
+  // unified kick can carve a per-LOD slice without thrashing one buffer.
+  stage->pool_epochs_scratch =
+    (uint32_t*)malloc((size_t)LOD_MAX_LEVELS * K * sizeof(uint32_t));
   CHECK(Fail, stage->pool_epochs_scratch);
 
   CHECK_MUL_OVERFLOW(Fail, M, stage->codec.max_output_size, SIZE_MAX);
@@ -99,110 +81,175 @@ compress_agg_init(struct compress_agg_stage* stage,
     CU(Fail, cuEventCreate(&stage->t_aggregate_end[fc], CU_EVENT_DEFAULT));
   }
 
-  // Per-level aggregate + shard + LUTs
+  // --- Unified across-LODs aggregate state ---------------------------------
+  // Mirrors the CPU pipeline (src/cpu/pipeline.c + src/cpu/aggregate.c).
+
+  stage->nlod = (uint8_t)cl->levels.nlod;
+
+  // Per-LOD aggregate_layouts: own copy so multiarray bind/unbind can swap
+  // them per-array. Each layout's GPU-side d_lifted_shape/strides are uploaded.
   for (int lv = 0; lv < cl->levels.nlod; ++lv) {
-    const struct level_layout_info* li = &cl->per_level[lv];
+    stage->per_lod_agg_layouts[lv] = cl->per_level[lv].agg_layout;
+    CHECK(Fail,
+          aggregate_layout_upload(&stage->per_lod_agg_layouts[lv]) == 0);
+  }
 
-    stage->levels[lv].agg_layout = li->agg_layout;
-    CHECK(Fail, aggregate_layout_upload(&stage->levels[lv].agg_layout) == 0);
+  // Cached max batch layout assuming each LOD fires its worst-case active count.
+  {
+    uint32_t per_lod_max[LOD_MAX_LEVELS] = { 0 };
+    for (int lv = 0; lv < cl->levels.nlod; ++lv)
+      per_lod_max[lv] = cl->per_level[lv].batch_active_count;
+    const size_t page_size = cl->per_level[0].agg_layout.page_size;
+    CHECK(Fail,
+          batch_aggregate_layout_init(&stage->max_batch_layout,
+                                      stage->per_lod_agg_layouts,
+                                      per_lod_max,
+                                      stage->nlod,
+                                      page_size) == 0);
+    stage->max_total_batch_chunks = stage->max_batch_layout.total_batch_chunks;
+    stage->max_total_batch_covering =
+      stage->max_batch_layout.total_batch_covering;
+    stage->max_total_data_bytes = stage->max_batch_layout.total_data_bytes;
+  }
 
-    stage->levels[lv].batch_active_count = li->batch_active_count;
-
-    uint32_t slot_count =
-      li->batch_active_count > 0 ? li->batch_active_count : 1;
-    uint64_t chunks_lv = cl->levels.level[lv].chunk_count;
-    uint64_t batch_chunks = (uint64_t)slot_count * chunks_lv;
-    uint64_t batch_covering =
-      (uint64_t)slot_count * li->agg_layout.covering_count;
-    size_t batch_agg_bytes = agg_pool_bytes_layout(&li->agg_layout);
-
-    const uint64_t num_shards = li->agg_layout.num_shards;
-
-    for (int i = 0; i < 2; ++i) {
+  // Unified aggregate slot per fc. Sized for the max-batch case:
+  //   d_aggregated: max_total_data_bytes (page-aligned across LOD segments)
+  //   d_offsets/d_permuted_sizes/h_*: max_total_batch_covering + nlod
+  //     entries each (one sentinel slot per LOD for the +lv shift in
+  //     aggregate_batch_luts_unified). The CUB exclusive scan fills all
+  //     sentinel positions, so no per-LOD write_total fixup is needed.
+  //   d_perm: max_total_batch_chunks
+  if (stage->max_total_batch_chunks > 0) {
+    // aggregate_batch_slot_init allocates (C+1) entries for d_offsets /
+    // d_permuted_sizes / h_offsets and C entries for h_permuted_sizes. We
+    // want all to fit total_batch_covering + nlod entries, so pass
+    // C = max_total_batch_covering + nlod (h_permuted_sizes ends up exactly
+    // matching the scan output length).
+    const uint64_t C_max =
+      stage->max_total_batch_covering + (uint64_t)stage->nlod;
+    for (int fc = 0; fc < 2; ++fc) {
       CHECK(Fail,
-            aggregate_batch_slot_init(&stage->levels[lv].agg[i],
-                                      batch_chunks,
-                                      batch_covering,
-                                      batch_agg_bytes) == 0);
-      CU(Fail, cuEventRecord(stage->levels[lv].agg[i].ready, compute));
+            aggregate_batch_slot_init(&stage->agg[fc],
+                                      stage->max_total_batch_chunks,
+                                      C_max,
+                                      stage->max_total_data_bytes) == 0);
+      CU(Fail, cuEventRecord(stage->agg[fc].ready, compute));
     }
-
-    // Per-LOD persistent tail-carry state (GPU-resident).
-    if (num_shards > 0 && li->agg_layout.page_size > 0) {
-      const size_t carry_bytes = num_shards * li->agg_layout.page_size;
-      CU(Fail, cuMemAlloc(&stage->levels[lv].d_tail_carry, carry_bytes));
-      CU(Fail, cuMemsetD8(stage->levels[lv].d_tail_carry, 0, carry_bytes));
-      CU(Fail,
-         cuMemAlloc((CUdeviceptr*)&stage->levels[lv].d_tail_bytes,
-                    num_shards * sizeof(size_t)));
-      CU(Fail,
-         cuMemsetD8((CUdeviceptr)stage->levels[lv].d_tail_bytes,
-                    0,
-                    num_shards * sizeof(size_t)));
-      stage->levels[lv].h_tail_bytes =
-        (size_t*)calloc(num_shards, sizeof(size_t));
-      CHECK(Fail, stage->levels[lv].h_tail_bytes);
-    }
-
-    CHECK(Fail, init_shard_state(&stage->levels[lv].shard, li) == 0);
   }
 
-  // Batch LUTs (gather + perm, epoch-major shard order).
-  for (int lv = 0; lv < cl->levels.nlod; ++lv) {
-    struct level_flush_state* lvl = &stage->levels[lv];
-    uint32_t batch_count = lvl->batch_active_count;
-    uint32_t slot_count = batch_count > 0 ? batch_count : 1;
-    uint64_t chunks_lv = cl->levels.level[lv].chunk_count;
-    uint64_t lut_len = (uint64_t)slot_count * chunks_lv;
+  // Unified LUT buffers + host scratch.
+  if (stage->max_total_batch_chunks > 0) {
+    CU(Fail,
+       cuMemAlloc(&stage->d_batch_gather,
+                  stage->max_total_batch_chunks * sizeof(uint32_t)));
+    CU(Fail,
+       cuMemAlloc(&stage->d_batch_perm,
+                  stage->max_total_batch_chunks * sizeof(uint32_t)));
+    stage->h_lut_gather_scratch =
+      (uint32_t*)malloc(stage->max_total_batch_chunks * sizeof(uint32_t));
+    stage->h_lut_perm_scratch =
+      (uint32_t*)malloc(stage->max_total_batch_chunks * sizeof(uint32_t));
+    CHECK(Fail, stage->h_lut_gather_scratch && stage->h_lut_perm_scratch);
+  }
 
-    if (lut_len == 0)
-      continue;
+  // Per-LOD sentinel index buffer for write_total_unified_k.
+  CU(Fail,
+     cuMemAlloc((CUdeviceptr*)&stage->d_lod_last_idx,
+                LOD_MAX_LEVELS * sizeof(uint64_t)));
+  stage->h_lod_last_idx_scratch =
+    (uint64_t*)malloc(LOD_MAX_LEVELS * sizeof(uint64_t));
+  CHECK(Fail, stage->h_lod_last_idx_scratch);
 
-    uint32_t* h_gather = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
-    uint32_t* h_perm = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
-    CHECK(Fail, h_gather && h_perm);
+  // Per-shard tables. total_shards = sum_lv num_shards[lv].
+  {
+    uint64_t total_shards = 0;
+    for (int lv = 0; lv < cl->levels.nlod; ++lv) {
+      stage->shards.shards_begin[lv] = (uint32_t)total_shards;
+      stage->shards.n_shards[lv] =
+        (uint32_t)cl->per_level[lv].agg_layout.num_shards;
+      total_shards += cl->per_level[lv].agg_layout.num_shards;
+    }
+    stage->shards.total_shards = total_shards;
+    stage->shards.page_size = cl->per_level[0].agg_layout.page_size;
 
-    {
-      uint32_t* pool_epochs = stage->pool_epochs_scratch;
-      for (uint32_t a = 0; a < slot_count; ++a) {
-        uint32_t period = 1;
-        if (cl->dims.append_downsample && lv > 0)
-          period = 1u << lv;
-        pool_epochs[a] = (a + 1) * period - 1;
+    if (total_shards > 0) {
+      stage->shards.h_base_offsets =
+        (size_t*)malloc(total_shards * sizeof(size_t));
+      stage->shards.h_shard_capacity =
+        (size_t*)malloc(total_shards * sizeof(size_t));
+      stage->shards.h_tps_group =
+        (uint64_t*)malloc(total_shards * sizeof(uint64_t));
+      stage->shards.h_offsets_base =
+        (uint64_t*)malloc(total_shards * sizeof(uint64_t));
+      stage->shards.h_shard_lod =
+        (uint8_t*)malloc(total_shards * sizeof(uint8_t));
+      stage->shards.h_tail_bytes =
+        (size_t*)calloc(total_shards, sizeof(size_t));
+      CHECK(Fail,
+            stage->shards.h_base_offsets && stage->shards.h_shard_capacity &&
+              stage->shards.h_tps_group && stage->shards.h_offsets_base &&
+              stage->shards.h_shard_lod && stage->shards.h_tail_bytes);
+      for (uint64_t i = 0; i < total_shards; ++i) {
+        for (int lv = 0; lv < cl->levels.nlod; ++lv) {
+          if (i >= stage->shards.shards_begin[lv] &&
+              i < stage->shards.shards_begin[lv] + stage->shards.n_shards[lv]) {
+            stage->shards.h_shard_lod[i] = (uint8_t)lv;
+            stage->shards.h_shard_capacity[i] =
+              cl->per_level[lv].agg_layout.shard_capacity;
+            break;
+          }
+        }
       }
-      aggregate_batch_luts(&lvl->agg_layout,
-                           &cl->levels,
-                           lv,
-                           slot_count,
-                           pool_epochs,
-                           h_gather,
-                           h_perm);
 
-      // Snapshot the steady-state pool epoch pattern for the kick fast path.
-      lvl->steady_pool_epochs =
-        (uint32_t*)malloc((size_t)slot_count * sizeof(uint32_t));
-      CHECK(LutFail, lvl->steady_pool_epochs);
-      memcpy(lvl->steady_pool_epochs,
-             pool_epochs,
-             (size_t)slot_count * sizeof(uint32_t));
+      CU(Fail,
+         cuMemAlloc((CUdeviceptr*)&stage->shards.d_base_offsets,
+                    total_shards * sizeof(size_t)));
+      CU(Fail,
+         cuMemAlloc((CUdeviceptr*)&stage->shards.d_shard_capacity,
+                    total_shards * sizeof(size_t)));
+      CU(Fail,
+         cuMemAlloc((CUdeviceptr*)&stage->shards.d_tps_group,
+                    total_shards * sizeof(uint64_t)));
+      CU(Fail,
+         cuMemAlloc((CUdeviceptr*)&stage->shards.d_offsets_base,
+                    total_shards * sizeof(uint64_t)));
+      CU(Fail,
+         cuMemAlloc((CUdeviceptr*)&stage->shards.d_tail_bytes,
+                    total_shards * sizeof(size_t)));
+      CU(Fail,
+         cuMemsetD8((CUdeviceptr)stage->shards.d_tail_bytes,
+                    0,
+                    total_shards * sizeof(size_t)));
+
+      // d_shard_capacity stays constant across batches in steady state; upload
+      // it once now. d_base_offsets / d_tps_group / d_offsets_base depend on
+      // per-batch active counts and are uploaded by the kick.
+      CU(Fail,
+         cuMemcpyHtoD((CUdeviceptr)stage->shards.d_shard_capacity,
+                      stage->shards.h_shard_capacity,
+                      total_shards * sizeof(size_t)));
+
+      // Tail-carry buffer: total_shards * page_size bytes; uniform layout
+      // across LODs (sink page size is uniform).
+      if (stage->shards.page_size > 0) {
+        stage->shards.tail_carry_bytes =
+          total_shards * stage->shards.page_size;
+        CU(Fail,
+           cuMemAlloc(&stage->shards.d_tail_carry,
+                      stage->shards.tail_carry_bytes));
+        CU(Fail,
+           cuMemsetD8(stage->shards.d_tail_carry,
+                      0,
+                      stage->shards.tail_carry_bytes));
+      }
     }
-
-    CU(LutFail, cuMemAlloc(&lvl->d_batch_gather, lut_len * sizeof(uint32_t)));
-    CU(LutFail,
-       cuMemcpyHtoD(lvl->d_batch_gather, h_gather, lut_len * sizeof(uint32_t)));
-    CU(LutFail, cuMemAlloc(&lvl->d_batch_perm, lut_len * sizeof(uint32_t)));
-    CU(LutFail,
-       cuMemcpyHtoD(lvl->d_batch_perm, h_perm, lut_len * sizeof(uint32_t)));
-
-    free(h_gather);
-    free(h_perm);
-    continue;
-
-  LutFail:
-    free(h_gather);
-    free(h_perm);
-    goto Fail;
   }
+
+  // Per-LOD shard_state (writers + tail/footer pools + generation
+  // bookkeeping). The unified kick/D2H path iterates this directly.
+  for (int lv = 0; lv < cl->levels.nlod; ++lv)
+    CHECK(Fail,
+          init_shard_state(&stage->shard[lv], &cl->per_level[lv]) == 0);
 
   // Seed events
   for (int fc = 0; fc < 2; ++fc) {
@@ -232,22 +279,107 @@ compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
     cu_event_destroy(stage->t_compress_end[fc]);
     cu_event_destroy(stage->t_aggregate_end[fc]);
   }
-  for (int lv = 0; lv < nlod; ++lv) {
-    const struct level_flush_state* lls = &stage->levels[lv];
-    const uint64_t total = lls->lut_steady_count + lls->lut_recompute_count;
-    if (total > 0) {
-      log_debug("compress_agg lv=%d lut_steady=%llu lut_recompute=%llu "
-                "(steady=%.1f%%)",
-                lv,
-                (unsigned long long)lls->lut_steady_count,
-                (unsigned long long)lls->lut_recompute_count,
-                100.0 * (double)lls->lut_steady_count / (double)total);
-    }
-    destroy_level_state(&stage->levels[lv]);
+  if (stage->lut_steady_count + stage->lut_recompute_count > 0) {
+    const uint64_t tot = stage->lut_steady_count + stage->lut_recompute_count;
+    log_debug("compress_agg unified lut_steady=%llu lut_recompute=%llu "
+              "(steady=%.1f%%)",
+              (unsigned long long)stage->lut_steady_count,
+              (unsigned long long)stage->lut_recompute_count,
+              100.0 * (double)stage->lut_steady_count / (double)tot);
   }
+  for (int fc = 0; fc < 2; ++fc)
+    aggregate_slot_destroy(&stage->agg[fc]);
+  cu_mem_free(stage->d_batch_gather);
+  cu_mem_free(stage->d_batch_perm);
+  cu_mem_free((CUdeviceptr)stage->d_lod_last_idx);
+  free(stage->h_lut_gather_scratch);
+  free(stage->h_lut_perm_scratch);
+  free(stage->h_lod_last_idx_scratch);
+  stage->h_lut_gather_scratch = NULL;
+  stage->h_lut_perm_scratch = NULL;
+  stage->h_lod_last_idx_scratch = NULL;
+  for (int lv = 0; lv < nlod; ++lv) {
+    aggregate_layout_destroy(&stage->per_lod_agg_layouts[lv]);
+    shard_state_destroy(&stage->shard[lv]);
+  }
+  free(stage->shards.h_base_offsets);
+  free(stage->shards.h_shard_capacity);
+  free(stage->shards.h_tps_group);
+  free(stage->shards.h_offsets_base);
+  free(stage->shards.h_shard_lod);
+  free(stage->shards.h_tail_bytes);
+  cu_mem_free((CUdeviceptr)stage->shards.d_base_offsets);
+  cu_mem_free((CUdeviceptr)stage->shards.d_shard_capacity);
+  cu_mem_free((CUdeviceptr)stage->shards.d_tps_group);
+  cu_mem_free((CUdeviceptr)stage->shards.d_offsets_base);
+  cu_mem_free((CUdeviceptr)stage->shards.d_tail_bytes);
+  cu_mem_free(stage->shards.d_tail_carry);
+  memset(&stage->shards, 0, sizeof(stage->shards));
 }
 
 // --- Kick ---
+
+// Build per-shard tables for this batch's `layout`. Populates host shadows
+// and uploads to device on `stream`. tables.h_shard_capacity is constant and
+// uploaded at init; not re-uploaded here.
+static int
+build_and_upload_shard_tables(struct compress_agg_stage* stage,
+                              const struct batch_aggregate_layout* layout,
+                              CUstream stream)
+{
+  struct shard_tables* t = &stage->shards;
+  if (t->total_shards == 0)
+    return 0;
+
+  for (uint8_t lv = 0; lv < layout->nlod; ++lv) {
+    const struct lod_segment* seg = &layout->lods[lv];
+    const struct aggregate_layout* al = &stage->per_lod_agg_layouts[lv];
+    const uint32_t begin = t->shards_begin[lv];
+    const uint32_t n = t->n_shards[lv];
+    const uint64_t cps_inner = al->cps_inner;
+    const uint64_t tps_group_lv = (uint64_t)seg->n_active * cps_inner;
+    // Each LOD's offsets range starts at seg->batch_covering_offset + lv
+    // (the +lv is the per-LOD shift built into aggregate_batch_luts_unified).
+    const uint64_t lod_offsets_base = seg->batch_covering_offset + (uint64_t)lv;
+
+    for (uint32_t si = 0; si < n; ++si) {
+      const uint32_t s = begin + si;
+      t->h_offsets_base[s] = lod_offsets_base + (uint64_t)si * tps_group_lv;
+      t->h_tps_group[s] = tps_group_lv;
+      t->h_base_offsets[s] =
+        seg->data_segment_offset + (size_t)si * al->shard_capacity;
+    }
+    // Sentinel index for this LOD's tail offset slot.
+    stage->h_lod_last_idx_scratch[lv] =
+      lod_offsets_base + (uint64_t)seg->n_active * seg->covering_count;
+  }
+
+  CU(Error,
+     cuMemcpyHtoDAsync((CUdeviceptr)t->d_base_offsets,
+                       t->h_base_offsets,
+                       t->total_shards * sizeof(size_t),
+                       stream));
+  CU(Error,
+     cuMemcpyHtoDAsync((CUdeviceptr)t->d_tps_group,
+                       t->h_tps_group,
+                       t->total_shards * sizeof(uint64_t),
+                       stream));
+  CU(Error,
+     cuMemcpyHtoDAsync((CUdeviceptr)t->d_offsets_base,
+                       t->h_offsets_base,
+                       t->total_shards * sizeof(uint64_t),
+                       stream));
+  CU(Error,
+     cuMemcpyHtoDAsync((CUdeviceptr)stage->d_lod_last_idx,
+                       stage->h_lod_last_idx_scratch,
+                       (size_t)layout->nlod * sizeof(uint64_t),
+                       stream));
+
+  return 0;
+
+Error:
+  return 1;
+}
 
 int
 compress_agg_kick(struct compress_agg_stage* stage,
@@ -262,10 +394,80 @@ compress_agg_kick(struct compress_agg_stage* stage,
   (void)dims;
   const int fc = in->fc;
   const uint32_t n_epochs = in->n_epochs;
+  const uint8_t nlod = stage->nlod;
 
-  // Pool work is submitted on the compute stream in order; a single batch-level
-  // pool_ready event recorded after the last scatter subsumes all prior ready
-  // signals.
+  // --- Phase 1: mask scan (LOD-aware ends here) ----------------------------
+  // Per-LOD pool_epochs slices from the [LOD_MAX_LEVELS * K] scratch.
+  uint32_t per_lod_n_active[LOD_MAX_LEVELS] = { 0 };
+  const uint32_t* per_lod_pool_epochs[LOD_MAX_LEVELS] = { 0 };
+  for (uint8_t lv = 0; lv < nlod; ++lv) {
+    uint32_t* dst = stage->pool_epochs_scratch + (size_t)lv * n_epochs;
+    uint32_t k = 0;
+    for (uint32_t e = 0; e < n_epochs; ++e)
+      if (in->batch_active_masks[e] & (1u << lv))
+        dst[k++] = e;
+    per_lod_n_active[lv] = k;
+    per_lod_pool_epochs[lv] = dst;
+  }
+
+  // --- Phase 2: build the per-kick unified batch layout --------------------
+  // Page size is uniform across LODs (sink-driven); read from LOD 0.
+  struct batch_aggregate_layout layout;
+  const size_t page_size = stage->per_lod_agg_layouts[0].page_size;
+  CHECK(Error,
+        batch_aggregate_layout_init(&layout,
+                                    stage->per_lod_agg_layouts,
+                                    per_lod_n_active,
+                                    nlod,
+                                    page_size) == 0);
+
+  CHECK(Error, layout.total_data_bytes <= stage->max_total_data_bytes);
+  CHECK(Error, layout.total_batch_chunks <= stage->max_total_batch_chunks);
+  CHECK(Error,
+        layout.total_batch_covering <= stage->max_total_batch_covering);
+
+  // --- Phase 3: build & upload unified LUTs (cached in steady state) -------
+  const int lut_steady =
+    stage->lut_cache_valid &&
+    memcmp(stage->cached_per_lod_n_active,
+           per_lod_n_active,
+           (size_t)nlod * sizeof(uint32_t)) == 0;
+  if (lut_steady) {
+    stage->lut_steady_count++;
+  } else {
+    stage->lut_recompute_count++;
+    if (layout.total_batch_chunks > 0) {
+      aggregate_batch_luts_unified(&layout,
+                                   stage->per_lod_agg_layouts,
+                                   levels,
+                                   per_lod_pool_epochs,
+                                   stage->h_lut_gather_scratch,
+                                   stage->h_lut_perm_scratch);
+      CU(Error,
+         cuMemcpyHtoDAsync(stage->d_batch_gather,
+                           stage->h_lut_gather_scratch,
+                           layout.total_batch_chunks * sizeof(uint32_t),
+                           compress_stream));
+      CU(Error,
+         cuMemcpyHtoDAsync(stage->d_batch_perm,
+                           stage->h_lut_perm_scratch,
+                           layout.total_batch_chunks * sizeof(uint32_t),
+                           compress_stream));
+    }
+    memcpy(stage->cached_per_lod_n_active,
+           per_lod_n_active,
+           (size_t)nlod * sizeof(uint32_t));
+    stage->lut_cache_valid = 1;
+  }
+
+  // --- Phase 4: per-shard tables ------------------------------------------
+  // Always rebuild + upload; the runtime cost is small (≤ a few KB) and the
+  // values depend on per_lod_n_active which can shift mid-stream. We do it
+  // unconditionally so any layout drift is reflected immediately.
+  CHECK(Error,
+        build_and_upload_shard_tables(stage, &layout, compress_stream) == 0);
+
+  // --- Phase 5: synchronization ------------------------------------------
   CU(Error, cuStreamWaitEvent(compress_stream, in->pool_ready, 0));
   if (in->lod_done)
     CU(Error, cuStreamWaitEvent(compress_stream, in->lod_done, 0));
@@ -276,8 +478,7 @@ compress_agg_kick(struct compress_agg_stage* stage,
   if (in->prev_d2h_done)
     CU(Error, cuStreamWaitEvent(compress_stream, in->prev_d2h_done, 0));
 
-  // CODEC_NONE: aggregate reads the chunk pool directly (gather strides match)
-  // so codec_compress would just DtoD the pool to d_compressed for nothing.
+  // --- Phase 6: compress --------------------------------------------------
   const int skip_compress = (stage->codec.type == CODEC_NONE);
   const CUdeviceptr d_aggregate_src =
     skip_compress ? in->pool_buf : stage->d_compressed[fc];
@@ -297,126 +498,52 @@ compress_agg_kick(struct compress_agg_stage* stage,
                         compress_stream) == 0);
   }
 
-  // Zero per-level active counts; populated below and copied into handoff so
-  // d2h delivery doesn't need to re-scan masks (the slot's masks buffer can
-  // be reset by a pool swap before delivery runs).
-  uint32_t active_counts[LOD_MAX_LEVELS] = { 0 };
-
-  // Per-level batch aggregate on compress stream.
-  // Always use the batch aggregate path (LUT-based) and derive pool positions
-  // from per-epoch masks (the steady-state pattern shifts when K doesn't
-  // divide the level period, so a pre-computed LUT is not always valid).
-  for (int lv = 0; lv < levels->nlod; ++lv) {
-    if (!(in->active_levels_mask & (1u << lv)))
-      continue;
-
-    struct level_flush_state* lvl = &stage->levels[lv];
-
-    uint32_t* pool_epochs_buf = stage->pool_epochs_scratch;
-    uint32_t active_count = 0;
-    for (uint32_t e = 0; e < n_epochs; ++e)
-      if (in->batch_active_masks[e] & (1u << lv))
-        pool_epochs_buf[active_count++] = e;
-    if (active_count == 0)
-      continue;
-    active_counts[lv] = active_count;
-
-    struct aggregate_slot* agg = &lvl->agg[fc];
-    uint64_t chunks_lv = levels->level[lv].chunk_count;
-    uint64_t batch_chunk_count = (uint64_t)active_count * chunks_lv;
-    uint64_t batch_covering =
-      (uint64_t)active_count * lvl->agg_layout.covering_count;
-
-    // LUT buffers are sized for max(batch_active_count, 1) * chunks_lv.
-    uint32_t lut_cap =
-      lvl->batch_active_count > 0 ? lvl->batch_active_count : 1;
-    CHECK(Error, active_count <= lut_cap);
-
-    // Fast path: when this batch's pool epochs match the init-time steady
-    // pattern, the cached LUTs (uploaded once at init) are still correct and
-    // we can skip the per-kick rebuild + 2 H2Ds. This is the common case for
-    // single-array streams and for multiscale steady state where K divides
-    // the level period.
-    const int lut_steady = lvl->steady_pool_epochs &&
-                           active_count == lvl->batch_active_count &&
-                           memcmp(pool_epochs_buf,
-                                  lvl->steady_pool_epochs,
-                                  (size_t)active_count * sizeof(uint32_t)) == 0;
-    if (lut_steady)
-      lvl->lut_steady_count++;
-    else
-      lvl->lut_recompute_count++;
-
-    if (!lut_steady) {
-      uint64_t lut_len = batch_chunk_count;
-      uint32_t* h_gather = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
-      uint32_t* h_perm = (uint32_t*)malloc(lut_len * sizeof(uint32_t));
-      CHECK(LutRecompute, h_gather && h_perm);
-
-      aggregate_batch_luts(&lvl->agg_layout,
-                           levels,
-                           lv,
-                           active_count,
-                           pool_epochs_buf,
-                           h_gather,
-                           h_perm);
-
-      CU(LutRecompute,
-         cuMemcpyHtoDAsync(lvl->d_batch_gather,
-                           h_gather,
-                           lut_len * sizeof(uint32_t),
-                           compress_stream));
-      CU(LutRecompute,
-         cuMemcpyHtoDAsync(lvl->d_batch_perm,
-                           h_perm,
-                           lut_len * sizeof(uint32_t),
-                           compress_stream));
-
-      free(h_gather);
-      free(h_perm);
-      goto LutRecomputeDone;
-
-    LutRecompute:
-      free(h_gather);
-      free(h_perm);
-      goto Error;
-    LutRecomputeDone:;
-    }
-
+  // --- Phase 7: unified aggregate dispatch --------------------------------
+  if (layout.total_batch_chunks > 0) {
     CHECK(Error,
-          aggregate_batch_by_shard_async(
+          aggregate_batch_unified_async(
             (const void*)d_aggregate_src,
             stage->codec.d_comp_sizes,
-            (const uint32_t*)(uintptr_t)lvl->d_batch_gather,
-            (const uint32_t*)(uintptr_t)lvl->d_batch_perm,
-            batch_chunk_count,
-            batch_covering,
+            (const uint32_t*)(uintptr_t)stage->d_batch_gather,
+            (const uint32_t*)(uintptr_t)stage->d_batch_perm,
+            layout.total_batch_chunks,
+            layout.total_batch_covering,
+            nlod,
+            stage->d_lod_last_idx,
             stage->codec.max_output_size,
-            &lvl->agg_layout,
-            agg,
-            lvl->d_tail_bytes,
-            lvl->d_tail_carry,
+            &stage->agg[fc],
+            stage->shards.d_base_offsets,
+            stage->shards.d_shard_capacity,
+            stage->shards.d_tps_group,
+            stage->shards.d_offsets_base,
+            stage->shards.d_tail_bytes,
+            stage->shards.d_tail_carry,
+            page_size,
+            stage->shards.total_shards,
             compress_stream) == 0);
   }
 
   CU(Error, cuEventRecord(stage->t_aggregate_end[fc], compress_stream));
 
-  // Fill handoff. active_counts is copied (not borrowed) so delivery can
-  // run after a pool swap has overwritten the slot's mask buffer.
+  // --- Phase 8: fill handoff ----------------------------------------------
   out->fc = fc;
   out->n_epochs = n_epochs;
   out->active_levels_mask = in->active_levels_mask;
   out->batch_active_masks = in->batch_active_masks;
+  out->nlod = nlod;
+  memcpy(out->per_lod_n_active,
+         per_lod_n_active,
+         (size_t)nlod * sizeof(uint32_t));
   out->t_aggregate_end = stage->t_aggregate_end[fc];
   out->t_compress_start = stage->t_compress_start[fc];
   out->t_compress_end = stage->t_compress_end[fc];
   out->max_output_size = stage->codec.max_output_size;
-
-  for (int lv = 0; lv < levels->nlod; ++lv) {
-    out->agg[lv] = &stage->levels[lv].agg[fc];
-    out->agg_layout[lv] = &stage->levels[lv].agg_layout;
-    out->active_counts[lv] = active_counts[lv];
-  }
+  out->agg = &stage->agg[fc];
+  out->layout = layout;
+  out->per_lod_agg_layouts = stage->per_lod_agg_layouts;
+  out->shards = &stage->shards;
+  for (uint8_t lv = 0; lv < nlod; ++lv)
+    out->shards_by_lod[lv] = &stage->shard[lv];
 
   return 0;
 

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -13,14 +13,10 @@
 
 int
 d2h_deliver_init(struct d2h_deliver_stage* stage,
-                 struct level_flush_state* levels,
-                 int nlod,
                  size_t shard_alignment,
                  CUstream compute)
 {
   memset(stage, 0, sizeof(*stage));
-  stage->levels = levels;
-  stage->nlod = nlod;
   stage->shard_alignment = shard_alignment;
 
   for (int fc = 0; fc < 2; ++fc) {
@@ -49,150 +45,41 @@ d2h_deliver_destroy(struct d2h_deliver_stage* stage)
     cu_event_destroy(stage->offsets_ready[fc]);
     cu_event_destroy(stage->ready[fc]);
   }
-  // levels is borrowed, not destroyed here
 }
 
 // --- Internal helpers ---
 
-// Wait for pending IO fences on aggregate slots before reuse.
-// Accumulates wall time into stage->metrics->io_fence_stall (if non-NULL).
+// Wait for any pending IO fence on the unified slot (across all LODs that
+// share it). Accumulates wall time into stage->metrics->io_fence_stall.
 static void
-wait_io_fences(const struct d2h_deliver_stage* stage,
-               int fc,
-               uint32_t level_mask,
-               struct shard_sink* sink)
+wait_io_fences(struct aggregate_slot* slot,
+               struct shard_sink* sink,
+               struct stream_metrics* metrics)
 {
   if (!sink->wait_fence)
     return;
   struct platform_clock clk = { 0 };
   platform_toc(&clk);
-  for (int lv = 0; lv < stage->nlod; ++lv) {
-    if (!(level_mask & (1u << lv)))
-      continue;
-    struct aggregate_slot* agg = &stage->levels[lv].agg[fc];
-    if (agg->io_done.seq > 0)
-      sink->wait_fence(sink, agg->io_done);
-  }
-  if (stage->metrics) {
+  if (slot->io_done.seq > 0)
+    sink->wait_fence(sink, slot->io_done);
+  if (metrics) {
     float ms = (float)(platform_toc(&clk) * 1000.0);
-    accumulate_metric_ms(&stage->metrics->io_fence_stall, ms, 0, 0);
+    accumulate_metric_ms(&metrics->io_fence_stall, ms, 0, 0);
   }
-}
-
-// Phase 1: D2H offsets only (non-blocking — no host sync).
-// Records offsets_ready[fc] when offsets are on the host.
-static int
-kick_offset_d2h(struct d2h_deliver_stage* stage,
-                const struct flush_handoff* handoff,
-                const struct level_geometry* levels,
-                const struct batch_state* batch,
-                const struct dim_info* dims,
-                CUstream d2h_stream)
-{
-  const int fc = handoff->fc;
-  const uint32_t level_mask = handoff->active_levels_mask;
-  (void)batch;
-  (void)dims;
-
-  for (int lv = 0; lv < levels->nlod; ++lv) {
-    if (!(level_mask & (1u << lv)))
-      continue;
-
-    struct level_flush_state* lvl = &stage->levels[lv];
-
-    uint32_t active_count = handoff->active_counts[lv];
-    if (active_count == 0)
-      continue;
-
-    struct aggregate_slot* agg = &lvl->agg[fc];
-    uint64_t covering = (uint64_t)active_count * lvl->agg_layout.covering_count;
-
-    CU(Error,
-       cuMemcpyDtoHAsync(agg->h_offsets,
-                         (CUdeviceptr)agg->d_offsets,
-                         (covering + 1) * sizeof(size_t),
-                         d2h_stream));
-    // Permuted per-chunk sizes are needed alongside offsets for delivery
-    // sizing and next-kick tail bookkeeping. Queue here so it lands together
-    // with offsets on the same d2h stream (was inline on the aggregate
-    // stream — that path is dead now).
-    CU(Error,
-       cuMemcpyDtoHAsync(agg->h_permuted_sizes,
-                         (CUdeviceptr)agg->d_permuted_sizes,
-                         covering * sizeof(size_t),
-                         d2h_stream));
-  }
-  CU(Error, cuEventRecord(stage->offsets_ready[fc], d2h_stream));
-
-  return 0;
-
-Error:
-  return 1;
-}
-
-// Phase 2: queue bulk D2H for each active level using the worst-case
-// (cap) size. Skips the offset sync so the host doesn't block waiting for
-// compress+aggregate to finish. For codec=none cap == actual. For
-// compressed codecs this wastes PCIe bandwidth up to (cap-actual) bytes
-// per level per batch, traded for keeping the main thread unblocked.
-// Delivery still uses the true bytes (from h_offsets, which lands via the
-// parallel offset D2H) to split the buffer into per-shard writes.
-static int
-queue_bulk_d2h(struct d2h_deliver_stage* stage,
-               const struct flush_handoff* handoff,
-               const struct level_geometry* levels,
-               const struct batch_state* batch,
-               const struct dim_info* dims,
-               CUstream d2h_stream)
-{
-  const int fc = handoff->fc;
-  const uint32_t level_mask = handoff->active_levels_mask;
-  (void)batch;
-  (void)dims;
-
-  for (int lv = 0; lv < levels->nlod; ++lv) {
-    if (!(level_mask & (1u << lv)))
-      continue;
-
-    struct level_flush_state* lvl = &stage->levels[lv];
-
-    uint32_t active_count = handoff->active_counts[lv];
-    if (active_count == 0)
-      continue;
-
-    struct aggregate_slot* agg = &lvl->agg[fc];
-
-    // Worst-case bytes across the aggregate buffer for this level/batch.
-    // Sized for shard-capacity reservations (one region per shard).
-    size_t cap = agg_pool_bytes_layout(&lvl->agg_layout);
-
-    CU(Error,
-       cuMemcpyDtoHAsync(
-         agg->h_aggregated, (CUdeviceptr)agg->d_aggregated, cap, d2h_stream));
-    CU(Error, cuEventRecord(agg->ready, d2h_stream));
-  }
-
-  CU(Error, cuEventRecord(stage->ready[fc], d2h_stream));
-
-  return 0;
-
-Error:
-  return 1;
 }
 
 static void
-record_flush_metrics(const struct d2h_deliver_stage* stage,
-                     const struct flush_handoff* handoff,
+record_flush_metrics(const struct flush_handoff* handoff,
                      const struct level_geometry* levels,
-                     const struct batch_state* batch,
                      const struct dim_info* dims,
                      const struct tile_stream_layout* layout,
                      const struct tile_stream_configuration* config,
                      const struct lod_state* lod,
                      const struct lod_shared_state* lod_shared,
-                     struct stream_metrics* metrics)
+                     struct stream_metrics* metrics,
+                     CUevent t_d2h_start,
+                     CUevent t_d2h_ready)
 {
-  (void)batch;
   const int fc = handoff->fc;
   const uint32_t n_epochs = handoff->n_epochs;
 
@@ -235,19 +122,14 @@ record_flush_metrics(const struct d2h_deliver_stage* stage,
     const size_t pool_bytes = (uint64_t)n_epochs * levels->total_chunks *
                               layout->chunk_stride * dtype_bpe(config->dtype);
 
-    // Compute actual aggregated bytes first (available after D2H sync).
+    // Aggregated bytes: sum of actual compressed chunk sizes across all LODs
+    // in this batch. h_permuted_sizes carries pre-bias per-chunk sizes (with
+    // a 0 sentinel slot inserted per LOD); summing those gives the real D2H
+    // payload regardless of the absolute/segment-relative offset semantics.
     size_t agg_bytes = 0;
-    for (int lv = 0; lv < levels->nlod; ++lv) {
-      if (!(handoff->active_levels_mask & (1u << lv)))
-        continue;
-      struct level_flush_state* lvl = &stage->levels[lv];
-      uint32_t active_count = handoff->active_counts[lv];
-      if (active_count == 0)
-        continue;
-      uint64_t batch_covering =
-        (uint64_t)active_count * lvl->agg_layout.covering_count;
-      agg_bytes += lvl->agg[fc].h_offsets[batch_covering];
-    }
+    const size_t n_perm = handoff->layout.total_batch_covering + handoff->nlod;
+    for (size_t i = 0; i < n_perm; ++i)
+      agg_bytes += handoff->agg->h_permuted_sizes[i];
 
     accumulate_metric_cu(&metrics->compress,
                          handoff->t_compress_start,
@@ -260,21 +142,37 @@ record_flush_metrics(const struct d2h_deliver_stage* stage,
                          agg_bytes,
                          agg_bytes);
     accumulate_metric_cu(&metrics->d2h,
-                         stage->t_d2h_start[fc],
-                         stage->ready[fc],
+                         t_d2h_start,
+                         t_d2h_ready,
                          agg_bytes,
                          agg_bytes);
   }
 }
 
-// Sync on ready[fc] (near-zero in steady state because kick queued the D2H
-// long ago), record metrics, deliver to sinks. No bulk D2H here — that was
-// queued in d2h_deliver_kick.
+// Build the per-LOD aggregate_result view into the unified host buffer for
+// delivery. The unified layout places each LOD's segment at
+// `data_segment_offset` within h_aggregated, and each LOD's
+// offsets/chunk_sizes start at `batch_covering_offset + lv`.
+static struct aggregate_result
+lod_view(const struct flush_handoff* handoff, uint8_t lv)
+{
+  const struct lod_segment* seg = &handoff->layout.lods[lv];
+  struct aggregate_slot* slot = handoff->agg;
+  struct aggregate_result ar = {
+    .data = (uint8_t*)slot->h_aggregated + seg->data_segment_offset,
+    .offsets = slot->h_offsets + seg->batch_covering_offset + lv,
+    .chunk_sizes =
+      slot->h_permuted_sizes + seg->batch_covering_offset + lv,
+  };
+  return ar;
+}
+
+// Sync on ready[fc] (near-zero in steady state), record metrics, deliver
+// to sinks.
 static struct writer_result
 sync_and_deliver(struct d2h_deliver_stage* stage,
                  const struct flush_handoff* handoff,
                  const struct level_geometry* levels,
-                 const struct batch_state* batch,
                  const struct dim_info* dims,
                  const struct tile_stream_layout* layout,
                  const struct tile_stream_configuration* config,
@@ -285,14 +183,10 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
 {
   const int fc = handoff->fc;
 
-  // Fail fast if async IO encountered an error.
   if (sink->has_error && sink->has_error(sink))
     goto Error;
 
   {
-    // Poll the D2H ready event with short sleeps instead of cuEventSynchronize.
-    // The driver wakes a blocked thread via OS scheduler; polling keeps the
-    // thread runnable and lets a follow-on thread-pool ingest pattern fit.
     struct platform_clock kick_clk = { 0 };
     platform_toc(&kick_clk);
     for (;;) {
@@ -300,9 +194,6 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
       if (r == CUDA_SUCCESS)
         break;
       if (r == CUDA_ERROR_DEINITIALIZED) {
-        // Context torn down (shutdown). Data is already on host for this
-        // poll site; treat as a clean exit. Logged so the swallow is
-        // observable if it ever happens outside teardown.
         log_debug("d2h_deliver: cuEventQuery returned DEINITIALIZED (fc=%d)",
                   fc);
         break;
@@ -311,76 +202,98 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
         handle_curesult(LOG_ERROR, r, __FILE__, __LINE__, "cuEventQuery");
         goto Error;
       }
-      platform_sleep_ns(50000); // 50 µs
+      platform_sleep_ns(50000);
     }
     float kick_ms = platform_toc(&kick_clk) * 1000.0f;
     accumulate_metric_ms(&metrics->kick_sync_stall, kick_ms, 0, 0);
   }
-  record_flush_metrics(stage,
-                       handoff,
+
+  record_flush_metrics(handoff,
                        levels,
-                       batch,
                        dims,
                        layout,
                        config,
                        lod,
                        lod_shared,
-                       metrics);
+                       metrics,
+                       stage->t_d2h_start[fc],
+                       stage->ready[fc]);
 
   {
     struct platform_clock sink_clock = { 0 };
     platform_toc(&sink_clock);
     size_t sink_bytes = 0;
+    struct shard_tables* shards = handoff->shards;
+    const size_t page_size = shards ? shards->page_size : 0;
 
-    for (int lv = 0; lv < levels->nlod; ++lv) {
-      if (!(handoff->active_levels_mask & (1u << lv)))
+    // Rebase per-LOD offsets to be segment-relative. GPU produces absolute
+    // offsets (each chunk's position in the unified d_aggregated buffer); the
+    // shard_delivery contract — shared with the CPU path — pairs a
+    // segment-shifted `result.data` with segment-relative offsets, so we
+    // subtract seg->data_segment_offset from each LOD's offsets here. This
+    // matches src/cpu/aggregate.c:330-338 which builds the same view shape.
+    for (uint8_t lv = 0; lv < handoff->nlod; ++lv) {
+      // LOD 0's segment offset is always 0; skip the no-op subtraction.
+      if (lv == 0 || handoff->per_lod_n_active[lv] == 0)
+        continue;
+      const struct lod_segment* seg = &handoff->layout.lods[lv];
+      size_t* off = handoff->agg->h_offsets + seg->batch_covering_offset + lv;
+      const uint64_t n = (uint64_t)seg->n_active * seg->covering_count + 1;
+      for (uint64_t i = 0; i < n; ++i)
+        off[i] -= seg->data_segment_offset;
+    }
+
+    for (uint8_t lv = 0; lv < handoff->nlod; ++lv) {
+      if (handoff->per_lod_n_active[lv] == 0)
         continue;
 
-      struct level_flush_state* lvl = &stage->levels[lv];
-      uint32_t active_count = handoff->active_counts[lv];
-      if (active_count == 0)
-        continue;
+      struct aggregate_result ar = lod_view(handoff, lv);
+      // Per-LOD slice of the unified host tail-bytes scratch.
+      size_t* h_tail_lv = NULL;
+      if (shards && shards->h_tail_bytes && page_size > 0)
+        h_tail_lv = shards->h_tail_bytes + shards->shards_begin[lv];
 
       size_t level_bytes = 0;
-      struct aggregate_result ar = {
-        .data = lvl->agg[fc].h_aggregated,
-        .offsets = lvl->agg[fc].h_offsets,
-        .chunk_sizes = lvl->agg[fc].h_permuted_sizes,
-      };
       if (deliver_to_shards_batch((uint8_t)lv,
-                                  &lvl->shard,
+                                  handoff->shards_by_lod[lv],
                                   &ar,
-                                  &lvl->agg_layout,
-                                  lvl->h_tail_bytes,
-                                  active_count,
+                                  &handoff->per_lod_agg_layouts[lv],
+                                  h_tail_lv,
+                                  handoff->per_lod_n_active[lv],
                                   sink,
                                   stage->shard_alignment,
                                   &level_bytes))
         goto Error;
       sink_bytes += level_bytes;
-
-      // Push host-computed post-delivery tail state to GPU. Host owns
-      // generation-boundary bookkeeping; GPU does not see it.
-      // Two bulk transfers (lengths + densely-packed tail bytes) regardless
-      // of shard count.
-      if (lvl->d_tail_bytes && lvl->h_tail_bytes &&
-          lvl->agg_layout.page_size > 0) {
-        const uint64_t num_shards = lvl->agg_layout.num_shards;
-        CU(Error,
-           cuMemcpyHtoD((CUdeviceptr)lvl->d_tail_bytes,
-                        lvl->h_tail_bytes,
-                        num_shards * sizeof(size_t)));
-        if (lvl->shard.tail_buf_pool && lvl->shard.tail_buf_pool_bytes > 0) {
-          CU(Error,
-             cuMemcpyHtoD(lvl->d_tail_carry,
-                          lvl->shard.tail_buf_pool,
-                          lvl->shard.tail_buf_pool_bytes));
-        }
-      }
-
-      if (sink->record_fence)
-        lvl->agg[fc].io_done = sink->record_fence(sink);
     }
+
+    // Push the post-delivery tail state back to GPU in two bulk HtoDs that
+    // cover all shards across all LODs at once. Replaces the per-LOD
+    // tail-state uploads from the legacy pipeline.
+    if (shards && shards->total_shards > 0 && page_size > 0) {
+      CU(Error,
+         cuMemcpyHtoD((CUdeviceptr)shards->d_tail_bytes,
+                      shards->h_tail_bytes,
+                      shards->total_shards * sizeof(size_t)));
+      // Concatenate per-shard tail_buf slices into a single contiguous block
+      // matching d_tail_carry's [total_shards * page_size] layout. We use
+      // a simple loop instead of separate per-LOD HtoDs.
+      for (uint8_t lv = 0; lv < handoff->nlod; ++lv) {
+        struct shard_state* ss = handoff->shards_by_lod[lv];
+        if (!ss || !ss->tail_buf_pool || ss->tail_buf_pool_bytes == 0)
+          continue;
+        const uint64_t begin = shards->shards_begin[lv];
+        CUdeviceptr dst =
+          shards->d_tail_carry + (CUdeviceptr)(begin * page_size);
+        CU(Error,
+           cuMemcpyHtoD(dst, ss->tail_buf_pool, ss->tail_buf_pool_bytes));
+      }
+    }
+
+    // Record an aggregate IO fence on the unified slot. wait_io_fences()
+    // checks slot->io_done at the next kick.
+    if (sink->record_fence)
+      handoff->agg->io_done = sink->record_fence(sink);
 
     float sink_ms = platform_toc(&sink_clock) * 1000.0f;
     accumulate_metric_ms(&metrics->sink, sink_ms, sink_bytes, sink_bytes);
@@ -394,12 +307,13 @@ Error:
 
 // Periodic metadata update (append-dim extents per level).
 static int
-maybe_update_metadata(const struct d2h_deliver_stage* stage,
+maybe_update_metadata(const struct flush_handoff* handoff,
                       const struct dim_info* dims_info,
                       const struct tile_stream_configuration* config,
                       struct shard_sink* sink,
                       struct platform_clock* metadata_update_clock)
 {
+  (void)config;
   if (!sink->update_append)
     return 0;
 
@@ -410,8 +324,10 @@ maybe_update_metadata(const struct d2h_deliver_stage* stage,
 
   *metadata_update_clock = peek;
   const uint8_t na = dim_info_n_append(dims_info);
-  for (int lv = 0; lv < stage->nlod; ++lv) {
-    struct shard_state* ss = &stage->levels[lv].shard;
+  for (uint8_t lv = 0; lv < handoff->nlod; ++lv) {
+    struct shard_state* ss = handoff->shards_by_lod[lv];
+    if (!ss)
+      continue;
     uint64_t flat_append_chunks =
       ss->shard_epoch * ss->chunks_per_shard_append + ss->epoch_in_shard;
     uint64_t append_sizes[HALF_MAX_RANK];
@@ -434,24 +350,54 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                  struct shard_sink* sink,
                  CUstream d2h_stream)
 {
+  (void)levels;
+  (void)batch;
+  (void)dims;
   const int fc = handoff->fc;
+  struct aggregate_slot* slot = handoff->agg;
+  const struct batch_aggregate_layout* layout = &handoff->layout;
 
-  // Wait on prior sink IO for this fc so we don't overwrite h_aggregated
-  // while the sink is still reading it. Host-blocking if sink is behind;
-  // no-op for async/discard sinks whose fence is already retired.
-  wait_io_fences(stage, fc, handoff->active_levels_mask, sink);
+  // Block on the prior IO retiring this slot (single fence across all LODs).
+  wait_io_fences(slot, sink, stage->metrics);
 
+  // d2h stream waits for aggregate to finish writing the unified buffer.
   CU(Error, cuStreamWaitEvent(d2h_stream, handoff->t_aggregate_end, 0));
   CU(Error, cuEventRecord(stage->t_d2h_start[fc], d2h_stream));
 
-  // Phase 1: queue offset D2H on d2h stream.
-  CHECK(Error,
-        kick_offset_d2h(stage, handoff, levels, batch, dims, d2h_stream) == 0);
+  // One D2H for the unified offsets array (covers all LOD ranges). The
+  // unified prefix-sum produces total_batch_covering + nlod offsets — each
+  // LOD's tail sentinel sits at position
+  // (batch_covering_offset + n_active*covering + lv), all within the scan's
+  // output range.
+  if (layout->total_batch_covering > 0) {
+    const size_t n =
+      layout->total_batch_covering + (size_t)handoff->nlod;
+    CU(Error,
+       cuMemcpyDtoHAsync(slot->h_offsets,
+                         (CUdeviceptr)slot->d_offsets,
+                         n * sizeof(size_t),
+                         d2h_stream));
+    CU(Error,
+       cuMemcpyDtoHAsync(slot->h_permuted_sizes,
+                         (CUdeviceptr)slot->d_permuted_sizes,
+                         n * sizeof(size_t),
+                         d2h_stream));
+  }
+  CU(Error, cuEventRecord(stage->offsets_ready[fc], d2h_stream));
 
-  // Phase 2: sync on offsets (tiny) and queue bulk D2H on the same stream.
-  // ready[fc] is recorded after bulk completes.
-  CHECK(Error,
-        queue_bulk_d2h(stage, handoff, levels, batch, dims, d2h_stream) == 0);
+  // One D2H for the unified aggregated data buffer. Sized to
+  // total_data_bytes (max across all LODs' page-aligned segments).
+  if (layout->total_data_bytes > 0) {
+    CU(Error,
+       cuMemcpyDtoHAsync(slot->h_aggregated,
+                         (CUdeviceptr)slot->d_aggregated,
+                         layout->total_data_bytes,
+                         d2h_stream));
+  }
+  CU(Error, cuEventRecord(stage->ready[fc], d2h_stream));
+  // Also signal the slot's own ready event so the next compress that reuses
+  // this slot waits on it.
+  CU(Error, cuEventRecord(slot->ready, d2h_stream));
 
   return 0;
 
@@ -473,10 +419,10 @@ d2h_deliver_drain(struct d2h_deliver_stage* stage,
                   struct stream_metrics* metrics,
                   struct platform_clock* metadata_update_clock)
 {
+  (void)batch;
   struct writer_result r = sync_and_deliver(stage,
                                             handoff,
                                             levels,
-                                            batch,
                                             dims,
                                             layout,
                                             config,
@@ -485,7 +431,7 @@ d2h_deliver_drain(struct d2h_deliver_stage* stage,
                                             lod_shared,
                                             metrics);
   if (!r.error) {
-    if (maybe_update_metadata(stage, dims, config, sink, metadata_update_clock))
+    if (maybe_update_metadata(handoff, dims, config, sink, metadata_update_clock))
       return writer_error();
   }
   return r;

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -21,10 +21,8 @@ d2h_deliver_init(struct d2h_deliver_stage* stage,
 
   for (int fc = 0; fc < 2; ++fc) {
     CU(Fail, cuEventCreate(&stage->t_d2h_start[fc], CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&stage->offsets_ready[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->ready[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventRecord(stage->t_d2h_start[fc], compute));
-    CU(Fail, cuEventRecord(stage->offsets_ready[fc], compute));
     CU(Fail, cuEventRecord(stage->ready[fc], compute));
   }
 
@@ -42,7 +40,6 @@ d2h_deliver_destroy(struct d2h_deliver_stage* stage)
     return;
   for (int fc = 0; fc < 2; ++fc) {
     cu_event_destroy(stage->t_d2h_start[fc]);
-    cu_event_destroy(stage->offsets_ready[fc]);
     cu_event_destroy(stage->ready[fc]);
   }
 }
@@ -232,6 +229,8 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     // segment-shifted `result.data` with segment-relative offsets, so we
     // subtract seg->data_segment_offset from each LOD's offsets here. This
     // matches src/cpu/aggregate.c:330-338 which builds the same view shape.
+    // The rebase mutates h_offsets in place; this is safe because the next
+    // kick's D2H repopulates the buffer before anything reads stale values.
     for (uint8_t lv = 0; lv < handoff->nlod; ++lv) {
       // LOD 0's segment offset is always 0; skip the no-op subtraction.
       if (lv == 0 || handoff->per_lod_n_active[lv] == 0)
@@ -383,7 +382,6 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                          n * sizeof(size_t),
                          d2h_stream));
   }
-  CU(Error, cuEventRecord(stage->offsets_ready[fc], d2h_stream));
 
   // One D2H for the unified aggregated data buffer. Sized to
   // total_data_bytes (max across all LODs' page-aligned segments).

--- a/src/gpu/flush.d2h_deliver.h
+++ b/src/gpu/flush.d2h_deliver.h
@@ -4,11 +4,8 @@
 #include "stream/dim_info.h"
 
 // Initialize the D2H+deliver stage. Returns 0 on success.
-// `levels` is borrowed from compress_agg_stage — must outlive this stage.
 int
 d2h_deliver_init(struct d2h_deliver_stage* stage,
-                 struct level_flush_state* levels,
-                 int nlod,
                  size_t shard_alignment,
                  CUstream compute);
 

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -2,29 +2,42 @@
 
 #include "gpu/aggregate.h"
 #include "lod/lod_plan.h"
+#include "stream/types.aggregate.h"
 
 #include <cuda.h>
 #include <stdint.h>
 
+struct shard_state;
+struct shard_tables;
+
 // Handoff from compress+aggregate to D2H+deliver.
+//
+// Post-unification, the GPU pipeline runs one aggregate dispatch over all
+// LODs producing a single unified slot. Per-LOD geometry is encoded in
+// `layout` (per-LOD segment offsets within the unified buffer) and the
+// borrowed `per_lod_agg_layouts` array. `per_lod_n_active[lv]` carries
+// the per-LOD active epoch count for delivery sizing.
+//
 // batch_active_masks is borrowed from the flush_slot_gpu that produced this
-// batch and is only safe to read inside compress+aggregate (before the slot's
-// masks buffer can be reused by the next batch at the same fc).  D2H delivery
-// runs later (potentially after a swap has already reset the slot), so it
-// reads from active_counts[lv], which is computed here at kick time.
+// batch and is safe to read only inside compress+aggregate. D2H delivery
+// must read per-LOD active counts from `per_lod_n_active` instead.
 struct flush_handoff
 {
-  int fc;                                 // flush slot index
-  uint32_t n_epochs;                      // epochs in batch
-  uint32_t active_levels_mask;            // which levels active
-  const uint32_t* batch_active_masks;     // borrowed [K] per-epoch masks
-  uint32_t active_counts[LOD_MAX_LEVELS]; // owned: per-level active epoch count
+  int fc;                                     // flush slot index
+  uint32_t n_epochs;                          // epochs in batch
+  uint32_t active_levels_mask;                // which levels active
+  const uint32_t* batch_active_masks;         // borrowed [K] per-epoch masks
+  uint32_t per_lod_n_active[LOD_MAX_LEVELS];  // owned, for delivery sizing
+  uint8_t nlod;
 
   CUevent t_aggregate_end;  // D2H waits on this
   CUevent t_compress_start; // for metrics
   CUevent t_compress_end;   // for metrics
 
-  struct aggregate_slot* agg[LOD_MAX_LEVELS]; // borrowed
-  const struct aggregate_layout* agg_layout[LOD_MAX_LEVELS];
-  size_t max_output_size; // codec bound
+  struct aggregate_slot* agg;                 // borrowed: unified slot for fc
+  struct batch_aggregate_layout layout;       // owned (by-value snapshot)
+  const struct aggregate_layout* per_lod_agg_layouts; // borrowed [nlod]
+  struct shard_state* shards_by_lod[LOD_MAX_LEVELS];  // borrowed
+  struct shard_tables* shards;                // borrowed (for tail HtoD)
+  size_t max_output_size;                     // codec bound
 };

--- a/src/gpu/flush.helpers.h
+++ b/src/gpu/flush.helpers.h
@@ -3,44 +3,4 @@
 #include "gpu/stream.internal.h"
 #include "stream/dim_info.h"
 
-// How many epochs fire for level `lv` within a batch of `n_epochs` epochs.
-// L0 fires every epoch; append-downsampled level lv fires every 2^lv epochs.
-// Returns 0 if the level doesn't fire at all in this batch.
-static inline uint32_t
-level_active_epochs(const struct level_flush_state* lvl,
-                    const struct batch_state* batch,
-                    const struct dim_info* dims,
-                    int lv,
-                    uint32_t n_epochs)
-{
-  uint32_t full = lvl->batch_active_count;
-  if (n_epochs >= batch->epochs_per_batch)
-    return full;
-  uint32_t period = (dims->append_downsample && lv > 0) ? (1u << lv) : 1;
-  return (n_epochs >= period) ? n_epochs / period : 0;
-}
-
-// Count actual active epochs for a level from per-epoch masks.
-// Always scans masks: the steady-state pattern shifts between batches when
-// K doesn't divide the level period, so lvl->batch_active_count is only a
-// safe upper bound (for buffer sizing), not the current batch's actual count.
-// Callers must pass masks that outlive any later pool/slot reuse — see
-// struct flush_handoff::active_counts for the pre-computed, lifetime-safe
-// alternative used by d2h delivery.
-static inline uint32_t
-level_actual_active_count(const struct level_flush_state* lvl,
-                          const struct batch_state* batch,
-                          const struct dim_info* dims,
-                          const uint32_t* batch_active_masks,
-                          int lv,
-                          uint32_t n_epochs)
-{
-  (void)lvl;
-  (void)batch;
-  (void)dims;
-  uint32_t n = 0;
-  for (uint32_t e = 0; e < n_epochs; ++e)
-    if (batch_active_masks[e] & (1u << lv))
-      n++;
-  return n;
-}
+// (no per-LOD helpers remain — the unified kick handles mask-scan inline.)

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -263,11 +263,12 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
   if (r.error)
     return r;
 
-  // Emit partial shards for all levels
+  // Emit partial shards for all levels (unified path: shard[lv] is the
+  // shard_state read by the new kick/D2H code).
   for (int lv = 0; lv < ctx->levels.nlod; ++lv) {
-    if (e->compress_agg.levels[lv].shard.epoch_in_shard > 0) {
+    if (e->compress_agg.shard[lv].epoch_in_shard > 0) {
       if (finalize_shards(
-            &e->compress_agg.levels[lv].shard, ctx->sink, ctx->shard_alignment))
+            &e->compress_agg.shard[lv], ctx->sink, ctx->shard_alignment))
         return writer_error();
     }
   }

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -136,22 +136,20 @@ struct compress_agg_input
 
 // Per-shard layout tables, sized to total_shards = sum(num_shards_lv) across
 // all LODs. These collapse what was N per-LOD shard-bias/leading-tail launches
-// into a single launch over the flat shard list. Host arrays are uploaded to
-// device on init (or on multiarray bind, when per-array per_lod_agg_layouts
-// change). All entries are stable across batches in steady state — the
-// uploads happen once at init for single-array streams.
+// into a single launch over the flat shard list. d_base_offsets / d_tps_group
+// / d_offsets_base are rebuilt and re-uploaded every kick (depends on
+// per_lod_n_active); d_shard_capacity is constant per array and uploaded once
+// at init (or on multiarray bind).
 struct shard_tables
 {
   uint64_t total_shards;
   // Per-shard parameters used by add_shard_bias_unified_k and
   // copy_leading_tail_unified_k. Host shadows are owned; device buffers are
-  // allocated once at init sized to the max across arrays.
+  // allocated at init sized to the max across arrays.
   size_t* h_base_offsets;      // base byte offset in d_aggregated
   size_t* h_shard_capacity;    // per shard
   uint64_t* h_tps_group;       // chunks-per-shard within a batch
   uint64_t* h_offsets_base;    // base index in d_offsets / d_permuted_sizes
-  // LOD this shard belongs to (for delivery dispatch and metrics).
-  uint8_t* h_shard_lod;
 
   size_t* d_base_offsets;
   size_t* d_shard_capacity;
@@ -185,7 +183,6 @@ struct compress_agg_stage
   // Unified aggregate slot (per-fc), sized to max_batch_layout maxima. Holds:
   //   d_aggregated:     max_batch_layout.total_data_bytes
   //   d_offsets/sizes:  total_batch_covering + LOD_MAX_LEVELS (+ 1 for offsets)
-  //   d_perm:           total_batch_chunks
   //   plus pinned host shadows of matching size.
   struct aggregate_slot agg[2];
   size_t max_total_batch_chunks;
@@ -193,12 +190,17 @@ struct compress_agg_stage
   size_t max_total_data_bytes;
 
   // Unified LUTs. Sized to max_total_batch_chunks. Uploaded per kick when the
-  // active-count pattern shifts; cached in steady state via h_cached_*.
+  // firing pattern shifts; cached in steady state by comparing both the
+  // per-LOD active counts AND each LOD's pool_epoch values, since the gather
+  // LUT encodes the actual pool_epoch values (mid-stream phase shifts can
+  // leave the counts unchanged while the epoch positions move).
   CUdeviceptr d_batch_gather;
   CUdeviceptr d_batch_perm;
   uint32_t* h_lut_gather_scratch; // for building unified LUT host-side
   uint32_t* h_lut_perm_scratch;
-  uint32_t cached_per_lod_n_active[LOD_MAX_LEVELS]; // last uploaded pattern
+  uint32_t cached_per_lod_n_active[LOD_MAX_LEVELS]; // last uploaded counts
+  uint32_t* cached_pool_epochs;   // [LOD_MAX_LEVELS * pool_epochs_stride]
+  uint32_t pool_epochs_stride;    // max K used by scratch + cache
   int lut_cache_valid;
   uint64_t lut_steady_count;
   uint64_t lut_recompute_count;
@@ -216,12 +218,6 @@ struct compress_agg_stage
   // Per-shard tables (replaces per-LOD d_tail_*, d_batch_gather/perm).
   struct shard_tables shards;
 
-  // [nlod] entries: index of each LOD's tail-sentinel in unified d_offsets.
-  // Uploaded per-kick; small (≤ LOD_MAX_LEVELS), so a fresh HtoDAsync each
-  // time is cheap.
-  uint64_t* d_lod_last_idx;
-  uint64_t* h_lod_last_idx_scratch;
-
   // Per-LOD shard_state (one shard_state per LOD, mirrors CPU). Carries
   // per-shard writers, tail/footer pools, generation-boundary bookkeeping.
   // The shard_state itself stays per-LOD because deliver_to_shards_batch and
@@ -233,9 +229,7 @@ struct compress_agg_stage
 struct d2h_deliver_stage
 {
   CUevent t_d2h_start[2];
-  CUevent
-    offsets_ready[2]; // phase 1 (offset D2H) completion; drain syncs on this
-  CUevent ready[2];   // phase 2 (bulk D2H) completion
+  CUevent ready[2]; // unified D2H completion (offsets+sizes+data)
 
   size_t shard_alignment;         // from sink; 0 = no alignment
   struct stream_metrics* metrics; // borrowed, for stall-time accumulation

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -46,40 +46,6 @@ struct flush_slot_gpu
   int batch_epoch_count;        // number of epochs accumulated in this batch
 };
 
-struct level_flush_state
-{
-  struct aggregate_layout agg_layout;
-  struct aggregate_slot agg[2]; // double-buffered, indexed by flush_current
-  struct shard_state shard;
-  CUdeviceptr
-    d_batch_gather; // [K_l * M_l] uint32: batch-chunk -> compressed idx
-  CUdeviceptr
-    d_batch_perm; // [K_l * M_l] uint32: batch-chunk -> shard-ordered pos
-  uint32_t batch_active_count; // K_l = K / 2^l for this level
-  // Steady-state pool-epoch pattern: the pool positions assumed when the
-  // init-time LUTs were computed. compress_agg_kick reuses the cached LUTs
-  // when the runtime pool_epochs match this pattern (the common case for
-  // single-array streams and multiscale steady state).
-  uint32_t* steady_pool_epochs; // [batch_active_count] host-side
-  // Hit counters for the LUT fast path. Reported at compress_agg_destroy
-  // so workloads can be evaluated for whether the optimization pays off
-  // (single-array steady ≈ all steady; multiscale partial-batch ≈ recompute).
-  uint64_t lut_steady_count;
-  uint64_t lut_recompute_count;
-  // Cross-batch tail carry-over (per-LOD persistent state, GPU-resident).
-  // d_tail_bytes [num_shards] is the per-shard ragged-tail length; read by
-  // compute_bias_k / copy_leading_tail_k at the start of each batch and
-  // uploaded by the host (from h_tail_bytes) at the end of every batch's
-  // delivery. d_tail_carry [num_shards * page_size] holds the actual tail
-  // bytes, also uploaded by the host. The host owns the per-generation
-  // bookkeeping (in deliver_to_shards_batch); the GPU has no view of where
-  // shard generations begin and end within a batch and so cannot compute
-  // the tail itself.
-  CUdeviceptr d_tail_carry;
-  size_t* d_tail_bytes;
-  size_t* h_tail_bytes;
-};
-
 // Per-frame-counter timing events (double-buffered).
 struct lod_timing
 {
@@ -168,6 +134,44 @@ struct compress_agg_input
   uint32_t epochs_per_batch;
 };
 
+// Per-shard layout tables, sized to total_shards = sum(num_shards_lv) across
+// all LODs. These collapse what was N per-LOD shard-bias/leading-tail launches
+// into a single launch over the flat shard list. Host arrays are uploaded to
+// device on init (or on multiarray bind, when per-array per_lod_agg_layouts
+// change). All entries are stable across batches in steady state — the
+// uploads happen once at init for single-array streams.
+struct shard_tables
+{
+  uint64_t total_shards;
+  // Per-shard parameters used by add_shard_bias_unified_k and
+  // copy_leading_tail_unified_k. Host shadows are owned; device buffers are
+  // allocated once at init sized to the max across arrays.
+  size_t* h_base_offsets;      // base byte offset in d_aggregated
+  size_t* h_shard_capacity;    // per shard
+  uint64_t* h_tps_group;       // chunks-per-shard within a batch
+  uint64_t* h_offsets_base;    // base index in d_offsets / d_permuted_sizes
+  // LOD this shard belongs to (for delivery dispatch and metrics).
+  uint8_t* h_shard_lod;
+
+  size_t* d_base_offsets;
+  size_t* d_shard_capacity;
+  uint64_t* d_tps_group;
+  uint64_t* d_offsets_base;
+
+  // Persistent across-batch tail state, unified across all shards. Sized to
+  // total_shards / total_shards * page_size. d_* uploaded by host after each
+  // batch's delivery; replaces the per-LOD d_tail_bytes / d_tail_carry pair.
+  size_t page_size; // uniform: sink-required alignment, or 0 for legacy
+  size_t* h_tail_bytes;
+  size_t* d_tail_bytes;
+  CUdeviceptr d_tail_carry;
+  size_t tail_carry_bytes; // == total_shards * page_size
+
+  // Per-LOD slice info, needed by delivery to view the unified slot buffers.
+  uint32_t shards_begin[LOD_MAX_LEVELS]; // first global shard index for LOD lv
+  uint32_t n_shards[LOD_MAX_LEVELS];     // num_shards_lv
+};
+
 struct compress_agg_stage
 {
   struct codec codec;
@@ -176,9 +180,54 @@ struct compress_agg_stage
   CUevent t_compress_end[2];
   CUevent t_aggregate_end[2];
 
-  uint32_t* pool_epochs_scratch; // [K] scratch for kick-time mask scans
+  uint32_t* pool_epochs_scratch; // [LOD_MAX_LEVELS * K] scratch for mask scans
 
-  struct level_flush_state levels[LOD_MAX_LEVELS];
+  // Unified aggregate slot (per-fc), sized to max_batch_layout maxima. Holds:
+  //   d_aggregated:     max_batch_layout.total_data_bytes
+  //   d_offsets/sizes:  total_batch_covering + LOD_MAX_LEVELS (+ 1 for offsets)
+  //   d_perm:           total_batch_chunks
+  //   plus pinned host shadows of matching size.
+  struct aggregate_slot agg[2];
+  size_t max_total_batch_chunks;
+  size_t max_total_batch_covering;
+  size_t max_total_data_bytes;
+
+  // Unified LUTs. Sized to max_total_batch_chunks. Uploaded per kick when the
+  // active-count pattern shifts; cached in steady state via h_cached_*.
+  CUdeviceptr d_batch_gather;
+  CUdeviceptr d_batch_perm;
+  uint32_t* h_lut_gather_scratch; // for building unified LUT host-side
+  uint32_t* h_lut_perm_scratch;
+  uint32_t cached_per_lod_n_active[LOD_MAX_LEVELS]; // last uploaded pattern
+  int lut_cache_valid;
+  uint64_t lut_steady_count;
+  uint64_t lut_recompute_count;
+
+  // Per-LOD aggregate layouts (immutable per array; switched on multiarray
+  // bind). One per LOD; carries shard_capacity, num_shards, cps_inner,
+  // page_size, etc. Read by host LUT builder and at delivery time.
+  struct aggregate_layout per_lod_agg_layouts[LOD_MAX_LEVELS];
+  uint8_t nlod;
+
+  // Cached "max" batch layout — segment offsets / total sizes assuming the
+  // worst-case active_count_max per LOD. Buffers are sized from this.
+  struct batch_aggregate_layout max_batch_layout;
+
+  // Per-shard tables (replaces per-LOD d_tail_*, d_batch_gather/perm).
+  struct shard_tables shards;
+
+  // [nlod] entries: index of each LOD's tail-sentinel in unified d_offsets.
+  // Uploaded per-kick; small (≤ LOD_MAX_LEVELS), so a fresh HtoDAsync each
+  // time is cheap.
+  uint64_t* d_lod_last_idx;
+  uint64_t* h_lod_last_idx_scratch;
+
+  // Per-LOD shard_state (one shard_state per LOD, mirrors CPU). Carries
+  // per-shard writers, tail/footer pools, generation-boundary bookkeeping.
+  // The shard_state itself stays per-LOD because deliver_to_shards_batch and
+  // finalize_shards iterate it; the per-shard tail/carry bytes consumed by
+  // the GPU kernels live in shard_tables instead.
+  struct shard_state shard[LOD_MAX_LEVELS];
 };
 
 struct d2h_deliver_stage
@@ -188,8 +237,6 @@ struct d2h_deliver_stage
     offsets_ready[2]; // phase 1 (offset D2H) completion; drain syncs on this
   CUevent ready[2];   // phase 2 (bulk D2H) completion
 
-  struct level_flush_state* levels; // borrowed
-  int nlod;
   size_t shard_alignment;         // from sink; 0 = no alignment
   struct stream_metrics* metrics; // borrowed, for stall-time accumulation
 };

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -253,8 +253,6 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
                           out->engine.streams.compute) == 0);
   CHECK(FailPhase2,
         d2h_deliver_init(&out->engine.d2h_deliver,
-                         out->engine.compress_agg.levels,
-                         out->ctx.levels.nlod,
                          out->ctx.shard_alignment,
                          out->engine.streams.compute) == 0);
 

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -38,18 +38,24 @@ struct array_descriptor_gpu
   uint64_t flush_pending_seq[2];
   uint64_t flush_next_seq;
   struct flush_handoff flush_pending_handoff[2];
-  struct shard_state shard[LOD_MAX_LEVELS];
   struct aggregate_layout agg_layout[LOD_MAX_LEVELS];
   uint32_t batch_active_count[LOD_MAX_LEVELS];
-  // Per-LOD tail-carry state. GPU buffers and host shadow are descriptor-
-  // owned; bind copies the pointers into the engine. Sharing across arrays
-  // would contaminate each array's first batch with the prior array's tail.
-  struct
-  {
-    CUdeviceptr d_tail_carry;
-    size_t* d_tail_bytes;
-    size_t* h_tail_bytes;
-  } tail[LOD_MAX_LEVELS];
+
+  // Per-array unified state. total_shards = sum_lv num_shards[lv]; tail
+  // buffers contiguous over all shards in this array. Bind swaps these
+  // into compress_agg_stage.{per_lod_agg_layouts, shard, shards}.
+  uint64_t u_total_shards;
+  uint32_t u_shards_begin[LOD_MAX_LEVELS];
+  uint32_t u_n_shards[LOD_MAX_LEVELS];
+  size_t u_page_size;
+  size_t u_tail_carry_bytes;
+  size_t* u_d_tail_bytes;
+  CUdeviceptr u_d_tail_carry;
+  size_t* u_h_tail_bytes;
+  size_t* u_h_shard_capacity;
+  uint8_t* u_h_shard_lod;
+  struct shard_state u_shard[LOD_MAX_LEVELS];
+
   int flushed; // 1 once flush body has run for this array
 };
 
@@ -69,13 +75,11 @@ struct pool_maxima
   size_t lod_morton_bytes; // max across arrays
   int any_multiscale;      // 1 if any array uses multiscale
 
-  struct
-  {
-    uint64_t batch_chunks;
-    uint64_t batch_covering;
-    size_t batch_agg_bytes;
-    uint64_t lut_len;
-  } level[LOD_MAX_LEVELS];
+  // Unified-pipeline maxima (max across arrays).
+  uint64_t u_max_total_batch_chunks;
+  uint64_t u_max_total_batch_covering;
+  size_t u_max_total_data_bytes;
+  uint64_t u_max_total_shards;
 };
 
 // ---- Main struct ----
@@ -129,13 +133,14 @@ static void
 drain_d2h_for_array(struct stream_engine* e, struct array_descriptor_gpu* desc)
 {
   cuStreamSynchronize(e->streams.d2h);
-  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-    for (int fc = 0; fc < 2; ++fc) {
-      struct aggregate_slot* agg = &e->d2h_deliver.levels[lv].agg[fc];
-      if (agg->io_done.seq > 0 && desc->ctx.sink->wait_fence)
-        desc->ctx.sink->wait_fence(desc->ctx.sink, agg->io_done);
-      agg->io_done.seq = 0;
-    }
+  // Drain the unified slot's io_done fence with the departing array's sink
+  // so the next-bound array doesn't wait on a fence that was issued by a
+  // different sink.
+  for (int fc = 0; fc < 2; ++fc) {
+    struct aggregate_slot* agg = &e->compress_agg.agg[fc];
+    if (agg->io_done.seq > 0 && desc->ctx.sink->wait_fence)
+      desc->ctx.sink->wait_fence(desc->ctx.sink, agg->io_done);
+    agg->io_done.seq = 0;
   }
 }
 
@@ -155,17 +160,37 @@ bind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
     e->flush.pending_handoff[i] = desc->flush_pending_handoff[i];
   }
   e->flush.next_seq = desc->flush_next_seq;
-  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-    e->compress_agg.levels[lv].shard = desc->shard[lv];
-    e->compress_agg.levels[lv].agg_layout = desc->agg_layout[lv];
-    e->compress_agg.levels[lv].batch_active_count =
-      desc->batch_active_count[lv];
-    e->compress_agg.levels[lv].d_tail_carry = desc->tail[lv].d_tail_carry;
-    e->compress_agg.levels[lv].d_tail_bytes = desc->tail[lv].d_tail_bytes;
-    e->compress_agg.levels[lv].h_tail_bytes = desc->tail[lv].h_tail_bytes;
-  }
-  e->d2h_deliver.nlod = desc->ctx.levels.nlod;
   e->d2h_deliver.shard_alignment = desc->ctx.shard_alignment;
+
+  // Unified-pipeline bind: swap per-array state into the engine. Engine
+  // buffers (agg[2], d_batch_gather/perm, d_lod_last_idx, h_lut_* scratch,
+  // d_*_offsets/_tps_group/_capacity) are sized to max and shared.
+  e->compress_agg.nlod = (uint8_t)desc->ctx.levels.nlod;
+  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
+    e->compress_agg.per_lod_agg_layouts[lv] = desc->agg_layout[lv];
+    e->compress_agg.shard[lv] = desc->u_shard[lv];
+  }
+  e->compress_agg.shards.total_shards = desc->u_total_shards;
+  e->compress_agg.shards.page_size = desc->u_page_size;
+  e->compress_agg.shards.tail_carry_bytes = desc->u_tail_carry_bytes;
+  for (int lv = 0; lv < LOD_MAX_LEVELS; ++lv) {
+    e->compress_agg.shards.shards_begin[lv] = desc->u_shards_begin[lv];
+    e->compress_agg.shards.n_shards[lv] = desc->u_n_shards[lv];
+  }
+  e->compress_agg.shards.h_tail_bytes = desc->u_h_tail_bytes;
+  e->compress_agg.shards.d_tail_bytes = desc->u_d_tail_bytes;
+  e->compress_agg.shards.d_tail_carry = desc->u_d_tail_carry;
+  // Per-array shard_capacity table is constant; re-upload on bind so the
+  // device-side d_shard_capacity reflects the active array's shard sizes.
+  // (h_base_offsets / h_tps_group / h_offsets_base are per-batch scratch,
+  // refreshed by the kick.)
+  if (desc->u_total_shards > 0 && desc->u_h_shard_capacity) {
+    cuMemcpyHtoD((CUdeviceptr)e->compress_agg.shards.d_shard_capacity,
+                 desc->u_h_shard_capacity,
+                 desc->u_total_shards * sizeof(size_t));
+  }
+  // Invalidate the LUT cache: per-array layouts differ.
+  e->compress_agg.lut_cache_valid = 0;
 
   // Per-array LOD state is now a single struct assignment.  Shared LOD
   // resources (d_linear, d_morton, timing) live in e->lod_shared and are
@@ -187,17 +212,17 @@ unbind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
     desc->flush_pending_handoff[i] = e->flush.pending_handoff[i];
   }
   desc->flush_next_seq = e->flush.next_seq;
-  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-    desc->shard[lv] = e->compress_agg.levels[lv].shard;
-    desc->agg_layout[lv] = e->compress_agg.levels[lv].agg_layout;
-    desc->batch_active_count[lv] =
-      e->compress_agg.levels[lv].batch_active_count;
-    // Clear engine-side aliases so any stale-pointer use crashes loudly
-    // rather than corrupting the next-bound array's tail state.
-    e->compress_agg.levels[lv].d_tail_carry = 0;
-    e->compress_agg.levels[lv].d_tail_bytes = NULL;
-    e->compress_agg.levels[lv].h_tail_bytes = NULL;
-  }
+  // Snapshot per-array state back into the descriptor. shard_state mutates
+  // over a batch (epoch_in_shard, shard_epoch, writer pointers); preserve it.
+  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv)
+    desc->u_shard[lv] = e->compress_agg.shard[lv];
+  // Clear engine-side per-array pointers so the next bind establishes them
+  // unambiguously.
+  e->compress_agg.shards.d_tail_bytes = NULL;
+  e->compress_agg.shards.d_tail_carry = 0;
+  e->compress_agg.shards.h_tail_bytes = NULL;
+  e->compress_agg.shards.total_shards = 0;
+  e->compress_agg.shards.tail_carry_bytes = 0;
 
   // Save per-array LOD state. counts[] tracks running append-accumulator
   // state across epochs; element_capacity is the fixed accumulator buffer
@@ -313,53 +338,89 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
     mx->lod_morton_bytes = max_sz(mx->lod_morton_bytes, morton_bytes);
   }
 
-  // Per-level aggregate + shard state
+  // Unified-pipeline per-array sizing.
+  desc->u_total_shards = 0;
+  desc->u_page_size = desc->cl.per_level[0].agg_layout.page_size;
+  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
+    desc->u_shards_begin[lv] = (uint32_t)desc->u_total_shards;
+    desc->u_n_shards[lv] =
+      (uint32_t)desc->cl.per_level[lv].agg_layout.num_shards;
+    desc->u_total_shards += desc->cl.per_level[lv].agg_layout.num_shards;
+  }
+  if (desc->u_total_shards > 0) {
+    desc->u_h_shard_capacity =
+      (size_t*)malloc(desc->u_total_shards * sizeof(size_t));
+    desc->u_h_shard_lod =
+      (uint8_t*)malloc(desc->u_total_shards * sizeof(uint8_t));
+    desc->u_h_tail_bytes =
+      (size_t*)calloc(desc->u_total_shards, sizeof(size_t));
+    if (!desc->u_h_shard_capacity || !desc->u_h_shard_lod ||
+        !desc->u_h_tail_bytes)
+      return 1;
+    for (uint64_t i = 0; i < desc->u_total_shards; ++i) {
+      for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
+        if (i >= desc->u_shards_begin[lv] &&
+            i < desc->u_shards_begin[lv] + desc->u_n_shards[lv]) {
+          desc->u_h_shard_lod[i] = (uint8_t)lv;
+          desc->u_h_shard_capacity[i] =
+            desc->cl.per_level[lv].agg_layout.shard_capacity;
+          break;
+        }
+      }
+    }
+    if (cuMemAlloc((CUdeviceptr*)&desc->u_d_tail_bytes,
+                   desc->u_total_shards * sizeof(size_t)) != CUDA_SUCCESS)
+      return 1;
+    if (cuMemsetD8((CUdeviceptr)desc->u_d_tail_bytes,
+                   0,
+                   desc->u_total_shards * sizeof(size_t)) != CUDA_SUCCESS)
+      return 1;
+    if (desc->u_page_size > 0) {
+      desc->u_tail_carry_bytes =
+        desc->u_total_shards * desc->u_page_size;
+      if (cuMemAlloc(&desc->u_d_tail_carry, desc->u_tail_carry_bytes) !=
+          CUDA_SUCCESS)
+        return 1;
+      if (cuMemsetD8(
+            desc->u_d_tail_carry, 0, desc->u_tail_carry_bytes) != CUDA_SUCCESS)
+        return 1;
+    }
+  }
+
+  // Pool-maxima inputs for the unified pipeline. Compute this array's
+  // max-batch layout and feed the maxima accumulator below.
+  struct batch_aggregate_layout array_max_layout;
+  {
+    struct aggregate_layout per_lod_layouts[LOD_MAX_LEVELS];
+    uint32_t per_lod_max[LOD_MAX_LEVELS] = { 0 };
+    for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
+      per_lod_layouts[lv] = desc->cl.per_level[lv].agg_layout;
+      per_lod_max[lv] = desc->cl.per_level[lv].batch_active_count;
+    }
+    if (batch_aggregate_layout_init(&array_max_layout,
+                                    per_lod_layouts,
+                                    per_lod_max,
+                                    (uint8_t)desc->ctx.levels.nlod,
+                                    desc->u_page_size))
+      return 1;
+  }
+  mx->u_max_total_batch_chunks =
+    max_u64(mx->u_max_total_batch_chunks, array_max_layout.total_batch_chunks);
+  mx->u_max_total_batch_covering =
+    max_u64(mx->u_max_total_batch_covering,
+            array_max_layout.total_batch_covering);
+  mx->u_max_total_data_bytes =
+    max_sz(mx->u_max_total_data_bytes, array_max_layout.total_data_bytes);
+  mx->u_max_total_shards =
+    max_u64(mx->u_max_total_shards, desc->u_total_shards);
+
+  // Per-LOD shard_state + agg_layout snapshot.
   for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
     const struct level_layout_info* li = &desc->cl.per_level[lv];
     desc->agg_layout[lv] = li->agg_layout;
     desc->batch_active_count[lv] = li->batch_active_count;
-
-    uint32_t slot_count =
-      li->batch_active_count > 0 ? li->batch_active_count : 1;
-    uint64_t chunks_lv = desc->ctx.levels.level[lv].chunk_count;
-    uint64_t batch_chunks = (uint64_t)slot_count * chunks_lv;
-    uint64_t batch_covering =
-      (uint64_t)slot_count * li->agg_layout.covering_count;
-    size_t batch_agg_bytes = agg_pool_bytes_layout(&li->agg_layout);
-
-    mx->level[lv].batch_chunks =
-      max_u64(mx->level[lv].batch_chunks, batch_chunks);
-    mx->level[lv].batch_covering =
-      max_u64(mx->level[lv].batch_covering, batch_covering);
-    mx->level[lv].batch_agg_bytes =
-      max_sz(mx->level[lv].batch_agg_bytes, batch_agg_bytes);
-    mx->level[lv].lut_len = max_u64(mx->level[lv].lut_len, batch_chunks);
-
-    if (init_shard_state(&desc->shard[lv], li))
+    if (init_shard_state(&desc->u_shard[lv], li))
       return 1;
-
-    // Per-LOD tail-carry state (descriptor-owned; bind copies pointers into
-    // the shared engine). Only allocate when alignment is required.
-    const uint64_t num_shards = li->agg_layout.num_shards;
-    const size_t page = li->agg_layout.page_size;
-    if (num_shards > 0 && page > 0) {
-      const size_t carry_bytes = num_shards * page;
-      if (cuMemAlloc(&desc->tail[lv].d_tail_carry, carry_bytes) != CUDA_SUCCESS)
-        return 1;
-      if (cuMemsetD8(desc->tail[lv].d_tail_carry, 0, carry_bytes) !=
-          CUDA_SUCCESS)
-        return 1;
-      if (cuMemAlloc((CUdeviceptr*)&desc->tail[lv].d_tail_bytes,
-                     num_shards * sizeof(size_t)) != CUDA_SUCCESS)
-        return 1;
-      if (cuMemsetD8((CUdeviceptr)desc->tail[lv].d_tail_bytes,
-                     0,
-                     num_shards * sizeof(size_t)) != CUDA_SUCCESS)
-        return 1;
-      desc->tail[lv].h_tail_bytes = (size_t*)calloc(num_shards, sizeof(size_t));
-      if (!desc->tail[lv].h_tail_bytes)
-        return 1;
-    }
   }
 
   return 0;
@@ -375,12 +436,14 @@ destroy_array_descriptor(struct array_descriptor_gpu* desc)
     desc->flush_slots[fc].batch_active_masks = NULL;
   }
   for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-    shard_state_destroy(&desc->shard[lv]);
+    shard_state_destroy(&desc->u_shard[lv]);
     aggregate_layout_destroy(&desc->agg_layout[lv]);
-    cu_mem_free(desc->tail[lv].d_tail_carry);
-    cu_mem_free((CUdeviceptr)desc->tail[lv].d_tail_bytes);
-    free(desc->tail[lv].h_tail_bytes);
   }
+  free(desc->u_h_shard_capacity);
+  free(desc->u_h_shard_lod);
+  free(desc->u_h_tail_bytes);
+  cu_mem_free((CUdeviceptr)desc->u_d_tail_bytes);
+  cu_mem_free(desc->u_d_tail_carry);
   // array_lod owns everything except d_linear/d_morton/timing (which stay 0
   // in the per-array struct). ctx.layout_gpu aliases array_lod.layout_gpu[0]
   // and is freed via array_lod destroy.
@@ -443,32 +506,76 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
        cuEventCreate(&e->compress_agg.t_aggregate_end[fc], CU_EVENT_DEFAULT));
   }
 
-  for (int lv = 0; lv < ms->max_nlod; ++lv) {
-    struct level_flush_state* lvl = &e->compress_agg.levels[lv];
-    for (int fc = 0; fc < 2; ++fc) {
-      if (mx->level[lv].batch_covering > 0) {
-        CHECK(Fail,
-              aggregate_batch_slot_init(&lvl->agg[fc],
-                                        mx->level[lv].batch_chunks,
-                                        mx->level[lv].batch_covering,
-                                        mx->level[lv].batch_agg_bytes) == 0);
-        CU(Fail, cuEventRecord(lvl->agg[fc].ready, e->streams.compute));
-      }
-    }
-    if (mx->level[lv].lut_len > 0) {
-      size_t lut_bytes = mx->level[lv].lut_len * sizeof(uint32_t);
-      CU(Fail, cuMemAlloc(&lvl->d_batch_gather, lut_bytes));
-      CU(Fail, cuMemAlloc(&lvl->d_batch_perm, lut_bytes));
-    }
-  }
-
   CHECK(Fail,
-        d2h_deliver_init(&e->d2h_deliver,
-                         e->compress_agg.levels,
-                         ms->max_nlod,
-                         0,
-                         e->streams.compute) == 0);
+        d2h_deliver_init(&e->d2h_deliver, 0, e->streams.compute) == 0);
   e->d2h_deliver.metrics = &e->metrics;
+
+  // Unified-pipeline shared resources. Sized to maxima across arrays.
+  e->compress_agg.max_total_batch_chunks = mx->u_max_total_batch_chunks;
+  e->compress_agg.max_total_batch_covering = mx->u_max_total_batch_covering;
+  e->compress_agg.max_total_data_bytes = mx->u_max_total_data_bytes;
+  if (mx->u_max_total_batch_chunks > 0) {
+    const uint64_t C_max =
+      mx->u_max_total_batch_covering + (uint64_t)ms->max_nlod;
+    for (int fc = 0; fc < 2; ++fc) {
+      CHECK(Fail,
+            aggregate_batch_slot_init(&e->compress_agg.agg[fc],
+                                      mx->u_max_total_batch_chunks,
+                                      C_max,
+                                      mx->u_max_total_data_bytes) == 0);
+      CU(Fail, cuEventRecord(e->compress_agg.agg[fc].ready, e->streams.compute));
+    }
+    CU(Fail,
+       cuMemAlloc(&e->compress_agg.d_batch_gather,
+                  mx->u_max_total_batch_chunks * sizeof(uint32_t)));
+    CU(Fail,
+       cuMemAlloc(&e->compress_agg.d_batch_perm,
+                  mx->u_max_total_batch_chunks * sizeof(uint32_t)));
+    e->compress_agg.h_lut_gather_scratch =
+      (uint32_t*)malloc(mx->u_max_total_batch_chunks * sizeof(uint32_t));
+    e->compress_agg.h_lut_perm_scratch =
+      (uint32_t*)malloc(mx->u_max_total_batch_chunks * sizeof(uint32_t));
+    CHECK(Fail,
+          e->compress_agg.h_lut_gather_scratch &&
+            e->compress_agg.h_lut_perm_scratch);
+  }
+  CU(Fail,
+     cuMemAlloc((CUdeviceptr*)&e->compress_agg.d_lod_last_idx,
+                LOD_MAX_LEVELS * sizeof(uint64_t)));
+  e->compress_agg.h_lod_last_idx_scratch =
+    (uint64_t*)malloc(LOD_MAX_LEVELS * sizeof(uint64_t));
+  CHECK(Fail, e->compress_agg.h_lod_last_idx_scratch);
+  // Engine-shared per-shard scratch + device buffers, sized to max shards.
+  if (mx->u_max_total_shards > 0) {
+    e->compress_agg.shards.h_base_offsets =
+      (size_t*)malloc(mx->u_max_total_shards * sizeof(size_t));
+    e->compress_agg.shards.h_tps_group =
+      (uint64_t*)malloc(mx->u_max_total_shards * sizeof(uint64_t));
+    e->compress_agg.shards.h_offsets_base =
+      (uint64_t*)malloc(mx->u_max_total_shards * sizeof(uint64_t));
+    CHECK(Fail,
+          e->compress_agg.shards.h_base_offsets &&
+            e->compress_agg.shards.h_tps_group &&
+            e->compress_agg.shards.h_offsets_base);
+    CU(Fail,
+       cuMemAlloc((CUdeviceptr*)&e->compress_agg.shards.d_base_offsets,
+                  mx->u_max_total_shards * sizeof(size_t)));
+    CU(Fail,
+       cuMemAlloc((CUdeviceptr*)&e->compress_agg.shards.d_shard_capacity,
+                  mx->u_max_total_shards * sizeof(size_t)));
+    CU(Fail,
+       cuMemAlloc((CUdeviceptr*)&e->compress_agg.shards.d_tps_group,
+                  mx->u_max_total_shards * sizeof(uint64_t)));
+    CU(Fail,
+       cuMemAlloc((CUdeviceptr*)&e->compress_agg.shards.d_offsets_base,
+                  mx->u_max_total_shards * sizeof(uint64_t)));
+  }
+  // Override the shared scratch sized at engine-init: the unified kick
+  // needs LOD_MAX_LEVELS * max_K entries to carve per-LOD pool_epochs slices.
+  free(e->compress_agg.pool_epochs_scratch);
+  e->compress_agg.pool_epochs_scratch = (uint32_t*)malloc(
+    (size_t)LOD_MAX_LEVELS * mx->epochs_per_batch * sizeof(uint32_t));
+  CHECK(Fail, e->compress_agg.pool_epochs_scratch);
 
   CU(Fail, cuEventRecord(e->pools.ready[0], e->streams.compute));
   CU(Fail, cuEventRecord(e->pools.ready[1], e->streams.compute));
@@ -686,13 +793,24 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
     cu_event_destroy(e->compress_agg.t_compress_end[fc]);
     cu_event_destroy(e->compress_agg.t_aggregate_end[fc]);
   }
-  for (int lv = 0; lv < ms->max_nlod; ++lv) {
-    struct level_flush_state* lvl = &e->compress_agg.levels[lv];
-    for (int fc = 0; fc < 2; ++fc)
-      aggregate_slot_destroy(&lvl->agg[fc]);
-    cu_mem_free(lvl->d_batch_gather);
-    cu_mem_free(lvl->d_batch_perm);
-  }
+
+  // Unified-pipeline shared resources (allocated in init_shared_resources).
+  for (int fc = 0; fc < 2; ++fc)
+    aggregate_slot_destroy(&e->compress_agg.agg[fc]);
+  cu_mem_free(e->compress_agg.d_batch_gather);
+  cu_mem_free(e->compress_agg.d_batch_perm);
+  cu_mem_free((CUdeviceptr)e->compress_agg.d_lod_last_idx);
+  free(e->compress_agg.h_lut_gather_scratch);
+  free(e->compress_agg.h_lut_perm_scratch);
+  free(e->compress_agg.h_lod_last_idx_scratch);
+  free(e->compress_agg.shards.h_base_offsets);
+  free(e->compress_agg.shards.h_tps_group);
+  free(e->compress_agg.shards.h_offsets_base);
+  cu_mem_free((CUdeviceptr)e->compress_agg.shards.d_base_offsets);
+  cu_mem_free((CUdeviceptr)e->compress_agg.shards.d_shard_capacity);
+  cu_mem_free((CUdeviceptr)e->compress_agg.shards.d_tps_group);
+  cu_mem_free((CUdeviceptr)e->compress_agg.shards.d_offsets_base);
+  memset(&e->compress_agg.shards, 0, sizeof(e->compress_agg.shards));
 
   // The per-array fields of e->lod are views of the last-bound descriptor
   // (freed above by destroy_array_descriptor).  Engine-owned shared LOD

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -53,7 +53,6 @@ struct array_descriptor_gpu
   CUdeviceptr u_d_tail_carry;
   size_t* u_h_tail_bytes;
   size_t* u_h_shard_capacity;
-  uint8_t* u_h_shard_lod;
   struct shard_state u_shard[LOD_MAX_LEVELS];
 
   int flushed; // 1 once flush body has run for this array
@@ -163,7 +162,7 @@ bind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
   e->d2h_deliver.shard_alignment = desc->ctx.shard_alignment;
 
   // Unified-pipeline bind: swap per-array state into the engine. Engine
-  // buffers (agg[2], d_batch_gather/perm, d_lod_last_idx, h_lut_* scratch,
+  // buffers (agg[2], d_batch_gather/perm, h_lut_* scratch,
   // d_*_offsets/_tps_group/_capacity) are sized to max and shared.
   e->compress_agg.nlod = (uint8_t)desc->ctx.levels.nlod;
   for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
@@ -217,12 +216,26 @@ unbind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
   for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv)
     desc->u_shard[lv] = e->compress_agg.shard[lv];
   // Clear engine-side per-array pointers so the next bind establishes them
-  // unambiguously.
+  // unambiguously. We zero everything that bind_context fills in so a stale
+  // pointer can't survive an unbind/destroy that isn't followed by a bind.
   e->compress_agg.shards.d_tail_bytes = NULL;
   e->compress_agg.shards.d_tail_carry = 0;
   e->compress_agg.shards.h_tail_bytes = NULL;
   e->compress_agg.shards.total_shards = 0;
   e->compress_agg.shards.tail_carry_bytes = 0;
+  e->compress_agg.shards.page_size = 0;
+  memset(e->compress_agg.shards.shards_begin,
+         0,
+         sizeof(e->compress_agg.shards.shards_begin));
+  memset(e->compress_agg.shards.n_shards,
+         0,
+         sizeof(e->compress_agg.shards.n_shards));
+  for (int lv = 0; lv < LOD_MAX_LEVELS; ++lv) {
+    memset(&e->compress_agg.per_lod_agg_layouts[lv],
+           0,
+           sizeof(e->compress_agg.per_lod_agg_layouts[lv]));
+  }
+  e->compress_agg.nlod = 0;
 
   // Save per-array LOD state. counts[] tracks running append-accumulator
   // state across epochs; element_capacity is the fixed accumulator buffer
@@ -350,18 +363,14 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
   if (desc->u_total_shards > 0) {
     desc->u_h_shard_capacity =
       (size_t*)malloc(desc->u_total_shards * sizeof(size_t));
-    desc->u_h_shard_lod =
-      (uint8_t*)malloc(desc->u_total_shards * sizeof(uint8_t));
     desc->u_h_tail_bytes =
       (size_t*)calloc(desc->u_total_shards, sizeof(size_t));
-    if (!desc->u_h_shard_capacity || !desc->u_h_shard_lod ||
-        !desc->u_h_tail_bytes)
+    if (!desc->u_h_shard_capacity || !desc->u_h_tail_bytes)
       return 1;
     for (uint64_t i = 0; i < desc->u_total_shards; ++i) {
       for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
         if (i >= desc->u_shards_begin[lv] &&
             i < desc->u_shards_begin[lv] + desc->u_n_shards[lv]) {
-          desc->u_h_shard_lod[i] = (uint8_t)lv;
           desc->u_h_shard_capacity[i] =
             desc->cl.per_level[lv].agg_layout.shard_capacity;
           break;
@@ -440,7 +449,6 @@ destroy_array_descriptor(struct array_descriptor_gpu* desc)
     aggregate_layout_destroy(&desc->agg_layout[lv]);
   }
   free(desc->u_h_shard_capacity);
-  free(desc->u_h_shard_lod);
   free(desc->u_h_tail_bytes);
   cu_mem_free((CUdeviceptr)desc->u_d_tail_bytes);
   cu_mem_free(desc->u_d_tail_carry);
@@ -539,12 +547,6 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
           e->compress_agg.h_lut_gather_scratch &&
             e->compress_agg.h_lut_perm_scratch);
   }
-  CU(Fail,
-     cuMemAlloc((CUdeviceptr*)&e->compress_agg.d_lod_last_idx,
-                LOD_MAX_LEVELS * sizeof(uint64_t)));
-  e->compress_agg.h_lod_last_idx_scratch =
-    (uint64_t*)malloc(LOD_MAX_LEVELS * sizeof(uint64_t));
-  CHECK(Fail, e->compress_agg.h_lod_last_idx_scratch);
   // Engine-shared per-shard scratch + device buffers, sized to max shards.
   if (mx->u_max_total_shards > 0) {
     e->compress_agg.shards.h_base_offsets =
@@ -572,10 +574,17 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
   }
   // Override the shared scratch sized at engine-init: the unified kick
   // needs LOD_MAX_LEVELS * max_K entries to carve per-LOD pool_epochs slices.
+  // Allocate the cache to the same shape so the LUT-steady check can compare
+  // each LOD's slice at a stable stride.
   free(e->compress_agg.pool_epochs_scratch);
+  e->compress_agg.pool_epochs_stride = mx->epochs_per_batch;
   e->compress_agg.pool_epochs_scratch = (uint32_t*)malloc(
     (size_t)LOD_MAX_LEVELS * mx->epochs_per_batch * sizeof(uint32_t));
-  CHECK(Fail, e->compress_agg.pool_epochs_scratch);
+  e->compress_agg.cached_pool_epochs = (uint32_t*)malloc(
+    (size_t)LOD_MAX_LEVELS * mx->epochs_per_batch * sizeof(uint32_t));
+  CHECK(Fail,
+        e->compress_agg.pool_epochs_scratch &&
+          e->compress_agg.cached_pool_epochs);
 
   CU(Fail, cuEventRecord(e->pools.ready[0], e->streams.compute));
   CU(Fail, cuEventRecord(e->pools.ready[1], e->streams.compute));
@@ -786,7 +795,9 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
 
   codec_free(&e->compress_agg.codec);
   free(e->compress_agg.pool_epochs_scratch);
+  free(e->compress_agg.cached_pool_epochs);
   e->compress_agg.pool_epochs_scratch = NULL;
+  e->compress_agg.cached_pool_epochs = NULL;
   for (int fc = 0; fc < 2; ++fc) {
     cu_mem_free(e->compress_agg.d_compressed[fc]);
     cu_event_destroy(e->compress_agg.t_compress_start[fc]);
@@ -799,10 +810,8 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
     aggregate_slot_destroy(&e->compress_agg.agg[fc]);
   cu_mem_free(e->compress_agg.d_batch_gather);
   cu_mem_free(e->compress_agg.d_batch_perm);
-  cu_mem_free((CUdeviceptr)e->compress_agg.d_lod_last_idx);
   free(e->compress_agg.h_lut_gather_scratch);
   free(e->compress_agg.h_lut_perm_scratch);
-  free(e->compress_agg.h_lod_last_idx_scratch);
   free(e->compress_agg.shards.h_base_offsets);
   free(e->compress_agg.shards.h_tps_group);
   free(e->compress_agg.shards.h_offsets_base);

--- a/tests/test_compress_agg.c
+++ b/tests/test_compress_agg.c
@@ -716,6 +716,111 @@ Fail:
   return ok ? 0 : 1;
 }
 
+// ---------------------------------------------------------------------------
+// Test 7: LUT cache must invalidate when pool_epoch positions shift even
+// though per-LOD active counts stay the same.
+//
+// This pins the regression for the "counts match but positions differ" case
+// (e.g. masks [1,0] then [0,1] both with n_active=1): the unified gather LUT
+// encodes the actual pool_epoch values, so a cache hit keyed only on counts
+// would replay the prior kick's gather indices and produce the prior kick's
+// data. Without the fix, kick 2 below would gather epoch 0 data while
+// reporting it as epoch 1 — the byte-exact check below catches that.
+// ---------------------------------------------------------------------------
+static int
+test_compress_agg_lut_cache_position_shift(void)
+{
+  log_info("=== test_compress_agg_lut_cache_position_shift ===");
+
+  struct ca_test_ctx c;
+  ca_ctx_init(&c);
+  void* h_agg = NULL;
+  int ok = 0;
+
+  CHECK(Fail,
+        ca_ctx_setup(&c, (struct codec_config){ .id = CODEC_NONE }, 2, 2) == 0);
+  CHECK(Fail, c.cl.epochs_per_batch == 2);
+
+  // Fill epoch 0 with one signature, epoch 1 with another.
+  CHECK(Fail, ca_ctx_fill_epoch(&c, 0, fill_epoch0) == 0);
+  CHECK(Fail, ca_ctx_fill_epoch(&c, 1, fill_epoch1) == 0);
+
+  // Kick 1: only epoch 0 active (mask [1, 0]).
+  // n_active=1, pool_epochs=[0]. Populates the LUT cache.
+  c.batch_active_masks[0] = 0x1;
+  c.batch_active_masks[1] = 0x0;
+  {
+    struct compress_agg_input in = {
+      .fc = 0,
+      .n_epochs = 2,
+      .active_levels_mask = 0x1,
+      .batch_active_masks = c.batch_active_masks,
+      .pool_buf = c.d_pool,
+      .pool_ready = c.pool_ready,
+      .lod_done = 0,
+      .epochs_per_batch = c.cl.epochs_per_batch,
+    };
+    struct flush_handoff handoff;
+    memset(&handoff, 0, sizeof(handoff));
+    CHECK(Fail,
+          compress_agg_kick(&c.stage,
+                            &in,
+                            &c.cl.levels,
+                            &c.batch,
+                            &c.cl.dims,
+                            c.compute,
+                            &handoff) == 0);
+    CU(Fail, cuStreamSynchronize(c.compute));
+  }
+
+  // Kick 2: only epoch 1 active (mask [0, 1]).
+  // Same n_active=1 as kick 1, but pool_epochs=[1] — a steady-state cache
+  // keyed on counts alone would mis-hit and gather from epoch 0 instead.
+  uint64_t lut_recompute_before = c.stage.lut_recompute_count;
+  c.batch_active_masks[0] = 0x0;
+  c.batch_active_masks[1] = 0x1;
+  struct flush_handoff handoff2;
+  memset(&handoff2, 0, sizeof(handoff2));
+  {
+    struct compress_agg_input in = {
+      .fc = 1,
+      .n_epochs = 2,
+      .active_levels_mask = 0x1,
+      .batch_active_masks = c.batch_active_masks,
+      .pool_buf = c.d_pool,
+      .pool_ready = c.pool_ready,
+      .lod_done = 0,
+      .epochs_per_batch = c.cl.epochs_per_batch,
+    };
+    CHECK(Fail,
+          compress_agg_kick(&c.stage,
+                            &in,
+                            &c.cl.levels,
+                            &c.batch,
+                            &c.cl.dims,
+                            c.compute,
+                            &handoff2) == 0);
+    CU(Fail, cuStreamSynchronize(c.compute));
+  }
+
+  // The cache must have missed (recompute count incremented) because the
+  // pool_epoch values changed even though n_active didn't.
+  CHECK(Fail, c.stage.lut_recompute_count > lut_recompute_before);
+
+  // The aggregated data must reflect epoch 1, not epoch 0.
+  uint64_t C = handoff2.per_lod_agg_layouts[0].covering_count;
+  CHECK(Fail, ca_ctx_fetch_agg(&handoff2, C, &h_agg) == 0);
+  CHECK(Fail, verify_tiles_none(&handoff2, &c, h_agg, fill_epoch1) == 0);
+
+  ok = 1;
+
+Fail:
+  free(h_agg);
+  ca_ctx_destroy(&c);
+  log_info("  %s", ok ? "PASS" : "FAIL");
+  return ok ? 0 : 1;
+}
+
 RUN_GPU_TESTS({ "compress_agg_single_epoch", test_compress_agg_single_epoch },
               { "compress_agg_batch", test_compress_agg_batch },
               { "compress_agg_partial_batch", test_compress_agg_partial_batch },
@@ -723,4 +828,6 @@ RUN_GPU_TESTS({ "compress_agg_single_epoch", test_compress_agg_single_epoch },
                 test_compress_agg_zstd_single_epoch },
               { "compress_agg_zstd_batch", test_compress_agg_zstd_batch },
               { "compress_agg_none_no_compressed_buffer",
-                test_compress_agg_none_no_compressed_buffer }, )
+                test_compress_agg_none_no_compressed_buffer },
+              { "compress_agg_lut_cache_position_shift",
+                test_compress_agg_lut_cache_position_shift }, )

--- a/tests/test_compress_agg.c
+++ b/tests/test_compress_agg.c
@@ -158,28 +158,40 @@ Fail:
 // Copies the full d_aggregated pool because the new tail-carryover layout
 // places each shard's chunks at fixed `s * shard_capacity` offsets — not
 // contiguously packed at the start as the old pad-to-page layout did.
+//
+// Unified handoff: the slot holds all LODs' offsets/sizes/data in a single
+// buffer. For single-LOD tests (lv=0), seg->batch_covering_offset == 0 and
+// seg->data_segment_offset == 0, so the +lv shift accounts for the per-LOD
+// disjoint-span offset built into aggregate_batch_luts_unified.
 static int
 ca_ctx_fetch_agg(struct flush_handoff* handoff,
                  uint64_t n_covering,
                  void** out_agg_data)
 {
-  struct aggregate_slot* agg = handoff->agg[0];
+  struct aggregate_slot* agg = handoff->agg;
+  const struct lod_segment* seg = &handoff->layout.lods[0];
+  const uint64_t base = seg->batch_covering_offset + 0; // lv=0
 
+  // (n_covering + 1) entries for LOD 0's offsets, shifted by base.
   CU(Fail,
-     cuMemcpyDtoH(agg->h_offsets,
-                  (CUdeviceptr)agg->d_offsets,
+     cuMemcpyDtoH(agg->h_offsets + base,
+                  (CUdeviceptr)(agg->d_offsets + base),
                   (n_covering + 1) * sizeof(size_t)));
   // Production fetches h_permuted_sizes via d2h_deliver_kick on d2h_stream;
   // tests that drive compress_agg_kick directly do the D2H here.
   CU(Fail,
-     cuMemcpyDtoH(agg->h_permuted_sizes,
-                  (CUdeviceptr)agg->d_permuted_sizes,
+     cuMemcpyDtoH(agg->h_permuted_sizes + base,
+                  (CUdeviceptr)(agg->d_permuted_sizes + base),
                   n_covering * sizeof(size_t)));
 
-  size_t pool_bytes = agg_pool_bytes_layout(handoff->agg_layout[0]);
+  size_t pool_bytes = agg_pool_bytes_layout(&handoff->per_lod_agg_layouts[0]);
   void* h_agg = malloc(pool_bytes);
   CHECK(Fail, h_agg);
-  CU(Fail, cuMemcpyDtoH(h_agg, (CUdeviceptr)agg->d_aggregated, pool_bytes));
+  CU(Fail,
+     cuMemcpyDtoH(h_agg,
+                  (CUdeviceptr)((const uint8_t*)agg->d_aggregated +
+                                seg->data_segment_offset),
+                  pool_bytes));
 
   *out_agg_data = h_agg;
   return 0;
@@ -195,8 +207,10 @@ verify_tiles_none(const struct flush_handoff* handoff,
                   const void* h_agg,
                   uint16_t (*fill_fn)(uint64_t))
 {
-  const struct aggregate_layout* al = handoff->agg_layout[0];
-  const struct aggregate_slot* agg = handoff->agg[0];
+  const struct aggregate_layout* al = &handoff->per_lod_agg_layouts[0];
+  const struct aggregate_slot* agg = handoff->agg;
+  const struct lod_segment* seg = &handoff->layout.lods[0];
+  const size_t* lv_offsets = agg->h_offsets + seg->batch_covering_offset + 0;
   const uint64_t total_chunks = c->cl.levels.total_chunks;
   const uint64_t chunk_stride = c->cl.layouts[0].chunk_stride;
   const size_t chunk_bytes = chunk_stride * dtype_bpe(c->config.dtype);
@@ -205,8 +219,8 @@ verify_tiles_none(const struct flush_handoff* handoff,
   for (uint64_t t = 0; t < total_chunks; ++t) {
     uint32_t pi =
       cpu_perm(t, al->lifted_rank, al->lifted_shape, al->lifted_strides);
-    size_t off = agg->h_offsets[pi];
-    size_t sz = agg->h_offsets[pi + 1] - off;
+    size_t off = lv_offsets[pi];
+    size_t sz = lv_offsets[pi + 1] - off;
     // Last chunk per shard may include alignment padding; check >= instead.
     if (sz < chunk_bytes) {
       if (errors < 5)
@@ -265,27 +279,28 @@ test_compress_agg_single_epoch(void)
   CHECK(Fail, handoff.t_compress_start != 0);
   CHECK(Fail, handoff.t_compress_end != 0);
   CHECK(Fail, handoff.max_output_size == chunk_bytes);
-  CHECK(Fail, handoff.agg[0] != NULL);
-  CHECK(Fail, handoff.agg_layout[0] != NULL);
+  CHECK(Fail, handoff.agg != NULL);
+  CHECK(Fail, handoff.per_lod_agg_layouts != NULL);
 
   // D2H and verify
-  uint64_t C = handoff.agg_layout[0]->covering_count;
+  const struct lod_segment* seg0 = &handoff.layout.lods[0];
+  const size_t* lv_offsets =
+    handoff.agg->h_offsets + seg0->batch_covering_offset + 0;
+  uint64_t C = handoff.per_lod_agg_layouts[0].covering_count;
   CHECK(Fail, ca_ctx_fetch_agg(&handoff, C, &h_agg) == 0);
-  CHECK(Fail, verify_offsets_monotonic(handoff.agg[0]->h_offsets, C) == 0);
+  CHECK(Fail, verify_offsets_monotonic(lv_offsets, C) == 0);
 
   {
     // h_offsets[C] is the un-biased prefix-sum sentinel: sum of all real
     // permuted_sizes — chunk_bytes per real chunk for CODEC_NONE.
     // Each shard's data starts at s * shard_capacity in h_agg.
-    const struct aggregate_layout* al = handoff.agg_layout[0];
+    const struct aggregate_layout* al = &handoff.per_lod_agg_layouts[0];
     uint64_t num_shards = C / al->cps_inner;
-    uint64_t N = (uint64_t)c.stage.levels[0].batch_active_count *
+    uint64_t N = (uint64_t)c.stage.per_lod_agg_layouts[0].active_count_max *
                  c.cl.levels.level[0].chunk_count;
-    CHECK(Fail, handoff.agg[0]->h_offsets[C] == N * chunk_bytes);
+    CHECK(Fail, lv_offsets[C] == N * chunk_bytes);
     for (uint64_t s = 0; s < num_shards; ++s)
-      CHECK(Fail,
-            handoff.agg[0]->h_offsets[s * al->cps_inner] ==
-              s * al->shard_capacity);
+      CHECK(Fail, lv_offsets[s * al->cps_inner] == s * al->shard_capacity);
   }
   CHECK(Fail, verify_tiles_none(&handoff, &c, h_agg, fill_epoch0) == 0);
 
@@ -327,15 +342,16 @@ test_compress_agg_batch(void)
   CHECK(Fail, handoff.max_output_size == chunk_bytes);
 
   // D2H aggregate
-  const struct aggregate_layout* al = handoff.agg_layout[0];
+  const struct aggregate_layout* al = &handoff.per_lod_agg_layouts[0];
+  const struct lod_segment* seg = &handoff.layout.lods[0];
+  const size_t* lv_offsets =
+    handoff.agg->h_offsets + seg->batch_covering_offset + 0;
   uint64_t C = al->covering_count;
-  uint32_t batch_count = c.stage.levels[0].batch_active_count;
+  uint32_t batch_count = c.stage.per_lod_agg_layouts[0].active_count_max;
   uint64_t batch_covering = (uint64_t)batch_count * C;
 
   CHECK(Fail, ca_ctx_fetch_agg(&handoff, batch_covering, &h_agg) == 0);
-  CHECK(Fail,
-        verify_offsets_monotonic(handoff.agg[0]->h_offsets, batch_covering) ==
-          0);
+  CHECK(Fail, verify_offsets_monotonic(lv_offsets, batch_covering) == 0);
 
   {
     // h_offsets[batch_covering] is the un-biased prefix-sum sentinel: real
@@ -344,10 +360,9 @@ test_compress_agg_batch(void)
     uint64_t num_shards = C / al->cps_inner;
     uint64_t tps_group = batch_covering / num_shards;
     uint64_t N = (uint64_t)batch_count * c.cl.levels.level[0].chunk_count;
-    CHECK(Fail, handoff.agg[0]->h_offsets[batch_covering] == N * chunk_bytes);
+    CHECK(Fail, lv_offsets[batch_covering] == N * chunk_bytes);
     for (uint64_t s = 0; s < num_shards; ++s)
-      CHECK(Fail,
-            handoff.agg[0]->h_offsets[s * tps_group] == s * al->shard_capacity);
+      CHECK(Fail, lv_offsets[s * tps_group] == s * al->shard_capacity);
   }
 
   // Verify data per epoch
@@ -364,8 +379,8 @@ test_compress_agg_batch(void)
         ravel(al->lifted_rank, al->lifted_shape, al->lifted_strides, j);
       uint64_t out_idx =
         ravel(2, shard_shape, shard_strides, perm_pos) + a * cps_inner;
-      size_t off = handoff.agg[0]->h_offsets[out_idx];
-      size_t sz = handoff.agg[0]->h_offsets[out_idx + 1] - off;
+      size_t off = lv_offsets[out_idx];
+      size_t sz = lv_offsets[out_idx + 1] - off;
       // Last chunk per shard may include alignment padding.
       if (sz < chunk_bytes) {
         if (errors < 5)
@@ -430,23 +445,24 @@ test_compress_agg_partial_batch(void)
 
   const size_t chunk_bytes =
     c.cl.layouts[0].chunk_stride * dtype_bpe(c.config.dtype);
-  uint64_t C = handoff.agg_layout[0]->covering_count;
+  const struct lod_segment* seg = &handoff.layout.lods[0];
+  const size_t* lv_offsets =
+    handoff.agg->h_offsets + seg->batch_covering_offset + 0;
+  uint64_t C = handoff.per_lod_agg_layouts[0].covering_count;
   CHECK(Fail, ca_ctx_fetch_agg(&handoff, C, &h_agg) == 0);
-  CHECK(Fail, verify_offsets_monotonic(handoff.agg[0]->h_offsets, C) == 0);
+  CHECK(Fail, verify_offsets_monotonic(lv_offsets, C) == 0);
 
   {
     // Partial batch: only the actually-active 1 epoch's worth of chunks are
     // filled by permute_sizes_batch_k; the rest of d_permuted_sizes stays 0
     // (from cuMemset). Sentinel h_offsets[C] therefore equals N*chunk_bytes
     // where N is the active-epoch chunk count, not K * chunks_lv.
-    const struct aggregate_layout* al = handoff.agg_layout[0];
+    const struct aggregate_layout* al = &handoff.per_lod_agg_layouts[0];
     uint64_t num_shards = C / al->cps_inner;
     uint64_t N = (uint64_t)1 * c.cl.levels.level[0].chunk_count; // n_epochs=1
-    CHECK(Fail, handoff.agg[0]->h_offsets[C] == N * chunk_bytes);
+    CHECK(Fail, lv_offsets[C] == N * chunk_bytes);
     for (uint64_t s = 0; s < num_shards; ++s)
-      CHECK(Fail,
-            handoff.agg[0]->h_offsets[s * al->cps_inner] ==
-              s * al->shard_capacity);
+      CHECK(Fail, lv_offsets[s * al->cps_inner] == s * al->shard_capacity);
   }
   CHECK(Fail, verify_tiles_none(&handoff, &c, h_agg, fill_epoch0) == 0);
 
@@ -484,10 +500,15 @@ test_compress_agg_zstd_single_epoch(void)
   const uint64_t chunk_stride = c.cl.layouts[0].chunk_stride;
   const size_t chunk_bytes = chunk_stride * dtype_bpe(c.config.dtype);
 
-  const struct aggregate_layout* al = handoff.agg_layout[0];
+  const struct aggregate_layout* al = &handoff.per_lod_agg_layouts[0];
+  const struct lod_segment* seg = &handoff.layout.lods[0];
+  const size_t* lv_offsets =
+    handoff.agg->h_offsets + seg->batch_covering_offset + 0;
+  const size_t* lv_sizes =
+    handoff.agg->h_permuted_sizes + seg->batch_covering_offset + 0;
   uint64_t C = al->covering_count;
   CHECK(Fail, ca_ctx_fetch_agg(&handoff, C, &h_agg) == 0);
-  CHECK(Fail, verify_offsets_monotonic(handoff.agg[0]->h_offsets, C) == 0);
+  CHECK(Fail, verify_offsets_monotonic(lv_offsets, C) == 0);
 
   decomp_buf = (uint8_t*)malloc(chunk_bytes);
   CHECK(Fail, decomp_buf);
@@ -496,8 +517,8 @@ test_compress_agg_zstd_single_epoch(void)
   for (uint64_t t = 0; t < total_chunks; ++t) {
     uint32_t pi =
       cpu_perm(t, al->lifted_rank, al->lifted_shape, al->lifted_strides);
-    size_t off = handoff.agg[0]->h_offsets[pi];
-    size_t comp_sz = handoff.agg[0]->h_permuted_sizes[pi];
+    size_t off = lv_offsets[pi];
+    size_t comp_sz = lv_sizes[pi];
     CHECK(Fail, comp_sz > 0);
     // Last chunk per shard may include alignment padding.
     CHECK(Fail, comp_sz <= handoff.max_output_size + al->page_size);
@@ -565,15 +586,16 @@ test_compress_agg_zstd_batch(void)
 
   const uint64_t chunk_stride = c.cl.layouts[0].chunk_stride;
   const size_t chunk_bytes = chunk_stride * dtype_bpe(c.config.dtype);
-  const struct aggregate_layout* al = handoff.agg_layout[0];
+  const struct aggregate_layout* al = &handoff.per_lod_agg_layouts[0];
+  const struct lod_segment* seg = &handoff.layout.lods[0];
+  const size_t* lv_offsets =
+    handoff.agg->h_offsets + seg->batch_covering_offset + 0;
   uint64_t C = al->covering_count;
-  uint32_t batch_count = c.stage.levels[0].batch_active_count;
+  uint32_t batch_count = c.stage.per_lod_agg_layouts[0].active_count_max;
   uint64_t batch_covering = (uint64_t)batch_count * C;
 
   CHECK(Fail, ca_ctx_fetch_agg(&handoff, batch_covering, &h_agg) == 0);
-  CHECK(Fail,
-        verify_offsets_monotonic(handoff.agg[0]->h_offsets, batch_covering) ==
-          0);
+  CHECK(Fail, verify_offsets_monotonic(lv_offsets, batch_covering) == 0);
 
   decomp_buf = (uint8_t*)malloc(chunk_bytes);
   CHECK(Fail, decomp_buf);
@@ -591,8 +613,8 @@ test_compress_agg_zstd_batch(void)
         ravel(al->lifted_rank, al->lifted_shape, al->lifted_strides, j);
       uint64_t out_idx =
         ravel(2, shard_shape, shard_strides, perm_pos) + a * cps_inner;
-      size_t off = handoff.agg[0]->h_offsets[out_idx];
-      size_t slot_sz = handoff.agg[0]->h_offsets[out_idx + 1] - off;
+      size_t off = lv_offsets[out_idx];
+      size_t slot_sz = lv_offsets[out_idx + 1] - off;
       CHECK(Fail, slot_sz > 0);
 
       // Slot may include shard-boundary padding; find the actual frame size.

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -82,8 +82,6 @@ test_ctx_setup(struct test_ctx* c,
 
   CHECK(Fail,
         d2h_deliver_init(&c->d2h,
-                         c->ca.levels,
-                         c->cl.levels.nlod,
                          platform_page_alignment(),
                          c->compute) == 0);
   c->d2h_inited = 1;
@@ -310,7 +308,7 @@ test_d2h_batch_none(void)
   // Parse finalized shard: index block at end
   // chunks_per_shard_total = 8, index = 8 * 16 bytes + 4 byte CRC
   {
-    struct shard_state* ss = &c.ca.levels[0].shard;
+    struct shard_state* ss = &c.ca.shard[0];
     uint64_t tps_total = ss->chunks_per_shard_total;
     size_t index_data_bytes = tps_total * 2 * sizeof(uint64_t);
     size_t index_total_bytes = index_data_bytes + 4;
@@ -323,8 +321,8 @@ test_d2h_batch_none(void)
 
     // Shard output layout: [num_shards, batch_count, cps_inner] row-major.
     // Slot → (si, epoch, ci) via unravel, then perm_pos = si * cps_inner + ci.
-    const struct aggregate_layout* al = &c.ca.levels[0].agg_layout;
-    uint32_t batch_count = c.ca.levels[0].batch_active_count;
+    const struct aggregate_layout* al = &c.ca.per_lod_agg_layouts[0];
+    uint32_t batch_count = c.ca.per_lod_agg_layouts[0].active_count_max;
     uint32_t cps_inner = (uint32_t)al->cps_inner;
     uint32_t num_shards = (uint32_t)(al->covering_count / cps_inner);
     uint64_t chunks_lv = c.cl.levels.level[0].chunk_count;
@@ -453,7 +451,7 @@ test_d2h_zstd_single_epoch(void)
 
   // Decompress and verify chunk data via the on-disk index.
   {
-    struct shard_state* ss = &c.ca.levels[0].shard;
+    struct shard_state* ss = &c.ca.shard[0];
     uint64_t tps_total = ss->chunks_per_shard_total;
     size_t index_data_bytes = tps_total * 2 * sizeof(uint64_t);
     size_t index_total_bytes = index_data_bytes + 4;
@@ -463,7 +461,7 @@ test_d2h_zstd_single_epoch(void)
     const uint64_t* idx =
       (const uint64_t*)(sink.writers[0][0].buf + index_start);
 
-    const struct aggregate_layout* al = &c.ca.levels[0].agg_layout;
+    const struct aggregate_layout* al = &c.ca.per_lod_agg_layouts[0];
     uint64_t cps_inner = ss->chunks_per_shard_inner;
 
     decomp_buf = (uint8_t*)malloc(chunk_bytes);
@@ -591,7 +589,7 @@ test_d2h_double_buffer(void)
 
   // Parse finalized shard and verify both epochs' data
   {
-    struct shard_state* ss = &c.ca.levels[0].shard;
+    struct shard_state* ss = &c.ca.shard[0];
     uint64_t tps_total = ss->chunks_per_shard_total;
     size_t index_data_bytes = tps_total * 2 * sizeof(uint64_t);
     size_t index_total_bytes = index_data_bytes + 4;
@@ -601,7 +599,7 @@ test_d2h_double_buffer(void)
     const uint64_t* idx =
       (const uint64_t*)(sink.writers[0][0].buf + index_start);
 
-    const struct aggregate_layout* al = &c.ca.levels[0].agg_layout;
+    const struct aggregate_layout* al = &c.ca.per_lod_agg_layouts[0];
     uint64_t cps_inner = ss->chunks_per_shard_inner;
 
     int errors = 0;

--- a/tests/test_flush_orchestration.c
+++ b/tests/test_flush_orchestration.c
@@ -110,8 +110,6 @@ orch_ctx_setup(struct orch_ctx* c,
   // D2H+deliver stage
   CHECK(Fail,
         d2h_deliver_init(&c->s->engine.d2h_deliver,
-                         c->s->engine.compress_agg.levels,
-                         c->cl.levels.nlod,
                          platform_page_alignment(),
                          c->s->engine.streams.compute) == 0);
 
@@ -383,7 +381,7 @@ test_accumulated_sync_partial(void)
   // rather than on-disk size.
   CHECK(Fail, sink.open_count >= 1);
   {
-    struct shard_state* ss = &c.s->engine.compress_agg.levels[0].shard;
+    struct shard_state* ss = &c.s->engine.compress_agg.shard[0];
     struct active_shard* sh = &ss->shards[0];
     CHECK(Fail, sh->tail_bytes > 0);
   }


### PR DESCRIPTION
## Summary
- Replace N per-LOD aggregate kernel dispatches with one unified dispatch over all active LODs, mirroring the CPU pipeline.
- Collapse N per-LOD D2H transfers into a single D2H of the unified slot; per-LOD delivery uses page-aligned views into the unified buffer.
- Per-shard parameter tables (base offsets, capacity, tps_group, offsets_base) move device-side so kernels cover all shards across all LODs in one launch.

## Notes
Sets up a future streaming-D2H rewrite that needs a single cursor against one unified buffer.

## Test plan
- [x] `ctest -R cross_validate` — byte-exact GPU vs CPU across basic/multishard/lod/lod_dim0
- [x] `ctest -R 'compress_agg|d2h_deliver|flush_orchestration|aggregate_contract|multiarray'`
- [x] Bench parity: livescreen-style sweep shows throughput within run-to-run jitter; aggregate stage avg_ms slightly lower