### PR TITLE
Fix tail-state upload race on the page-aligned GPU path

### DIFF
--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -248,26 +248,32 @@ compress_agg_init(struct compress_agg_stage* stage,
 
         // Tail-generation gate (shard_tables in stream.engine.h). The
         // support probe is an already-satisfied wait; without stream
-        // memops the lazy path host-drains instead (stream.flush.c).
-        CU(Fail,
-           cuMemHostAlloc((void**)&stage->shards.h_tail_seq_flag,
-                          sizeof(uint64_t),
-                          CU_MEMHOSTALLOC_DEVICEMAP));
-        *stage->shards.h_tail_seq_flag = 0;
-        CU(Fail,
-           cuMemHostGetDevicePointer(&stage->shards.d_tail_seq,
-                                     (void*)stage->shards.h_tail_seq_flag,
-                                     0));
-        {
+        // memops — or when the counter can't be allocated or mapped —
+        // the lazy path host-drains instead (stream.flush.c).
+        if (cuMemHostAlloc((void**)&stage->shards.h_tail_seq_flag,
+                           sizeof(uint64_t),
+                           CU_MEMHOSTALLOC_DEVICEMAP) != CUDA_SUCCESS) {
+          stage->shards.h_tail_seq_flag = NULL;
+        } else {
+          *stage->shards.h_tail_seq_flag = 0;
+          if (cuMemHostGetDevicePointer(&stage->shards.d_tail_seq,
+                                        (void*)stage->shards.h_tail_seq_flag,
+                                        0) != CUDA_SUCCESS) {
+            cuMemFreeHost((void*)stage->shards.h_tail_seq_flag);
+            stage->shards.h_tail_seq_flag = NULL;
+            stage->shards.d_tail_seq = 0;
+          }
+        }
+        if (stage->shards.d_tail_seq) {
           CUresult pr = cuStreamWaitValue64(
             compute, stage->shards.d_tail_seq, 0, CU_STREAM_WAIT_VALUE_GEQ);
           stage->shards.tail_gate_supported = (pr == CUDA_SUCCESS);
           if (pr != CUDA_SUCCESS && pr != CUDA_ERROR_NOT_SUPPORTED)
             CU(Fail, pr);
-          if (!stage->shards.tail_gate_supported)
-            log_warn("compress_agg: stream memops unsupported; page-aligned "
-                     "pipeline degrades to host-ordered tail uploads");
         }
+        if (!stage->shards.tail_gate_supported)
+          log_warn("compress_agg: tail gate unavailable; page-aligned "
+                   "pipeline degrades to host-ordered tail uploads");
       }
     }
   }

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -225,6 +225,29 @@ compress_agg_init(struct compress_agg_stage* stage,
         CU(Fail,
            cuMemsetD8(
              stage->shards.d_tail_carry, 0, stage->shards.tail_carry_bytes));
+
+        // Tail-generation gate (shard_tables in stream.engine.h). The
+        // support probe is an already-satisfied wait; without stream
+        // memops the lazy path host-drains instead (stream.flush.c).
+        CU(Fail,
+           cuMemHostAlloc((void**)&stage->shards.h_tail_seq_flag,
+                          sizeof(uint64_t),
+                          CU_MEMHOSTALLOC_DEVICEMAP));
+        *stage->shards.h_tail_seq_flag = 0;
+        CU(Fail,
+           cuMemHostGetDevicePointer(&stage->shards.d_tail_seq,
+                                     (void*)stage->shards.h_tail_seq_flag,
+                                     0));
+        {
+          CUresult pr = cuStreamWaitValue64(
+            compute, stage->shards.d_tail_seq, 0, CU_STREAM_WAIT_VALUE_GEQ);
+          stage->shards.tail_gate_supported = (pr == CUDA_SUCCESS);
+          if (pr != CUDA_SUCCESS && pr != CUDA_ERROR_NOT_SUPPORTED)
+            CU(Fail, pr);
+          if (!stage->shards.tail_gate_supported)
+            log_warn("compress_agg: stream memops unsupported; page-aligned "
+                     "pipeline degrades to host-ordered tail uploads");
+        }
       }
     }
   }
@@ -249,10 +272,25 @@ Fail:
 }
 
 void
+compress_agg_release_tail_gate(struct compress_agg_stage* stage)
+{
+  // kick_seq satisfies every threshold ever enqueued; UINT64_MAX would not
+  // (CU_STREAM_WAIT_VALUE_GEQ is a signed ring compare).
+  if (stage->shards.h_tail_seq_flag)
+    *stage->shards.h_tail_seq_flag = stage->shards.kick_seq;
+}
+
+void
 compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
 {
   if (!stage)
     return;
+  if (stage->shards.h_tail_seq_flag) {
+    // An undrained kick (failed flush) parks work on the compress stream;
+    // the frees below can block on pending work, so release first.
+    compress_agg_release_tail_gate(stage);
+    CUWARN(cuCtxSynchronize());
+  }
   codec_free(&stage->codec);
   free(stage->pool_epochs_scratch);
   free(stage->cached_pool_epochs);
@@ -283,6 +321,11 @@ compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
   for (int lv = 0; lv < nlod; ++lv) {
     aggregate_layout_destroy(&stage->per_lod_agg_layouts[lv]);
     shard_state_destroy(&stage->shard[lv]);
+  }
+  if (stage->shards.h_tail_seq_flag) {
+    cuMemFreeHost((void*)stage->shards.h_tail_seq_flag);
+    stage->shards.h_tail_seq_flag = NULL;
+    stage->shards.d_tail_seq = 0;
   }
   free(stage->shards.h_base_offsets);
   free(stage->shards.h_shard_capacity);
@@ -487,6 +530,23 @@ compress_agg_kick(struct compress_agg_stage* stage,
                         batch_chunks,
                         stage->codec.chunk_bytes,
                         compress_stream) == 0);
+  }
+
+  // --- Phase 6.5: tail-generation gate (page-aligned path only) -----------
+  // The dispatch below reads tail state that the previous kick's delivery
+  // uploads AFTER this enqueue (shard_tables in stream.engine.h). The wait
+  // goes after compress, which reads no tail state.
+  if (stage->shards.d_tail_seq) {
+    if (stage->shards.tail_gate_supported && layout.total_batch_chunks > 0 &&
+        stage->shards.total_shards > 0 && page_size > 0)
+      CU(Error,
+         cuStreamWaitValue64(compress_stream,
+                             stage->shards.d_tail_seq,
+                             stage->shards.kick_seq,
+                             CU_STREAM_WAIT_VALUE_GEQ));
+    // Counts even chunk-less kicks: every kick is drained exactly once, so
+    // the count stays the next kick's threshold.
+    stage->shards.kick_seq++;
   }
 
   // --- Phase 7: unified aggregate dispatch --------------------------------

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -207,6 +207,18 @@ compress_agg_init(struct compress_agg_stage* stage,
                     0,
                     total_shards * sizeof(size_t)));
 
+      // Delivery's tail upload is a synchronous HtoD from pageable memory,
+      // which may return before the DMA reaches the device; SYNC_MEMOPS
+      // makes it complete at the device first, so the tail-gate publish
+      // that follows it cannot outrun the copy (flush.d2h_deliver.c).
+      {
+        unsigned int sync_memops = 1;
+        CU(Fail,
+           cuPointerSetAttribute(&sync_memops,
+                                 CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                                 (CUdeviceptr)stage->shards.d_tail_bytes));
+      }
+
       // d_shard_capacity stays constant across batches in steady state; upload
       // it once now. d_base_offsets / d_tps_group / d_offsets_base depend on
       // per-batch active counts and are uploaded by the kick.
@@ -225,6 +237,14 @@ compress_agg_init(struct compress_agg_stage* stage,
         CU(Fail,
            cuMemsetD8(
              stage->shards.d_tail_carry, 0, stage->shards.tail_carry_bytes));
+        // Same pageable-HtoD constraint as d_tail_bytes above.
+        {
+          unsigned int sync_memops = 1;
+          CU(Fail,
+             cuPointerSetAttribute(&sync_memops,
+                                   CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                                   stage->shards.d_tail_carry));
+        }
 
         // Tail-generation gate (shard_tables in stream.engine.h). The
         // support probe is an already-satisfied wait; without stream

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -371,7 +371,8 @@ compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
 
 // Build per-shard tables for this batch's `layout`. Populates host shadows
 // and uploads to device on `stream`. tables.h_shard_capacity is constant and
-// uploaded at init; not re-uploaded here.
+// uploaded at init; not re-uploaded here. The rest is rebuilt every kick:
+// it depends on per_lod_n_active, which can shift mid-stream.
 static int
 build_and_upload_shard_tables(struct compress_agg_stage* stage,
                               const struct batch_aggregate_layout* layout,
@@ -423,55 +424,64 @@ Error:
   return 1;
 }
 
-int
-compress_agg_kick(struct compress_agg_stage* stage,
+static void
+scan_active_masks(struct compress_agg_stage* stage,
                   const struct compress_agg_input* in,
-                  const struct level_geometry* levels,
-                  CUstream compress_stream,
-                  struct flush_handoff* out)
+                  uint32_t* per_lod_n_active,
+                  const uint32_t** per_lod_pool_epochs)
 {
-  const int fc = in->fc;
-  const uint32_t n_epochs = in->n_epochs;
-  const uint8_t nlod = stage->nlod;
-
-  // --- Phase 1: mask scan (LOD-aware ends here) ----------------------------
-  // Per-LOD pool_epochs slices from the [LOD_MAX_LEVELS * K] scratch.
-  // Stride is the configured K (pool_epochs_stride), so the cache (same
-  // layout) can compare each LOD's slice at a stable offset.
   const uint32_t stride = stage->pool_epochs_stride;
-  uint32_t per_lod_n_active[LOD_MAX_LEVELS] = { 0 };
-  const uint32_t* per_lod_pool_epochs[LOD_MAX_LEVELS] = { 0 };
-  for (uint8_t lv = 0; lv < nlod; ++lv) {
+  for (uint8_t lv = 0; lv < stage->nlod; ++lv) {
     uint32_t* dst = stage->pool_epochs_scratch + (size_t)lv * stride;
     uint32_t k = 0;
-    for (uint32_t e = 0; e < n_epochs; ++e)
+    for (uint32_t e = 0; e < in->n_epochs; ++e)
       if (in->batch_active_masks[e] & (1u << lv))
         dst[k++] = e;
     per_lod_n_active[lv] = k;
     per_lod_pool_epochs[lv] = dst;
   }
+}
 
-  // --- Phase 2: build the per-kick unified batch layout --------------------
+static int
+build_batch_layout(struct compress_agg_stage* stage,
+                   const uint32_t* per_lod_n_active,
+                   struct batch_aggregate_layout* layout)
+{
   // Page size is uniform across LODs (sink-driven); read from LOD 0.
-  struct batch_aggregate_layout layout;
   const size_t page_size = stage->per_lod_agg_layouts[0].page_size;
-  CHECK(
-    Error,
-    batch_aggregate_layout_init(
-      &layout, stage->per_lod_agg_layouts, per_lod_n_active, nlod, page_size) ==
-      0);
+  CHECK(Error,
+        batch_aggregate_layout_init(layout,
+                                    stage->per_lod_agg_layouts,
+                                    per_lod_n_active,
+                                    stage->nlod,
+                                    page_size) == 0);
 
-  CHECK(Error, layout.total_data_bytes <= stage->max_total_data_bytes);
-  CHECK(Error, layout.total_batch_chunks <= stage->max_total_batch_chunks);
-  CHECK(Error, layout.total_batch_covering <= stage->max_total_batch_covering);
+  CHECK(Error, layout->total_data_bytes <= stage->max_total_data_bytes);
+  CHECK(Error, layout->total_batch_chunks <= stage->max_total_batch_chunks);
+  CHECK(Error, layout->total_batch_covering <= stage->max_total_batch_covering);
+  return 0;
 
-  // --- Phase 3: build & upload unified LUTs (cached in steady state) -------
-  // Cache key: per-LOD active count AND each LOD's pool_epoch values. Counts
-  // alone are insufficient — the gather LUT encodes the actual epoch indices,
-  // so two batches with identical counts but different active-epoch positions
-  // (mid-stream phase shifts when K doesn't divide an LOD's append period)
-  // would mis-hit and reuse stale gather indices. See
-  // [[ok-let-s-make-a-curious-prism]].
+Error:
+  return 1;
+}
+
+// Cache key: per-LOD active count AND each LOD's pool_epoch values. Counts
+// alone are insufficient — the gather LUT encodes the actual epoch indices,
+// so two batches with identical counts but different active-epoch positions
+// (mid-stream phase shifts when K doesn't divide an LOD's append period)
+// would mis-hit and reuse stale gather indices. See
+// [[ok-let-s-make-a-curious-prism]].
+static int
+build_and_upload_luts(struct compress_agg_stage* stage,
+                      const struct batch_aggregate_layout* layout,
+                      const struct level_geometry* levels,
+                      const uint32_t* per_lod_n_active,
+                      const uint32_t* const* per_lod_pool_epochs,
+                      CUstream compress_stream)
+{
+  const uint8_t nlod = stage->nlod;
+  const uint32_t stride = stage->pool_epochs_stride;
+
   int lut_steady =
     stage->lut_cache_valid && memcmp(stage->cached_per_lod_n_active,
                                      per_lod_n_active,
@@ -487,68 +497,79 @@ compress_agg_kick(struct compress_agg_stage* stage,
   }
   if (lut_steady) {
     stage->lut_steady_count++;
-  } else {
-    stage->lut_recompute_count++;
-    if (layout.total_batch_chunks > 0) {
-      aggregate_batch_luts_unified(&layout,
-                                   stage->per_lod_agg_layouts,
-                                   levels,
-                                   per_lod_pool_epochs,
-                                   stage->h_lut_gather_scratch,
-                                   stage->h_lut_perm_scratch);
-      CU(Error,
-         cuMemcpyHtoDAsync(stage->d_batch_gather,
-                           stage->h_lut_gather_scratch,
-                           layout.total_batch_chunks * sizeof(uint32_t),
-                           compress_stream));
-      CU(Error,
-         cuMemcpyHtoDAsync(stage->d_batch_perm,
-                           stage->h_lut_perm_scratch,
-                           layout.total_batch_chunks * sizeof(uint32_t),
-                           compress_stream));
-    }
-    memcpy(stage->cached_per_lod_n_active,
-           per_lod_n_active,
-           (size_t)nlod * sizeof(uint32_t));
-    for (uint8_t lv = 0; lv < nlod; ++lv) {
-      const uint32_t n_lv = per_lod_n_active[lv];
-      if (n_lv > 0)
-        memcpy(stage->cached_pool_epochs + (size_t)lv * stride,
-               per_lod_pool_epochs[lv],
-               (size_t)n_lv * sizeof(uint32_t));
-    }
-    stage->lut_cache_valid = 1;
+    return 0;
   }
 
-  // --- Phase 4: per-shard tables ------------------------------------------
-  // Always rebuild + upload; the runtime cost is small (≤ a few KB) and the
-  // values depend on per_lod_n_active which can shift mid-stream. We do it
-  // unconditionally so any layout drift is reflected immediately.
-  CHECK(Error,
-        build_and_upload_shard_tables(stage, &layout, compress_stream) == 0);
+  stage->lut_recompute_count++;
+  if (layout->total_batch_chunks > 0) {
+    aggregate_batch_luts_unified(layout,
+                                 stage->per_lod_agg_layouts,
+                                 levels,
+                                 per_lod_pool_epochs,
+                                 stage->h_lut_gather_scratch,
+                                 stage->h_lut_perm_scratch);
+    CU(Error,
+       cuMemcpyHtoDAsync(stage->d_batch_gather,
+                         stage->h_lut_gather_scratch,
+                         layout->total_batch_chunks * sizeof(uint32_t),
+                         compress_stream));
+    CU(Error,
+       cuMemcpyHtoDAsync(stage->d_batch_perm,
+                         stage->h_lut_perm_scratch,
+                         layout->total_batch_chunks * sizeof(uint32_t),
+                         compress_stream));
+  }
+  memcpy(stage->cached_per_lod_n_active,
+         per_lod_n_active,
+         (size_t)nlod * sizeof(uint32_t));
+  for (uint8_t lv = 0; lv < nlod; ++lv) {
+    const uint32_t n_lv = per_lod_n_active[lv];
+    if (n_lv > 0)
+      memcpy(stage->cached_pool_epochs + (size_t)lv * stride,
+             per_lod_pool_epochs[lv],
+             (size_t)n_lv * sizeof(uint32_t));
+  }
+  stage->lut_cache_valid = 1;
+  return 0;
 
-  // --- Phase 5: synchronization ------------------------------------------
+Error:
+  return 1;
+}
+
+static int
+wait_upstream_events(const struct compress_agg_input* in,
+                     CUstream compress_stream)
+{
   CU(Error, cuStreamWaitEvent(compress_stream, in->pool_ready, 0));
   if (in->lod_done)
     CU(Error, cuStreamWaitEvent(compress_stream, in->lod_done, 0));
-
-  // Aggregate writes to agg[fc].d_aggregated; ensure the prior D2H at this
-  // fc has finished reading from it before we overwrite. prev_d2h_done is
-  // initialized signaled, so the first kick on each fc no-ops here.
   if (in->prev_d2h_done)
     CU(Error, cuStreamWaitEvent(compress_stream, in->prev_d2h_done, 0));
+  return 0;
 
-  // --- Phase 6: compress --------------------------------------------------
+Error:
+  return 1;
+}
+
+// Selects the aggregate source: CODEC_NONE aggregates straight from the
+// pool buffer, skipping compress (events still recorded for timing).
+static int
+kick_compress_phase(struct compress_agg_stage* stage,
+                    const struct compress_agg_input* in,
+                    const struct level_geometry* levels,
+                    CUstream compress_stream,
+                    CUdeviceptr* d_aggregate_src)
+{
+  const int fc = in->fc;
   const int skip_compress = (stage->codec.type == CODEC_NONE);
-  const CUdeviceptr d_aggregate_src =
-    skip_compress ? in->pool_buf : stage->d_compressed[fc];
+  *d_aggregate_src = skip_compress ? in->pool_buf : stage->d_compressed[fc];
 
   if (skip_compress) {
     CU(Error, cuEventRecord(stage->t_compress_start[fc], compress_stream));
     CU(Error, cuEventRecord(stage->t_compress_end[fc], compress_stream));
   } else {
-    CHECK_MUL_OVERFLOW(Error, n_epochs, levels->total_chunks, UINT64_MAX);
-    uint64_t batch_chunks = (uint64_t)n_epochs * levels->total_chunks;
+    CHECK_MUL_OVERFLOW(Error, in->n_epochs, levels->total_chunks, UINT64_MAX);
+    uint64_t batch_chunks = (uint64_t)in->n_epochs * levels->total_chunks;
     CHECK(Error,
           kick_compress(stage,
                         fc,
@@ -557,35 +578,57 @@ compress_agg_kick(struct compress_agg_stage* stage,
                         stage->codec.chunk_bytes,
                         compress_stream) == 0);
   }
+  return 0;
 
-  // --- Phase 6.5: tail-generation gate (page-aligned path only) -----------
-  // The dispatch below reads tail state that the previous kick's delivery
-  // uploads AFTER this enqueue (shard_tables in stream.engine.h). The wait
-  // goes after compress, which reads no tail state.
-  if (stage->shards.d_tail_seq) {
-    if (stage->shards.tail_gate_supported && layout.total_batch_chunks > 0 &&
-        stage->shards.total_shards > 0 && page_size > 0)
-      CU(Error,
-         cuStreamWaitValue64(compress_stream,
-                             stage->shards.d_tail_seq,
-                             stage->shards.kick_seq,
-                             CU_STREAM_WAIT_VALUE_GEQ));
-    // Counts even chunk-less kicks: every kick is drained exactly once, so
-    // the count stays the next kick's threshold.
-    stage->shards.kick_seq++;
-  }
+Error:
+  return 1;
+}
 
-  // --- Phase 7: unified aggregate dispatch --------------------------------
-  if (layout.total_batch_chunks > 0) {
+// Page-aligned path only. The aggregate dispatch reads tail state that the
+// previous kick's delivery uploads AFTER this enqueue (shard_tables in
+// stream.engine.h). The wait goes after compress, which reads no tail state.
+static int
+arm_tail_gate(struct compress_agg_stage* stage,
+              const struct batch_aggregate_layout* layout,
+              CUstream compress_stream)
+{
+  if (!stage->shards.d_tail_seq)
+    return 0;
+  const size_t page_size = stage->per_lod_agg_layouts[0].page_size;
+  if (stage->shards.tail_gate_supported && layout->total_batch_chunks > 0 &&
+      stage->shards.total_shards > 0 && page_size > 0)
+    CU(Error,
+       cuStreamWaitValue64(compress_stream,
+                           stage->shards.d_tail_seq,
+                           stage->shards.kick_seq,
+                           CU_STREAM_WAIT_VALUE_GEQ));
+  // Counts even chunk-less kicks: every kick is drained exactly once, so
+  // the count stays the next kick's threshold.
+  stage->shards.kick_seq++;
+  return 0;
+
+Error:
+  return 1;
+}
+
+static int
+dispatch_aggregate(struct compress_agg_stage* stage,
+                   const struct batch_aggregate_layout* layout,
+                   int fc,
+                   CUdeviceptr d_aggregate_src,
+                   CUstream compress_stream)
+{
+  if (layout->total_batch_chunks > 0) {
+    const size_t page_size = stage->per_lod_agg_layouts[0].page_size;
     CHECK(Error,
           aggregate_batch_unified_async(
             (const void*)d_aggregate_src,
             stage->codec.d_comp_sizes,
             (const uint32_t*)(uintptr_t)stage->d_batch_gather,
             (const uint32_t*)(uintptr_t)stage->d_batch_perm,
-            layout.total_batch_chunks,
-            layout.total_batch_covering,
-            nlod,
+            layout->total_batch_chunks,
+            layout->total_batch_covering,
+            stage->nlod,
             stage->codec.max_output_size,
             &stage->agg[fc],
             stage->shards.d_base_offsets,
@@ -600,10 +643,23 @@ compress_agg_kick(struct compress_agg_stage* stage,
   }
 
   CU(Error, cuEventRecord(stage->t_aggregate_end[fc], compress_stream));
+  return 0;
 
-  // --- Phase 8: fill handoff ----------------------------------------------
+Error:
+  return 1;
+}
+
+static void
+fill_handoff(struct compress_agg_stage* stage,
+             const struct compress_agg_input* in,
+             const struct batch_aggregate_layout* layout,
+             const uint32_t* per_lod_n_active,
+             struct flush_handoff* out)
+{
+  const int fc = in->fc;
+  const uint8_t nlod = stage->nlod;
   out->fc = fc;
-  out->n_epochs = n_epochs;
+  out->n_epochs = in->n_epochs;
   out->active_levels_mask = in->active_levels_mask;
   out->batch_active_masks = in->batch_active_masks;
   out->nlod = nlod;
@@ -615,12 +671,46 @@ compress_agg_kick(struct compress_agg_stage* stage,
   out->max_output_size = stage->codec.max_output_size;
   out->passthrough = (stage->codec.type == CODEC_NONE);
   out->agg = &stage->agg[fc];
-  out->layout = layout;
+  out->layout = *layout;
   out->per_lod_agg_layouts = stage->per_lod_agg_layouts;
   out->shards = &stage->shards;
   for (uint8_t lv = 0; lv < nlod; ++lv)
     out->shards_by_lod[lv] = &stage->shard[lv];
+}
 
+int
+compress_agg_kick(struct compress_agg_stage* stage,
+                  const struct compress_agg_input* in,
+                  const struct level_geometry* levels,
+                  CUstream compress_stream,
+                  struct flush_handoff* out)
+{
+  uint32_t per_lod_n_active[LOD_MAX_LEVELS] = { 0 };
+  const uint32_t* per_lod_pool_epochs[LOD_MAX_LEVELS] = { 0 };
+  scan_active_masks(stage, in, per_lod_n_active, per_lod_pool_epochs);
+
+  struct batch_aggregate_layout layout;
+  CHECK(Error, build_batch_layout(stage, per_lod_n_active, &layout) == 0);
+  CHECK(Error,
+        build_and_upload_luts(stage,
+                              &layout,
+                              levels,
+                              per_lod_n_active,
+                              per_lod_pool_epochs,
+                              compress_stream) == 0);
+  CHECK(Error,
+        build_and_upload_shard_tables(stage, &layout, compress_stream) == 0);
+  CHECK(Error, wait_upstream_events(in, compress_stream) == 0);
+
+  CUdeviceptr d_aggregate_src = 0;
+  CHECK(Error,
+        kick_compress_phase(
+          stage, in, levels, compress_stream, &d_aggregate_src) == 0);
+  CHECK(Error, arm_tail_gate(stage, &layout, compress_stream) == 0);
+  CHECK(Error,
+        dispatch_aggregate(
+          stage, &layout, in->fc, d_aggregate_src, compress_stream) == 0);
+  fill_handoff(stage, in, &layout, per_lod_n_active, out);
   return 0;
 
 Error:

--- a/src/gpu/flush.compress_agg.h
+++ b/src/gpu/flush.compress_agg.h
@@ -13,6 +13,12 @@ compress_agg_init(struct compress_agg_stage* stage,
 void
 compress_agg_destroy(struct compress_agg_stage* stage, int nlod);
 
+// Satisfy every tail-gate wait ever enqueued. Required before any blocking
+// stream/context sync when a kick may have been left undrained (failed
+// flush): its parked wait would otherwise never complete.
+void
+compress_agg_release_tail_gate(struct compress_agg_stage* stage);
+
 int
 compress_agg_kick(struct compress_agg_stage* stage,
                   const struct compress_agg_input* in,

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -219,6 +219,21 @@ Error:
   return 1;
 }
 
+// Publishes the drained kick's tail generation; must run exactly once per
+// drain, on failure exits too — the gate threshold counts kicks
+// (shard_tables in stream.engine.h), so a skipped publish leaves the gate
+// unsatisfiable and destroy's auto-flush hangs in poll_event. Tail-state
+// content is moot once the drain has failed.
+static struct writer_result
+finish_drain(struct shard_tables* shards, int err)
+{
+  if (shards && shards->h_tail_seq_flag) {
+    shards->tail_seq++;
+    *shards->h_tail_seq_flag = shards->tail_seq;
+  }
+  return err ? writer_error() : writer_ok();
+}
+
 static struct writer_result
 sync_and_deliver(struct d2h_deliver_stage* stage,
                  const struct flush_handoff* handoff,
@@ -378,7 +393,10 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
 
     // Push the post-delivery tail state back to GPU in two bulk HtoDs that
     // cover all shards across all LODs at once. Replaces the per-LOD
-    // tail-state uploads from the legacy pipeline.
+    // tail-state uploads from the legacy pipeline. SYNC_MEMOPS on the
+    // destinations guarantees these copies have completed at the device
+    // before they return, so the tail-gate publish in finish_drain cannot
+    // outrun them.
     if (shards && shards->total_shards > 0 && page_size > 0) {
       CU(Error,
          cuMemcpyHtoD((CUdeviceptr)shards->d_tail_bytes,
@@ -397,14 +415,6 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
         CU(Error,
            cuMemcpyHtoD(dst, ss->tail_buf_pool, ss->tail_buf_pool_bytes));
       }
-
-      // Publish to the tail gate (shard_tables). The copies above are
-      // synchronous, so a gated reader sees the complete generation; this
-      // batch's own readers already retired (h_chunk_index_ready polled).
-      if (shards->h_tail_seq_flag) {
-        shards->tail_seq++;
-        *shards->h_tail_seq_flag = shards->tail_seq;
-      }
     }
 
     // Record an aggregate IO fence on the unified slot. wait_io_fences()
@@ -416,10 +426,10 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     accumulate_metric_ms(&metrics->sink, sink_ms, sink_bytes, sink_bytes);
   }
 
-  return writer_ok();
+  return finish_drain(handoff->shards, 0);
 
 Error:
-  return writer_error();
+  return finish_drain(handoff->shards, 1);
 }
 
 // Periodic metadata update (append-dim extents per level).

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -391,12 +391,9 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
       sink_bytes += level_bytes;
     }
 
-    // Push the post-delivery tail state back to GPU in two bulk HtoDs that
-    // cover all shards across all LODs at once. Replaces the per-LOD
-    // tail-state uploads from the legacy pipeline. SYNC_MEMOPS on the
-    // destinations guarantees these copies have completed at the device
-    // before they return, so the tail-gate publish in finish_drain cannot
-    // outrun them.
+    // SYNC_MEMOPS on the destinations guarantees these copies have
+    // completed at the device before they return, so the tail-gate publish
+    // in finish_drain cannot outrun them.
     if (shards && shards->total_shards > 0 && page_size > 0) {
       CU(Error,
          cuMemcpyHtoD((CUdeviceptr)shards->d_tail_bytes,

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -37,6 +37,9 @@ d2h_deliver_init(struct d2h_deliver_stage* stage,
     CU(Fail, cuEventRecord(stage->ready[fc], compute));
   }
 
+  // Drain-time copies must not share the d2h stream (see d2h_deliver_stage).
+  CU(Fail, cuStreamCreate(&stage->drain_stream, CU_STREAM_NON_BLOCKING));
+
   return 0;
 
 Fail:
@@ -54,6 +57,8 @@ d2h_deliver_destroy(struct d2h_deliver_stage* stage)
     cu_event_destroy(stage->h_chunk_index_ready[fc]);
     cu_event_destroy(stage->ready[fc]);
   }
+  cu_stream_destroy(stage->drain_stream);
+  stage->drain_stream = NULL;
 }
 
 // --- Internal helpers ---
@@ -224,8 +229,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
                  struct shard_sink* sink,
                  const struct lod_state* lod,
                  const struct lod_shared_state* lod_shared,
-                 struct stream_metrics* metrics,
-                 CUstream d2h_stream)
+                 struct stream_metrics* metrics)
 {
   const int fc = handoff->fc;
   struct aggregate_slot* slot = handoff->agg;
@@ -245,6 +249,8 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
       if (poll_event(stage->h_chunk_index_ready[fc], fc))
         goto Error;
 
+      // Bulk copies go on drain_stream, never d2h_stream — sharing
+      // deadlocks against the tail gate (see d2h_deliver_stage).
       int dispatch_err = 0;
       if (alayout->page_size > 0) {
         for (uint8_t lv = 0; lv < handoff->nlod && !dispatch_err; ++lv) {
@@ -262,7 +268,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
                     (uint8_t*)slot->h_aggregated + seg->data_segment_offset,
                     (CUdeviceptr)slot->d_aggregated + seg->data_segment_offset,
                     actual,
-                    d2h_stream));
+                    stage->drain_stream));
         }
       } else if (alayout->total_batch_covering > 0) {
         const size_t n = alayout->total_batch_covering + (size_t)handoff->nlod;
@@ -274,15 +280,15 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
                   cuMemcpyDtoHAsync(slot->h_aggregated,
                                     (CUdeviceptr)slot->d_aggregated,
                                     total,
-                                    d2h_stream));
+                                    stage->drain_stream));
       }
 
       // Always record completion events, even if the D2H dispatch above
       // failed: cap-stacking waiters block on slot->ready and would hang
       // otherwise. Record-on-error is harmless because the stream is
       // already in an error state and the next op will short-circuit.
-      CU(Error, cuEventRecord(stage->ready[fc], d2h_stream));
-      CU(Error, cuEventRecord(slot->ready, d2h_stream));
+      CU(Error, cuEventRecord(stage->ready[fc], stage->drain_stream));
+      CU(Error, cuEventRecord(slot->ready, stage->drain_stream));
 
       if (dispatch_err)
         goto Error;
@@ -390,6 +396,14 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
           shards->d_tail_carry + (CUdeviceptr)(begin * page_size);
         CU(Error,
            cuMemcpyHtoD(dst, ss->tail_buf_pool, ss->tail_buf_pool_bytes));
+      }
+
+      // Publish to the tail gate (shard_tables). The copies above are
+      // synchronous, so a gated reader sees the complete generation; this
+      // batch's own readers already retired (h_chunk_index_ready polled).
+      if (shards->h_tail_seq_flag) {
+        shards->tail_seq++;
+        *shards->h_tail_seq_flag = shards->tail_seq;
       }
     }
 
@@ -518,6 +532,7 @@ d2h_deliver_drain(struct d2h_deliver_stage* stage,
                   struct platform_clock* metadata_update_clock,
                   CUstream d2h_stream)
 {
+  (void)d2h_stream; // drain-time copies use stage->drain_stream
   struct writer_result r = sync_and_deliver(stage,
                                             handoff,
                                             levels,
@@ -527,8 +542,7 @@ d2h_deliver_drain(struct d2h_deliver_stage* stage,
                                             sink,
                                             lod,
                                             lod_shared,
-                                            metrics,
-                                            d2h_stream);
+                                            metrics);
   if (!r.error) {
     if (maybe_update_metadata(
           handoff, dims, config, sink, metadata_update_clock))

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -165,6 +165,19 @@ struct shard_tables
   CUdeviceptr d_tail_carry;
   size_t tail_carry_bytes; // == total_shards * page_size
 
+  // Tail-generation gate (page-aligned lazy pipeline). Kick #k's tail reads
+  // consume the d_tail_bytes/d_tail_carry upload made by kick #k-1's
+  // delivery, which on the lazy path runs AFTER kick #k is enqueued;
+  // nothing else orders that host upload against the queued kernels. Kick
+  // #k waits d_tail_seq >= k, the delivery publishes after each upload
+  // (flush.d2h_deliver.c), and drains are oldest-first, so tail_seq counts
+  // delivered kicks.
+  volatile uint64_t* h_tail_seq_flag; // pinned + device-mapped; host-written
+  CUdeviceptr d_tail_seq;             // device view of h_tail_seq_flag
+  uint64_t kick_seq;                  // kicks enqueued (gate threshold)
+  uint64_t tail_seq;                  // uploads published (host mirror)
+  int tail_gate_supported;            // stream memops may be unsupported
+
   // Per-LOD slice info, needed by delivery to view the unified slot buffers.
   uint32_t shards_begin[LOD_MAX_LEVELS]; // first global shard index for LOD lv
   uint32_t n_shards[LOD_MAX_LEVELS];     // num_shards_lv
@@ -231,6 +244,13 @@ struct d2h_deliver_stage
   CUevent t_d2h_start[2];
   CUevent h_chunk_index_ready[2]; // h_offsets + h_permuted_sizes on host
   CUevent ready[2];               // full D2H done; gates slot reuse
+
+  // Drain-time copies must not share the d2h stream: by drain time it can
+  // already hold the next kick's t_aggregate_end wait, which the tail gate
+  // (shard_tables) keeps parked until THIS drain publishes — sharing would
+  // deadlock. The drain's host poll of h_chunk_index_ready already proves
+  // the copy source is stable, so no device-side ordering is needed here.
+  CUstream drain_stream;
 
   size_t shard_alignment;         // from sink; 0 = no alignment
   struct stream_metrics* metrics; // borrowed, for stall-time accumulation

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -127,6 +127,17 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
       return r;
   }
 
+  // Tail-gate fallback: without stream memops the tail upload cannot be
+  // ordered device-side (shard_tables in stream.engine.h), so also drain
+  // the other, newer pending batch — order stays oldest-first, pipeline
+  // degrades to depth 1 — and the kick below sees published tail state.
+  if (e->compress_agg.shards.d_tail_seq &&
+      !e->compress_agg.shards.tail_gate_supported) {
+    struct writer_result r = drain_fc(e, ctx, completed_pool ^ 1);
+    if (r.error)
+      return r;
+  }
+
   fs->batch_epoch_count = (int)e->batch.accumulated;
   struct compress_agg_input in =
     make_compress_input(e, ctx, completed_pool, e->batch.accumulated);

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -127,11 +127,13 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
       return r;
   }
 
-  // Tail-gate fallback: without stream memops the tail upload cannot be
-  // ordered device-side (shard_tables in stream.engine.h), so also drain
-  // the other, newer pending batch — order stays oldest-first, pipeline
+  // Tail-gate fallback: without the gate (stream memops unsupported, or
+  // the counter failed to map at init) the tail upload cannot be ordered
+  // device-side (shard_tables in stream.engine.h), so also drain the
+  // other, newer pending batch — order stays oldest-first, pipeline
   // degrades to depth 1 — and the kick below sees published tail state.
-  if (e->compress_agg.shards.d_tail_seq &&
+  if (e->compress_agg.shards.page_size > 0 &&
+      e->compress_agg.shards.total_shards > 0 &&
       !e->compress_agg.shards.tail_gate_supported) {
     struct writer_result r = drain_fc(e, ctx, completed_pool ^ 1);
     if (r.error)

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -68,6 +68,10 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
     s->flushed = 1;
   }
 
+  // A failed flush can leave a kick parked on the tail gate; release it or
+  // the syncs below never return.
+  compress_agg_release_tail_gate(&s->engine.compress_agg);
+
   // Ensure all GPU work completes before tearing down events/memory.
   sync(s->engine.streams.h2d);
   sync(s->engine.streams.compute);

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -384,6 +384,16 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
                    0,
                    desc->u_total_shards * sizeof(size_t)) != CUDA_SUCCESS)
       return 1;
+    // Delivery's tail upload is a synchronous HtoD from pageable memory,
+    // which may return before the DMA reaches the device; SYNC_MEMOPS makes
+    // it complete at the device first, so work enqueued after the drain
+    // cannot read a stale tail (flush.d2h_deliver.c).
+    unsigned int sync_memops = 1;
+    if (cuPointerSetAttribute(&sync_memops,
+                              CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                              (CUdeviceptr)desc->u_d_tail_bytes) !=
+        CUDA_SUCCESS)
+      return 1;
     if (desc->u_page_size > 0) {
       desc->u_tail_carry_bytes =
         desc->u_total_shards * desc->u_page_size;
@@ -392,6 +402,11 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
         return 1;
       if (cuMemsetD8(
             desc->u_d_tail_carry, 0, desc->u_tail_carry_bytes) != CUDA_SUCCESS)
+        return 1;
+      // Same pageable-HtoD constraint as u_d_tail_bytes above.
+      if (cuPointerSetAttribute(&sync_memops,
+                                CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                                desc->u_d_tail_carry) != CUDA_SUCCESS)
         return 1;
     }
   }

--- a/tests/test_compress_agg.c
+++ b/tests/test_compress_agg.c
@@ -117,6 +117,17 @@ Fail:
   return 1;
 }
 
+// Stand in for delivery's tail publish (flush.d2h_deliver.c): tests drive
+// compress_agg_kick without the delivery loop, and an unpublished
+// generation parks the next kick's tail gate forever.
+static void
+ca_ctx_publish_tail(struct ca_test_ctx* c)
+{
+  struct shard_tables* sh = &c->stage.shards;
+  if (sh->h_tail_seq_flag)
+    *sh->h_tail_seq_flag = ++sh->tail_seq;
+}
+
 // Build input, kick compress_agg, sync.
 static int
 ca_ctx_kick(struct ca_test_ctx* c,
@@ -146,6 +157,7 @@ ca_ctx_kick(struct ca_test_ctx* c,
                           c->compute,
                           handoff) == 0);
   CU(Fail, cuStreamSynchronize(c->compute));
+  ca_ctx_publish_tail(c);
   return 0;
 
 Fail:
@@ -767,6 +779,7 @@ test_compress_agg_lut_cache_position_shift(void)
                             c.compute,
                             &handoff) == 0);
     CU(Fail, cuStreamSynchronize(c.compute));
+    ca_ctx_publish_tail(&c);
   }
 
   // Kick 2: only epoch 1 active (mask [0, 1]).
@@ -795,6 +808,7 @@ test_compress_agg_lut_cache_position_shift(void)
                             c.compute,
                             &handoff2) == 0);
     CU(Fail, cuStreamSynchronize(c.compute));
+    ca_ctx_publish_tail(&c);
   }
 
   // The cache must have missed (recompute count incremented) because the

--- a/tests/test_cross_validate.c
+++ b/tests/test_cross_validate.c
@@ -30,6 +30,7 @@ struct mem_writer
 struct mem_sink
 {
   struct shard_sink base;
+  size_t alignment; // 0 = none; >0 reported as required_shard_alignment
   struct mem_writer w[MAX_LEVELS][MAX_SHARDS];
 };
 
@@ -72,11 +73,18 @@ ms_open(struct shard_sink* self, uint8_t level, uint64_t shard_index)
   return &w->base;
 }
 
+static size_t
+ms_alignment(const struct shard_sink* self)
+{
+  return ((const struct mem_sink*)self)->alignment;
+}
+
 static void
 ms_init(struct mem_sink* s)
 {
   memset(s, 0, sizeof(*s));
   s->base.open = ms_open;
+  s->base.required_shard_alignment = ms_alignment;
 }
 
 static void
@@ -610,6 +618,110 @@ Fail:
   return 1;
 }
 
+// ---- Page-aligned tail carry (lazy pipeline) ----
+// A sink alignment requirement activates the carry-over delivery path,
+// whose tail kernels consume an upload the host makes only after the
+// previous batch delivers — later than the kernels are enqueued.
+// CODEC_NONE keeps the race window open (aggregate runs as soon as it is
+// enqueued); the CPU pipeline is the byte-exact oracle.
+#define TC_Z 32  // 32 epochs (chunk_size 1), one shard generation
+#define TC_Y 144 // 2 chunks of 72
+#define TC_X 80  // 2 chunks of 40
+
+static int
+test_gpu_page_aligned_tail_carry(void)
+{
+  log_info("=== test_gpu_page_aligned_tail_carry ===");
+
+  struct mem_sink gpu_sink, cpu_sink;
+  ms_init(&gpu_sink);
+  ms_init(&cpu_sink);
+  gpu_sink.alignment = 4096;
+  cpu_sink.alignment = 4096;
+
+  struct tile_stream_gpu* gpu = NULL;
+  struct tile_stream_cpu* cpu = NULL;
+  uint16_t* data = NULL;
+
+  struct dimension dims[] = {
+    { .size = TC_Z,
+      .chunk_size = 1,
+      .chunks_per_shard = TC_Z,
+      .storage_position = 0 },
+    { .size = TC_Y,
+      .chunk_size = 72,
+      .chunks_per_shard = 2,
+      .storage_position = 1 },
+    { .size = TC_X,
+      .chunk_size = 40,
+      .chunks_per_shard = 2,
+      .storage_position = 2 },
+  };
+
+  // chunk = 72*40 u16 = 5760 B; 4 chunks/epoch, 2 epochs/batch => 46080 B
+  // per shard per batch = 11*4096 + 1024, so every batch moves the ragged
+  // tail and a one-generation-stale read is wrong from batch 2 onward.
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 1 << 16,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .epochs_per_batch = 2,
+  };
+
+  const uint64_t total_elements = (uint64_t)TC_Z * TC_Y * TC_X;
+
+  gpu = tile_stream_gpu_create(&config, &gpu_sink.base);
+  CHECK(Fail, gpu);
+  data = make_input(total_elements);
+  CHECK(Fail, data);
+
+  {
+    struct writer* w = tile_stream_gpu_writer(gpu);
+    size_t bytes = total_elements * sizeof(uint16_t);
+    struct slice sl = { .beg = data, .end = (const char*)data + bytes };
+    struct writer_result r = writer_append(w, sl);
+    CHECK(Fail, r.error == 0);
+    r = writer_flush(w);
+    CHECK(Fail, r.error == 0);
+  }
+
+  cpu = tile_stream_cpu_create(&config, &cpu_sink.base);
+  CHECK(Fail, cpu);
+
+  {
+    struct writer* w = tile_stream_cpu_writer(cpu);
+    size_t bytes = total_elements * sizeof(uint16_t);
+    struct slice sl = { .beg = data, .end = (const char*)data + bytes };
+    struct writer_result r = writer_append(w, sl);
+    CHECK(Fail, r.error == 0);
+    r = writer_flush(w);
+    CHECK(Fail, r.error == 0);
+  }
+
+  int mismatches = compare_shards(&gpu_sink, &cpu_sink, "page_tail_carry");
+  CHECK(Fail, mismatches == 0);
+  CHECK(Fail, tile_stream_gpu_cursor(gpu) == tile_stream_cpu_cursor(cpu));
+
+  free(data);
+  tile_stream_gpu_destroy(gpu);
+  tile_stream_cpu_destroy(cpu);
+  ms_free(&gpu_sink);
+  ms_free(&cpu_sink);
+  log_info("  PASS");
+  return 0;
+
+Fail:
+  free(data);
+  tile_stream_gpu_destroy(gpu);
+  tile_stream_cpu_destroy(cpu);
+  ms_free(&gpu_sink);
+  ms_free(&cpu_sink);
+  log_error("  FAIL");
+  return 1;
+}
+
 // ---- GPU zstd round trip ----
 // nvcomp and libzstd emit different frame bytes for the same input, so
 // shards cannot be byte-compared; compare decompressed values instead.
@@ -956,5 +1068,6 @@ RUN_GPU_TESTS({ "cross_validate_basic", test_cross_validate_basic },
               { "cross_validate_multishard", test_cross_validate_multishard },
               { "cross_validate_lod", test_cross_validate_lod },
               { "cross_validate_lod_dim0", test_cross_validate_lod_dim0 },
+              { "gpu_page_aligned_tail_carry", test_gpu_page_aligned_tail_carry },
               { "gpu_zstd_round_trip", test_gpu_zstd_round_trip },
               { "gpu_zstd_determinism", test_gpu_zstd_determinism }, )


### PR DESCRIPTION
Closes #141.

## Description

### Background: what the page-aligned path does

When a sink requires aligned writes (`required_shard_alignment > 0`, e.g. an
O_DIRECT filesystem sink), the GPU pipeline writes each shard in whole pages
and carries the sub-page remainder — the "ragged tail" — into the next batch.
Two pieces of state describe that tail for every shard: how long it is
(`d_tail_bytes`) and its content (`d_tail_carry`). The host owns this state:
after delivering a batch to the sink it recomputes the tail and pushes both
buffers back to the GPU with plain synchronous copies
(`src/gpu/flush.d2h_deliver.c`). On the GPU side, the next batch's aggregate
step reads them: it copies the carried tail to the head of each shard's
output region and shifts every chunk offset past it (`src/gpu/aggregate.cu`).

### The bug: the reader is queued before its input exists

Queuing GPU work is not running it. At each batch boundary the producer
thread (1) delivers the oldest in-flight batch and uploads the new tail
state, (2) queues compress+aggregate for the just-finished batch, (3) queues
its device-to-host copy, and moves on. With the pipeline two batches deep,
the aggregate queued for batch N needs the tail state that batch N-1's
delivery will upload — at the NEXT boundary, after batch N's kernels are
already sitting in the queue.

Nothing held those kernels back. All pipeline streams are non-blocking, so
the host's synchronous uploads do not serialize against them; the events the
kick waits on are all satisfied around the kick itself; and an event
record/wait pair cannot express "wait for something the host has not done
yet" — a queued wait only observes records that already happened.

So whether the kernels read the right tail came down to timing. With a slow
codec (zstd on large batches) compress usually kept the stream busy long
enough — which is why this stayed hidden. With CODEC_NONE the kernels run
within microseconds of the kick and read the previous generation on
essentially every batch: wrong tail length, wrong tail bytes, every chunk
offset in the shard shifted by the wrong amount. A half-updated (torn) read
is also possible when the timing is close. The multiarray path is immune: it
delivers synchronously after every kick, so the upload always lands before
the next kick is queued. The same goes for unaligned sinks (no tail state at
all) — matching the symptom profile in #141.

There was no test coverage of GPU + lazy pipeline + page-aligned before this
PR.

### The fix: a tail-generation gate

The dependency is "kernels of kick #k must run after the k-th tail upload",
so make the count visible to the device:

- `shard_tables` gains an 8-byte pinned, device-visible counter of completed
  tail uploads (allocated only when the page-aligned path is active).
- Each kick queues `cuStreamWaitValue64(compress_stream, counter, k, GEQ)`
  between compress and the aggregate dispatch, where k = number of prior
  kicks. Batches are always delivered oldest-first, so "counter >= k" is
  exactly "deliveries of kicks 0..k-1 have published their uploads".
- After its tail uploads, delivery bumps the counter with a plain store.
  Two things make that store safe: the destination buffers carry
  `CU_POINTER_ATTRIBUTE_SYNC_MEMOPS`, so the synchronous copies cannot
  return before the DMA has completed at the device (a pageable-source
  `cuMemcpyHtoD` may otherwise return earlier); and the publish runs
  exactly once per drain — on failure exits too — so a failed delivery can
  never leave the gate permanently unsatisfiable. The producer thread never
  blocks; in zstd steady state the counter is bumped long before compress
  finishes, so the gate adds no stall where compress is the bottleneck.
- Where stream memops are unsupported (probed at init) — or the gate
  counter cannot be allocated/mapped — the boundary drains the other
  pending batch too; pipeline depth drops to 1, host-ordered but correct.

Three consequences of the gate, all in the first commit:

1. **Drain copies move to their own stream.** For compressed codecs the
   exact-size bulk D2H is queued at drain time, and by then the shared d2h
   stream already holds the NEXT kick's wait on `t_aggregate_end` — which
   the gate keeps parked until this very drain publishes. Queuing the
   drain's copy behind it would deadlock (the drain would poll a copy that
   waits on the drain). A dedicated `drain_stream` needs no device-side
   ordering: the drain has already host-polled `h_chunk_index_ready`, which
   proves the copy source is final.
2. **Teardown releases the gate.** `tile_stream_gpu_destroy` synchronizes
   the streams before tearing down stages. If a failed flush left a kick
   undelivered, its parked wait would never satisfy and destroy would hang.
   `compress_agg_release_tail_gate` publishes `kick_seq` — which satisfies
   every threshold ever queued (GEQ is a ring compare, so a UINT64_MAX
   sentinel would NOT work) — before any blocking call, in both destroy and
   the stage's own teardown.
3. **Tests that drive the stage directly must stand in for delivery.**
   `test_compress_agg` calls `compress_agg_kick` without the delivery loop,
   so nothing would ever bump the counter and the second kick would wait
   forever (caught as a ctest timeout). Its harness now publishes a
   generation after each kick — same one-line store delivery does. Other
   direct-driver tests (`test_d2h_deliver`) run a real drain per kick and
   need no change.

### Why an event can't do this

`cuStreamWaitEvent` snapshots the event's most recent record when the wait
is queued. The record this dependency needs does not exist yet at kick time.
The alternatives were restructuring the pipeline to defer the aggregate
queueing by a boundary, or blocking the producer thread; the wait-on-value
gate is the smallest CUDA-native primitive for "stream waits for a future
host action".

### Evidence (L40, sm_89, RelWithDebInfo)

- **Red→green** — new test `gpu_page_aligned_tail_carry`
  (tests/test_cross_validate.c): GPU vs CPU pipelines on identical input,
  4096-aligned in-memory sink, CODEC_NONE, 16 lazy batches sized so every
  batch moves the ragged tail (per-shard batch bytes = 11*4096 + 1024). On
  the base branch it fails with a real shard-data mismatch; with the gate
  it passes. No instrumentation or artificial delays.
- **Detector** (uncommitted instrumentation, device-side stream-ordered
  checksum probes queued around the tail-consuming kernels, no host syncs):
  unfixed, the kernels read a stale generation on ~15/16 batches with
  CODEC_NONE and zstd variants, plus torn reads; fixed, every kick reads
  exactly the generation it needs, 0 stale / 0 torn, both codecs.
- **Failed-drain liveness** (fault injection, not committed): with a drain
  forced to fail mid-delivery, destroy previously hung indefinitely on the
  unsatisfiable gate (killed at 90 s); with the exactly-once publish it
  exits in 4 s.
- **Full suite**: `ctest -E "(s3)"` — 46/46 pass, revalidated after every
  commit below, including `test_compress_agg` (timed out before the harness
  fix) and the #140 regression tests; `gpu_page_aligned_tail_carry` passes
  8/8 repetitions.
- **Perf** (directional; NFS-backed store, single runs of
  `bench_stream_orca2_single --backend gpu --codec zstd -o <dir>`): the
  issue's symptom reproduces on base (D2H avg 0.23 GB/s, avg 322 ms — the
  racing kernels stall the D2H poll); fixed, D2H avg ms drops to 204 and
  end-to-end throughput improves 2.17 -> 2.32 GiB/s (+7%). The wait now
  shows up under Aggregate (avg 112 ms), which is the gate doing its job
  device-side. Base numbers are not a real baseline anyway: base writes
  corrupt shards on this path.

## Commit guide

- `Gate aggregate tail reads on upload` — the gate (init/probe, kick wait,
  delivery publish, memops fallback), the drain-stream split, the teardown
  release, and the `test_compress_agg` harness publish. The full test suite
  is green at this commit alone.
- `Add page-aligned tail-carry test` — the red→green regression test; first
  coverage of GPU + lazy + page-aligned.
- `Harden tail gate publish ordering` — review findings:
  `CU_POINTER_ATTRIBUTE_SYNC_MEMOPS` on the tail destinations (including
  the multiarray-owned allocations that bind into the same tables), and the
  publish moved to a single exit (`finish_drain`) so failed drains still
  publish — the failed-drain liveness item above.
- `Degrade gracefully on gate init failure` — gate-counter mapping failure
  now falls back to host-ordered draining (same as unsupported stream
  memops) instead of failing stream creation.
- `Decompose compress_agg_kick into phases` — behavior-neutral: the eight
  phase banners became named static functions; the kick body is now 38
  lines.
- `Trim narration comment in d2h deliver` — comment hygiene, no code
  change.
