### PR TITLE
Macro-aggregation scaffolding (slot_batches, cursors, slot_chunk_cap)

### DIFF
--- a/src/defs.limits.h
+++ b/src/defs.limits.h
@@ -17,3 +17,8 @@
 // One chunk per upload part, so parts-count = chunks per shard.
 #define MAX_PARTS_PER_SHARD S3_MAX_PARTS
 #define MAX_BYTES_PER_PART (5ull * 1024 * 1024 * 1024) // S3 single-part ceiling
+
+// Minimum bytes any compressed chunk could plausibly occupy. Sets the
+// upper bound on descriptors-per-slot when macro-aggregating compressed
+// batches.
+#define MIN_COMPRESSED_CHUNK_BYTES 128

--- a/src/gpu/aggregate.cu
+++ b/src/gpu/aggregate.cu
@@ -141,6 +141,7 @@ aggregate_slot_destroy(struct aggregate_slot* slot)
   cuMemFreeHost(slot->h_offsets);
   cuMemFreeHost(slot->h_permuted_sizes);
   cuMemFree((CUdeviceptr)slot->d_temp);
+  free(slot->slot_batches);
   memset(slot, 0, sizeof(*slot));
 }
 
@@ -196,24 +197,23 @@ gather_batch_k(const void* __restrict__ d_compressed,
 extern "C" int
 aggregate_batch_slot_init(struct aggregate_slot* slot,
                           uint64_t batch_chunk_count,
-                          uint64_t batch_covering_count,
-                          size_t comp_pool_bytes)
+                          uint64_t slot_chunk_cap,
+                          size_t comp_pool_bytes,
+                          uint32_t batches_per_slot_cap)
 {
-  uint64_t C = batch_covering_count;
+  uint64_t C = slot_chunk_cap;
   (void)batch_chunk_count;
 
   CHECK(Error, slot);
+  CHECK(Error, batches_per_slot_cap >= 1);
   memset(slot, 0, sizeof(*slot));
 
   CU(Error,
-     cuMemAlloc((CUdeviceptr*)&slot->d_permuted_sizes,
-                (C + 1) * sizeof(size_t)));
-  CU(Error,
-     cuMemAlloc((CUdeviceptr*)&slot->d_offsets, (C + 1) * sizeof(size_t)));
+     cuMemAlloc((CUdeviceptr*)&slot->d_permuted_sizes, C * sizeof(size_t)));
+  CU(Error, cuMemAlloc((CUdeviceptr*)&slot->d_offsets, C * sizeof(size_t)));
   CU(Error, cuMemAlloc((CUdeviceptr*)&slot->d_aggregated, comp_pool_bytes));
   CU(Error, cuMemHostAlloc(&slot->h_aggregated, comp_pool_bytes, 0));
-  CU(Error,
-     cuMemHostAlloc((void**)&slot->h_offsets, (C + 1) * sizeof(size_t), 0));
+  CU(Error, cuMemHostAlloc((void**)&slot->h_offsets, C * sizeof(size_t), 0));
   CU(Error,
      cuMemHostAlloc((void**)&slot->h_permuted_sizes, C * sizeof(size_t), 0));
 
@@ -227,6 +227,11 @@ aggregate_batch_slot_init(struct aggregate_slot* slot,
 
   if (slot->temp_bytes > 0)
     CU(Error, cuMemAlloc((CUdeviceptr*)&slot->d_temp, slot->temp_bytes));
+
+  slot->batches_per_slot_cap = batches_per_slot_cap;
+  slot->slot_batches = (struct batch_slice_entry*)calloc(
+    batches_per_slot_cap, sizeof(struct batch_slice_entry));
+  CHECK(Error, slot->slot_batches);
 
   CU(Error, cuEventCreate(&slot->ready, CU_EVENT_DEFAULT));
 
@@ -264,8 +269,7 @@ add_shard_bias_unified_k(size_t* __restrict__ d_offsets,
   const uint64_t tps_group = d_shard_tps_group[s];
   __shared__ size_t bias_s;
   if (threadIdx.x == 0)
-    bias_s =
-      d_shard_base_offsets[s] + d_tail_bytes_prev[s] - d_offsets[base];
+    bias_s = d_shard_base_offsets[s] + d_tail_bytes_prev[s] - d_offsets[base];
   __syncthreads();
   for (uint64_t k = threadIdx.x; k < tps_group; k += blockDim.x)
     d_offsets[base + k] += bias_s;
@@ -410,6 +414,8 @@ aggregate_batch_unified_async(const void* d_compressed,
                               uint8_t nlod,
                               size_t max_comp_chunk_bytes,
                               struct aggregate_slot* slot,
+                              size_t slot_data_base,
+                              uint64_t slot_desc_base,
                               const size_t* d_shard_base_offsets,
                               const size_t* d_shard_capacity,
                               const uint64_t* d_shard_tps_group,
@@ -425,42 +431,47 @@ aggregate_batch_unified_async(const void* d_compressed,
   const uint64_t C = total_batch_covering;
   cudaStream_t cuda_stream = (cudaStream_t)stream;
 
-  // Zero permuted_sizes (C + nlod entries: covering plus one sentinel per LOD)
+  // Biased buffer views: kernels operate batch-locally; the slot bases
+  // hide cumulative cursor advancement across batches within a slot.
+  // Phase 2: bases are always 0 (one batch per slot).
+  size_t* d_perm_sizes_b = slot->d_permuted_sizes + slot_desc_base;
+  size_t* d_offsets_b = slot->d_offsets + slot_desc_base;
+  void* d_aggregated_b = (void*)((uint8_t*)slot->d_aggregated + slot_data_base);
+
+  // Zero permuted_sizes for this batch's slice (C + nlod entries).
   CU(Error,
-     cuMemsetD8Async((CUdeviceptr)slot->d_permuted_sizes,
-                     0,
-                     (C + nlod) * sizeof(size_t),
-                     stream));
+     cuMemsetD8Async(
+       (CUdeviceptr)d_perm_sizes_b, 0, (C + nlod) * sizeof(size_t), stream));
 
   // Pass 1: permute sizes using unified LUTs (perm targets already shifted
-  // by +lv per LOD inside aggregate_batch_luts_unified).
+  // by +lv per LOD inside aggregate_batch_luts_unified; targets are
+  // batch-local within d_perm_sizes_b).
   {
     const int block = 256;
     const int grid = (int)((N + block - 1) / block);
     permute_sizes_batch_k<<<grid, block, 0, cuda_stream>>>(
-      d_comp_sizes, slot->d_permuted_sizes, d_batch_gather, d_batch_perm, N);
+      d_comp_sizes, d_perm_sizes_b, d_batch_gather, d_batch_perm, N);
   }
 
-  // Pass 2: single exclusive prefix sum across the unified covering range
-  // plus one sentinel slot per LOD. The scan writes every LOD's
-  // tail-sentinel position; no separate write_total fixup needed.
+  // Pass 2: exclusive prefix sum over this batch's slice only (each batch's
+  // scan is independent of prior batches' sentinels).
   {
     size_t temp = slot->temp_bytes;
     cub::DeviceScan::ExclusiveSum(slot->d_temp,
                                   temp,
-                                  slot->d_permuted_sizes,
-                                  slot->d_offsets,
+                                  d_perm_sizes_b,
+                                  d_offsets_b,
                                   (int)(C + nlod),
                                   cuda_stream);
   }
 
   if (page_size > 0 && total_shards > 0) {
     // Pass 3a: per-shard bias. Anchors each shard's first chunk at its
-    // base byte offset + tail_in, packs subsequent chunks tightly.
+    // batch-local base byte offset + tail_in.
     {
       const int block = 256;
       add_shard_bias_unified_k<<<(int)total_shards, block, 0, cuda_stream>>>(
-        slot->d_offsets,
+        d_offsets_b,
         d_tail_bytes,
         d_shard_base_offsets,
         d_shard_tps_group,
@@ -468,11 +479,11 @@ aggregate_batch_unified_async(const void* d_compressed,
         total_shards);
     }
     // Pass 3b: stage prior batch's ragged tail at the head of each shard's
-    // region so chunks pack just past it.
+    // region in this batch's slice.
     {
       const int block = 256;
       copy_leading_tail_unified_k<<<(int)total_shards, block, 0, cuda_stream>>>(
-        slot->d_aggregated,
+        d_aggregated_b,
         (const void*)d_tail_carry,
         d_tail_bytes,
         d_shard_base_offsets,
@@ -480,21 +491,18 @@ aggregate_batch_unified_async(const void* d_compressed,
     }
   }
 
-  // Pass 4: gather compressed tiles using unified LUTs.
+  // Pass 4: gather compressed tiles into this batch's slice.
   {
     const int block = 256;
     const int grid = (int)N;
     gather_batch_k<<<grid, block, 0, cuda_stream>>>(d_compressed,
-                                                    slot->d_aggregated,
+                                                    d_aggregated_b,
                                                     d_comp_sizes,
-                                                    slot->d_offsets,
+                                                    d_offsets_b,
                                                     d_batch_gather,
                                                     d_batch_perm,
                                                     max_comp_chunk_bytes);
   }
-
-  // d_tail_bytes / d_tail_carry are uploaded by host post-delivery
-  // (flush.d2h_deliver.c).
 
   return 0;
 

--- a/src/gpu/aggregate.h
+++ b/src/gpu/aggregate.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "defs.limits.h"
 #include "stream/types.aggregate.h"
 #include "writer.h"
 
@@ -16,17 +17,45 @@ extern "C"
   // Writes result to *out_bytes. Returns 0 on success.
   int aggregate_cub_temp_bytes(uint64_t count, size_t* out_bytes);
 
+  // One batch's slice inside a slot. Phase 2 always has batches_per_slot=1
+  // and base offsets stay at 0; Phase 3 will stack multiple entries with
+  // monotonically advancing bases.
+  //
+  // Slot-relative byte offset for LOD lv =
+  //   data_base + per_lod_lods[lv].data_segment_offset
+  // Slot-relative descriptor index for LOD lv =
+  //   desc_base + per_lod_lods[lv].batch_covering_offset + lv
+  struct batch_slice_entry
+  {
+    size_t data_base_offset;
+    uint64_t desc_base_offset;
+    uint8_t nlod;
+    struct lod_segment per_lod_lods[LOD_MAX_LEVELS];
+  };
+
   struct aggregate_slot
   {
-    size_t* d_permuted_sizes; // device: (C+1) size_t, zeroed each epoch
-    size_t* d_offsets;        // device: (C+1) size_t
+    size_t* d_permuted_sizes; // device: slot_chunk_cap size_t
+    size_t* d_offsets;        // device: slot_chunk_cap size_t
     void* d_aggregated;       // device: comp_pool_bytes
     void* h_aggregated;       // host pinned: comp_pool_bytes
-    size_t* h_offsets;        // host pinned: (C+1) size_t
-    size_t* h_permuted_sizes; // host pinned: C size_t (real compressed sizes)
+    size_t* h_offsets;        // host pinned: slot_chunk_cap size_t
+    size_t* h_permuted_sizes; // host pinned: slot_chunk_cap size_t
     void* d_temp;             // CUB scratch
     size_t temp_bytes;
-    CUevent ready;           // D2H completion
+
+    // Macro-aggregation state (Phase 2: scaffolding only).
+    size_t slot_cursor;      // bytes written in d_aggregated
+    size_t slot_desc_cursor; // entries written in d_offsets / d_permuted_sizes
+    uint32_t batches_per_slot;
+    uint32_t batches_per_slot_cap;
+    struct batch_slice_entry* slot_batches; // [batches_per_slot_cap]
+
+    CUevent ready; // D2H completion
+    // TODO(phase3): single io_event per slot means all K batches in a
+    // macro-group share one IO fence. Fine for delivery serialization but
+    // batches can't be retired independently. Acceptable for the planned
+    // flush-on-close model.
     struct io_event io_done; // tracks IO completion from this slot's data
   };
 
@@ -38,10 +67,16 @@ extern "C"
 
   void aggregate_slot_destroy(struct aggregate_slot* slot);
 
+  // slot_chunk_cap is the descriptor-array length (entries). Sized once at
+  // init to W / min_compressed_chunk_bytes so Phase 3 macro-agg can pack
+  // many batches' descriptors into the same slot without resize.
+  // batches_per_slot_cap is the size of the slot_batches[] table. Phase 2
+  // uses 1; Phase 3 will raise it.
   int aggregate_batch_slot_init(struct aggregate_slot* slot,
                                 uint64_t batch_chunk_count,
-                                uint64_t batch_covering_count,
-                                size_t comp_pool_bytes);
+                                uint64_t slot_chunk_cap,
+                                size_t comp_pool_bytes,
+                                uint32_t batches_per_slot_cap);
 
   // d_tail_bytes: persistent per-LOD device array of size_t[num_shards]; read
   //   by add_shard_bias_k for this batch's leading-tail accounting. The host
@@ -75,17 +110,19 @@ extern "C"
   //                          Maps unified output position -> permuted index in
   //                          d_offsets/d_permuted_sizes (already LOD-shifted
   //                          by +lv inside aggregate_batch_luts_unified).
-  //   total_batch_chunks   : M_total = sum_lv n_active[lv] * chunks_per_epoch[lv]
-  //   total_batch_covering : C_total = sum_lv n_active[lv] * covering_count[lv]
-  //   nlod                 : number of LODs
+  //   total_batch_chunks   : M_total = sum_lv n_active[lv] *
+  //   chunks_per_epoch[lv] total_batch_covering : C_total = sum_lv n_active[lv]
+  //   * covering_count[lv] nlod                 : number of LODs
   //   max_comp_chunk_bytes : uniform pool stride
   //   slot                 : unified aggregate_slot (d_aggregated sized to
   //                          max_total_data_bytes; d_offsets/d_permuted_sizes
-  //                          sized to max_total_batch_covering + LOD_MAX_LEVELS).
+  //                          sized to max_total_batch_covering +
+  //                          LOD_MAX_LEVELS).
   //   d_shard_base_offsets : [total_shards] base byte offset in d_aggregated
   //                          for each shard. Replaces uniform s*shard_capacity.
   //   d_shard_capacity     : [total_shards] each shard's capacity in bytes
-  //                          (unused by gather_batch_k but kept for symmetry/asserts).
+  //                          (unused by gather_batch_k but kept for
+  //                          symmetry/asserts).
   //   d_shard_tps_group    : [total_shards] chunks-per-shard within this batch.
   //                          Replaces uniform tps_group.
   //   d_shard_offsets_base : [total_shards] base index in d_offsets for each
@@ -99,25 +136,34 @@ extern "C"
   //                          0 = no carry-over path.
   //   total_shards         : sum_lv num_shards[lv]
   //   stream               : compress stream
-  int aggregate_batch_unified_async(
-    const void* d_compressed,
-    size_t* d_comp_sizes,
-    const uint32_t* d_batch_gather,
-    const uint32_t* d_batch_perm,
-    uint64_t total_batch_chunks,
-    uint64_t total_batch_covering,
-    uint8_t nlod,
-    size_t max_comp_chunk_bytes,
-    struct aggregate_slot* slot,
-    const size_t* d_shard_base_offsets,
-    const size_t* d_shard_capacity,
-    const uint64_t* d_shard_tps_group,
-    const uint64_t* d_shard_offsets_base,
-    const size_t* d_tail_bytes,
-    CUdeviceptr d_tail_carry,
-    size_t page_size,
-    uint64_t total_shards,
-    CUstream stream);
+  // slot_data_base / slot_desc_base bias kernels' writes into the slot's
+  // d_aggregated / d_offsets / d_permuted_sizes so multiple batches in
+  // Phase 3 can stack without aliasing. Phase 2 passes 0 for both.
+  //
+  // TODO(phase3): when batches_per_slot > 1, compress_agg_kick will need
+  // to call this once per batch with advancing slot_*_base, OR this fn
+  // will need to take a batch index and iterate. The single-dispatch
+  // shape today aggregates one batch per call.
+  int aggregate_batch_unified_async(const void* d_compressed,
+                                    size_t* d_comp_sizes,
+                                    const uint32_t* d_batch_gather,
+                                    const uint32_t* d_batch_perm,
+                                    uint64_t total_batch_chunks,
+                                    uint64_t total_batch_covering,
+                                    uint8_t nlod,
+                                    size_t max_comp_chunk_bytes,
+                                    struct aggregate_slot* slot,
+                                    size_t slot_data_base,
+                                    uint64_t slot_desc_base,
+                                    const size_t* d_shard_base_offsets,
+                                    const size_t* d_shard_capacity,
+                                    const uint64_t* d_shard_tps_group,
+                                    const uint64_t* d_shard_offsets_base,
+                                    const size_t* d_tail_bytes,
+                                    CUdeviceptr d_tail_carry,
+                                    size_t page_size,
+                                    uint64_t total_shards,
+                                    CUstream stream);
 
 #ifdef __cplusplus
 }

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -116,26 +116,30 @@ compress_agg_init(struct compress_agg_stage* stage,
     stage->max_total_data_bytes = stage->max_batch_layout.total_data_bytes;
   }
 
-  // Unified aggregate slot per fc. Sized for the max-batch case:
-  //   d_aggregated: max_total_data_bytes (page-aligned across LOD segments)
-  //   d_offsets/d_permuted_sizes/h_*: max_total_batch_covering + nlod
-  //     entries each (one sentinel slot per LOD for the +lv shift in
-  //     aggregate_batch_luts_unified). The CUB exclusive scan fills all
-  //     sentinel positions, so no per-LOD write_total fixup is needed.
+  // Unified aggregate slot per fc. Descriptor arrays (d_offsets,
+  // d_permuted_sizes, host mirrors) are sized to slot_chunk_cap so Phase 3
+  // can pack multiple compressed batches' descriptors into one slot
+  // without reallocation. For pass-through codecs we never macro-agg, so
+  // the cap stays at one batch's worth of entries.
   if (stage->max_total_batch_chunks > 0) {
-    // aggregate_batch_slot_init allocates (C+1) entries for d_offsets /
-    // d_permuted_sizes / h_offsets and C entries for h_permuted_sizes. We
-    // want all to fit total_batch_covering + nlod entries, so pass
-    // C = max_total_batch_covering + nlod (h_permuted_sizes ends up exactly
-    // matching the scan output length).
-    const uint64_t C_max =
+    const uint64_t C_per_batch =
       stage->max_total_batch_covering + (uint64_t)stage->nlod;
+    uint64_t slot_chunk_cap = C_per_batch;
+    if (stage->codec.type != CODEC_NONE) {
+      const size_t W = stage->max_total_data_bytes;
+      const uint64_t by_min =
+        (uint64_t)(W / MIN_COMPRESSED_CHUNK_BYTES) + (uint64_t)stage->nlod;
+      if (by_min > slot_chunk_cap)
+        slot_chunk_cap = by_min;
+    }
+    const uint32_t batches_per_slot_cap = 1; // Phase 3 will raise this.
     for (int fc = 0; fc < 2; ++fc) {
       CHECK(Fail,
             aggregate_batch_slot_init(&stage->agg[fc],
                                       stage->max_total_batch_chunks,
-                                      C_max,
-                                      stage->max_total_data_bytes) == 0);
+                                      slot_chunk_cap,
+                                      stage->max_total_data_bytes,
+                                      batches_per_slot_cap) == 0);
       CU(Fail, cuEventRecord(stage->agg[fc].ready, compute));
     }
   }
@@ -512,6 +516,8 @@ compress_agg_kick(struct compress_agg_stage* stage,
             nlod,
             stage->codec.max_output_size,
             &stage->agg[fc],
+            stage->agg[fc].slot_cursor,
+            stage->agg[fc].slot_desc_cursor,
             stage->shards.d_base_offsets,
             stage->shards.d_shard_capacity,
             stage->shards.d_tps_group,
@@ -544,6 +550,20 @@ compress_agg_kick(struct compress_agg_stage* stage,
   out->shards = &stage->shards;
   for (uint8_t lv = 0; lv < nlod; ++lv)
     out->shards_by_lod[lv] = &stage->shard[lv];
+
+  // Macro-agg slot bookkeeping (Phase 2: one batch per slot at offset 0).
+  struct aggregate_slot* slot = &stage->agg[fc];
+  slot->slot_cursor = 0;
+  slot->slot_desc_cursor = 0;
+  slot->batches_per_slot = 0;
+  CHECK(Error, slot->batches_per_slot < slot->batches_per_slot_cap);
+  struct batch_slice_entry* be = &slot->slot_batches[slot->batches_per_slot];
+  be->data_base_offset = slot->slot_cursor;
+  be->desc_base_offset = slot->slot_desc_cursor;
+  be->nlod = nlod;
+  memcpy(
+    be->per_lod_lods, layout.lods, (size_t)nlod * sizeof(struct lod_segment));
+  slot->batches_per_slot = 1;
 
   return 0;
 

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -40,7 +40,6 @@ Error:
 
 // --- Init / Destroy ---
 
-
 int
 compress_agg_init(struct compress_agg_stage* stage,
                   const struct computed_stream_layouts* cl,
@@ -78,9 +77,9 @@ compress_agg_init(struct compress_agg_stage* stage,
   const int need_compressed = (stage->codec.type != CODEC_NONE);
   for (int fc = 0; fc < 2; ++fc) {
     if (need_compressed)
-      CU(Fail,
-         cuMemAlloc(&stage->d_compressed[fc],
-                    M * stage->codec.max_output_size));
+      CU(
+        Fail,
+        cuMemAlloc(&stage->d_compressed[fc], M * stage->codec.max_output_size));
     CU(Fail, cuEventCreate(&stage->t_compress_start[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->t_compress_end[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->t_aggregate_end[fc], CU_EVENT_DEFAULT));
@@ -95,11 +94,11 @@ compress_agg_init(struct compress_agg_stage* stage,
   // them per-array. Each layout's GPU-side d_lifted_shape/strides are uploaded.
   for (int lv = 0; lv < cl->levels.nlod; ++lv) {
     stage->per_lod_agg_layouts[lv] = cl->per_level[lv].agg_layout;
-    CHECK(Fail,
-          aggregate_layout_upload(&stage->per_lod_agg_layouts[lv]) == 0);
+    CHECK(Fail, aggregate_layout_upload(&stage->per_lod_agg_layouts[lv]) == 0);
   }
 
-  // Cached max batch layout assuming each LOD fires its worst-case active count.
+  // Cached max batch layout assuming each LOD fires its worst-case active
+  // count.
   {
     uint32_t per_lod_max[LOD_MAX_LEVELS] = { 0 };
     for (int lv = 0; lv < cl->levels.nlod; ++lv)
@@ -225,15 +224,13 @@ compress_agg_init(struct compress_agg_stage* stage,
       // Tail-carry buffer: total_shards * page_size bytes; uniform layout
       // across LODs (sink page size is uniform).
       if (stage->shards.page_size > 0) {
-        stage->shards.tail_carry_bytes =
-          total_shards * stage->shards.page_size;
+        stage->shards.tail_carry_bytes = total_shards * stage->shards.page_size;
         CU(Fail,
            cuMemAlloc(&stage->shards.d_tail_carry,
                       stage->shards.tail_carry_bytes));
         CU(Fail,
-           cuMemsetD8(stage->shards.d_tail_carry,
-                      0,
-                      stage->shards.tail_carry_bytes));
+           cuMemsetD8(
+             stage->shards.d_tail_carry, 0, stage->shards.tail_carry_bytes));
       }
     }
   }
@@ -241,8 +238,7 @@ compress_agg_init(struct compress_agg_stage* stage,
   // Per-LOD shard_state (writers + tail/footer pools + generation
   // bookkeeping). The unified kick/D2H path iterates this directly.
   for (int lv = 0; lv < cl->levels.nlod; ++lv)
-    CHECK(Fail,
-          init_shard_state(&stage->shard[lv], &cl->per_level[lv]) == 0);
+    CHECK(Fail, init_shard_state(&stage->shard[lv], &cl->per_level[lv]) == 0);
 
   // Seed events
   for (int fc = 0; fc < 2; ++fc) {
@@ -400,28 +396,27 @@ compress_agg_kick(struct compress_agg_stage* stage,
   // Page size is uniform across LODs (sink-driven); read from LOD 0.
   struct batch_aggregate_layout layout;
   const size_t page_size = stage->per_lod_agg_layouts[0].page_size;
-  CHECK(Error,
-        batch_aggregate_layout_init(&layout,
-                                    stage->per_lod_agg_layouts,
-                                    per_lod_n_active,
-                                    nlod,
-                                    page_size) == 0);
+  CHECK(
+    Error,
+    batch_aggregate_layout_init(
+      &layout, stage->per_lod_agg_layouts, per_lod_n_active, nlod, page_size) ==
+      0);
 
   CHECK(Error, layout.total_data_bytes <= stage->max_total_data_bytes);
   CHECK(Error, layout.total_batch_chunks <= stage->max_total_batch_chunks);
-  CHECK(Error,
-        layout.total_batch_covering <= stage->max_total_batch_covering);
+  CHECK(Error, layout.total_batch_covering <= stage->max_total_batch_covering);
 
   // --- Phase 3: build & upload unified LUTs (cached in steady state) -------
   // Cache key: per-LOD active count AND each LOD's pool_epoch values. Counts
   // alone are insufficient — the gather LUT encodes the actual epoch indices,
   // so two batches with identical counts but different active-epoch positions
   // (mid-stream phase shifts when K doesn't divide an LOD's append period)
-  // would mis-hit and reuse stale gather indices. See [[ok-let-s-make-a-curious-prism]].
-  int lut_steady = stage->lut_cache_valid &&
-                   memcmp(stage->cached_per_lod_n_active,
-                          per_lod_n_active,
-                          (size_t)nlod * sizeof(uint32_t)) == 0;
+  // would mis-hit and reuse stale gather indices. See
+  // [[ok-let-s-make-a-curious-prism]].
+  int lut_steady =
+    stage->lut_cache_valid && memcmp(stage->cached_per_lod_n_active,
+                                     per_lod_n_active,
+                                     (size_t)nlod * sizeof(uint32_t)) == 0;
   for (uint8_t lv = 0; lut_steady && lv < nlod; ++lv) {
     const uint32_t n_lv = per_lod_n_active[lv];
     if (n_lv == 0)
@@ -536,13 +531,13 @@ compress_agg_kick(struct compress_agg_stage* stage,
   out->active_levels_mask = in->active_levels_mask;
   out->batch_active_masks = in->batch_active_masks;
   out->nlod = nlod;
-  memcpy(out->per_lod_n_active,
-         per_lod_n_active,
-         (size_t)nlod * sizeof(uint32_t));
+  memcpy(
+    out->per_lod_n_active, per_lod_n_active, (size_t)nlod * sizeof(uint32_t));
   out->t_aggregate_end = stage->t_aggregate_end[fc];
   out->t_compress_start = stage->t_compress_start[fc];
   out->t_compress_end = stage->t_compress_end[fc];
   out->max_output_size = stage->codec.max_output_size;
+  out->passthrough = (stage->codec.type == CODEC_NONE);
   out->agg = &stage->agg[fc];
   out->layout = layout;
   out->per_lod_agg_layouts = stage->per_lod_agg_layouts;

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -7,6 +7,7 @@
 #include "util/prelude.h"
 #include "zarr/shard_delivery.h"
 
+#include <assert.h>
 #include <string.h>
 
 // --- Init / Destroy ---
@@ -21,8 +22,10 @@ d2h_deliver_init(struct d2h_deliver_stage* stage,
 
   for (int fc = 0; fc < 2; ++fc) {
     CU(Fail, cuEventCreate(&stage->t_d2h_start[fc], CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&stage->h_chunk_index_ready[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->ready[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventRecord(stage->t_d2h_start[fc], compute));
+    CU(Fail, cuEventRecord(stage->h_chunk_index_ready[fc], compute));
     CU(Fail, cuEventRecord(stage->ready[fc], compute));
   }
 
@@ -40,6 +43,7 @@ d2h_deliver_destroy(struct d2h_deliver_stage* stage)
     return;
   for (int fc = 0; fc < 2; ++fc) {
     cu_event_destroy(stage->t_d2h_start[fc]);
+    cu_event_destroy(stage->h_chunk_index_ready[fc]);
     cu_event_destroy(stage->ready[fc]);
   }
 }
@@ -138,11 +142,8 @@ record_flush_metrics(const struct flush_handoff* handoff,
                          handoff->t_aggregate_end,
                          agg_bytes,
                          agg_bytes);
-    accumulate_metric_cu(&metrics->d2h,
-                         t_d2h_start,
-                         t_d2h_ready,
-                         agg_bytes,
-                         agg_bytes);
+    accumulate_metric_cu(
+      &metrics->d2h, t_d2h_start, t_d2h_ready, agg_bytes, agg_bytes);
   }
 }
 
@@ -158,14 +159,52 @@ lod_view(const struct flush_handoff* handoff, uint8_t lv)
   struct aggregate_result ar = {
     .data = (uint8_t*)slot->h_aggregated + seg->data_segment_offset,
     .offsets = slot->h_offsets + seg->batch_covering_offset + lv,
-    .chunk_sizes =
-      slot->h_permuted_sizes + seg->batch_covering_offset + lv,
+    .chunk_sizes = slot->h_permuted_sizes + seg->batch_covering_offset + lv,
   };
   return ar;
 }
 
-// Sync on ready[fc] (near-zero in steady state), record metrics, deliver
-// to sinks.
+// Poll a CUDA event with a sleep loop. Returns 0 on success / deinit,
+// 1 on error.
+static int
+poll_event(CUevent ev, int fc)
+{
+  for (;;) {
+    CUresult r = cuEventQuery(ev);
+    if (r == CUDA_SUCCESS)
+      return 0;
+    if (r == CUDA_ERROR_DEINITIALIZED) {
+      log_debug("d2h_deliver: cuEventQuery returned DEINITIALIZED (fc=%d)", fc);
+      return 0;
+    }
+    if (r != CUDA_ERROR_NOT_READY) {
+      handle_curesult(LOG_ERROR, r, __FILE__, __LINE__, "cuEventQuery");
+      return 1;
+    }
+    platform_sleep_ns(50000);
+  }
+}
+
+// Per-LOD actual bytes in d_aggregated. End of last chunk (last shard's
+// last chunk in shard-permuted order) minus the LOD segment base. h_offsets
+// here must be the pre-rebase (absolute) values produced by the unified
+// scan + bias.
+static size_t
+lod_actual_bytes(const struct flush_handoff* handoff, uint8_t lv)
+{
+  const struct lod_segment* seg = &handoff->layout.lods[lv];
+  if (seg->n_active == 0)
+    return 0;
+  const struct aggregate_slot* slot = handoff->agg;
+  const uint64_t total = (uint64_t)seg->n_active * seg->covering_count;
+  const size_t last = seg->batch_covering_offset + (size_t)lv + total - 1;
+  const size_t end = slot->h_offsets[last] + slot->h_permuted_sizes[last];
+  assert(slot->h_offsets[last] >= seg->data_segment_offset);
+  const size_t actual = end - seg->data_segment_offset;
+  assert(actual <= seg->data_segment_bytes);
+  return actual;
+}
+
 static struct writer_result
 sync_and_deliver(struct d2h_deliver_stage* stage,
                  const struct flush_handoff* handoff,
@@ -176,9 +215,12 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
                  struct shard_sink* sink,
                  const struct lod_state* lod,
                  const struct lod_shared_state* lod_shared,
-                 struct stream_metrics* metrics)
+                 struct stream_metrics* metrics,
+                 CUstream d2h_stream)
 {
   const int fc = handoff->fc;
+  struct aggregate_slot* slot = handoff->agg;
+  const struct batch_aggregate_layout* alayout = &handoff->layout;
 
   if (sink->has_error && sink->has_error(sink))
     goto Error;
@@ -186,21 +228,56 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
   {
     struct platform_clock kick_clk = { 0 };
     platform_toc(&kick_clk);
-    for (;;) {
-      CUresult r = cuEventQuery(stage->ready[fc]);
-      if (r == CUDA_SUCCESS)
-        break;
-      if (r == CUDA_ERROR_DEINITIALIZED) {
-        log_debug("d2h_deliver: cuEventQuery returned DEINITIALIZED (fc=%d)",
-                  fc);
-        break;
-      }
-      if (r != CUDA_ERROR_NOT_READY) {
-        handle_curesult(LOG_ERROR, r, __FILE__, __LINE__, "cuEventQuery");
+
+    if (handoff->passthrough) {
+      // Bulk D2H was queued in d2h_deliver_kick; just wait for it.
+      if (poll_event(stage->ready[fc], fc))
         goto Error;
+    } else {
+      // Compressed: wait for the chunk index on host, then dispatch the
+      // exact-size bulk D2H per LOD (carry-over) or once for the whole
+      // batch (contiguous).
+      if (poll_event(stage->h_chunk_index_ready[fc], fc))
+        goto Error;
+
+      if (alayout->page_size > 0) {
+        for (uint8_t lv = 0; lv < handoff->nlod; ++lv) {
+          if (handoff->per_lod_n_active[lv] == 0)
+            continue;
+          const struct lod_segment* seg = &alayout->lods[lv];
+          const size_t actual = lod_actual_bytes(handoff, lv);
+          if (actual == 0)
+            continue;
+          CU(Error,
+             cuMemcpyDtoHAsync(
+               (uint8_t*)slot->h_aggregated + seg->data_segment_offset,
+               (CUdeviceptr)slot->d_aggregated + seg->data_segment_offset,
+               actual,
+               d2h_stream));
+        }
+      } else if (alayout->total_batch_covering > 0) {
+        // Position n-1 is the last LOD's tail sentinel (size 0 there), so
+        // h_offsets[n-1] is the cumulative byte total. Adding
+        // h_permuted_sizes[n-1] is a no-op for the sentinel.
+        const size_t n = alayout->total_batch_covering + (size_t)handoff->nlod;
+        const size_t total =
+          slot->h_offsets[n - 1] + slot->h_permuted_sizes[n - 1];
+        if (total > 0) {
+          CU(Error,
+             cuMemcpyDtoHAsync(slot->h_aggregated,
+                               (CUdeviceptr)slot->d_aggregated,
+                               total,
+                               d2h_stream));
+        }
       }
-      platform_sleep_ns(50000);
+
+      CU(Error, cuEventRecord(stage->ready[fc], d2h_stream));
+      CU(Error, cuEventRecord(slot->ready, d2h_stream));
+
+      if (poll_event(stage->ready[fc], fc))
+        goto Error;
     }
+
     float kick_ms = platform_toc(&kick_clk) * 1000.0f;
     accumulate_metric_ms(&metrics->kick_sync_stall, kick_ms, 0, 0);
   }
@@ -356,21 +433,16 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
   struct aggregate_slot* slot = handoff->agg;
   const struct batch_aggregate_layout* layout = &handoff->layout;
 
-  // Block on the prior IO retiring this slot (single fence across all LODs).
   wait_io_fences(slot, sink, stage->metrics);
 
-  // d2h stream waits for aggregate to finish writing the unified buffer.
   CU(Error, cuStreamWaitEvent(d2h_stream, handoff->t_aggregate_end, 0));
   CU(Error, cuEventRecord(stage->t_d2h_start[fc], d2h_stream));
 
-  // One D2H for the unified offsets array (covers all LOD ranges). The
-  // unified prefix-sum produces total_batch_covering + nlod offsets — each
-  // LOD's tail sentinel sits at position
-  // (batch_covering_offset + n_active*covering + lv), all within the scan's
-  // output range.
+  // Offsets + permuted sizes. Compressed codecs use these in drain to size
+  // exact per-LOD transfers; pass-through copies them too so delivery's
+  // chunk-index walk works uniformly.
   if (layout->total_batch_covering > 0) {
-    const size_t n =
-      layout->total_batch_covering + (size_t)handoff->nlod;
+    const size_t n = layout->total_batch_covering + (size_t)handoff->nlod;
     CU(Error,
        cuMemcpyDtoHAsync(slot->h_offsets,
                          (CUdeviceptr)slot->d_offsets,
@@ -383,19 +455,21 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                          d2h_stream));
   }
 
-  // One D2H for the unified aggregated data buffer. Sized to
-  // total_data_bytes (max across all LODs' page-aligned segments).
-  if (layout->total_data_bytes > 0) {
+  CU(Error, cuEventRecord(stage->h_chunk_index_ready[fc], d2h_stream));
+
+  // Pass-through: per-LOD actual equals worst-case. Dispatch the bulk D2H
+  // now so it pipelines with the next batch's compute (matches pre-Phase-1
+  // behavior). Compressed path defers bulk dispatch to sync_and_deliver
+  // once the chunk index has landed.
+  if (handoff->passthrough && layout->total_data_bytes > 0) {
     CU(Error,
        cuMemcpyDtoHAsync(slot->h_aggregated,
                          (CUdeviceptr)slot->d_aggregated,
                          layout->total_data_bytes,
                          d2h_stream));
+    CU(Error, cuEventRecord(stage->ready[fc], d2h_stream));
+    CU(Error, cuEventRecord(slot->ready, d2h_stream));
   }
-  CU(Error, cuEventRecord(stage->ready[fc], d2h_stream));
-  // Also signal the slot's own ready event so the next compress that reuses
-  // this slot waits on it.
-  CU(Error, cuEventRecord(slot->ready, d2h_stream));
 
   return 0;
 
@@ -415,7 +489,8 @@ d2h_deliver_drain(struct d2h_deliver_stage* stage,
                   const struct lod_state* lod,
                   const struct lod_shared_state* lod_shared,
                   struct stream_metrics* metrics,
-                  struct platform_clock* metadata_update_clock)
+                  struct platform_clock* metadata_update_clock,
+                  CUstream d2h_stream)
 {
   (void)batch;
   struct writer_result r = sync_and_deliver(stage,
@@ -427,9 +502,11 @@ d2h_deliver_drain(struct d2h_deliver_stage* stage,
                                             sink,
                                             lod,
                                             lod_shared,
-                                            metrics);
+                                            metrics,
+                                            d2h_stream);
   if (!r.error) {
-    if (maybe_update_metadata(handoff, dims, config, sink, metadata_update_clock))
+    if (maybe_update_metadata(
+          handoff, dims, config, sink, metadata_update_clock))
       return writer_error();
   }
   return r;

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -127,6 +127,9 @@ record_flush_metrics(const struct flush_handoff* handoff,
     // in this batch. h_permuted_sizes carries pre-bias per-chunk sizes (with
     // a 0 sentinel slot inserted per LOD); summing those gives the real D2H
     // payload regardless of the absolute/segment-relative offset semantics.
+    // TODO(phase3): with batches_per_slot > 1, sum across all slot batches
+    // (slot->slot_batches[0..batches_per_slot-1]) instead of just the
+    // current handoff->layout. handoff carries the latest batch only.
     size_t agg_bytes = 0;
     const size_t n_perm = handoff->layout.total_batch_covering + handoff->nlod;
     for (size_t i = 0; i < n_perm; ++i)
@@ -147,19 +150,33 @@ record_flush_metrics(const struct flush_handoff* handoff,
   }
 }
 
-// Build the per-LOD aggregate_result view into the unified host buffer for
-// delivery. The unified layout places each LOD's segment at
-// `data_segment_offset` within h_aggregated, and each LOD's
-// offsets/chunk_sizes start at `batch_covering_offset + lv`.
-static struct aggregate_result
-lod_view(const struct flush_handoff* handoff, uint8_t lv)
+// Slot-relative byte offset for batch be's LOD lv segment.
+static size_t
+slot_data_offset(const struct batch_slice_entry* be, uint8_t lv)
 {
-  const struct lod_segment* seg = &handoff->layout.lods[lv];
-  struct aggregate_slot* slot = handoff->agg;
+  return be->data_base_offset + be->per_lod_lods[lv].data_segment_offset;
+}
+
+// Slot-relative descriptor entry index for batch be's LOD lv chunks.
+static uint64_t
+slot_desc_offset(const struct batch_slice_entry* be, uint8_t lv)
+{
+  return be->desc_base_offset + be->per_lod_lods[lv].batch_covering_offset +
+         (uint64_t)lv;
+}
+
+// Per-batch / per-LOD aggregate_result view into the slot's host mirrors.
+static struct aggregate_result
+batch_lod_view(struct aggregate_slot* slot,
+               const struct batch_slice_entry* be,
+               uint8_t lv)
+{
+  const size_t off = slot_data_offset(be, lv);
+  const uint64_t desc = slot_desc_offset(be, lv);
   struct aggregate_result ar = {
-    .data = (uint8_t*)slot->h_aggregated + seg->data_segment_offset,
-    .offsets = slot->h_offsets + seg->batch_covering_offset + lv,
-    .chunk_sizes = slot->h_permuted_sizes + seg->batch_covering_offset + lv,
+    .data = (uint8_t*)slot->h_aggregated + off,
+    .offsets = slot->h_offsets + desc,
+    .chunk_sizes = slot->h_permuted_sizes + desc,
   };
   return ar;
 }
@@ -185,22 +202,24 @@ poll_event(CUevent ev, int fc)
   }
 }
 
-// Per-LOD actual bytes in d_aggregated. End of last chunk (last shard's
-// last chunk in shard-permuted order) minus the LOD segment base. h_offsets
-// here must be the pre-rebase (absolute) values produced by the unified
-// scan + bias.
+// Per-batch / per-LOD actual bytes in d_aggregated. End of last chunk
+// (last shard's last chunk in shard-permuted order) minus the LOD segment
+// base within the slot. h_offsets here must be the pre-rebase (absolute)
+// values produced by the unified scan + bias.
 static size_t
-lod_actual_bytes(const struct flush_handoff* handoff, uint8_t lv)
+batch_lod_actual_bytes(const struct aggregate_slot* slot,
+                       const struct batch_slice_entry* be,
+                       uint8_t lv)
 {
-  const struct lod_segment* seg = &handoff->layout.lods[lv];
+  const struct lod_segment* seg = &be->per_lod_lods[lv];
   if (seg->n_active == 0)
     return 0;
-  const struct aggregate_slot* slot = handoff->agg;
   const uint64_t total = (uint64_t)seg->n_active * seg->covering_count;
-  const size_t last = seg->batch_covering_offset + (size_t)lv + total - 1;
+  const uint64_t last = slot_desc_offset(be, lv) + total - 1;
+  const size_t base = slot_data_offset(be, lv);
   const size_t end = slot->h_offsets[last] + slot->h_permuted_sizes[last];
-  assert(slot->h_offsets[last] >= seg->data_segment_offset);
-  const size_t actual = end - seg->data_segment_offset;
+  assert(slot->h_offsets[last] >= base);
+  const size_t actual = end - base;
   assert(actual <= seg->data_segment_bytes);
   return actual;
 }
@@ -235,33 +254,43 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
         goto Error;
     } else {
       // Compressed: wait for the chunk index on host, then dispatch the
-      // exact-size bulk D2H per LOD (carry-over) or once for the whole
-      // batch (contiguous).
+      // exact-size bulk D2H per batch×LOD (carry-over) or once across the
+      // slot's contiguous data (contiguous mode).
       if (poll_event(stage->h_chunk_index_ready[fc], fc))
         goto Error;
 
       if (alayout->page_size > 0) {
-        for (uint8_t lv = 0; lv < handoff->nlod; ++lv) {
-          if (handoff->per_lod_n_active[lv] == 0)
-            continue;
-          const struct lod_segment* seg = &alayout->lods[lv];
-          const size_t actual = lod_actual_bytes(handoff, lv);
-          if (actual == 0)
-            continue;
-          CU(Error,
-             cuMemcpyDtoHAsync(
-               (uint8_t*)slot->h_aggregated + seg->data_segment_offset,
-               (CUdeviceptr)slot->d_aggregated + seg->data_segment_offset,
-               actual,
-               d2h_stream));
+        for (uint32_t b = 0; b < slot->batches_per_slot; ++b) {
+          const struct batch_slice_entry* be = &slot->slot_batches[b];
+          for (uint8_t lv = 0; lv < be->nlod; ++lv) {
+            if (be->per_lod_lods[lv].n_active == 0)
+              continue;
+            const size_t off = slot_data_offset(be, lv);
+            const size_t actual = batch_lod_actual_bytes(slot, be, lv);
+            if (actual == 0)
+              continue;
+            CU(Error,
+               cuMemcpyDtoHAsync((uint8_t*)slot->h_aggregated + off,
+                                 (CUdeviceptr)slot->d_aggregated + off,
+                                 actual,
+                                 d2h_stream));
+          }
         }
-      } else if (alayout->total_batch_covering > 0) {
-        // Position n-1 is the last LOD's tail sentinel (size 0 there), so
-        // h_offsets[n-1] is the cumulative byte total. Adding
-        // h_permuted_sizes[n-1] is a no-op for the sentinel.
-        const size_t n = alayout->total_batch_covering + (size_t)handoff->nlod;
+      } else if (slot->batches_per_slot > 0) {
+        // Cumulative-end index = last sentinel of the slot's last batch.
+        // Without bias (page_size==0), h_offsets there is the running sum
+        // of all chunk sizes across this batch's slice; with Phase 3
+        // macro-agg the desc_base_offset advances per batch.
+        const struct batch_slice_entry* last_be =
+          &slot->slot_batches[slot->batches_per_slot - 1];
+        uint64_t C_batch = 0;
+        for (uint8_t lv = 0; lv < last_be->nlod; ++lv)
+          C_batch += (uint64_t)last_be->per_lod_lods[lv].n_active *
+                     last_be->per_lod_lods[lv].covering_count;
+        const uint64_t last =
+          last_be->desc_base_offset + C_batch + (uint64_t)last_be->nlod - 1;
         const size_t total =
-          slot->h_offsets[n - 1] + slot->h_permuted_sizes[n - 1];
+          slot->h_offsets[last] + slot->h_permuted_sizes[last];
         if (total > 0) {
           CU(Error,
              cuMemcpyDtoHAsync(slot->h_aggregated,
@@ -300,47 +329,53 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     struct shard_tables* shards = handoff->shards;
     const size_t page_size = shards ? shards->page_size : 0;
 
-    // Rebase per-LOD offsets to be segment-relative. GPU produces absolute
-    // offsets (each chunk's position in the unified d_aggregated buffer); the
-    // shard_delivery contract — shared with the CPU path — pairs a
-    // segment-shifted `result.data` with segment-relative offsets, so we
-    // subtract seg->data_segment_offset from each LOD's offsets here. This
-    // matches src/cpu/aggregate.c:330-338 which builds the same view shape.
-    // The rebase mutates h_offsets in place; this is safe because the next
-    // kick's D2H repopulates the buffer before anything reads stale values.
-    for (uint8_t lv = 0; lv < handoff->nlod; ++lv) {
-      // LOD 0's segment offset is always 0; skip the no-op subtraction.
-      if (lv == 0 || handoff->per_lod_n_active[lv] == 0)
-        continue;
-      const struct lod_segment* seg = &handoff->layout.lods[lv];
-      size_t* off = handoff->agg->h_offsets + seg->batch_covering_offset + lv;
-      const uint64_t n = (uint64_t)seg->n_active * seg->covering_count + 1;
-      for (uint64_t i = 0; i < n; ++i)
-        off[i] -= seg->data_segment_offset;
+    // Rebase per-batch / per-LOD offsets to be segment-relative. GPU
+    // produces absolute (slot-relative) offsets; the shard_delivery
+    // contract — shared with the CPU path — pairs a segment-shifted
+    // `result.data` with segment-relative offsets, so we subtract the
+    // slot-relative base from each batch × LOD's offsets. The rebase
+    // mutates h_offsets in place; safe because the next kick's D2H
+    // repopulates the buffer before anything reads stale values.
+    for (uint32_t b = 0; b < slot->batches_per_slot; ++b) {
+      const struct batch_slice_entry* be = &slot->slot_batches[b];
+      for (uint8_t lv = 0; lv < be->nlod; ++lv) {
+        const struct lod_segment* seg = &be->per_lod_lods[lv];
+        if (seg->n_active == 0)
+          continue;
+        const size_t base = slot_data_offset(be, lv);
+        if (base == 0)
+          continue;
+        size_t* off = slot->h_offsets + slot_desc_offset(be, lv);
+        const uint64_t n = (uint64_t)seg->n_active * seg->covering_count + 1;
+        for (uint64_t i = 0; i < n; ++i)
+          off[i] -= base;
+      }
     }
 
-    for (uint8_t lv = 0; lv < handoff->nlod; ++lv) {
-      if (handoff->per_lod_n_active[lv] == 0)
-        continue;
+    for (uint32_t b = 0; b < slot->batches_per_slot; ++b) {
+      const struct batch_slice_entry* be = &slot->slot_batches[b];
+      for (uint8_t lv = 0; lv < be->nlod; ++lv) {
+        if (be->per_lod_lods[lv].n_active == 0)
+          continue;
 
-      struct aggregate_result ar = lod_view(handoff, lv);
-      // Per-LOD slice of the unified host tail-bytes scratch.
-      size_t* h_tail_lv = NULL;
-      if (shards && shards->h_tail_bytes && page_size > 0)
-        h_tail_lv = shards->h_tail_bytes + shards->shards_begin[lv];
+        struct aggregate_result ar = batch_lod_view(slot, be, lv);
+        size_t* h_tail_lv = NULL;
+        if (shards && shards->h_tail_bytes && page_size > 0)
+          h_tail_lv = shards->h_tail_bytes + shards->shards_begin[lv];
 
-      size_t level_bytes = 0;
-      if (deliver_to_shards_batch((uint8_t)lv,
-                                  handoff->shards_by_lod[lv],
-                                  &ar,
-                                  &handoff->per_lod_agg_layouts[lv],
-                                  h_tail_lv,
-                                  handoff->per_lod_n_active[lv],
-                                  sink,
-                                  stage->shard_alignment,
-                                  &level_bytes))
-        goto Error;
-      sink_bytes += level_bytes;
+        size_t level_bytes = 0;
+        if (deliver_to_shards_batch((uint8_t)lv,
+                                    handoff->shards_by_lod[lv],
+                                    &ar,
+                                    &handoff->per_lod_agg_layouts[lv],
+                                    h_tail_lv,
+                                    be->per_lod_lods[lv].n_active,
+                                    sink,
+                                    stage->shard_alignment,
+                                    &level_bytes))
+          goto Error;
+        sink_bytes += level_bytes;
+      }
     }
 
     // Push the post-delivery tail state back to GPU in two bulk HtoDs that

--- a/src/gpu/flush.d2h_deliver.h
+++ b/src/gpu/flush.d2h_deliver.h
@@ -27,7 +27,8 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                  CUstream d2h_stream);
 
 // Synchronize D2H, record metrics, deliver to sinks.
-// Returns writer_ok() on success.
+// Returns writer_ok() on success. d2h_stream is used to dispatch the
+// exact-size bulk D2H once h_offsets/h_permuted_sizes have landed.
 struct writer_result
 d2h_deliver_drain(struct d2h_deliver_stage* stage,
                   const struct flush_handoff* handoff,
@@ -40,4 +41,5 @@ d2h_deliver_drain(struct d2h_deliver_stage* stage,
                   const struct lod_state* lod,
                   const struct lod_shared_state* lod_shared,
                   struct stream_metrics* metrics,
-                  struct platform_clock* metadata_update_clock);
+                  struct platform_clock* metadata_update_clock,
+                  CUstream d2h_stream);

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -23,21 +23,26 @@ struct shard_tables;
 // must read per-LOD active counts from `per_lod_n_active` instead.
 struct flush_handoff
 {
-  int fc;                                     // flush slot index
-  uint32_t n_epochs;                          // epochs in batch
-  uint32_t active_levels_mask;                // which levels active
-  const uint32_t* batch_active_masks;         // borrowed [K] per-epoch masks
-  uint32_t per_lod_n_active[LOD_MAX_LEVELS];  // owned, for delivery sizing
+  int fc;                                    // flush slot index
+  uint32_t n_epochs;                         // epochs in batch
+  uint32_t active_levels_mask;               // which levels active
+  const uint32_t* batch_active_masks;        // borrowed [K] per-epoch masks
+  uint32_t per_lod_n_active[LOD_MAX_LEVELS]; // owned, for delivery sizing
   uint8_t nlod;
 
   CUevent t_aggregate_end;  // D2H waits on this
   CUevent t_compress_start; // for metrics
   CUevent t_compress_end;   // for metrics
 
-  struct aggregate_slot* agg;                 // borrowed: unified slot for fc
-  struct batch_aggregate_layout layout;       // owned (by-value snapshot)
+  struct aggregate_slot* agg;           // borrowed: unified slot for fc
+  struct batch_aggregate_layout layout; // owned (by-value snapshot)
   const struct aggregate_layout* per_lod_agg_layouts; // borrowed [nlod]
   struct shard_state* shards_by_lod[LOD_MAX_LEVELS];  // borrowed
-  struct shard_tables* shards;                // borrowed (for tail HtoD)
-  size_t max_output_size;                     // codec bound
+  struct shard_tables* shards; // borrowed (for tail HtoD)
+  size_t max_output_size;      // codec bound
+
+  // Pass-through codec (CODEC_NONE): per-LOD bytes equal worst-case, so
+  // delivery skips the exact-size sync and keeps the kick-time bulk D2H
+  // path that overlaps with the next batch's compute.
+  uint8_t passthrough;
 };

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -146,10 +146,10 @@ struct shard_tables
   // Per-shard parameters used by add_shard_bias_unified_k and
   // copy_leading_tail_unified_k. Host shadows are owned; device buffers are
   // allocated at init sized to the max across arrays.
-  size_t* h_base_offsets;      // base byte offset in d_aggregated
-  size_t* h_shard_capacity;    // per shard
-  uint64_t* h_tps_group;       // chunks-per-shard within a batch
-  uint64_t* h_offsets_base;    // base index in d_offsets / d_permuted_sizes
+  size_t* h_base_offsets;   // base byte offset in d_aggregated
+  size_t* h_shard_capacity; // per shard
+  uint64_t* h_tps_group;    // chunks-per-shard within a batch
+  uint64_t* h_offsets_base; // base index in d_offsets / d_permuted_sizes
 
   size_t* d_base_offsets;
   size_t* d_shard_capacity;
@@ -199,8 +199,8 @@ struct compress_agg_stage
   uint32_t* h_lut_gather_scratch; // for building unified LUT host-side
   uint32_t* h_lut_perm_scratch;
   uint32_t cached_per_lod_n_active[LOD_MAX_LEVELS]; // last uploaded counts
-  uint32_t* cached_pool_epochs;   // [LOD_MAX_LEVELS * pool_epochs_stride]
-  uint32_t pool_epochs_stride;    // max K used by scratch + cache
+  uint32_t* cached_pool_epochs; // [LOD_MAX_LEVELS * pool_epochs_stride]
+  uint32_t pool_epochs_stride;  // max K used by scratch + cache
   int lut_cache_valid;
   uint64_t lut_steady_count;
   uint64_t lut_recompute_count;
@@ -229,7 +229,8 @@ struct compress_agg_stage
 struct d2h_deliver_stage
 {
   CUevent t_d2h_start[2];
-  CUevent ready[2]; // unified D2H completion (offsets+sizes+data)
+  CUevent h_chunk_index_ready[2]; // h_offsets + h_permuted_sizes on host
+  CUevent ready[2];               // full D2H done; gates slot reuse
 
   size_t shard_alignment;         // from sink; 0 = no alignment
   struct stream_metrics* metrics; // borrowed, for stall-time accumulation

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -95,7 +95,8 @@ drain_fc(struct stream_engine* e, struct stream_context* ctx, int fc)
                                              &e->lod,
                                              &e->lod_shared,
                                              &e->metrics,
-                                             &e->metadata_update_clock);
+                                             &e->metadata_update_clock,
+                                             e->streams.d2h);
   float ms = (float)(platform_toc(&stall_clk) * 1000.0);
   accumulate_metric_ms(&e->metrics.flush_stall, ms, 0, 0);
 

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -385,13 +385,12 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
                    desc->u_total_shards * sizeof(size_t)) != CUDA_SUCCESS)
       return 1;
     if (desc->u_page_size > 0) {
-      desc->u_tail_carry_bytes =
-        desc->u_total_shards * desc->u_page_size;
+      desc->u_tail_carry_bytes = desc->u_total_shards * desc->u_page_size;
       if (cuMemAlloc(&desc->u_d_tail_carry, desc->u_tail_carry_bytes) !=
           CUDA_SUCCESS)
         return 1;
-      if (cuMemsetD8(
-            desc->u_d_tail_carry, 0, desc->u_tail_carry_bytes) != CUDA_SUCCESS)
+      if (cuMemsetD8(desc->u_d_tail_carry, 0, desc->u_tail_carry_bytes) !=
+          CUDA_SUCCESS)
         return 1;
     }
   }
@@ -415,9 +414,8 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
   }
   mx->u_max_total_batch_chunks =
     max_u64(mx->u_max_total_batch_chunks, array_max_layout.total_batch_chunks);
-  mx->u_max_total_batch_covering =
-    max_u64(mx->u_max_total_batch_covering,
-            array_max_layout.total_batch_covering);
+  mx->u_max_total_batch_covering = max_u64(
+    mx->u_max_total_batch_covering, array_max_layout.total_batch_covering);
   mx->u_max_total_data_bytes =
     max_sz(mx->u_max_total_data_bytes, array_max_layout.total_data_bytes);
   mx->u_max_total_shards =
@@ -514,8 +512,7 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
        cuEventCreate(&e->compress_agg.t_aggregate_end[fc], CU_EVENT_DEFAULT));
   }
 
-  CHECK(Fail,
-        d2h_deliver_init(&e->d2h_deliver, 0, e->streams.compute) == 0);
+  CHECK(Fail, d2h_deliver_init(&e->d2h_deliver, 0, e->streams.compute) == 0);
   e->d2h_deliver.metrics = &e->metrics;
 
   // Unified-pipeline shared resources. Sized to maxima across arrays.
@@ -523,15 +520,24 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
   e->compress_agg.max_total_batch_covering = mx->u_max_total_batch_covering;
   e->compress_agg.max_total_data_bytes = mx->u_max_total_data_bytes;
   if (mx->u_max_total_batch_chunks > 0) {
-    const uint64_t C_max =
+    const uint64_t C_per_batch =
       mx->u_max_total_batch_covering + (uint64_t)ms->max_nlod;
+    // Conservative: multiarray binds across codecs, so size for the
+    // compressed-codec macro-agg case (W / MIN_COMPRESSED_CHUNK_BYTES).
+    const uint64_t by_min =
+      (uint64_t)(mx->u_max_total_data_bytes / MIN_COMPRESSED_CHUNK_BYTES) +
+      (uint64_t)ms->max_nlod;
+    const uint64_t slot_chunk_cap = by_min > C_per_batch ? by_min : C_per_batch;
+    const uint32_t batches_per_slot_cap = 1; // Phase 3 will raise this.
     for (int fc = 0; fc < 2; ++fc) {
       CHECK(Fail,
             aggregate_batch_slot_init(&e->compress_agg.agg[fc],
                                       mx->u_max_total_batch_chunks,
-                                      C_max,
-                                      mx->u_max_total_data_bytes) == 0);
-      CU(Fail, cuEventRecord(e->compress_agg.agg[fc].ready, e->streams.compute));
+                                      slot_chunk_cap,
+                                      mx->u_max_total_data_bytes,
+                                      batches_per_slot_cap) == 0);
+      CU(Fail,
+         cuEventRecord(e->compress_agg.agg[fc].ready, e->streams.compute));
     }
     CU(Fail,
        cuMemAlloc(&e->compress_agg.d_batch_gather,

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -12,9 +12,9 @@
 struct stream_metric
 {
   const char* name;
-  float ms;                 // cumulative
-  float best_ms;            // best single measurement (1e30f = not yet measured)
-  double best_input_bytes;  // input_bytes at the best-ms call (for best GiB/s)
+  float ms;                // cumulative
+  float best_ms;           // best single measurement (1e30f = not yet measured)
+  double best_input_bytes; // input_bytes at the best-ms call (for best GiB/s)
   double best_output_bytes; // output_bytes at the best-ms call
   double input_bytes;       // cumulative bytes read by stage
   double output_bytes;      // cumulative bytes written by stage
@@ -44,10 +44,11 @@ struct stream_metrics
   // flush_stall + kick_sync_stall + sink over-counts wall time. To isolate
   // the drain-side overhead not already attributed elsewhere, compute
   // flush_stall - kick_sync_stall - (sink portion inside drain).
-  struct stream_metric flush_stall; // whole d2h_deliver_drain call
-                                    // (drain_fc in stream.flush.c)
-  struct stream_metric kick_sync_stall; // cuEventSynchronize(ready[fc])
-                                        // in sync_and_deliver
+  struct stream_metric flush_stall;     // whole d2h_deliver_drain call
+                                        // (drain_fc in stream.flush.c)
+  struct stream_metric kick_sync_stall; // host wait in sync_and_deliver:
+                                        // h_chunk_index_ready poll + bulk
+                                        // D2H dispatch + ready[fc] poll
   struct stream_metric io_fence_stall;  // GPU: wait_io_fences in
                                         // d2h_deliver_kick. CPU: wait_fence
                                         // before aggregate in

--- a/tests/test_aggregate_contract_gpu.c
+++ b/tests/test_aggregate_contract_gpu.c
@@ -126,7 +126,8 @@ run_gpu_aggregate(struct gpu_run* r,
   const size_t comp_pool_bytes = N * g->max_comp;
 
   CHECK(Fail,
-        aggregate_batch_slot_init(&r->slot, N, batch_C, comp_pool_bytes) == 0);
+        aggregate_batch_slot_init(
+          &r->slot, N, batch_C + 1, comp_pool_bytes, 1) == 0);
 
   // Synthetic compressed pool: chunk i has size (10 + i%7), filled with
   // value (i+1)&0xff. Same shape as the CPU test.

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -81,9 +81,7 @@ test_ctx_setup(struct test_ctx* c,
   c->ca_inited = 1;
 
   CHECK(Fail,
-        d2h_deliver_init(&c->d2h,
-                         platform_page_alignment(),
-                         c->compute) == 0);
+        d2h_deliver_init(&c->d2h, platform_page_alignment(), c->compute) == 0);
   c->d2h_inited = 1;
 
   size_t pool_bytes = (uint64_t)n_pool_epochs * c->cl.levels.total_chunks *
@@ -175,7 +173,8 @@ test_ctx_kick_and_drain(struct test_ctx* c,
                                              &c->lod,
                                              &c->lod_shared,
                                              &c->metrics,
-                                             &c->metadata_clock);
+                                             &c->metadata_clock,
+                                             c->d2h_stream);
   CHECK(Fail, r.error == 0);
 
   return 0;


### PR DESCRIPTION
Phase 2 infrastructure for stacking multiple compressed batches into one D2H slot. No behavior change — `batches_per_slot` stays at 1, cursors at 0. Phase 3 will activate by raising `batches_per_slot_cap` and advancing cursors per kick.

**Stacks on #137** — merge that first.

- `struct batch_slice_entry`: per-batch slice metadata (data/desc base + per-LOD segments)
- `aggregate_slot`: adds `slot_cursor`, `slot_desc_cursor`, `slot_batches[]`, `batches_per_slot_cap`
- `slot_chunk_cap = W / 128 + nlod` for compressed codecs; pass-through stays at `C_per_batch + nlod`
- `aggregate_batch_unified_async` takes `slot_data_base` / `slot_desc_base` — kernels operate on biased views (Phase 2 values are 0)
- Delivery loop is now `batches × LODs` (degenerate outer loop)
- Contiguous-mode D2H derives end position from `slot->slot_batches[last]` rather than `handoff->layout`
- TODO comments mark Phase 3 traps (per-batch dispatch, metrics aggregation, single io_event per slot)