### PR TITLE
Declare GPU stream ordering in one edge table

### DIFF
--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -135,10 +135,17 @@ print_bench_report(const struct stream_metrics* metrics,
 
   // Stall stats — wall-clock time the host is blocked waiting. Emitted only
   // if any stall was observed.
+  const size_t n_edge_stalls =
+    sizeof(metrics->edge_stall) / sizeof(metrics->edge_stall[0]);
+  int have_edge_stalls = 0;
+  for (size_t i = 0; i < n_edge_stalls; ++i)
+    if (metrics->edge_stall[i].count > 0)
+      have_edge_stalls = 1;
   int have_stalls =
     metrics->flush_stall.count > 0 || metrics->kick_sync_stall.count > 0 ||
     metrics->io_fence_stall.count > 0 || metrics->backpressure.count > 0 ||
-    metrics->max_append_ms > 0 || metrics->peak_pending_bytes > 0;
+    metrics->max_append_ms > 0 || metrics->peak_pending_bytes > 0 ||
+    have_edge_stalls;
   if (have_stalls) {
     fputc('\n', stderr);
     print_report("  --- Stall stats ---");
@@ -146,6 +153,8 @@ print_bench_report(const struct stream_metrics* metrics,
     print_metric_row(&metrics->kick_sync_stall);
     print_metric_row(&metrics->io_fence_stall);
     print_metric_row(&metrics->backpressure);
+    for (size_t i = 0; i < n_edge_stalls; ++i)
+      print_metric_row(&metrics->edge_stall[i]);
     print_report("  max append ms:   %.2f", (double)metrics->max_append_ms);
     char pbuf[32];
     format_bytes(pbuf, sizeof(pbuf), (uint64_t)metrics->peak_pending_bytes);

--- a/docs/gpu-orchestration.md
+++ b/docs/gpu-orchestration.md
@@ -112,27 +112,47 @@ different stage implementations; multiarray becomes composition (N pipelines
 sharing pools) instead of the bind/copy checklist in
 `src/multiarray/stream.gpu.c`.
 
-## Current edge inventory (2026-06 audits)
+## Edge table (as implemented in step 1, `src/gpu/ordering.{h,c}`)
 
-Known load-bearing edges (full table with file:line is step 1's first
-deliverable; counts below from grep of main + #142):
+| enum | producer → consumer | guards | kind | inst | backing |
+|---|---|---|---|---|---|
+| `GPU_EDGE_STAGING_SCATTER_DONE` | compute → h2d | staging `d_in` reuse (scatter read before H2D overwrite) | EVENT, seeded | ×2 slot | owned |
+| `GPU_EDGE_STAGING_H2D_DONE` | h2d → compute | staging `d_in` contents | EVENT, seeded | ×2 slot | owned |
+| `GPU_EDGE_STAGING_FREE` | h2d → HOST poll (`stream.c` append) | staging `h_in` refill | EVENT | ×2 slot | alias of STAGING_H2D_DONE |
+| `GPU_EDGE_POOL_FILLED` | compute → compress | chunk-pool batch contents | EVENT, seeded | ×1 | owned |
+| `GPU_EDGE_LOD_DONE` | compute → compress | LOD chunks in pool | EVENT, seeded | ×2 fc | bound to `lod_shared.timing[fc].t_end` |
+| `GPU_EDGE_AGG_DONE` | compress → d2h | aggregate slot outputs | EVENT, seeded | ×2 fc | owned |
+| `GPU_EDGE_POOL_CONSUMED` | compress → compute | chunk pool `buf[fc]` reuse/re-zero (#140) | EVENT | ×2 fc | alias of AGG_DONE |
+| `GPU_EDGE_SLOT_DRAINED` | d2h\|drain → compress | `agg[fc]` slot reuse | EVENT, seeded | ×2 fc | owned |
+| `GPU_EDGE_D2H_DONE` | d2h\|drain → HOST poll | `h_aggregated` stable for delivery | EVENT | ×2 fc | alias of SLOT_DRAINED |
+| `GPU_EDGE_CHUNK_INDEX_READY` | d2h → HOST poll | `h_offsets`/`h_permuted_sizes`; drain-copy source | EVENT, seeded; compressed-only | ×2 fc | owned |
+| `GPU_EDGE_TAIL_PUBLISHED` | HOST → compress | `d_tail_bytes`/`d_tail_carry` generation (#142) | GEN_COUNTER | ×1 | ordering-owned pinned devicemap counter |
+| `GPU_EDGE_DRAIN_BEFORE_REKICK` | HOST rule | pending handoff + agg host buffers per fc | HOST_RULE | per fc | debug assert in kick/swap |
+| `GPU_EDGE_DELIVER_OLDEST_FIRST` | HOST rule | tail-gate GEQ monotonicity, shard write order | HOST_RULE | per fc | debug assert in drain |
 
-| edge (name to assign)   | producer → consumer            | guards            | kind        |
-|-------------------------|--------------------------------|-------------------|-------------|
-| pool_filled (`pool_ready`)       | h2d/compute → compress | chunk pool epoch  | EVENT       |
-| pool_consumed (`t_aggregate_end`)| compress → compute     | chunk pool epoch  | EVENT (#140)|
-| agg_done (`t_aggregate_end`)     | compress → d2h         | aggregate slot    | EVENT       |
-| slot_drained (`ready`/`prev_d2h_done`) | d2h → compress  | aggregate slot    | EVENT       |
-| chunk_index_ready (`h_chunk_index_ready`) | d2h → HOST poll | drain copy source | EVENT+poll |
-| staging_free (`t_h2d_end`)       | h2d → HOST poll        | staging slot      | EVENT+poll (unmetered busy-wait) |
-| tail_published (`d_tail_seq`)    | HOST → compress        | tail state        | GEN_COUNTER (#142) |
-| ingest cross-waits (stream.ingest.c ×4) | h2d ↔ compute | staging/pool      | EVENT       |
-| drain-before-rekick; oldest-first delivery | HOST order  | slots, gate GEQ   | HOST_RULE (undeclared) |
+TIMING events stay outside the table (metric intervals only): staging
+`t_h2d_start`/`t_scatter_start`, `t_compress_start/end`, `t_d2h_start`, lod
+`t_start/t_scatter_end/t_reduce_end/t_append_end`.
 
-~30 `cuEventRecord` sites, ~9 `cuStreamWaitEvent` sites, 2
-`cuStreamWaitValue64`, 3 `cuEventQuery` poll loops, plus multiarray's own
-record sites. Dead-edge candidates from the c3885f9 review (`pools.ready[2]`
-et al.) must be re-verified against current main before deletion.
+Deleted as verified-dead in step 1: `pool_state.ready[2]`,
+`aggregate_slot.ready` (only waiter was #139's abandoned cap-stacking), and
+the passthrough-path CHUNK_INDEX_READY record (never polled there).
+
+Design notes from implementation:
+- **Bind, not own, for dual-use events** (`gpu_ordering_bind`): lod `t_end`
+  serves timing and EDGE_LOD_DONE with one record; test harnesses use bind
+  to fake producers.
+- **Aliases**: one event may back several named edges guarding different
+  resources for different consumers (`alias_of`) — each stays separately
+  declared, asserted, and metered.
+- The wait-without-record assert is weak for EVENT edges (all are seeded at
+  init); the #141-class protection in practice is GEN_COUNTER publish
+  discipline plus end-of-run dead-edge accounting — which mutation testing
+  confirmed catches a removed wait.
+- Some edges are config-dependent (POOL_CONSUMED idle on sync/multiarray
+  paths; CHUNK_INDEX_READY compressed-only): debug dead-edge warnings fire
+  by design there. Per-config expected-edge sets are a candidate refinement
+  for steps 2–4.
 
 ## Migration: five steps, shippable at every point
 

--- a/docs/gpu-orchestration.md
+++ b/docs/gpu-orchestration.md
@@ -1,0 +1,194 @@
+# GPU stream orchestration: target design and migration plan
+
+Status: accepted direction, migration in progress (step 1).
+Base: main + #142. Related: #140, #141, PR #142, `gpu-output-slot-ledger.md`.
+
+## Why
+
+Three findings from the 2026-06 investigation drive this:
+
+1. **Ordering is implicit and has shipped two silent-corruption races.**
+   Cross-stream rules live as `cuEventRecord`/`cuStreamWaitEvent` pairs spread
+   across six files, plus host call-order assumptions ("drain fc before
+   re-kicking fc", "deliver oldest-first") written nowhere. #140 was a missing
+   pool-reuse edge; #141 was a dependency an event *cannot* express (wait on a
+   future host action). Several events are recorded but never waited — dead
+   edges are indistinguishable from load-bearing ones.
+2. **Both races were resource-lifetime bugs, not stage-logic bugs.** A buffer
+   generation was reused (pool re-zero) or read (tail state) while the
+   previous reader/writer was still in flight. Stage code forgot an edge; the
+   architecture let it.
+3. **The L40 stage baseline says the next optimizations are structural.**
+   Wall time is ~100% host/producer-side (ingest staging memcpy is the
+   ×1.65–1.94 lever; D2H-free buys ≤×1.01 — see PR #139's retrospective).
+   Decoupling data movement from orchestration must not become another race
+   factory; ordering has to be auditable first.
+
+## End state
+
+Five concepts, four of which exist today in partial form:
+
+### 1. Resources: slotted pools with generation-carried ordering
+
+Every device-side buffer that cycles (staging slots, chunk-pool epochs,
+compressed buffers, aggregate output slots, tail state) becomes a slot in a
+pool with an acquire/release protocol:
+
+- `acquire(pool, slot, stream)` — queues a wait on the slot's previous
+  generation's release before handing out the pointer.
+- `release(pool, slot, stream)` — records the generation's completion event.
+- Host-published resources (tail state) release via generation counter +
+  `cuStreamWaitValue64` instead of an event (the #142 mechanism), behind the
+  same API.
+
+A stage cannot observe a raw pointer without its synchronization. Forgetting
+an edge stops being possible at the call site; #140 and #141 become
+unwritable. Teardown is `pool_release_all` per pool — the #142 hang class
+(F2) dies structurally.
+
+### 2. Edges: one declared table (`src/gpu/ordering.{h,c}`)
+
+The audit layer, and step 1 of the migration. Every cross-stream /
+host-stream rule is a named entry:
+
+```c
+enum gpu_edge { EDGE_POOL_FILLED, EDGE_POOL_CONSUMED, EDGE_AGG_DONE,
+                EDGE_SLOT_DRAINED, EDGE_TAIL_PUBLISHED, EDGE_STAGING_FREE,
+                /* ... */ EDGE_COUNT };
+
+struct gpu_edge_desc {
+  const char*        name;
+  enum gpu_stream_id producer, consumer;  // stream id or HOST
+  const char*        guards;              // the resource this edge protects
+  enum edge_kind     kind;                // EVENT | GEN_COUNTER | HOST_RULE
+  uint8_t            per_fc;              // instanced per pipeline slot
+};
+```
+
+Call sites go through `edge_record` / `edge_wait` / `edge_publish` /
+`edge_release_all`. Debug builds assert: consumer stream matches the
+declaration; no wait without a live record/publish (the #141 class); at
+destroy, edges with records but zero waits over the run are flagged dead.
+Timing-only events (`t_compress_start/end`, lod timing) are excluded or
+tagged TIMING — metrics events must not masquerade as ordering. Host-rule
+edges (drain-before-rekick, oldest-first delivery — the invariant #142's GEQ
+gate relies on) get debug asserts even though no GPU primitive backs them.
+
+Per-edge wait/stall accounting comes for free, closing the unmetered
+staging-slot busy-poll gap found in the baseline (`stream.c` append loop).
+
+When step 3 lands, most EVENT edges collapse into pool acquire/release; the
+table remains as the registry the pools draw from and the audit surface.
+
+### 3. Stages: config in, state owned, handoff out, edges declared
+
+A stage is independently testable when its boundary is data:
+
+- created from a small config; owns its state; no reaching into engine
+  globals.
+- inputs/outputs are explicit handoff structs (`flush_handoff` is the
+  existing model) plus declared edges.
+- any neighbor can be faked in one line (the `test_compress_agg` harness
+  publish is the proven pattern — that property becomes a requirement).
+
+Variations that change the *dependency shape* (memops-unsupported fallback
+dropping pipeline depth, codec NONE skipping compress, page-aligned tail
+carry) move out of intra-stage branches and into the schedule (below).
+
+### 4. Scheduler: one owner for streams, depth, and fallbacks
+
+A single module owns: stream creation, pipeline depth, which stages run for
+the active configuration, and degraded schedules (e.g. depth-1 host-ordered
+when stream memops are unavailable). Orchestration stays single-threaded —
+the producer thread *decides*; it stops *moving bytes*:
+
+### 5. Workers: data movement behind queues
+
+Ingest staging copies and sink delivery become queue-fed workers. This is
+the baseline's top lever (×1.65–1.94) and the most race-prone change on the
+roadmap — it lands last, when every handoff it touches is declared (edges)
+or carried (pools). CPU and GPU backends become the same orchestration over
+different stage implementations; multiarray becomes composition (N pipelines
+sharing pools) instead of the bind/copy checklist in
+`src/multiarray/stream.gpu.c`.
+
+## Current edge inventory (2026-06 audits)
+
+Known load-bearing edges (full table with file:line is step 1's first
+deliverable; counts below from grep of main + #142):
+
+| edge (name to assign)   | producer → consumer            | guards            | kind        |
+|-------------------------|--------------------------------|-------------------|-------------|
+| pool_filled (`pool_ready`)       | h2d/compute → compress | chunk pool epoch  | EVENT       |
+| pool_consumed (`t_aggregate_end`)| compress → compute     | chunk pool epoch  | EVENT (#140)|
+| agg_done (`t_aggregate_end`)     | compress → d2h         | aggregate slot    | EVENT       |
+| slot_drained (`ready`/`prev_d2h_done`) | d2h → compress  | aggregate slot    | EVENT       |
+| chunk_index_ready (`h_chunk_index_ready`) | d2h → HOST poll | drain copy source | EVENT+poll |
+| staging_free (`t_h2d_end`)       | h2d → HOST poll        | staging slot      | EVENT+poll (unmetered busy-wait) |
+| tail_published (`d_tail_seq`)    | HOST → compress        | tail state        | GEN_COUNTER (#142) |
+| ingest cross-waits (stream.ingest.c ×4) | h2d ↔ compute | staging/pool      | EVENT       |
+| drain-before-rekick; oldest-first delivery | HOST order  | slots, gate GEQ   | HOST_RULE (undeclared) |
+
+~30 `cuEventRecord` sites, ~9 `cuStreamWaitEvent` sites, 2
+`cuStreamWaitValue64`, 3 `cuEventQuery` poll loops, plus multiarray's own
+record sites. Dead-edge candidates from the c3885f9 review (`pools.ready[2]`
+et al.) must be re-verified against current main before deletion.
+
+## Migration: five steps, shippable at every point
+
+The end state is reached **in place** — each step replaces one subsystem
+behind an existing seam. No flag day, no second engine.
+
+1. **Ordering table.** `ordering.{h,c}`; migrate every record/wait/publish
+   call site; re-derive the full edge table; tag timing events; add debug
+   asserts + per-edge stall metrics. Separate commit deletes verified-dead
+   edges. Behavior-neutral.
+   *Exit: suite green; edge table in code matches a hand audit; dead edges
+   gone; stall metrics visible in bench output.*
+2. **Unify init/teardown and multiarray binding.** Single engine init/destroy
+   shared by single-array and multiarray; kill the field-by-field copy
+   checklist and the hand-mirrored memory estimate. Behavior-neutral.
+   *Exit: suite green; multiarray bind is one struct handoff; memory estimate
+   derived, not duplicated.*
+3. **Resource pools with generations.** Introduce the pool API; move staging
+   slots, chunk pool, aggregate slots, tail state into it; EVENT edges
+   guarding those resources collapse into acquire/release; #142's gate
+   becomes the pool's GEN_COUNTER release kind.
+   *Exit: suite green; no raw cycled-buffer pointer crosses a stage boundary
+   outside the pool API; determinism + tail-carry + round-trip still red on
+   deliberately-broken builds (mutation check).*
+4. **Extract the scheduler.** May be written greenfield and dropped in behind
+   the now-clean stage interfaces in one PR — by then it moves wiring, not
+   behavior. Dependency-shape variations (fallbacks, codec NONE, page-aligned)
+   become schedule selections.
+   *Exit: suite green; `stream.flush.c` orchestration state replaced; depth/
+   fallback decisions in one module.*
+5. **Workers.** Ingest staging copies and delivery move behind queues; the
+   producer thread stops doing large memcpys.
+   *Exit: suite green; L40 baseline rerun shows the ingest lever realized
+   without zstd-path regressions; no new edges outside the table/pools.*
+
+### Gates at every step
+
+`ctest -E "(s3)"` full suite; `gpu_zstd_determinism`, `gpu_zstd_round_trip`,
+`gpu_page_aligned_tail_carry` (≥8 reps); zero new build warnings; L40
+baseline sweep rerun (`launch.sh` harness) at steps 3 and 5.
+
+### Escape hatch
+
+If during steps 2–3 adapter shims start outweighing the code they adapt, or
+the seam inventory proves wrong, flip the remainder to a greenfield engine
+behind the same stage interfaces — the landed steps still pay, having
+sharpened the seams and the test spec a rewrite needs. The criterion is
+mechanical: adapter LOC > adapted LOC in a step's diff ⇒ stop and reassess.
+
+## Non-goals
+
+- No change to layout math (`stream/config.c`), kernels (`aggregate.cu`,
+  `lod.cu`), codec backends, or the zarr/sink layer — they keep their
+  signatures throughout.
+- No CUDA Graphs adoption: the pipeline is small enough that a declared
+  table + pools gives the auditability without a graph executor (revisit
+  only if the scheduler step shows dispatch overhead that matters).
+- No attempt to preserve PR #139's cap-stacking; the baseline showed D2H
+  batching is not a lever (≤×1.01).

--- a/src/gpu/CMakeLists.txt
+++ b/src/gpu/CMakeLists.txt
@@ -12,6 +12,7 @@ add_src_lib(stream
         stream.ingest.c stream.ingest.h
         stream.lod.c stream.lod.h
         stream.internal.h
+        ordering.c ordering.h
         flush.compress_agg.c flush.compress_agg.h
         flush.d2h_deliver.c flush.d2h_deliver.h
         flush.handoff.h flush.helpers.h

--- a/src/gpu/aggregate.cu
+++ b/src/gpu/aggregate.cu
@@ -132,8 +132,6 @@ aggregate_slot_destroy(struct aggregate_slot* slot)
 {
   if (!slot)
     return;
-  if (slot->ready)
-    cuEventDestroy(slot->ready);
   cuMemFree((CUdeviceptr)slot->d_permuted_sizes);
   cuMemFree((CUdeviceptr)slot->d_offsets);
   cuMemFree((CUdeviceptr)slot->d_aggregated);
@@ -225,8 +223,6 @@ aggregate_batch_slot_init(struct aggregate_slot* slot,
 
   if (slot->temp_bytes > 0)
     CU(Error, cuMemAlloc((CUdeviceptr*)&slot->d_temp, slot->temp_bytes));
-
-  CU(Error, cuEventCreate(&slot->ready, CU_EVENT_DEFAULT));
 
   return 0;
 

--- a/src/gpu/aggregate.h
+++ b/src/gpu/aggregate.h
@@ -26,7 +26,6 @@ extern "C"
     size_t* h_permuted_sizes; // host pinned: C size_t (real compressed sizes)
     void* d_temp;             // CUB scratch
     size_t temp_bytes;
-    CUevent ready;           // D2H completion
     struct io_event io_done; // tracks IO completion from this slot's data
   };
 

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -44,9 +44,11 @@ int
 compress_agg_init(struct compress_agg_stage* stage,
                   const struct computed_stream_layouts* cl,
                   const struct tile_stream_configuration* config,
+                  struct gpu_ordering* ord,
                   CUstream compute)
 {
   memset(stage, 0, sizeof(*stage));
+  stage->ord = ord;
 
   const size_t bytes_per_element = dtype_bpe(config->dtype);
   const uint32_t K = cl->epochs_per_batch;
@@ -82,7 +84,6 @@ compress_agg_init(struct compress_agg_stage* stage,
         cuMemAlloc(&stage->d_compressed[fc], M * stage->codec.max_output_size));
     CU(Fail, cuEventCreate(&stage->t_compress_start[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->t_compress_end[fc], CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&stage->t_aggregate_end[fc], CU_EVENT_DEFAULT));
   }
 
   // --- Unified across-LODs aggregate state ---------------------------------
@@ -246,32 +247,11 @@ compress_agg_init(struct compress_agg_stage* stage,
                                    stage->shards.d_tail_carry));
         }
 
-        // Tail-generation gate (shard_tables in stream.engine.h). The
-        // support probe is an already-satisfied wait; without stream
-        // memops — or when the counter can't be allocated or mapped —
-        // the lazy path host-drains instead (stream.flush.c).
-        if (cuMemHostAlloc((void**)&stage->shards.h_tail_seq_flag,
-                           sizeof(uint64_t),
-                           CU_MEMHOSTALLOC_DEVICEMAP) != CUDA_SUCCESS) {
-          stage->shards.h_tail_seq_flag = NULL;
-        } else {
-          *stage->shards.h_tail_seq_flag = 0;
-          if (cuMemHostGetDevicePointer(&stage->shards.d_tail_seq,
-                                        (void*)stage->shards.h_tail_seq_flag,
-                                        0) != CUDA_SUCCESS) {
-            cuMemFreeHost((void*)stage->shards.h_tail_seq_flag);
-            stage->shards.h_tail_seq_flag = NULL;
-            stage->shards.d_tail_seq = 0;
-          }
-        }
-        if (stage->shards.d_tail_seq) {
-          CUresult pr = cuStreamWaitValue64(
-            compute, stage->shards.d_tail_seq, 0, CU_STREAM_WAIT_VALUE_GEQ);
-          stage->shards.tail_gate_supported = (pr == CUDA_SUCCESS);
-          if (pr != CUDA_SUCCESS && pr != CUDA_ERROR_NOT_SUPPORTED)
-            CU(Fail, pr);
-        }
-        if (!stage->shards.tail_gate_supported)
+        // Tail-generation gate (shard_tables in stream.engine.h). Without
+        // stream memops — or when the counter can't be allocated or mapped
+        // — the lazy path host-drains instead (stream.flush.c).
+        CHECK(Fail, gpu_ordering_gate_init(ord, compute) == 0);
+        if (!gpu_ordering_gate_supported(ord))
           log_warn("compress_agg: tail gate unavailable; page-aligned "
                    "pipeline degrades to host-ordered tail uploads");
       }
@@ -283,11 +263,10 @@ compress_agg_init(struct compress_agg_stage* stage,
   for (int lv = 0; lv < cl->levels.nlod; ++lv)
     CHECK(Fail, init_shard_state(&stage->shard[lv], &cl->per_level[lv]) == 0);
 
-  // Seed events
+  // Seed timing events so the first metric reads see a valid interval.
   for (int fc = 0; fc < 2; ++fc) {
     CU(Fail, cuEventRecord(stage->t_compress_start[fc], compute));
     CU(Fail, cuEventRecord(stage->t_compress_end[fc], compute));
-    CU(Fail, cuEventRecord(stage->t_aggregate_end[fc], compute));
   }
 
   return 0;
@@ -298,23 +277,14 @@ Fail:
 }
 
 void
-compress_agg_release_tail_gate(struct compress_agg_stage* stage)
-{
-  // kick_seq satisfies every threshold ever enqueued; UINT64_MAX would not
-  // (CU_STREAM_WAIT_VALUE_GEQ is a signed ring compare).
-  if (stage->shards.h_tail_seq_flag)
-    *stage->shards.h_tail_seq_flag = stage->shards.kick_seq;
-}
-
-void
 compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
 {
   if (!stage)
     return;
-  if (stage->shards.h_tail_seq_flag) {
+  if (stage->ord && gpu_ordering_gate_active(stage->ord)) {
     // An undrained kick (failed flush) parks work on the compress stream;
     // the frees below can block on pending work, so release first.
-    compress_agg_release_tail_gate(stage);
+    gpu_edge_release_all(stage->ord);
     CUWARN(cuCtxSynchronize());
   }
   codec_free(&stage->codec);
@@ -326,7 +296,6 @@ compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
     cu_mem_free(stage->d_compressed[fc]);
     cu_event_destroy(stage->t_compress_start[fc]);
     cu_event_destroy(stage->t_compress_end[fc]);
-    cu_event_destroy(stage->t_aggregate_end[fc]);
   }
   if (stage->lut_steady_count + stage->lut_recompute_count > 0) {
     const uint64_t tot = stage->lut_steady_count + stage->lut_recompute_count;
@@ -347,11 +316,6 @@ compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
   for (int lv = 0; lv < nlod; ++lv) {
     aggregate_layout_destroy(&stage->per_lod_agg_layouts[lv]);
     shard_state_destroy(&stage->shard[lv]);
-  }
-  if (stage->shards.h_tail_seq_flag) {
-    cuMemFreeHost((void*)stage->shards.h_tail_seq_flag);
-    stage->shards.h_tail_seq_flag = NULL;
-    stage->shards.d_tail_seq = 0;
   }
   free(stage->shards.h_base_offsets);
   free(stage->shards.h_shard_capacity);
@@ -536,15 +500,23 @@ Error:
   return 1;
 }
 
+// GPU_EDGE_SLOT_DRAINED: aggregate must not overwrite agg[fc].d_aggregated
+// before the prior D2H on the same fc has read it (seeded at init).
 static int
-wait_upstream_events(const struct compress_agg_input* in,
+wait_upstream_events(struct compress_agg_stage* stage,
+                     const struct compress_agg_input* in,
                      CUstream compress_stream)
 {
-  CU(Error, cuStreamWaitEvent(compress_stream, in->pool_ready, 0));
-  if (in->lod_done)
-    CU(Error, cuStreamWaitEvent(compress_stream, in->lod_done, 0));
-  if (in->prev_d2h_done)
-    CU(Error, cuStreamWaitEvent(compress_stream, in->prev_d2h_done, 0));
+  CHECK(Error,
+        gpu_edge_wait(
+          stage->ord, GPU_EDGE_POOL_FILLED, 0, compress_stream) == 0);
+  if (in->lod_active)
+    CHECK(Error,
+          gpu_edge_wait(
+            stage->ord, GPU_EDGE_LOD_DONE, in->fc, compress_stream) == 0);
+  CHECK(Error,
+        gpu_edge_wait(
+          stage->ord, GPU_EDGE_SLOT_DRAINED, in->fc, compress_stream) == 0);
   return 0;
 
 Error:
@@ -592,23 +564,11 @@ arm_tail_gate(struct compress_agg_stage* stage,
               const struct batch_aggregate_layout* layout,
               CUstream compress_stream)
 {
-  if (!stage->shards.d_tail_seq)
-    return 0;
   const size_t page_size = stage->per_lod_agg_layouts[0].page_size;
-  if (stage->shards.tail_gate_supported && layout->total_batch_chunks > 0 &&
-      stage->shards.total_shards > 0 && page_size > 0)
-    CU(Error,
-       cuStreamWaitValue64(compress_stream,
-                           stage->shards.d_tail_seq,
-                           stage->shards.kick_seq,
-                           CU_STREAM_WAIT_VALUE_GEQ));
-  // Counts even chunk-less kicks: every kick is drained exactly once, so
-  // the count stays the next kick's threshold.
-  stage->shards.kick_seq++;
-  return 0;
-
-Error:
-  return 1;
+  const int enable = layout->total_batch_chunks > 0 &&
+                     stage->shards.total_shards > 0 && page_size > 0;
+  return gpu_edge_wait_gen(
+    stage->ord, GPU_EDGE_TAIL_PUBLISHED, compress_stream, enable);
 }
 
 static int
@@ -642,7 +602,9 @@ dispatch_aggregate(struct compress_agg_stage* stage,
             compress_stream) == 0);
   }
 
-  CU(Error, cuEventRecord(stage->t_aggregate_end[fc], compress_stream));
+  CHECK(Error,
+        gpu_edge_record(stage->ord, GPU_EDGE_AGG_DONE, fc, compress_stream) ==
+          0);
   return 0;
 
 Error:
@@ -665,7 +627,7 @@ fill_handoff(struct compress_agg_stage* stage,
   out->nlod = nlod;
   memcpy(
     out->per_lod_n_active, per_lod_n_active, (size_t)nlod * sizeof(uint32_t));
-  out->t_aggregate_end = stage->t_aggregate_end[fc];
+  out->t_aggregate_end = gpu_ordering_event(stage->ord, GPU_EDGE_AGG_DONE, fc);
   out->t_compress_start = stage->t_compress_start[fc];
   out->t_compress_end = stage->t_compress_end[fc];
   out->max_output_size = stage->codec.max_output_size;
@@ -700,7 +662,7 @@ compress_agg_kick(struct compress_agg_stage* stage,
                               compress_stream) == 0);
   CHECK(Error,
         build_and_upload_shard_tables(stage, &layout, compress_stream) == 0);
-  CHECK(Error, wait_upstream_events(in, compress_stream) == 0);
+  CHECK(Error, wait_upstream_events(stage, in, compress_stream) == 0);
 
   CUdeviceptr d_aggregate_src = 0;
   CHECK(Error,

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -131,7 +131,6 @@ compress_agg_init(struct compress_agg_stage* stage,
             aggregate_batch_slot_init(&stage->agg[fc],
                                       C_max,
                                       stage->max_total_data_bytes) == 0);
-      CU(Fail, cuEventRecord(stage->agg[fc].ready, compute));
     }
   }
 

--- a/src/gpu/flush.compress_agg.h
+++ b/src/gpu/flush.compress_agg.h
@@ -8,16 +8,11 @@ int
 compress_agg_init(struct compress_agg_stage* stage,
                   const struct computed_stream_layouts* cl,
                   const struct tile_stream_configuration* config,
+                  struct gpu_ordering* ord,
                   CUstream compute);
 
 void
 compress_agg_destroy(struct compress_agg_stage* stage, int nlod);
-
-// Satisfy every tail-gate wait ever enqueued. Required before any blocking
-// stream/context sync when a kick may have been left undrained (failed
-// flush): its parked wait would otherwise never complete.
-void
-compress_agg_release_tail_gate(struct compress_agg_stage* stage);
 
 int
 compress_agg_kick(struct compress_agg_stage* stage,

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -23,22 +23,22 @@
 int
 d2h_deliver_init(struct d2h_deliver_stage* stage,
                  size_t shard_alignment,
+                 struct gpu_ordering* ord,
                  CUstream compute)
 {
   memset(stage, 0, sizeof(*stage));
+  stage->ord = ord;
   stage->shard_alignment = shard_alignment;
 
+  // Seed timing events so the first metric reads see a valid interval.
   for (int fc = 0; fc < 2; ++fc) {
     CU(Fail, cuEventCreate(&stage->t_d2h_start[fc], CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&stage->h_chunk_index_ready[fc], CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&stage->ready[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventRecord(stage->t_d2h_start[fc], compute));
-    CU(Fail, cuEventRecord(stage->h_chunk_index_ready[fc], compute));
-    CU(Fail, cuEventRecord(stage->ready[fc], compute));
   }
 
   // Drain-time copies must not share the d2h stream (see d2h_deliver_stage).
   CU(Fail, cuStreamCreate(&stage->drain_stream, CU_STREAM_NON_BLOCKING));
+  gpu_ordering_register_stream(ord, GPU_STREAM_DRAIN, stage->drain_stream);
 
   return 0;
 
@@ -52,11 +52,8 @@ d2h_deliver_destroy(struct d2h_deliver_stage* stage)
 {
   if (!stage)
     return;
-  for (int fc = 0; fc < 2; ++fc) {
+  for (int fc = 0; fc < 2; ++fc)
     cu_event_destroy(stage->t_d2h_start[fc]);
-    cu_event_destroy(stage->h_chunk_index_ready[fc]);
-    cu_event_destroy(stage->ready[fc]);
-  }
   cu_stream_destroy(stage->drain_stream);
   stage->drain_stream = NULL;
 }
@@ -176,25 +173,6 @@ lod_view(const struct flush_handoff* handoff, uint8_t lv, size_t data_base)
   return ar;
 }
 
-static int
-poll_event(CUevent ev, int fc)
-{
-  for (;;) {
-    CUresult r = cuEventQuery(ev);
-    if (r == CUDA_SUCCESS)
-      return 0;
-    if (r == CUDA_ERROR_DEINITIALIZED) {
-      log_debug("d2h_deliver: cuEventQuery returned DEINITIALIZED (fc=%d)", fc);
-      return 0;
-    }
-    if (r != CUDA_ERROR_NOT_READY) {
-      handle_curesult(LOG_ERROR, r, __FILE__, __LINE__, "cuEventQuery");
-      return 1;
-    }
-    platform_sleep_ns(50000);
-  }
-}
-
 // h_offsets must be pre-rebase (absolute, slot-relative) values here.
 static int
 lod_actual_bytes(const struct flush_handoff* handoff,
@@ -220,17 +198,13 @@ Error:
 }
 
 // Publishes the drained kick's tail generation; must run exactly once per
-// drain, on failure exits too — the gate threshold counts kicks
-// (shard_tables in stream.engine.h), so a skipped publish leaves the gate
-// unsatisfiable and destroy's auto-flush hangs in poll_event. Tail-state
-// content is moot once the drain has failed.
+// drain, on failure exits too — the gate threshold counts kicks, so a
+// skipped publish leaves the gate unsatisfiable and destroy's auto-flush
+// hangs polling. Tail-state content is moot once the drain has failed.
 static struct writer_result
-finish_drain(struct shard_tables* shards, int err)
+finish_drain(struct gpu_ordering* ord, int err)
 {
-  if (shards && shards->h_tail_seq_flag) {
-    shards->tail_seq++;
-    *shards->h_tail_seq_flag = shards->tail_seq;
-  }
+  gpu_edge_publish(ord, GPU_EDGE_TAIL_PUBLISHED);
   return err ? writer_error() : writer_ok();
 }
 
@@ -258,10 +232,10 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     platform_toc(&kick_clk);
 
     if (handoff->passthrough) {
-      if (poll_event(stage->ready[fc], fc))
+      if (gpu_edge_host_wait(stage->ord, GPU_EDGE_D2H_DONE, fc))
         goto Error;
     } else {
-      if (poll_event(stage->h_chunk_index_ready[fc], fc))
+      if (gpu_edge_host_wait(stage->ord, GPU_EDGE_CHUNK_INDEX_READY, fc))
         goto Error;
 
       // Bulk copies go on drain_stream, never d2h_stream — sharing
@@ -302,12 +276,15 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
       // failed: cap-stacking waiters block on slot->ready and would hang
       // otherwise. Record-on-error is harmless because the stream is
       // already in an error state and the next op will short-circuit.
-      CU(Error, cuEventRecord(stage->ready[fc], stage->drain_stream));
+      CHECK(Error,
+            gpu_edge_record(
+              stage->ord, GPU_EDGE_SLOT_DRAINED, fc, stage->drain_stream) ==
+              0);
       CU(Error, cuEventRecord(slot->ready, stage->drain_stream));
 
       if (dispatch_err)
         goto Error;
-      if (poll_event(stage->ready[fc], fc))
+      if (gpu_edge_host_wait(stage->ord, GPU_EDGE_D2H_DONE, fc))
         goto Error;
     }
 
@@ -324,7 +301,8 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
                        lod_shared,
                        metrics,
                        stage->t_d2h_start[fc],
-                       stage->ready[fc]);
+                       gpu_ordering_event(stage->ord, GPU_EDGE_SLOT_DRAINED,
+                                          fc));
 
   {
     struct platform_clock sink_clock = { 0 };
@@ -423,10 +401,10 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     accumulate_metric_ms(&metrics->sink, sink_ms, sink_bytes, sink_bytes);
   }
 
-  return finish_drain(handoff->shards, 0);
+  return finish_drain(stage->ord, 0);
 
 Error:
-  return finish_drain(handoff->shards, 1);
+  return finish_drain(stage->ord, 1);
 }
 
 // Periodic metadata update (append-dim extents per level).
@@ -476,7 +454,8 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
 
   wait_io_fences(slot, sink, stage->metrics);
 
-  CU(Error, cuStreamWaitEvent(d2h_stream, handoff->t_aggregate_end, 0));
+  CHECK(Error,
+        gpu_edge_wait(stage->ord, GPU_EDGE_AGG_DONE, fc, d2h_stream) == 0);
   CU(Error, cuEventRecord(stage->t_d2h_start[fc], d2h_stream));
 
   // Compressed codecs use these in drain to size exact per-LOD transfers;
@@ -498,10 +477,9 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                                 n * sizeof(size_t),
                                 d2h_stream));
   }
-  if (!dispatch_err)
-    D2H_TRY(dispatch_err,
-            "cuEventRecord",
-            cuEventRecord(stage->h_chunk_index_ready[fc], d2h_stream));
+  if (!dispatch_err &&
+      gpu_edge_record(stage->ord, GPU_EDGE_CHUNK_INDEX_READY, fc, d2h_stream))
+    dispatch_err = 1;
 
   // Compressed defers bulk D2H to sync_and_deliver once the chunk index lands.
   if (!dispatch_err && handoff->passthrough && layout->total_data_bytes > 0)
@@ -515,7 +493,9 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
   // Always record passthrough completion events even on dispatch error:
   // cap-stacking waiters block on slot->ready and would hang otherwise.
   if (handoff->passthrough) {
-    CU(Error, cuEventRecord(stage->ready[fc], d2h_stream));
+    CHECK(Error,
+          gpu_edge_record(stage->ord, GPU_EDGE_SLOT_DRAINED, fc, d2h_stream) ==
+            0);
     CU(Error, cuEventRecord(slot->ready, d2h_stream));
   }
 

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -272,15 +272,15 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
                                     stage->drain_stream));
       }
 
-      // Always record completion events, even if the D2H dispatch above
-      // failed: cap-stacking waiters block on slot->ready and would hang
-      // otherwise. Record-on-error is harmless because the stream is
-      // already in an error state and the next op will short-circuit.
+      // Always record the slot-drained edge, even if the D2H dispatch above
+      // failed: the host poll below and the next kick's wait block on it
+      // and would hang otherwise. Record-on-error is harmless because the
+      // stream is already in an error state and the next op will
+      // short-circuit.
       CHECK(Error,
             gpu_edge_record(
               stage->ord, GPU_EDGE_SLOT_DRAINED, fc, stage->drain_stream) ==
               0);
-      CU(Error, cuEventRecord(slot->ready, stage->drain_stream));
 
       if (dispatch_err)
         goto Error;
@@ -477,7 +477,9 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                                 n * sizeof(size_t),
                                 d2h_stream));
   }
-  if (!dispatch_err &&
+  // Passthrough never polls the chunk index (its drain waits on the
+  // slot-drained edge recorded after the bulk copy below).
+  if (!dispatch_err && !handoff->passthrough &&
       gpu_edge_record(stage->ord, GPU_EDGE_CHUNK_INDEX_READY, fc, d2h_stream))
     dispatch_err = 1;
 
@@ -490,13 +492,12 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                               layout->total_data_bytes,
                               d2h_stream));
 
-  // Always record passthrough completion events even on dispatch error:
-  // cap-stacking waiters block on slot->ready and would hang otherwise.
+  // Always record the passthrough slot-drained edge even on dispatch
+  // error: the drain's host poll blocks on it and would hang otherwise.
   if (handoff->passthrough) {
     CHECK(Error,
           gpu_edge_record(stage->ord, GPU_EDGE_SLOT_DRAINED, fc, d2h_stream) ==
             0);
-    CU(Error, cuEventRecord(slot->ready, d2h_stream));
   }
 
   return dispatch_err;

--- a/src/gpu/flush.d2h_deliver.h
+++ b/src/gpu/flush.d2h_deliver.h
@@ -6,6 +6,7 @@
 int
 d2h_deliver_init(struct d2h_deliver_stage* stage,
                  size_t shard_alignment,
+                 struct gpu_ordering* ord,
                  CUstream compute);
 
 void

--- a/src/gpu/ordering.c
+++ b/src/gpu/ordering.c
@@ -285,8 +285,11 @@ gpu_edge_wait(struct gpu_ordering* ord, enum gpu_edge e, int i, CUstream stream)
 {
   CUevent ev = ord->edge[owner_of(e)].ev[i];
   if (!ev) {
+    // Returning success here would silently drop an ordering rule; callers
+    // must gate on the binding (e.g. lod_active), so fail in release too.
+    log_error("gpu_ordering: wait on unbound edge %s[%d]", DESC[e].name, i);
     assert(!"gpu_ordering: wait on unbound edge");
-    return 0;
+    return 1;
   }
 #ifndef NDEBUG
   assert(DESC[e].kind == GPU_EDGE_EVENT);
@@ -338,9 +341,10 @@ gpu_edge_host_wait(struct gpu_ordering* ord, enum gpu_edge e, int i)
     }
     platform_sleep_ns(50000); // 50 us
   }
-  if (m)
-    accumulate_metric_ms(m, timed ? (float)(platform_toc(&clk) * 1000.0) : 0.0f,
-                         0, 0);
+  // Only blocked polls become samples — a zero sample per call would turn
+  // the stall rows into poll counts rather than stall time.
+  if (m && timed)
+    accumulate_metric_ms(m, (float)(platform_toc(&clk) * 1000.0), 0, 0);
   return 0;
 }
 

--- a/src/gpu/ordering.c
+++ b/src/gpu/ordering.c
@@ -1,0 +1,449 @@
+#include "gpu/ordering.h"
+
+#include "gpu/prelude.cuda.h"
+#include "platform/platform.h"
+#include "util/metric.h"
+
+#include <assert.h>
+#include <string.h>
+
+static const struct gpu_edge_desc DESC[GPU_EDGE_COUNT] = {
+  [GPU_EDGE_STAGING_SCATTER_DONE] = { "staging_scatter_done",
+                                      GPU_STREAM_COMPUTE,
+                                      GPU_STREAM_NONE,
+                                      GPU_STREAM_H2D,
+                                      "staging d_in slot reuse",
+                                      GPU_EDGE_EVENT,
+                                      1,
+                                      1,
+                                      -1,
+                                      0 },
+  [GPU_EDGE_STAGING_H2D_DONE] = { "staging_h2d_done",
+                                  GPU_STREAM_H2D,
+                                  GPU_STREAM_NONE,
+                                  GPU_STREAM_COMPUTE,
+                                  "staging d_in contents",
+                                  GPU_EDGE_EVENT,
+                                  1,
+                                  1,
+                                  -1,
+                                  0 },
+  [GPU_EDGE_STAGING_FREE] = { "staging_free",
+                              GPU_STREAM_H2D,
+                              GPU_STREAM_NONE,
+                              GPU_STREAM_HOST,
+                              "staging h_in refill",
+                              GPU_EDGE_EVENT,
+                              1,
+                              1,
+                              GPU_EDGE_STAGING_H2D_DONE,
+                              0 },
+  [GPU_EDGE_POOL_FILLED] = { "pool_filled",
+                             GPU_STREAM_COMPUTE,
+                             GPU_STREAM_NONE,
+                             GPU_STREAM_COMPRESS,
+                             "chunk-pool batch contents",
+                             GPU_EDGE_EVENT,
+                             0,
+                             1,
+                             -1,
+                             0 },
+  [GPU_EDGE_LOD_DONE] = { "lod_done",
+                          GPU_STREAM_COMPUTE,
+                          GPU_STREAM_NONE,
+                          GPU_STREAM_COMPRESS,
+                          "LOD chunks in pool",
+                          GPU_EDGE_EVENT,
+                          1,
+                          1,
+                          -1,
+                          1 },
+  [GPU_EDGE_AGG_DONE] = { "agg_done",
+                          GPU_STREAM_COMPRESS,
+                          GPU_STREAM_NONE,
+                          GPU_STREAM_D2H,
+                          "aggregate slot outputs",
+                          GPU_EDGE_EVENT,
+                          1,
+                          1,
+                          -1,
+                          0 },
+  [GPU_EDGE_POOL_CONSUMED] = { "pool_consumed",
+                               GPU_STREAM_COMPRESS,
+                               GPU_STREAM_NONE,
+                               GPU_STREAM_COMPUTE,
+                               "chunk pool buf[fc] reuse",
+                               GPU_EDGE_EVENT,
+                               1,
+                               1,
+                               GPU_EDGE_AGG_DONE,
+                               0 },
+  [GPU_EDGE_SLOT_DRAINED] = { "slot_drained",
+                              GPU_STREAM_D2H,
+                              GPU_STREAM_DRAIN,
+                              GPU_STREAM_COMPRESS,
+                              "aggregate slot agg[fc] reuse",
+                              GPU_EDGE_EVENT,
+                              1,
+                              1,
+                              -1,
+                              0 },
+  [GPU_EDGE_D2H_DONE] = { "d2h_done",
+                          GPU_STREAM_D2H,
+                          GPU_STREAM_DRAIN,
+                          GPU_STREAM_HOST,
+                          "h_aggregated stable for sink",
+                          GPU_EDGE_EVENT,
+                          1,
+                          1,
+                          GPU_EDGE_SLOT_DRAINED,
+                          0 },
+  [GPU_EDGE_CHUNK_INDEX_READY] = { "chunk_index_ready",
+                                   GPU_STREAM_D2H,
+                                   GPU_STREAM_NONE,
+                                   GPU_STREAM_HOST,
+                                   "h_offsets/h_permuted_sizes",
+                                   GPU_EDGE_EVENT,
+                                   1,
+                                   1,
+                                   -1,
+                                   0 },
+  [GPU_EDGE_TAIL_PUBLISHED] = { "tail_published",
+                                GPU_STREAM_HOST,
+                                GPU_STREAM_NONE,
+                                GPU_STREAM_COMPRESS,
+                                "d_tail_bytes/d_tail_carry generation",
+                                GPU_EDGE_GEN_COUNTER,
+                                0,
+                                0,
+                                -1,
+                                0 },
+  [GPU_EDGE_DRAIN_BEFORE_REKICK] = { "drain_before_rekick",
+                                     GPU_STREAM_HOST,
+                                     GPU_STREAM_NONE,
+                                     GPU_STREAM_HOST,
+                                     "pending handoff + agg host buffers",
+                                     GPU_EDGE_HOST_RULE,
+                                     1,
+                                     0,
+                                     -1,
+                                     0 },
+  [GPU_EDGE_DELIVER_OLDEST_FIRST] = { "deliver_oldest_first",
+                                      GPU_STREAM_HOST,
+                                      GPU_STREAM_NONE,
+                                      GPU_STREAM_HOST,
+                                      "tail-gate GEQ monotonicity",
+                                      GPU_EDGE_HOST_RULE,
+                                      1,
+                                      0,
+                                      -1,
+                                      0 },
+};
+
+const struct gpu_edge_desc*
+gpu_edge_describe(enum gpu_edge e)
+{
+  return &DESC[e];
+}
+
+static int
+n_inst(enum gpu_edge e)
+{
+  return DESC[e].per_fc ? 2 : 1;
+}
+
+// Owner edge whose event backs `e`.
+static enum gpu_edge
+owner_of(enum gpu_edge e)
+{
+  return DESC[e].alias_of >= 0 ? (enum gpu_edge)DESC[e].alias_of : e;
+}
+
+#ifndef NDEBUG
+static void
+check_stream(const struct gpu_ordering* ord,
+             enum gpu_edge e,
+             enum gpu_stream_id want,
+             enum gpu_stream_id want_alt,
+             CUstream got,
+             const char* role)
+{
+  if (want != GPU_STREAM_NONE && ord->streams[want] &&
+      ord->streams[want] == got)
+    return;
+  if (want_alt != GPU_STREAM_NONE && ord->streams[want_alt] &&
+      ord->streams[want_alt] == got)
+    return;
+  // Unregistered declared stream(s): cannot check (test harnesses).
+  if ((want == GPU_STREAM_NONE || !ord->streams[want]) &&
+      (want_alt == GPU_STREAM_NONE || !ord->streams[want_alt]))
+    return;
+  log_error("gpu_ordering: edge %s %s on undeclared stream", DESC[e].name,
+            role);
+  assert(!"gpu_ordering: stream does not match edge declaration");
+}
+#endif
+
+int
+gpu_ordering_init(struct gpu_ordering* ord, CUstream seed_stream)
+{
+  memset(ord, 0, sizeof(*ord));
+  for (int e = 0; e < GPU_EDGE_COUNT; ++e) {
+    const struct gpu_edge_desc* d = &DESC[e];
+    if (d->kind != GPU_EDGE_EVENT || d->alias_of >= 0 || d->external)
+      continue;
+    for (int i = 0; i < n_inst((enum gpu_edge)e); ++i) {
+      CU(Fail, cuEventCreate(&ord->edge[e].ev[i], CU_EVENT_DEFAULT));
+      ord->edge[e].owned[i] = 1;
+      if (d->seeded)
+        CU(Fail, cuEventRecord(ord->edge[e].ev[i], seed_stream));
+    }
+  }
+  return 0;
+
+Fail:
+  gpu_ordering_destroy(ord);
+  return 1;
+}
+
+void
+gpu_ordering_destroy(struct gpu_ordering* ord)
+{
+  if (!ord)
+    return;
+#ifndef NDEBUG
+  for (int e = 0; e < GPU_EDGE_COUNT; ++e) {
+    const struct gpu_edge_desc* d = &DESC[e];
+    if (d->kind != GPU_EDGE_EVENT)
+      continue;
+    const struct gpu_edge_state* owner = &ord->edge[owner_of((enum gpu_edge)e)];
+    for (int i = 0; i < n_inst((enum gpu_edge)e); ++i) {
+      if (owner->records[i] > 0 && ord->edge[e].waits[i] == 0)
+        log_warn("gpu_ordering: dead edge %s[%d]: %llu records, 0 waits",
+                 d->name,
+                 i,
+                 (unsigned long long)owner->records[i]);
+    }
+  }
+#endif
+  for (int e = 0; e < GPU_EDGE_COUNT; ++e) {
+    for (int i = 0; i < 2; ++i) {
+      if (ord->edge[e].owned[i])
+        cu_event_destroy(ord->edge[e].ev[i]);
+      ord->edge[e].ev[i] = NULL;
+      ord->edge[e].owned[i] = 0;
+    }
+  }
+  if (ord->h_tail_seq_flag) {
+    cuMemFreeHost((void*)ord->h_tail_seq_flag);
+    ord->h_tail_seq_flag = NULL;
+    ord->d_tail_seq = 0;
+  }
+}
+
+void
+gpu_ordering_register_stream(struct gpu_ordering* ord,
+                             enum gpu_stream_id id,
+                             CUstream stream)
+{
+  ord->streams[id] = stream;
+}
+
+void
+gpu_ordering_bind(struct gpu_ordering* ord, enum gpu_edge e, int i, CUevent ev)
+{
+  assert(DESC[e].external && DESC[e].alias_of < 0);
+  assert(!ord->edge[e].owned[i]);
+  ord->edge[e].ev[i] = ev;
+}
+
+CUevent
+gpu_ordering_event(const struct gpu_ordering* ord, enum gpu_edge e, int i)
+{
+  return ord->edge[owner_of(e)].ev[i];
+}
+
+int
+gpu_edge_record(struct gpu_ordering* ord, enum gpu_edge e, int i, CUstream stream)
+{
+  struct gpu_edge_state* st = &ord->edge[e];
+#ifndef NDEBUG
+  assert(DESC[e].kind == GPU_EDGE_EVENT && DESC[e].alias_of < 0);
+  check_stream(ord, e, DESC[e].producer, DESC[e].producer_alt, stream,
+               "record");
+  st->records[i]++;
+#endif
+  CU(Error, cuEventRecord(st->ev[i], stream));
+  return 0;
+
+Error:
+  return 1;
+}
+
+int
+gpu_edge_wait(struct gpu_ordering* ord, enum gpu_edge e, int i, CUstream stream)
+{
+  CUevent ev = ord->edge[owner_of(e)].ev[i];
+  if (!ev) {
+    assert(!"gpu_ordering: wait on unbound edge");
+    return 0;
+  }
+#ifndef NDEBUG
+  assert(DESC[e].kind == GPU_EDGE_EVENT);
+  check_stream(ord, e, DESC[e].consumer, GPU_STREAM_NONE, stream, "wait");
+  // #141 class: a wait whose record only happens via a future host action.
+  // Seeded edges start live; external edges are seeded by their owner.
+  if (!DESC[owner_of(e)].seeded && !DESC[owner_of(e)].external)
+    assert(ord->edge[owner_of(e)].records[i] > 0 &&
+           "gpu_ordering: wait without live record");
+  ord->edge[e].waits[i]++;
+#endif
+  CU(Error, cuStreamWaitEvent(stream, ev, 0));
+  return 0;
+
+Error:
+  return 1;
+}
+
+int
+gpu_edge_host_wait(struct gpu_ordering* ord, enum gpu_edge e, int i)
+{
+  CUevent ev = ord->edge[owner_of(e)].ev[i];
+#ifndef NDEBUG
+  assert(DESC[e].kind == GPU_EDGE_EVENT &&
+         DESC[e].consumer == GPU_STREAM_HOST);
+  ord->edge[e].waits[i]++;
+#endif
+  struct stream_metric* m = ord->edge[e].stall;
+  struct platform_clock clk = { 0 };
+  int timed = 0;
+  for (;;) {
+    CUresult r = cuEventQuery(ev);
+    if (r == CUDA_SUCCESS)
+      break;
+    if (r == CUDA_ERROR_DEINITIALIZED) {
+      // Context torn down (shutdown); data needed by this poll site is
+      // already on the host, so a clean exit is correct. Logged so the
+      // swallow is observable outside teardown.
+      log_debug("gpu_ordering: %s[%d] poll saw DEINITIALIZED", DESC[e].name, i);
+      break;
+    }
+    if (r != CUDA_ERROR_NOT_READY) {
+      handle_curesult(LOG_ERROR, r, __FILE__, __LINE__, "cuEventQuery");
+      return 1;
+    }
+    if (m && !timed) {
+      platform_toc(&clk);
+      timed = 1;
+    }
+    platform_sleep_ns(50000); // 50 us
+  }
+  if (m)
+    accumulate_metric_ms(m, timed ? (float)(platform_toc(&clk) * 1000.0) : 0.0f,
+                         0, 0);
+  return 0;
+}
+
+void
+gpu_ordering_attach_stall_metric(struct gpu_ordering* ord,
+                                 enum gpu_edge e,
+                                 struct stream_metric* m)
+{
+  ord->edge[e].stall = m;
+}
+
+int
+gpu_ordering_gate_init(struct gpu_ordering* ord, CUstream probe_stream)
+{
+  if (cuMemHostAlloc((void**)&ord->h_tail_seq_flag,
+                     sizeof(uint64_t),
+                     CU_MEMHOSTALLOC_DEVICEMAP) != CUDA_SUCCESS) {
+    ord->h_tail_seq_flag = NULL;
+  } else {
+    *ord->h_tail_seq_flag = 0;
+    if (cuMemHostGetDevicePointer(&ord->d_tail_seq,
+                                  (void*)ord->h_tail_seq_flag,
+                                  0) != CUDA_SUCCESS) {
+      cuMemFreeHost((void*)ord->h_tail_seq_flag);
+      ord->h_tail_seq_flag = NULL;
+      ord->d_tail_seq = 0;
+    }
+  }
+  if (ord->d_tail_seq) {
+    // Support probe: an already-satisfied wait.
+    CUresult pr = cuStreamWaitValue64(
+      probe_stream, ord->d_tail_seq, 0, CU_STREAM_WAIT_VALUE_GEQ);
+    ord->tail_gate_supported = (pr == CUDA_SUCCESS);
+    if (pr != CUDA_SUCCESS && pr != CUDA_ERROR_NOT_SUPPORTED)
+      CU(Fail, pr);
+  }
+  return 0;
+
+Fail:
+  return 1;
+}
+
+int
+gpu_edge_wait_gen(struct gpu_ordering* ord,
+                  enum gpu_edge e,
+                  CUstream stream,
+                  int enable)
+{
+  (void)e;
+  assert(DESC[e].kind == GPU_EDGE_GEN_COUNTER);
+  if (!ord->d_tail_seq)
+    return 0;
+#ifndef NDEBUG
+  check_stream(ord, e, DESC[e].consumer, GPU_STREAM_NONE, stream, "wait_gen");
+  ord->edge[e].waits[0]++;
+#endif
+  if (enable && ord->tail_gate_supported)
+    CU(Error,
+       cuStreamWaitValue64(
+         stream, ord->d_tail_seq, ord->kick_seq, CU_STREAM_WAIT_VALUE_GEQ));
+  // Counts even disabled (chunk-less) kicks: every kick is drained exactly
+  // once, so the count stays the next kick's threshold.
+  ord->kick_seq++;
+  return 0;
+
+Error:
+  return 1;
+}
+
+void
+gpu_edge_publish(struct gpu_ordering* ord, enum gpu_edge e)
+{
+  (void)e;
+  assert(DESC[e].kind == GPU_EDGE_GEN_COUNTER);
+#ifndef NDEBUG
+  ord->edge[e].records[0]++;
+#endif
+  if (ord->h_tail_seq_flag) {
+    ord->tail_seq++;
+    *ord->h_tail_seq_flag = ord->tail_seq;
+  }
+}
+
+void
+gpu_edge_release_all(struct gpu_ordering* ord)
+{
+  if (ord->h_tail_seq_flag)
+    *ord->h_tail_seq_flag = ord->kick_seq;
+}
+
+#ifndef NDEBUG
+void
+gpu_edge_host_rule_check(struct gpu_ordering* ord,
+                         enum gpu_edge e,
+                         int cond,
+                         const char* file,
+                         int line)
+{
+  (void)ord;
+  if (cond)
+    return;
+  log_log(LOG_ERROR, file, line, "gpu_ordering: host rule %s violated",
+          DESC[e].name);
+  assert(!"gpu_ordering: host rule violated");
+}
+#endif

--- a/src/gpu/ordering.h
+++ b/src/gpu/ordering.h
@@ -1,0 +1,225 @@
+#pragma once
+
+// Declared cross-stream / host-stream ordering edges for the GPU pipeline
+// (docs/gpu-orchestration.md). Every cuEventRecord/cuStreamWaitEvent/
+// cuStreamWaitValue64/cuEventQuery pair that orders work between streams (or
+// between the host and a stream) goes through this table; an edge that is
+// not declared here must be timing-only.
+//
+// Timing-only events are excluded (they must not masquerade as ordering):
+//   staging t_h2d_start/t_scatter_start; compress t_compress_start/end;
+//   d2h t_d2h_start; lod timing t_start/t_scatter_end/t_reduce_end/
+//   t_append_end (t_end doubles as GPU_EDGE_LOD_DONE and is bound here).
+
+#include <cuda.h>
+#include <stdint.h>
+
+struct stream_metric;
+
+enum gpu_stream_id
+{
+  GPU_STREAM_NONE = 0,
+  GPU_STREAM_HOST,
+  GPU_STREAM_H2D,
+  GPU_STREAM_COMPUTE,
+  GPU_STREAM_COMPRESS,
+  GPU_STREAM_D2H,
+  GPU_STREAM_DRAIN, // d2h_deliver_stage.drain_stream
+  GPU_STREAM_ID_COUNT,
+};
+
+enum gpu_edge_kind
+{
+  GPU_EDGE_EVENT,       // CUevent record/wait
+  GPU_EDGE_GEN_COUNTER, // host-published generation + cuStreamWaitValue64 GEQ
+  GPU_EDGE_HOST_RULE,   // host call-order invariant; no GPU primitive
+};
+
+enum gpu_edge
+{
+  // Ingest staging (instanced by staging slot, not fc).
+  GPU_EDGE_STAGING_SCATTER_DONE, // compute -> h2d: scatter/copy finished
+                                 // reading d_in before H2D overwrites it
+  GPU_EDGE_STAGING_H2D_DONE,     // h2d -> compute: d_in contents landed
+  GPU_EDGE_STAGING_FREE,         // h2d -> HOST (alias of STAGING_H2D_DONE):
+                                 // h_in safe to refill (stream.c poll)
+
+  // Batch pipeline (instanced by fc unless noted).
+  GPU_EDGE_POOL_FILLED, // compute -> compress: chunk-pool batch contents
+                        // (single instance; one batch in flight at record)
+  GPU_EDGE_LOD_DONE,    // compute -> compress: LOD chunks in pool
+                        // (bound to lod_shared timing t_end; multiscale only)
+  GPU_EDGE_AGG_DONE,    // compress -> d2h: aggregate slot outputs ready
+  GPU_EDGE_POOL_CONSUMED, // compress -> compute (alias of AGG_DONE):
+                          // pool buf[fc] reuse / re-zero (#140)
+  GPU_EDGE_SLOT_DRAINED,  // d2h|drain -> compress: agg slot reuse
+  GPU_EDGE_D2H_DONE,      // d2h|drain -> HOST (alias of SLOT_DRAINED):
+                          // h_aggregated stable for sink delivery
+  GPU_EDGE_CHUNK_INDEX_READY, // d2h -> HOST: h_offsets/h_permuted_sizes
+                              // landed; drain copy source stable
+
+  // Tail-generation gate (#142).
+  GPU_EDGE_TAIL_PUBLISHED, // HOST -> compress: d_tail_bytes/d_tail_carry
+                           // generation k published by kick k's delivery
+
+  // Host call-order invariants (debug-asserted; no GPU primitive).
+  GPU_EDGE_DRAIN_BEFORE_REKICK,  // drain pending[fc] before re-kicking fc
+  GPU_EDGE_DELIVER_OLDEST_FIRST, // drains follow kick order (tail gate GEQ
+                                 // relies on this)
+
+  GPU_EDGE_COUNT,
+};
+
+struct gpu_edge_desc
+{
+  const char* name;
+  enum gpu_stream_id producer;
+  enum gpu_stream_id producer_alt; // 0 = none
+  enum gpu_stream_id consumer;
+  const char* guards; // the resource this edge protects
+  enum gpu_edge_kind kind;
+  uint8_t per_fc;   // 1 = instanced x2 (fc or staging slot)
+  uint8_t seeded;   // recorded-signaled at init
+  int8_t alias_of;  // shares the owner edge's event; -1 = none
+  uint8_t external; // event owned elsewhere; attached via gpu_ordering_bind
+};
+
+const struct gpu_edge_desc*
+gpu_edge_describe(enum gpu_edge e);
+
+struct gpu_edge_state
+{
+  CUevent ev[2];
+  uint8_t owned[2];
+  struct stream_metric* stall; // host-poll stall accumulation; may be NULL
+#ifndef NDEBUG
+  uint64_t records[2]; // edge_record/publish calls (seeds excluded)
+  uint64_t waits[2];   // edge_wait/host_wait/wait_gen calls
+#endif
+};
+
+struct gpu_ordering
+{
+  struct gpu_edge_state edge[GPU_EDGE_COUNT];
+  CUstream streams[GPU_STREAM_ID_COUNT]; // registered for debug decl checks
+
+  // GEN_COUNTER runtime (GPU_EDGE_TAIL_PUBLISHED). Pinned + device-mapped;
+  // absent (NULL/0) when the gate was never initialized or could not be
+  // allocated/mapped — the lazy flush path then host-drains instead
+  // (stream.flush.c).
+  volatile uint64_t* h_tail_seq_flag;
+  CUdeviceptr d_tail_seq;
+  uint64_t kick_seq; // kicks enqueued (gate threshold)
+  uint64_t tail_seq; // uploads published (host mirror)
+  int tail_gate_supported;
+};
+
+// Create + seed owned events on seed_stream. External edges stay unbound
+// until gpu_ordering_bind.
+int
+gpu_ordering_init(struct gpu_ordering* ord, CUstream seed_stream);
+
+// Destroys owned events and the gate counter. Debug builds log a dead-edge
+// warning for declared edges that were recorded but never waited this run.
+void
+gpu_ordering_destroy(struct gpu_ordering* ord);
+
+// Optional: lets debug builds check record/wait streams against the
+// declaration. Unregistered ids skip the check.
+void
+gpu_ordering_register_stream(struct gpu_ordering* ord,
+                             enum gpu_stream_id id,
+                             CUstream stream);
+
+// Attach an externally owned (already seeded) event to an external edge.
+void
+gpu_ordering_bind(struct gpu_ordering* ord,
+                  enum gpu_edge e,
+                  int i,
+                  CUevent ev);
+
+// The edge's event (alias edges resolve to their owner's). NULL if unbound.
+CUevent
+gpu_ordering_event(const struct gpu_ordering* ord, enum gpu_edge e, int i);
+
+int
+gpu_edge_record(struct gpu_ordering* ord,
+                enum gpu_edge e,
+                int i,
+                CUstream stream);
+
+int
+gpu_edge_wait(struct gpu_ordering* ord, enum gpu_edge e, int i, CUstream stream);
+
+// Host-side poll (cuEventQuery loop). Returns 0 on completion — including
+// CUDA_ERROR_DEINITIALIZED at context teardown, where exiting cleanly is
+// correct — and 1 on any other error. Blocked time accrues to the edge's
+// stall metric when attached.
+int
+gpu_edge_host_wait(struct gpu_ordering* ord, enum gpu_edge e, int i);
+
+void
+gpu_ordering_attach_stall_metric(struct gpu_ordering* ord,
+                                 enum gpu_edge e,
+                                 struct stream_metric* m);
+
+// --- GEN_COUNTER (tail gate) ---
+
+// Allocate + map the pinned counter and probe cuStreamWaitValue64 support
+// with an already-satisfied wait on probe_stream. Degrades gracefully:
+// alloc/map failure or CUDA_ERROR_NOT_SUPPORTED leaves the gate off
+// (gate_supported 0) and returns 0; only unexpected probe errors return 1.
+int
+gpu_ordering_gate_init(struct gpu_ordering* ord, CUstream probe_stream);
+
+static inline int
+gpu_ordering_gate_supported(const struct gpu_ordering* ord)
+{
+  return ord->tail_gate_supported;
+}
+
+static inline int
+gpu_ordering_gate_active(const struct gpu_ordering* ord)
+{
+  return ord->h_tail_seq_flag != NULL;
+}
+
+// Queue a wait for the published generation to reach this kick's threshold,
+// then advance the threshold. The threshold advances even when enable is 0:
+// every kick is drained (published) exactly once, so the count stays the
+// next kick's threshold. No-op when the gate was never initialized.
+int
+gpu_edge_wait_gen(struct gpu_ordering* ord,
+                  enum gpu_edge e,
+                  CUstream stream,
+                  int enable);
+
+// Publish the drained kick's generation. Must run exactly once per drain,
+// on failure exits too — a skipped publish leaves the gate unsatisfiable.
+void
+gpu_edge_publish(struct gpu_ordering* ord, enum gpu_edge e);
+
+// Satisfy every gate wait ever enqueued. Required before any blocking
+// stream/context sync when a kick may have been left undrained. kick_seq
+// satisfies every threshold; UINT64_MAX would not (CU_STREAM_WAIT_VALUE_GEQ
+// is a signed ring compare).
+void
+gpu_edge_release_all(struct gpu_ordering* ord);
+
+// --- HOST_RULE debug assert ---
+
+#ifndef NDEBUG
+void
+gpu_edge_host_rule_check(struct gpu_ordering* ord,
+                         enum gpu_edge e,
+                         int cond,
+                         const char* file,
+                         int line);
+#define gpu_edge_host_rule(ord, e, cond)                                       \
+  gpu_edge_host_rule_check((ord), (e), (cond), __FILE__, __LINE__)
+#else
+#define gpu_edge_host_rule(ord, e, cond)                                       \
+  do {                                                                         \
+    (void)(ord);                                                               \
+  } while (0)
+#endif

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -126,37 +126,22 @@ stream_append_body(struct stream_engine* e,
           struct staging_slot* ss = &e->stage.slot[si];
           // Poll instead of cuEventSynchronize to keep the producer thread
           // hot — it has memcpy work queued up immediately after.
-          for (;;) {
-            CUresult r = cuEventQuery(ss->t_h2d_end);
-            if (r == CUDA_SUCCESS)
-              break;
-            if (r == CUDA_ERROR_DEINITIALIZED) {
-              // Context torn down (shutdown). Data is already on host for
-              // this poll site; clean exit is correct. Logged so the
-              // swallow is observable outside teardown.
-              log_debug("stream.append: cuEventQuery returned DEINITIALIZED "
-                        "(slot=%d)",
-                        si);
-              break;
-            }
-            if (r != CUDA_ERROR_NOT_READY) {
-              handle_curesult(LOG_ERROR, r, __FILE__, __LINE__, "cuEventQuery");
-              goto Error;
-            }
-            platform_sleep_ns(50000); // 50 µs
-          }
+          if (gpu_edge_host_wait(&e->ord, GPU_EDGE_STAGING_FREE, si))
+            goto Error;
 
           if (ctx->cursor_elements > 0) {
-            accumulate_metric_cu(&e->metrics.h2d,
-                                 ss->t_h2d_start,
-                                 ss->t_h2d_end,
-                                 ss->dispatched_bytes,
-                                 ss->dispatched_bytes);
-            accumulate_metric_cu(&e->metrics.scatter,
-                                 ss->t_scatter_start,
-                                 ss->t_scatter_end,
-                                 ss->dispatched_bytes,
-                                 ss->dispatched_bytes);
+            accumulate_metric_cu(
+              &e->metrics.h2d,
+              ss->t_h2d_start,
+              gpu_ordering_event(&e->ord, GPU_EDGE_STAGING_H2D_DONE, si),
+              ss->dispatched_bytes,
+              ss->dispatched_bytes);
+            accumulate_metric_cu(
+              &e->metrics.scatter,
+              ss->t_scatter_start,
+              gpu_ordering_event(&e->ord, GPU_EDGE_STAGING_SCATTER_DONE, si),
+              ss->dispatched_bytes,
+              ss->dispatched_bytes);
           }
         }
 

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -41,6 +41,20 @@ stream_engine_init_metrics(int enable_multiscale)
   };
 }
 
+void
+stream_engine_attach_edge_stalls(struct stream_engine* e)
+{
+  e->metrics.edge_stall[0] = mk_stream_metric("StagingFree");
+  e->metrics.edge_stall[1] = mk_stream_metric("ChunkIndex");
+  e->metrics.edge_stall[2] = mk_stream_metric("D2HDone");
+  gpu_ordering_attach_stall_metric(
+    &e->ord, GPU_EDGE_STAGING_FREE, &e->metrics.edge_stall[0]);
+  gpu_ordering_attach_stall_metric(
+    &e->ord, GPU_EDGE_CHUNK_INDEX_READY, &e->metrics.edge_stall[1]);
+  gpu_ordering_attach_stall_metric(
+    &e->ord, GPU_EDGE_D2H_DONE, &e->metrics.edge_stall[2]);
+}
+
 void*
 stream_engine_pool_epoch(struct stream_engine* e,
                          struct stream_context* ctx,

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -83,7 +83,6 @@ engine_dispatch_ingest(struct stream_engine* e, struct stream_context* ctx)
       &ctx->layout,
       &ctx->layout_gpu,
       stream_engine_pool_epoch(e, ctx, e->batch.accumulated),
-      e->pools.ready[e->pools.current],
       &ctx->cursor_elements,
       dtype_bpe(ctx->config.dtype),
       e->streams.h2d,

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -319,6 +319,11 @@ stream_engine_pool_epoch(struct stream_engine* e,
 struct stream_metrics
 stream_engine_init_metrics(int enable_multiscale);
 
+// Point the ordering host-poll edges at this engine's edge_stall metrics.
+// Call after assigning engine.metrics; the bench prints the rows.
+void
+stream_engine_attach_edge_stalls(struct stream_engine* e);
+
 // Append data to the stream. Handles staging, dispatch, epoch boundaries,
 // batch flush, and backpressure. Used by both single-array and multiarray.
 struct writer_result

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -3,6 +3,7 @@
 #include "gpu/aggregate.h"
 #include "gpu/compress.h"
 #include "gpu/flush.handoff.h"
+#include "gpu/ordering.h"
 #include "gpu/reduce_csr_gpu.h"
 #include "platform/platform.h"
 #include "stream.gpu.h"
@@ -19,14 +20,14 @@ struct pool_state
   int current; // 0 or 1
 };
 
+// Ordering events (h2d-done, scatter-done) live in gpu_ordering, instanced
+// by staging slot; only timing-interval starts stay here.
 struct staging_slot
 {
   void* h_in;              // pinned host WC, size = buffer_capacity_bytes
   CUdeviceptr d_in;        // device, size = buffer_capacity_bytes
-  CUevent t_h2d_end;       // recorded after H2D memcpy completes
-  CUevent t_h2d_start;     // recorded before H2D memcpy
-  CUevent t_scatter_start; // recorded before scatter kernel
-  CUevent t_scatter_end;   // recorded after scatter kernel
+  CUevent t_h2d_start;     // recorded before H2D memcpy (timing)
+  CUevent t_scatter_start; // recorded before scatter kernel (timing)
   size_t dispatched_bytes; // bytes transferred in last dispatch
 };
 
@@ -35,6 +36,7 @@ struct staging_state
   struct staging_slot slot[2];
   int current;          // 0 or 1: which buffer the host is filling
   size_t bytes_written; // bytes written to current slot's h_in so far
+  struct gpu_ordering* ord; // borrowed
 };
 
 // Per flush-slot: mutable batch state (masks + epoch count).
@@ -106,14 +108,13 @@ struct gpu_streams
   CUstream h2d, compute, compress, d2h;
 };
 
-// Batch accumulation: config + mutable counter + single pool-ready event.
-// All K scatter ops run on the compute stream in order, so a single event
-// recorded after the K-th scatter subsumes all per-epoch ready signals.
+// Batch accumulation. Pool readiness is GPU_EDGE_POOL_FILLED: all K scatter
+// ops run on the compute stream in order, so one record after the K-th
+// scatter subsumes all per-epoch ready signals.
 struct batch_state
 {
   uint32_t epochs_per_batch; // K (immutable after create)
   uint32_t accumulated;      // mutable: 0..K-1
-  CUevent pool_ready;        // recorded on compute after last accumulated epoch
 };
 
 // --- Stage types ---
@@ -125,12 +126,7 @@ struct compress_agg_input
   uint32_t active_levels_mask;
   const uint32_t* batch_active_masks; // borrowed from flush_slot_gpu [K]
   CUdeviceptr pool_buf;
-  CUevent pool_ready; // batch-level (from batch_state.pool_ready)
-  CUevent lod_done;
-  CUevent prev_d2h_done; // prior D2H on same fc; compress waits on this so
-                         // aggregate doesn't overwrite agg[fc].d_aggregated
-                         // before the prior D2H has read it. Initialized
-                         // signaled.
+  int lod_active; // wait GPU_EDGE_LOD_DONE (multiscale with bound edge only)
   uint32_t epochs_per_batch;
 };
 
@@ -169,14 +165,10 @@ struct shard_tables
   // consume the d_tail_bytes/d_tail_carry upload made by kick #k-1's
   // delivery, which on the lazy path runs AFTER kick #k is enqueued;
   // nothing else orders that host upload against the queued kernels. Kick
-  // #k waits d_tail_seq >= k, the delivery publishes after each upload
-  // (flush.d2h_deliver.c), and drains are oldest-first, so tail_seq counts
-  // delivered kicks.
-  volatile uint64_t* h_tail_seq_flag; // pinned + device-mapped; host-written
-  CUdeviceptr d_tail_seq;             // device view of h_tail_seq_flag
-  uint64_t kick_seq;                  // kicks enqueued (gate threshold)
-  uint64_t tail_seq;                  // uploads published (host mirror)
-  int tail_gate_supported;            // stream memops may be unsupported
+  // #k waits the generation counter >= k, the delivery publishes after each
+  // upload (flush.d2h_deliver.c), and drains are oldest-first, so the
+  // published count tracks delivered kicks. Counter state lives in
+  // gpu_ordering (GPU_EDGE_TAIL_PUBLISHED).
 
   // Per-LOD slice info, needed by delivery to view the unified slot buffers.
   uint32_t shards_begin[LOD_MAX_LEVELS]; // first global shard index for LOD lv
@@ -185,11 +177,11 @@ struct shard_tables
 
 struct compress_agg_stage
 {
+  struct gpu_ordering* ord; // borrowed
   struct codec codec;
   CUdeviceptr d_compressed[2];
-  CUevent t_compress_start[2];
-  CUevent t_compress_end[2];
-  CUevent t_aggregate_end[2];
+  CUevent t_compress_start[2]; // timing
+  CUevent t_compress_end[2];   // timing
 
   uint32_t* pool_epochs_scratch; // [LOD_MAX_LEVELS * K] scratch for mask scans
 
@@ -241,15 +233,14 @@ struct compress_agg_stage
 
 struct d2h_deliver_stage
 {
-  CUevent t_d2h_start[2];
-  CUevent h_chunk_index_ready[2]; // h_offsets + h_permuted_sizes on host
-  CUevent ready[2];               // full D2H done; gates slot reuse
+  struct gpu_ordering* ord; // borrowed
+  CUevent t_d2h_start[2];   // timing
 
   // Drain-time copies must not share the d2h stream: by drain time it can
-  // already hold the next kick's t_aggregate_end wait, which the tail gate
-  // (shard_tables) keeps parked until THIS drain publishes — sharing would
-  // deadlock. The drain's host poll of h_chunk_index_ready already proves
-  // the copy source is stable, so no device-side ordering is needed here.
+  // already hold the next kick's GPU_EDGE_AGG_DONE wait, which the tail
+  // gate keeps parked until THIS drain publishes — sharing would deadlock.
+  // The drain's host poll of GPU_EDGE_CHUNK_INDEX_READY already proves the
+  // copy source is stable, so no device-side ordering is needed here.
   CUstream drain_stream;
 
   size_t shard_alignment;         // from sink; 0 = no alignment
@@ -300,6 +291,7 @@ struct stream_engine
 {
   int sync_flush; // 1 = synchronous batch flush (multiarray); 0 = pipelined
   struct gpu_streams streams;
+  struct gpu_ordering ord;
   struct pool_state pools;
   size_t pool_bytes;
   struct staging_state stage;

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -16,7 +16,6 @@
 struct pool_state
 {
   CUdeviceptr buf[2];
-  CUevent ready[2];
   int current; // 0 or 1
 };
 

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -412,7 +412,6 @@ flush_partial_append(struct stream_engine* e, struct stream_context* ctx)
                                    e->streams.compute) == 0);
   }
 
-  CU(Error, cuEventRecord(e->pools.ready[fc], e->streams.compute));
   if (gpu_ordering_event(&e->ord, GPU_EDGE_LOD_DONE, fc))
     CHECK(Error,
           gpu_edge_record(

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -28,12 +28,8 @@ make_compress_input(struct stream_engine* e,
     .active_levels_mask = fs->active_levels_mask,
     .batch_active_masks = fs->batch_active_masks,
     .pool_buf = e->pools.buf[fc],
-    .pool_ready = e->batch.pool_ready,
-    .lod_done =
-      (ctx->levels.enable_multiscale && e->lod_shared.timing[fc].t_end)
-        ? e->lod_shared.timing[fc].t_end
-        : NULL,
-    .prev_d2h_done = e->d2h_deliver.ready[fc],
+    .lod_active = ctx->levels.enable_multiscale &&
+                  gpu_ordering_event(&e->ord, GPU_EDGE_LOD_DONE, fc) != NULL,
     .epochs_per_batch = e->batch.epochs_per_batch,
   };
 }
@@ -55,6 +51,7 @@ flush_run_epoch_lod(struct stream_engine* e, struct stream_context* ctx)
     CHECK(Error,
           lod_run_epoch(&e->lod,
                         &e->lod_shared,
+                        &e->ord,
                         e->pools.current,
                         &ctx->levels,
                         stream_engine_pool_epoch(e, ctx, e->batch.accumulated),
@@ -81,6 +78,12 @@ drain_fc(struct stream_engine* e, struct stream_context* ctx, int fc)
 {
   if (!e->flush.pending[fc])
     return writer_ok();
+
+  // The tail gate's GEQ threshold assumes drains follow kick order.
+  gpu_edge_host_rule(&e->ord,
+                     GPU_EDGE_DELIVER_OLDEST_FIRST,
+                     !e->flush.pending[fc ^ 1] ||
+                       e->flush.pending_seq[fc] < e->flush.pending_seq[fc ^ 1]);
 
   struct platform_clock stall_clk = { 0 };
   platform_toc(&stall_clk);
@@ -134,12 +137,15 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
   // degrades to depth 1 — and the kick below sees published tail state.
   if (e->compress_agg.shards.page_size > 0 &&
       e->compress_agg.shards.total_shards > 0 &&
-      !e->compress_agg.shards.tail_gate_supported) {
+      !gpu_ordering_gate_supported(&e->ord)) {
     struct writer_result r = drain_fc(e, ctx, completed_pool ^ 1);
     if (r.error)
       return r;
   }
 
+  gpu_edge_host_rule(&e->ord,
+                     GPU_EDGE_DRAIN_BEFORE_REKICK,
+                     !e->flush.pending[completed_pool]);
   fs->batch_epoch_count = (int)e->batch.accumulated;
   struct compress_agg_input in =
     make_compress_input(e, ctx, completed_pool, e->batch.accumulated);
@@ -164,12 +170,13 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
 
   // Phase 5: swap to fresh pool and zero it for next batch.
   e->pools.current ^= 1;
-  // t_aggregate_end[current] marks the last read of this pool; reusing it
-  // any earlier corrupts the in-flight batch.
-  CU(Error,
-     cuStreamWaitEvent(e->streams.compute,
-                       e->compress_agg.t_aggregate_end[e->pools.current],
-                       0));
+  // The aggregate's last pool read gates reuse; re-zeroing any earlier
+  // corrupts the in-flight batch (#140).
+  CHECK(Error,
+        gpu_edge_wait(&e->ord,
+                      GPU_EDGE_POOL_CONSUMED,
+                      e->pools.current,
+                      e->streams.compute) == 0);
   size_t pool_bytes = (uint64_t)K * ctx->levels.total_chunks *
                       ctx->layout.chunk_stride * dtype_bpe(ctx->config.dtype);
   CU(Error,
@@ -202,9 +209,11 @@ flush_accumulate_epoch(struct stream_engine* e, struct stream_context* ctx)
   if (e->batch.accumulated < e->batch.epochs_per_batch)
     return writer_ok();
 
-  // Record pool_ready once after the last epoch's scatter; compute-stream
+  // Record pool-filled once after the last epoch's scatter; compute-stream
   // ordering means this subsumes per-epoch ready signals.
-  CU(Error, cuEventRecord(e->batch.pool_ready, e->streams.compute));
+  CHECK(Error,
+        gpu_edge_record(
+          &e->ord, GPU_EDGE_POOL_FILLED, 0, e->streams.compute) == 0);
 
   if (e->sync_flush) {
     // Synchronous path: flush the full batch immediately (no pool swap).
@@ -243,6 +252,8 @@ flush_kick_batch(struct stream_engine* e,
                  int fc,
                  uint32_t n_epochs)
 {
+  gpu_edge_host_rule(&e->ord, GPU_EDGE_DRAIN_BEFORE_REKICK,
+                     !e->flush.pending[fc]);
   struct compress_agg_input in = make_compress_input(e, ctx, fc, n_epochs);
   struct flush_handoff handoff = { 0 };
 
@@ -306,8 +317,9 @@ flush_accumulated_sync(struct stream_engine* e, struct stream_context* ctx)
 
   fs->batch_epoch_count = (int)e->batch.accumulated;
 
-  // Record pool_ready after all scatter ops for this (possibly partial) batch.
-  if (cuEventRecord(e->batch.pool_ready, e->streams.compute) != CUDA_SUCCESS)
+  // Record pool-filled after all scatter ops for this (possibly partial)
+  // batch.
+  if (gpu_edge_record(&e->ord, GPU_EDGE_POOL_FILLED, 0, e->streams.compute))
     return writer_error();
 
   if (flush_kick_batch(e, ctx, fc, e->batch.accumulated))
@@ -401,11 +413,14 @@ flush_partial_append(struct stream_engine* e, struct stream_context* ctx)
   }
 
   CU(Error, cuEventRecord(e->pools.ready[fc], e->streams.compute));
-  if (e->lod_shared.timing[fc].t_end)
-    CU(Error,
-       cuEventRecord(e->lod_shared.timing[fc].t_end, e->streams.compute));
+  if (gpu_ordering_event(&e->ord, GPU_EDGE_LOD_DONE, fc))
+    CHECK(Error,
+          gpu_edge_record(
+            &e->ord, GPU_EDGE_LOD_DONE, fc, e->streams.compute) == 0);
 
-  CU(Error, cuEventRecord(e->batch.pool_ready, e->streams.compute));
+  CHECK(Error,
+        gpu_edge_record(
+          &e->ord, GPU_EDGE_POOL_FILLED, 0, e->streams.compute) == 0);
   if (flush_kick_batch(e, ctx, fc, 1))
     return writer_error();
   return drain_fc(e, ctx, fc);

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -2,26 +2,27 @@
 
 #include "gpu/prelude.cuda.h"
 #include "gpu/transpose.h"
+#include "util/prelude.h"
 
 #include <string.h>
 
 int
 ingest_init(struct staging_state* stage,
             size_t buffer_capacity_bytes,
+            struct gpu_ordering* ord,
             CUstream compute)
 {
   memset(stage, 0, sizeof(*stage));
+  stage->ord = ord;
+  // Ordering events (h2d-done, scatter-done) are owned and seeded by ord;
+  // only the timing-interval starts are created here.
   for (int i = 0; i < 2; ++i) {
     CU(Fail, cuMemHostAlloc(&stage->slot[i].h_in, buffer_capacity_bytes, 0));
     CU(Fail, cuMemAlloc(&stage->slot[i].d_in, buffer_capacity_bytes));
-    CU(Fail, cuEventCreate(&stage->slot[i].t_h2d_end, CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->slot[i].t_h2d_start, CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->slot[i].t_scatter_start, CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&stage->slot[i].t_scatter_end, CU_EVENT_DEFAULT));
-    CU(Fail, cuEventRecord(stage->slot[i].t_h2d_end, compute));
     CU(Fail, cuEventRecord(stage->slot[i].t_h2d_start, compute));
     CU(Fail, cuEventRecord(stage->slot[i].t_scatter_start, compute));
-    CU(Fail, cuEventRecord(stage->slot[i].t_scatter_end, compute));
   }
   return 0;
 Fail:
@@ -36,10 +37,8 @@ ingest_destroy(struct staging_state* stage)
     struct staging_slot* ss = &stage->slot[i];
     cu_mem_freehost(ss->h_in);
     cu_mem_free(ss->d_in);
-    cu_event_destroy(ss->t_h2d_end);
     cu_event_destroy(ss->t_h2d_start);
     cu_event_destroy(ss->t_scatter_start);
-    cu_event_destroy(ss->t_scatter_end);
   }
 }
 
@@ -67,13 +66,18 @@ ingest_dispatch_scatter(struct staging_state* stage,
   ss->dispatched_bytes = stage->bytes_written;
 
   // H2D — wait for prior scatter to finish reading d_in before overwriting
-  CU(Error, cuStreamWaitEvent(h2d, ss->t_scatter_end, 0));
+  CHECK(Error,
+        gpu_edge_wait(
+          stage->ord, GPU_EDGE_STAGING_SCATTER_DONE, idx, h2d) == 0);
   CU(Error, cuEventRecord(ss->t_h2d_start, h2d));
   CU(Error, cuMemcpyHtoDAsync(ss->d_in, ss->h_in, stage->bytes_written, h2d));
-  CU(Error, cuEventRecord(ss->t_h2d_end, h2d));
+  CHECK(Error,
+        gpu_edge_record(stage->ord, GPU_EDGE_STAGING_H2D_DONE, idx, h2d) == 0);
 
   // Scatter into chunk pool
-  CU(Error, cuStreamWaitEvent(compute, ss->t_h2d_end, 0));
+  CHECK(Error,
+        gpu_edge_wait(
+          stage->ord, GPU_EDGE_STAGING_H2D_DONE, idx, compute) == 0);
   CU(Error, cuEventRecord(ss->t_scatter_start, compute));
   transpose((CUdeviceptr)pool_epoch,
             ss->d_in,
@@ -84,7 +88,9 @@ ingest_dispatch_scatter(struct staging_state* stage,
             layout_gpu->d_lifted_shape,
             layout_gpu->d_lifted_strides,
             compute);
-  CU(Error, cuEventRecord(ss->t_scatter_end, compute));
+  CHECK(Error,
+        gpu_edge_record(
+          stage->ord, GPU_EDGE_STAGING_SCATTER_DONE, idx, compute) == 0);
 
   CU(Error, cuEventRecord(pool_ready, compute));
 
@@ -118,13 +124,18 @@ ingest_dispatch_multiscale(struct staging_state* stage,
   ss->dispatched_bytes = stage->bytes_written;
 
   // H2D — wait for prior d_linear copy to finish reading d_in
-  CU(Error, cuStreamWaitEvent(h2d, ss->t_scatter_end, 0));
+  CHECK(Error,
+        gpu_edge_wait(
+          stage->ord, GPU_EDGE_STAGING_SCATTER_DONE, idx, h2d) == 0);
   CU(Error, cuEventRecord(ss->t_h2d_start, h2d));
   CU(Error, cuMemcpyHtoDAsync(ss->d_in, ss->h_in, stage->bytes_written, h2d));
-  CU(Error, cuEventRecord(ss->t_h2d_end, h2d));
+  CHECK(Error,
+        gpu_edge_record(stage->ord, GPU_EDGE_STAGING_H2D_DONE, idx, h2d) == 0);
 
   // Copy raw input to linear epoch buffer for LOD downsampling
-  CU(Error, cuStreamWaitEvent(compute, ss->t_h2d_end, 0));
+  CHECK(Error,
+        gpu_edge_wait(
+          stage->ord, GPU_EDGE_STAGING_H2D_DONE, idx, compute) == 0);
   CU(Error, cuEventRecord(ss->t_scatter_start, compute));
   {
     uint64_t epoch_offset = (*cursor % epoch_elements) * bpe;
@@ -132,7 +143,9 @@ ingest_dispatch_multiscale(struct staging_state* stage,
        cuMemcpyDtoDAsync(
          d_linear + epoch_offset, ss->d_in, elements * bpe, compute));
   }
-  CU(Error, cuEventRecord(ss->t_scatter_end, compute));
+  CHECK(Error,
+        gpu_edge_record(
+          stage->ord, GPU_EDGE_STAGING_SCATTER_DONE, idx, compute) == 0);
 
   *cursor += elements;
   stage->current ^= 1;

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -47,7 +47,6 @@ ingest_dispatch_scatter(struct staging_state* stage,
                         const struct tile_stream_layout* layout,
                         const struct tile_stream_layout_gpu* layout_gpu,
                         void* pool_epoch,
-                        CUevent pool_ready,
                         uint64_t* cursor,
                         size_t bpe,
                         CUstream h2d,
@@ -91,8 +90,6 @@ ingest_dispatch_scatter(struct staging_state* stage,
   CHECK(Error,
         gpu_edge_record(
           stage->ord, GPU_EDGE_STAGING_SCATTER_DONE, idx, compute) == 0);
-
-  CU(Error, cuEventRecord(pool_ready, compute));
 
   *cursor += elements;
   stage->current ^= 1;

--- a/src/gpu/stream.ingest.h
+++ b/src/gpu/stream.ingest.h
@@ -16,7 +16,6 @@ ingest_destroy(struct staging_state* stage);
 
 // H2D transfer + scatter into chunk pool.
 // pool_epoch: pointer to the target epoch's chunk region in the pool.
-// pool_ready: event to record after scatter completes.
 // cursor: in/out, incremented by elements transferred.
 // Returns 0 on success, non-zero on error.
 int
@@ -24,7 +23,6 @@ ingest_dispatch_scatter(struct staging_state* stage,
                         const struct tile_stream_layout* layout,
                         const struct tile_stream_layout_gpu* layout_gpu,
                         void* pool_epoch,
-                        CUevent pool_ready,
                         uint64_t* cursor,
                         size_t bpe,
                         CUstream h2d,

--- a/src/gpu/stream.ingest.h
+++ b/src/gpu/stream.ingest.h
@@ -2,10 +2,12 @@
 
 #include "gpu/stream.internal.h"
 
-// Allocate double-buffered staging buffers and events. Returns 0 on success.
+// Allocate double-buffered staging buffers and timing events; ordering
+// events live in ord. Returns 0 on success.
 int
 ingest_init(struct staging_state* stage,
             size_t buffer_capacity_bytes,
+            struct gpu_ordering* ord,
             CUstream compute);
 
 // Free staging buffers and events.

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -37,12 +37,6 @@ destroy_chunk_pools(struct pool_state* pools)
 }
 
 static void
-destroy_batch_events(struct batch_state* batch)
-{
-  cu_event_destroy(batch->pool_ready);
-}
-
-static void
 destroy_flush_pipeline(struct flush_pipeline* fp);
 
 static void
@@ -70,7 +64,7 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
 
   // A failed flush can leave a kick parked on the tail gate; release it or
   // the syncs below never return.
-  compress_agg_release_tail_gate(&s->engine.compress_agg);
+  gpu_edge_release_all(&s->engine.ord);
 
   // Ensure all GPU work completes before tearing down events/memory.
   sync(s->engine.streams.h2d);
@@ -78,7 +72,6 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.compress);
   sync(s->engine.streams.d2h);
 
-  destroy_batch_events(&s->engine.batch);
   destroy_flush_pipeline(&s->engine.flush);
   d2h_deliver_destroy(&s->engine.d2h_deliver);
   compress_agg_destroy(&s->engine.compress_agg, s->ctx.levels.nlod);
@@ -86,6 +79,7 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   lod_state_destroy(&s->engine.lod);
   lod_shared_state_destroy(&s->engine.lod_shared);
   ingest_destroy(&s->engine.stage);
+  gpu_ordering_destroy(&s->engine.ord);
   destroy_cuda_streams_and_events(&s->engine.streams, &s->engine.pools);
   free(s);
 }
@@ -126,17 +120,6 @@ init_chunk_pools(struct pool_state* pools,
     CU(Fail, cuMemsetD8Async(pools->buf[i], 0, pool_bytes, compute));
   }
 
-  return 0;
-Fail:
-  return 1;
-}
-
-// Create and seed the batch pool-ready event.
-static int
-init_batch_events(struct batch_state* batch, CUstream compute)
-{
-  CU(Fail, cuEventCreate(&batch->pool_ready, CU_EVENT_DEFAULT));
-  CU(Fail, cuEventRecord(batch->pool_ready, compute));
   return 0;
 Fail:
   return 1;
@@ -233,8 +216,19 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
         init_cuda_streams_and_events(&out->engine.streams,
                                      &out->engine.pools) == 0);
   CHECK(FailPhase2,
+        gpu_ordering_init(&out->engine.ord, out->engine.streams.compute) == 0);
+  gpu_ordering_register_stream(
+    &out->engine.ord, GPU_STREAM_H2D, out->engine.streams.h2d);
+  gpu_ordering_register_stream(
+    &out->engine.ord, GPU_STREAM_COMPUTE, out->engine.streams.compute);
+  gpu_ordering_register_stream(
+    &out->engine.ord, GPU_STREAM_COMPRESS, out->engine.streams.compress);
+  gpu_ordering_register_stream(
+    &out->engine.ord, GPU_STREAM_D2H, out->engine.streams.d2h);
+  CHECK(FailPhase2,
         ingest_init(&out->engine.stage,
                     out->ctx.config.buffer_capacity_bytes,
+                    &out->engine.ord,
                     out->engine.streams.compute) == 0);
   CHECK(FailPhase2,
         lod_state_init(&out->engine.lod, &out->ctx.levels, &out->ctx.config) ==
@@ -254,15 +248,14 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
         compress_agg_init(&out->engine.compress_agg,
                           &cl,
                           config,
+                          &out->engine.ord,
                           out->engine.streams.compute) == 0);
   CHECK(FailPhase2,
         d2h_deliver_init(&out->engine.d2h_deliver,
                          out->ctx.shard_alignment,
+                         &out->engine.ord,
                          out->engine.streams.compute) == 0);
 
-  CHECK(FailPhase2,
-        init_batch_events(&out->engine.batch, out->engine.streams.compute) ==
-          0);
   if (out->ctx.levels.enable_multiscale) {
     const size_t bpe = dtype_bpe(out->ctx.config.dtype);
     const size_t linear_bytes = out->engine.lod.layouts[0].epoch_elements * bpe;
@@ -275,6 +268,12 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
                                 linear_bytes,
                                 morton_bytes,
                                 out->engine.streams.compute) == 0);
+    // t_end doubles as GPU_EDGE_LOD_DONE; already seeded by the init above.
+    for (int fc = 0; fc < 2; ++fc)
+      gpu_ordering_bind(&out->engine.ord,
+                        GPU_EDGE_LOD_DONE,
+                        fc,
+                        out->engine.lod_shared.timing[fc].t_end);
     if (out->ctx.dims.append_downsample)
       CHECK(FailPhase2,
             lod_state_init_accumulators(&out->engine.lod, &out->ctx.config) ==

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -300,6 +300,7 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
   out->engine.metrics =
     stream_engine_init_metrics(out->ctx.levels.enable_multiscale);
   out->engine.d2h_deliver.metrics = &out->engine.metrics;
+  stream_engine_attach_edge_stalls(&out->engine);
 
   // Initialize metadata update timer
   out->engine.metadata_update_clock = (struct platform_clock){ 0 };

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -17,16 +17,12 @@
 #include <string.h>
 
 static void
-destroy_cuda_streams_and_events(struct gpu_streams* streams,
-                                struct pool_state* pools)
+destroy_cuda_streams(struct gpu_streams* streams)
 {
   cu_stream_destroy(streams->h2d);
   cu_stream_destroy(streams->compute);
   cu_stream_destroy(streams->compress);
   cu_stream_destroy(streams->d2h);
-
-  for (int i = 0; i < 2; ++i)
-    cu_event_destroy(pools->ready[i]);
 }
 
 static void
@@ -80,24 +76,19 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   lod_shared_state_destroy(&s->engine.lod_shared);
   ingest_destroy(&s->engine.stage);
   gpu_ordering_destroy(&s->engine.ord);
-  destroy_cuda_streams_and_events(&s->engine.streams, &s->engine.pools);
+  destroy_cuda_streams(&s->engine.streams);
   free(s);
 }
 
 // --- Create ---
 
 static int
-init_cuda_streams_and_events(struct gpu_streams* streams,
-                             struct pool_state* pools)
+init_cuda_streams(struct gpu_streams* streams)
 {
   CU(Fail, cuStreamCreate(&streams->h2d, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuStreamCreate(&streams->compute, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuStreamCreate(&streams->compress, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuStreamCreate(&streams->d2h, CU_STREAM_NON_BLOCKING));
-
-  for (int i = 0; i < 2; ++i) {
-    CU(Fail, cuEventCreate(&pools->ready[i], CU_EVENT_DEFAULT));
-  }
 
   return 0;
 Fail:
@@ -144,16 +135,6 @@ destroy_flush_pipeline(struct flush_pipeline* fp)
     free(fp->slot[fc].batch_active_masks);
     fp->slot[fc].batch_active_masks = NULL;
   }
-}
-
-static int
-seed_events(const struct pool_state* pools, CUstream compute)
-{
-  CU(Fail, cuEventRecord(pools->ready[0], compute));
-  CU(Fail, cuEventRecord(pools->ready[1], compute));
-  return 0;
-Fail:
-  return 1;
 }
 
 struct tile_stream_gpu*
@@ -212,9 +193,7 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
         init_flush_pipeline(&out->engine.flush, cl.epochs_per_batch) == 0);
 
   // GPU allocation and init.
-  CHECK(FailPhase2,
-        init_cuda_streams_and_events(&out->engine.streams,
-                                     &out->engine.pools) == 0);
+  CHECK(FailPhase2, init_cuda_streams(&out->engine.streams) == 0);
   CHECK(FailPhase2,
         gpu_ordering_init(&out->engine.ord, out->engine.streams.compute) == 0);
   gpu_ordering_register_stream(
@@ -279,9 +258,6 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
             lod_state_init_accumulators(&out->engine.lod, &out->ctx.config) ==
               0);
   }
-  CHECK(FailPhase2,
-        seed_events(&out->engine.pools, out->engine.streams.compute) == 0);
-
   CU(FailPhase2, cuStreamSynchronize(out->engine.streams.compute));
 
   // Precompute total_element_limit (configured stream length) so the body can

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -657,6 +657,7 @@ Error:
 int
 lod_run_epoch(struct lod_state* lod,
               struct lod_shared_state* sh,
+              struct gpu_ordering* ord,
               int fc,
               const struct level_geometry* levels,
               void* pool_epoch,
@@ -731,7 +732,8 @@ lod_run_epoch(struct lod_state* lod,
           lod, sh, levels, pool_epoch, dtype, active_levels_mask, compute) ==
           0);
 
-  CU(Error, cuEventRecord(t->t_end, compute));
+  // t_end doubles as GPU_EDGE_LOD_DONE (bound at engine init).
+  CHECK(Error, gpu_edge_record(ord, GPU_EDGE_LOD_DONE, fc, compute) == 0);
 
   *out_active_mask = active_levels_mask;
   return 0;

--- a/src/gpu/stream.lod.h
+++ b/src/gpu/stream.lod.h
@@ -52,6 +52,7 @@ lod_state_destroy(struct lod_state* lod);
 int
 lod_run_epoch(struct lod_state* lod,
               struct lod_shared_state* sh,
+              struct gpu_ordering* ord,
               int fc,
               const struct level_geometry* levels,
               void* pool_epoch,

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -488,9 +488,6 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
   CU(Fail, cuStreamCreate(&e->streams.compress, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuStreamCreate(&e->streams.d2h, CU_STREAM_NON_BLOCKING));
 
-  for (int i = 0; i < 2; ++i)
-    CU(Fail, cuEventCreate(&e->pools.ready[i], CU_EVENT_DEFAULT));
-
   CHECK(Fail, gpu_ordering_init(&e->ord, e->streams.compute) == 0);
   gpu_ordering_register_stream(&e->ord, GPU_STREAM_H2D, e->streams.h2d);
   gpu_ordering_register_stream(&e->ord, GPU_STREAM_COMPUTE, e->streams.compute);
@@ -551,7 +548,6 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
             aggregate_batch_slot_init(&e->compress_agg.agg[fc],
                                       C_max,
                                       mx->u_max_total_data_bytes) == 0);
-      CU(Fail, cuEventRecord(e->compress_agg.agg[fc].ready, e->streams.compute));
     }
     CU(Fail,
        cuMemAlloc(&e->compress_agg.d_batch_gather,
@@ -605,9 +601,6 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
   CHECK(Fail,
         e->compress_agg.pool_epochs_scratch &&
           e->compress_agg.cached_pool_epochs);
-
-  CU(Fail, cuEventRecord(e->pools.ready[0], e->streams.compute));
-  CU(Fail, cuEventRecord(e->pools.ready[1], e->streams.compute));
 
   for (int fc = 0; fc < 2; ++fc) {
     CU(Fail,
@@ -845,10 +838,8 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
   // resources live in e->lod_shared.
   lod_shared_state_destroy(&e->lod_shared);
 
-  for (int i = 0; i < 2; ++i) {
+  for (int i = 0; i < 2; ++i)
     cu_mem_free(e->pools.buf[i]);
-    cu_event_destroy(e->pools.ready[i]);
-  }
 
   ingest_destroy(&e->stage);
 

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -938,6 +938,7 @@ multiarray_tile_stream_gpu_create(
     }
   }
   ms->engine.metrics = stream_engine_init_metrics(all_multiscale);
+  stream_engine_attach_edge_stalls(&ms->engine);
   ms->engine.metadata_update_clock = (struct platform_clock){ 0 };
   platform_toc(&ms->engine.metadata_update_clock);
 

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -491,8 +491,17 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
   for (int i = 0; i < 2; ++i)
     CU(Fail, cuEventCreate(&e->pools.ready[i], CU_EVENT_DEFAULT));
 
+  CHECK(Fail, gpu_ordering_init(&e->ord, e->streams.compute) == 0);
+  gpu_ordering_register_stream(&e->ord, GPU_STREAM_H2D, e->streams.h2d);
+  gpu_ordering_register_stream(&e->ord, GPU_STREAM_COMPUTE, e->streams.compute);
+  gpu_ordering_register_stream(
+    &e->ord, GPU_STREAM_COMPRESS, e->streams.compress);
+  gpu_ordering_register_stream(&e->ord, GPU_STREAM_D2H, e->streams.d2h);
+  e->compress_agg.ord = &e->ord;
+
   CHECK(Fail,
-        ingest_init(&e->stage, mx->buffer_capacity, e->streams.compute) == 0);
+        ingest_init(&e->stage, mx->buffer_capacity, &e->ord,
+                    e->streams.compute) == 0);
 
   e->pool_bytes = mx->pool_bytes;
   for (int i = 0; i < 2; ++i) {
@@ -502,8 +511,6 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
   }
 
   e->batch.epochs_per_batch = mx->epochs_per_batch;
-  CU(Fail, cuEventCreate(&e->batch.pool_ready, CU_EVENT_DEFAULT));
-  CU(Fail, cuEventRecord(e->batch.pool_ready, e->streams.compute));
 
   // Per-slot batch_active_masks live on each array descriptor (bind/unbind
   // copies them in). Stage scratch is shared and sized to the max K.
@@ -525,12 +532,11 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
        cuEventCreate(&e->compress_agg.t_compress_start[fc], CU_EVENT_DEFAULT));
     CU(Fail,
        cuEventCreate(&e->compress_agg.t_compress_end[fc], CU_EVENT_DEFAULT));
-    CU(Fail,
-       cuEventCreate(&e->compress_agg.t_aggregate_end[fc], CU_EVENT_DEFAULT));
   }
 
   CHECK(Fail,
-        d2h_deliver_init(&e->d2h_deliver, 0, e->streams.compute) == 0);
+        d2h_deliver_init(&e->d2h_deliver, 0, &e->ord, e->streams.compute) ==
+          0);
   e->d2h_deliver.metrics = &e->metrics;
 
   // Unified-pipeline shared resources. Sized to maxima across arrays.
@@ -608,8 +614,6 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
        cuEventRecord(e->compress_agg.t_compress_start[fc], e->streams.compute));
     CU(Fail,
        cuEventRecord(e->compress_agg.t_compress_end[fc], e->streams.compute));
-    CU(Fail,
-       cuEventRecord(e->compress_agg.t_aggregate_end[fc], e->streams.compute));
   }
 
   // Shared LOD buffers (sized to max across arrays). Only allocated if any
@@ -622,6 +626,10 @@ init_shared_resources(struct multiarray_tile_stream_gpu* ms,
                                 mx->lod_linear_bytes,
                                 mx->lod_morton_bytes,
                                 e->streams.compute) == 0);
+    // t_end doubles as GPU_EDGE_LOD_DONE; already seeded by the init above.
+    for (int fc = 0; fc < 2; ++fc)
+      gpu_ordering_bind(
+        &e->ord, GPU_EDGE_LOD_DONE, fc, e->lod_shared.timing[fc].t_end);
   }
 
   CU(Fail, cuStreamSynchronize(e->streams.compute));
@@ -803,8 +811,6 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
 
   struct stream_engine* e = &ms->engine;
 
-  cu_event_destroy(e->batch.pool_ready);
-
   d2h_deliver_destroy(&e->d2h_deliver);
 
   codec_free(&e->compress_agg.codec);
@@ -816,7 +822,6 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
     cu_mem_free(e->compress_agg.d_compressed[fc]);
     cu_event_destroy(e->compress_agg.t_compress_start[fc]);
     cu_event_destroy(e->compress_agg.t_compress_end[fc]);
-    cu_event_destroy(e->compress_agg.t_aggregate_end[fc]);
   }
 
   // Unified-pipeline shared resources (allocated in init_shared_resources).
@@ -846,6 +851,8 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
   }
 
   ingest_destroy(&e->stage);
+
+  gpu_ordering_destroy(&e->ord);
 
   cu_stream_destroy(e->streams.h2d);
   cu_stream_destroy(e->streams.compute);

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -46,9 +46,10 @@ struct stream_metrics
   // flush_stall - kick_sync_stall - (sink portion inside drain).
   struct stream_metric flush_stall;     // whole d2h_deliver_drain call
                                         // (drain_fc in stream.flush.c)
-  // Passthrough: ready[fc] poll only. Compressed: h_chunk_index_ready
-  // poll + per-LOD bulk D2H dispatch + ready[fc] poll (the second poll
-  // now includes DMA transfer wall time).
+  // Passthrough: GPU_EDGE_D2H_DONE poll only. Compressed:
+  // GPU_EDGE_CHUNK_INDEX_READY poll + per-LOD bulk D2H dispatch +
+  // GPU_EDGE_D2H_DONE poll (the second poll includes DMA transfer wall
+  // time).
   struct stream_metric kick_sync_stall;
   struct stream_metric io_fence_stall;  // GPU: wait_io_fences in
                                         // d2h_deliver_kick. CPU: wait_fence

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -55,6 +55,10 @@ struct stream_metrics
                                         // before aggregate in
                                         // cpu_pipeline_flush_batch.
   struct stream_metric backpressure; // wait at epoch boundary for IO to drain
+  // Host-poll blocked time attributed to GPU ordering edges (gpu/ordering.h:
+  // staging_free, chunk_index_ready, d2h_done). GPU engines wire these up;
+  // entries stay zero (count 0) elsewhere.
+  struct stream_metric edge_stall[3];
   float max_append_ms;               // longest tile_stream_gpu_append body
   size_t peak_pending_bytes;         // max sink->pending_bytes seen
 };

--- a/tests/test_compress_agg.c
+++ b/tests/test_compress_agg.c
@@ -26,9 +26,9 @@ struct ca_test_ctx
   struct compress_agg_stage stage;
   CUstream compute;
   CUdeviceptr d_pool;
-  CUevent pool_ready;           // recorded after last fill_epoch call
+  struct gpu_ordering ord;      // pool-filled record stands in for the engine
   uint32_t* batch_active_masks; // [K] owned scratch for tests
-  struct batch_state batch;
+  int ord_inited;
   int stage_inited;
 };
 
@@ -43,9 +43,10 @@ ca_ctx_destroy(struct ca_test_ctx* c)
 {
   if (c->stage_inited)
     compress_agg_destroy(&c->stage, c->cl.levels.nlod);
+  if (c->ord_inited)
+    gpu_ordering_destroy(&c->ord);
   computed_stream_layouts_free(&c->cl);
   cu_mem_free(c->d_pool);
-  cu_event_destroy(c->pool_ready);
   free(c->batch_active_masks);
   cu_stream_destroy(c->compute);
 }
@@ -66,8 +67,11 @@ ca_ctx_setup(struct ca_test_ctx* c,
                                &c->cl) == 0);
 
   CU(Fail, cuStreamCreate(&c->compute, CU_STREAM_NON_BLOCKING));
+  CHECK(Fail, gpu_ordering_init(&c->ord, c->compute) == 0);
+  c->ord_inited = 1;
   CHECK(Fail,
-        compress_agg_init(&c->stage, &c->cl, &c->config, c->compute) == 0);
+        compress_agg_init(&c->stage, &c->cl, &c->config, &c->ord, c->compute) ==
+          0);
   c->stage_inited = 1;
 
   size_t pool_bytes = (uint64_t)n_pool_epochs * c->cl.levels.total_chunks *
@@ -75,17 +79,9 @@ ca_ctx_setup(struct ca_test_ctx* c,
                       dtype_bpe(c->config.dtype);
   CU(Fail, cuMemAlloc(&c->d_pool, pool_bytes));
 
-  CU(Fail, cuEventCreate(&c->pool_ready, CU_EVENT_DEFAULT));
-
   c->batch_active_masks =
     (uint32_t*)calloc(c->cl.epochs_per_batch, sizeof(uint32_t));
   CHECK(Fail, c->batch_active_masks);
-
-  c->batch = (struct batch_state){
-    .epochs_per_batch = c->cl.epochs_per_batch,
-    .accumulated = 0,
-    .pool_ready = c->pool_ready,
-  };
   return 0;
 
 Fail:
@@ -108,9 +104,10 @@ ca_ctx_fill_epoch(struct ca_test_ctx* c,
           epoch_ptr, total_chunks, chunk_stride, bytes_per_element, fill_fn) ==
           0);
 
-  // Re-record pool_ready on the compute stream after every fill so the test
-  // can rely on the latest event signaling batch-level readiness.
-  CU(Fail, cuEventRecord(c->pool_ready, c->compute));
+  // Re-record pool-filled on the compute stream after every fill so the
+  // kick's wait sees batch-level readiness.
+  CHECK(Fail,
+        gpu_edge_record(&c->ord, GPU_EDGE_POOL_FILLED, 0, c->compute) == 0);
   return 0;
 
 Fail:
@@ -123,9 +120,7 @@ Fail:
 static void
 ca_ctx_publish_tail(struct ca_test_ctx* c)
 {
-  struct shard_tables* sh = &c->stage.shards;
-  if (sh->h_tail_seq_flag)
-    *sh->h_tail_seq_flag = ++sh->tail_seq;
+  gpu_edge_publish(&c->ord, GPU_EDGE_TAIL_PUBLISHED);
 }
 
 // Build input, kick compress_agg, sync.
@@ -143,8 +138,7 @@ ca_ctx_kick(struct ca_test_ctx* c,
     .active_levels_mask = 0x1,
     .batch_active_masks = c->batch_active_masks,
     .pool_buf = c->d_pool,
-    .pool_ready = c->pool_ready,
-    .lod_done = 0,
+    .lod_active = 0,
     .epochs_per_batch = c->cl.epochs_per_batch,
   };
 
@@ -766,8 +760,7 @@ test_compress_agg_lut_cache_position_shift(void)
       .active_levels_mask = 0x1,
       .batch_active_masks = c.batch_active_masks,
       .pool_buf = c.d_pool,
-      .pool_ready = c.pool_ready,
-      .lod_done = 0,
+      .lod_active = 0,
       .epochs_per_batch = c.cl.epochs_per_batch,
     };
     struct flush_handoff handoff;
@@ -797,8 +790,7 @@ test_compress_agg_lut_cache_position_shift(void)
       .active_levels_mask = 0x1,
       .batch_active_masks = c.batch_active_masks,
       .pool_buf = c.d_pool,
-      .pool_ready = c.pool_ready,
-      .lod_done = 0,
+      .lod_active = 0,
       .epochs_per_batch = c.cl.epochs_per_batch,
     };
     CHECK(Fail,

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -28,13 +28,13 @@ struct test_ctx
   CUstream compute;
   CUstream d2h_stream;
   CUdeviceptr d_pool;
-  CUevent pool_ready;
+  struct gpu_ordering ord; // pool-filled record stands in for the engine
   uint32_t* batch_active_masks;
-  struct batch_state batch;
   struct stream_metrics metrics;
   struct lod_state lod;
   struct lod_shared_state lod_shared;
   struct platform_clock metadata_clock;
+  int ord_inited;
   int ca_inited;
   int d2h_inited;
 };
@@ -52,9 +52,10 @@ test_ctx_destroy(struct test_ctx* c)
     d2h_deliver_destroy(&c->d2h);
   if (c->ca_inited)
     compress_agg_destroy(&c->ca, c->cl.levels.nlod);
+  if (c->ord_inited)
+    gpu_ordering_destroy(&c->ord);
   computed_stream_layouts_free(&c->cl);
   cu_mem_free(c->d_pool);
-  cu_event_destroy(c->pool_ready);
   free(c->batch_active_masks);
   cu_stream_destroy(c->compute);
   cu_stream_destroy(c->d2h_stream);
@@ -77,28 +78,27 @@ test_ctx_setup(struct test_ctx* c,
   CU(Fail, cuStreamCreate(&c->compute, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuStreamCreate(&c->d2h_stream, CU_STREAM_NON_BLOCKING));
 
-  CHECK(Fail, compress_agg_init(&c->ca, &c->cl, config, c->compute) == 0);
+  CHECK(Fail, gpu_ordering_init(&c->ord, c->compute) == 0);
+  c->ord_inited = 1;
+  gpu_ordering_register_stream(&c->ord, GPU_STREAM_COMPUTE, c->compute);
+  gpu_ordering_register_stream(&c->ord, GPU_STREAM_D2H, c->d2h_stream);
+
+  CHECK(Fail,
+        compress_agg_init(&c->ca, &c->cl, config, &c->ord, c->compute) == 0);
   c->ca_inited = 1;
 
   CHECK(Fail,
-        d2h_deliver_init(&c->d2h, platform_page_alignment(), c->compute) == 0);
+        d2h_deliver_init(
+          &c->d2h, platform_page_alignment(), &c->ord, c->compute) == 0);
   c->d2h_inited = 1;
 
   size_t pool_bytes = (uint64_t)n_pool_epochs * c->cl.levels.total_chunks *
                       c->cl.layouts[0].chunk_stride * dtype_bpe(config->dtype);
   CU(Fail, cuMemAlloc(&c->d_pool, pool_bytes));
 
-  CU(Fail, cuEventCreate(&c->pool_ready, CU_EVENT_DEFAULT));
-
   c->batch_active_masks =
     (uint32_t*)calloc(c->cl.epochs_per_batch, sizeof(uint32_t));
   CHECK(Fail, c->batch_active_masks);
-
-  c->batch = (struct batch_state){
-    .epochs_per_batch = c->cl.epochs_per_batch,
-    .accumulated = 0,
-    .pool_ready = c->pool_ready,
-  };
 
   memset(&c->metrics, 0, sizeof(c->metrics));
   c->metrics.compress = mk_stream_metric("Compress");
@@ -125,7 +125,6 @@ test_ctx_kick_and_drain(struct test_ctx* c,
                         int fc,
                         uint32_t n_epochs,
                         CUdeviceptr pool_buf,
-                        CUevent pool_ready,
                         struct flush_handoff* handoff)
 {
   for (uint32_t i = 0; i < n_epochs; ++i)
@@ -137,8 +136,7 @@ test_ctx_kick_and_drain(struct test_ctx* c,
     .active_levels_mask = 0x1,
     .batch_active_masks = c->batch_active_masks,
     .pool_buf = pool_buf,
-    .pool_ready = pool_ready,
-    .lod_done = 0,
+    .lod_active = 0,
     .epochs_per_batch = c->cl.epochs_per_batch,
   };
 
@@ -212,15 +210,15 @@ test_d2h_single_epoch_none(void)
       c.d_pool, total_chunks, chunk_stride, bytes_per_element, fill_epoch0) ==
       0);
 
-  // Record pool_ready after the fill
-  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
+  // Record pool-filled after the fill
+  CHECK(Fail,
+        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
 
   // Kick compress_agg + D2H + drain
   struct flush_handoff handoff;
   CHECK(Fail,
         test_ctx_kick_and_drain(
-          &c, &config, &sink.base, 0, 1, c.d_pool, c.pool_ready, &handoff) ==
-          0);
+          &c, &config, &sink.base, 0, 1, c.d_pool, &handoff) == 0);
 
   // Verify sink state
   CHECK(Fail, sink.open_count == 1);     // shard_inner_count=1
@@ -283,14 +281,14 @@ test_d2h_batch_none(void)
                         bytes_per_element,
                         fill_epoch1) == 0);
 
-  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
+  CHECK(Fail,
+        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
 
   // Kick with 2 epochs
   struct flush_handoff handoff;
   CHECK(Fail,
         test_ctx_kick_and_drain(
-          &c, &config, &sink.base, 0, 2, c.d_pool, c.pool_ready, &handoff) ==
-          0);
+          &c, &config, &sink.base, 0, 2, c.d_pool, &handoff) == 0);
 
   // tps_0=2, 2 epochs → shard complete
   CHECK(Fail, sink.finalize_count == 1);
@@ -428,13 +426,13 @@ test_d2h_zstd_single_epoch(void)
                         bytes_per_element,
                         fill_epoch0) == 0);
 
-  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
+  CHECK(Fail,
+        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
 
   struct flush_handoff handoff;
   CHECK(Fail,
         test_ctx_kick_and_drain(
-          &c, &config, &sink.base, 0, 2, c.d_pool, c.pool_ready, &handoff) ==
-          0);
+          &c, &config, &sink.base, 0, 2, c.d_pool, &handoff) == 0);
 
   CHECK(Fail, sink.finalize_count == 1);
   CHECK(Fail, sink.writers[0][0].size > 0);
@@ -541,14 +539,14 @@ test_d2h_double_buffer(void)
     fill_pool_epoch(
       c.d_pool, total_chunks, chunk_stride, bytes_per_element, fill_epoch0) ==
       0);
-  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
+  CHECK(Fail,
+        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
     CHECK(Fail,
           test_ctx_kick_and_drain(
-            &c, &config, &sink.base, 0, 1, c.d_pool, c.pool_ready, &handoff) ==
-            0);
+            &c, &config, &sink.base, 0, 1, c.d_pool, &handoff) == 0);
   }
 
   CHECK(Fail, sink.finalize_count == 0); // 1 of 2 epochs
@@ -560,7 +558,8 @@ test_d2h_double_buffer(void)
                         chunk_stride,
                         bytes_per_element,
                         fill_epoch1) == 0);
-  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
+  CHECK(Fail,
+        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
@@ -571,7 +570,6 @@ test_d2h_double_buffer(void)
                                   1,
                                   1,
                                   c.d_pool + epoch_pool_bytes,
-                                  c.pool_ready,
                                   &handoff) == 0);
   }
 
@@ -642,9 +640,9 @@ Fail:
   return ok ? 0 : 1;
 }
 
-// Three-cycle compressed run: cycle 3 reuses fc=0, so slot->ready
-// recorded in cycle 1 must survive into cycle 3's compress wait. Two
-// cycles would never reuse a slot.
+// Three-cycle compressed run: cycle 3 reuses fc=0, so the slot-drained
+// edge recorded in cycle 1 must survive into cycle 3's compress wait.
+// Two cycles would never reuse a slot.
 static int
 test_d2h_zstd_double_buffer(void)
 {
@@ -675,14 +673,14 @@ test_d2h_zstd_double_buffer(void)
     fill_pool_epoch(
       c.d_pool, total_chunks, chunk_stride, bytes_per_element, fill_epoch0) ==
       0);
-  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
+  CHECK(Fail,
+        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
     CHECK(Fail,
           test_ctx_kick_and_drain(
-            &c, &config, &sink.base, 0, 1, c.d_pool, c.pool_ready, &handoff) ==
-            0);
+            &c, &config, &sink.base, 0, 1, c.d_pool, &handoff) == 0);
   }
 
   CHECK(Fail, sink.finalize_count == 0);
@@ -693,7 +691,8 @@ test_d2h_zstd_double_buffer(void)
                         chunk_stride,
                         bytes_per_element,
                         fill_epoch1) == 0);
-  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
+  CHECK(Fail,
+        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
@@ -704,27 +703,26 @@ test_d2h_zstd_double_buffer(void)
                                   1,
                                   1,
                                   c.d_pool + epoch_pool_bytes,
-                                  c.pool_ready,
                                   &handoff) == 0);
   }
 
   CHECK(Fail, sink.finalize_count == 1);
 
-  // Cycle 3: reuse fc=0. compress_agg's wait on prev_d2h_done depends on
-  // sync_and_deliver having recorded slot->ready in cycle 1.
+  // Cycle 3: reuse fc=0. compress_agg's GPU_EDGE_SLOT_DRAINED wait depends
+  // on sync_and_deliver having recorded the edge in cycle 1.
   CHECK(
     Fail,
     fill_pool_epoch(
       c.d_pool, total_chunks, chunk_stride, bytes_per_element, fill_epoch2) ==
       0);
-  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
+  CHECK(Fail,
+        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
     CHECK(Fail,
           test_ctx_kick_and_drain(
-            &c, &config, &sink.base, 0, 1, c.d_pool, c.pool_ready, &handoff) ==
-            0);
+            &c, &config, &sink.base, 0, 1, c.d_pool, &handoff) == 0);
   }
 
   CHECK(Fail, sink.finalize_count == 1);
@@ -737,7 +735,8 @@ test_d2h_zstd_double_buffer(void)
                         chunk_stride,
                         bytes_per_element,
                         fill_epoch3) == 0);
-  CU(Fail, cuEventRecord(c.pool_ready, c.compute));
+  CHECK(Fail,
+        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
@@ -748,7 +747,6 @@ test_d2h_zstd_double_buffer(void)
                                   1,
                                   1,
                                   c.d_pool + epoch_pool_bytes,
-                                  c.pool_ready,
                                   &handoff) == 0);
   }
 

--- a/tests/test_flush_orchestration.c
+++ b/tests/test_flush_orchestration.c
@@ -45,10 +45,8 @@ orch_ctx_destroy(struct orch_ctx* c)
     compress_agg_destroy(&c->s->engine.compress_agg, c->cl.levels.nlod);
 
     // Pools
-    for (int i = 0; i < 2; ++i) {
+    for (int i = 0; i < 2; ++i)
       cu_mem_free(c->s->engine.pools.buf[i]);
-      cu_event_destroy(c->s->engine.pools.ready[i]);
-    }
 
     gpu_ordering_destroy(&c->s->engine.ord);
 
@@ -133,10 +131,6 @@ orch_ctx_setup(struct orch_ctx* c,
                        0,
                        pool_bytes,
                        c->s->engine.streams.compute));
-    CU(Fail, cuEventCreate(&c->s->engine.pools.ready[i], CU_EVENT_DEFAULT));
-    CU(
-      Fail,
-      cuEventRecord(c->s->engine.pools.ready[i], c->s->engine.streams.compute));
   }
   c->s->engine.pools.current = 0;
 

--- a/tests/test_flush_orchestration.c
+++ b/tests/test_flush_orchestration.c
@@ -36,8 +36,6 @@ static void
 orch_ctx_destroy(struct orch_ctx* c)
 {
   if (c->s) {
-    cu_event_destroy(c->s->engine.batch.pool_ready);
-
     for (int fc = 0; fc < 2; ++fc) {
       free(c->s->engine.flush.slot[fc].batch_active_masks);
       c->s->engine.flush.slot[fc].batch_active_masks = NULL;
@@ -51,6 +49,8 @@ orch_ctx_destroy(struct orch_ctx* c)
       cu_mem_free(c->s->engine.pools.buf[i]);
       cu_event_destroy(c->s->engine.pools.ready[i]);
     }
+
+    gpu_ordering_destroy(&c->s->engine.ord);
 
     cu_stream_destroy(c->s->engine.streams.compute);
     cu_stream_destroy(c->s->engine.streams.compress);
@@ -100,17 +100,29 @@ orch_ctx_setup(struct orch_ctx* c,
      cuStreamCreate(&c->s->engine.streams.compress, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuStreamCreate(&c->s->engine.streams.d2h, CU_STREAM_NON_BLOCKING));
 
+  CHECK(Fail,
+        gpu_ordering_init(&c->s->engine.ord, c->s->engine.streams.compute) ==
+          0);
+  gpu_ordering_register_stream(
+    &c->s->engine.ord, GPU_STREAM_COMPUTE, c->s->engine.streams.compute);
+  gpu_ordering_register_stream(
+    &c->s->engine.ord, GPU_STREAM_COMPRESS, c->s->engine.streams.compress);
+  gpu_ordering_register_stream(
+    &c->s->engine.ord, GPU_STREAM_D2H, c->s->engine.streams.d2h);
+
   // Compress+aggregate stage
   CHECK(Fail,
         compress_agg_init(&c->s->engine.compress_agg,
                           &c->cl,
                           config,
+                          &c->s->engine.ord,
                           c->s->engine.streams.compute) == 0);
 
   // D2H+deliver stage
   CHECK(Fail,
         d2h_deliver_init(&c->s->engine.d2h_deliver,
                          platform_page_alignment(),
+                         &c->s->engine.ord,
                          c->s->engine.streams.compute) == 0);
 
   // Double-buffered chunk pools
@@ -128,13 +140,9 @@ orch_ctx_setup(struct orch_ctx* c,
   }
   c->s->engine.pools.current = 0;
 
-  // Batch state + pool_ready event
+  // Batch state
   c->s->engine.batch.epochs_per_batch = K;
   c->s->engine.batch.accumulated = 0;
-  CU(Fail, cuEventCreate(&c->s->engine.batch.pool_ready, CU_EVENT_DEFAULT));
-  CU(
-    Fail,
-    cuEventRecord(c->s->engine.batch.pool_ready, c->s->engine.streams.compute));
 
   // Flush pipeline state
   memset(&c->s->engine.flush, 0, sizeof(c->s->engine.flush));

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -75,6 +75,7 @@ test_ingest_single_epoch(void)
            (unsigned long)pool_bytes);
 
   struct staging_state stage = { 0 };
+  struct gpu_ordering ord = { 0 };
   struct tile_stream_layout layout = { 0 };
   struct tile_stream_layout_gpu layout_gpu = { 0 };
   CUstream h2d = 0, compute = 0;
@@ -86,7 +87,10 @@ test_ingest_single_epoch(void)
 
   CU(Fail, cuStreamCreate(&h2d, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuStreamCreate(&compute, CU_STREAM_NON_BLOCKING));
-  CHECK(Fail, ingest_init(&stage, src_bytes, compute) == 0);
+  CHECK(Fail, gpu_ordering_init(&ord, compute) == 0);
+  gpu_ordering_register_stream(&ord, GPU_STREAM_H2D, h2d);
+  gpu_ordering_register_stream(&ord, GPU_STREAM_COMPUTE, compute);
+  CHECK(Fail, ingest_init(&stage, src_bytes, &ord, compute) == 0);
 
   CU(Fail, cuMemAlloc(&d_pool, pool_bytes));
   CU(Fail, cuMemsetD8(d_pool, 0, pool_bytes));
@@ -162,6 +166,7 @@ Fail:
   free(h_src);
   free(h_pool);
   ingest_destroy(&stage);
+  gpu_ordering_destroy(&ord);
   destroy_layout_gpu(&layout_gpu);
   cu_mem_free(d_pool);
   cu_event_destroy(pool_ready);
@@ -205,6 +210,7 @@ test_ingest_incremental(void)
   const size_t half = src_bytes / 2;
 
   struct staging_state stage = { 0 };
+  struct gpu_ordering ord = { 0 };
   struct tile_stream_layout layout = { 0 };
   struct tile_stream_layout_gpu layout_gpu = { 0 };
   CUstream h2d = 0, compute = 0;
@@ -216,7 +222,10 @@ test_ingest_incremental(void)
 
   CU(Fail, cuStreamCreate(&h2d, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuStreamCreate(&compute, CU_STREAM_NON_BLOCKING));
-  CHECK(Fail, ingest_init(&stage, half, compute) == 0);
+  CHECK(Fail, gpu_ordering_init(&ord, compute) == 0);
+  gpu_ordering_register_stream(&ord, GPU_STREAM_H2D, h2d);
+  gpu_ordering_register_stream(&ord, GPU_STREAM_COMPUTE, compute);
+  CHECK(Fail, ingest_init(&stage, half, &ord, compute) == 0);
 
   CU(Fail, cuMemAlloc(&d_pool, pool_bytes));
   CU(Fail, cuMemsetD8(d_pool, 0, pool_bytes));
@@ -256,7 +265,9 @@ test_ingest_incremental(void)
                                   compute) == 0);
     CHECK(Fail, cursor == epoch_elements / 2);
 
-    CU(Fail, cuEventSynchronize(stage.slot[stage.current].t_h2d_end));
+    CU(Fail,
+       cuEventSynchronize(gpu_ordering_event(
+         &ord, GPU_EDGE_STAGING_H2D_DONE, stage.current)));
     memcpy(stage.slot[stage.current].h_in, (uint8_t*)h_src + half, half);
     stage.bytes_written = half;
     CHECK(Fail,
@@ -307,6 +318,7 @@ Fail:
   free(h_src);
   free(h_pool);
   ingest_destroy(&stage);
+  gpu_ordering_destroy(&ord);
   destroy_layout_gpu(&layout_gpu);
   cu_mem_free(d_pool);
   cu_event_destroy(pool_ready);
@@ -328,6 +340,7 @@ test_ingest_multiscale(void)
   const size_t src_bytes = epoch_elements * bytes_per_element;
 
   struct staging_state stage = { 0 };
+  struct gpu_ordering ord = { 0 };
   CUstream h2d = 0, compute = 0;
   CUdeviceptr d_linear = 0;
   uint16_t* h_src = NULL;
@@ -336,7 +349,10 @@ test_ingest_multiscale(void)
 
   CU(Fail, cuStreamCreate(&h2d, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuStreamCreate(&compute, CU_STREAM_NON_BLOCKING));
-  CHECK(Fail, ingest_init(&stage, src_bytes, compute) == 0);
+  CHECK(Fail, gpu_ordering_init(&ord, compute) == 0);
+  gpu_ordering_register_stream(&ord, GPU_STREAM_H2D, h2d);
+  gpu_ordering_register_stream(&ord, GPU_STREAM_COMPUTE, compute);
+  CHECK(Fail, ingest_init(&stage, src_bytes, &ord, compute) == 0);
 
   CU(Fail, cuMemAlloc(&d_linear, src_bytes));
   CU(Fail, cuMemsetD8(d_linear, 0, src_bytes));
@@ -377,6 +393,7 @@ Fail:
   free(h_src);
   free(h_out);
   ingest_destroy(&stage);
+  gpu_ordering_destroy(&ord);
   cu_mem_free(d_linear);
   cu_stream_destroy(h2d);
   cu_stream_destroy(compute);

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -80,7 +80,6 @@ test_ingest_single_epoch(void)
   struct tile_stream_layout_gpu layout_gpu = { 0 };
   CUstream h2d = 0, compute = 0;
   CUdeviceptr d_pool = 0;
-  CUevent pool_ready = 0;
   void* h_pool = NULL;
   uint16_t* h_src = NULL;
   int ok = 0;
@@ -94,8 +93,6 @@ test_ingest_single_epoch(void)
 
   CU(Fail, cuMemAlloc(&d_pool, pool_bytes));
   CU(Fail, cuMemsetD8(d_pool, 0, pool_bytes));
-  CU(Fail, cuEventCreate(&pool_ready, CU_EVENT_DEFAULT));
-  CU(Fail, cuEventRecord(pool_ready, compute));
 
   layout.lifted_rank = lifted_rank;
   memcpy(layout.lifted_shape, lifted_shape, lifted_rank * sizeof(uint64_t));
@@ -123,7 +120,6 @@ test_ingest_single_epoch(void)
                                   &layout,
                                   &layout_gpu,
                                   (void*)d_pool,
-                                  pool_ready,
                                   &cursor,
                                   bytes_per_element,
                                   h2d,
@@ -169,7 +165,6 @@ Fail:
   gpu_ordering_destroy(&ord);
   destroy_layout_gpu(&layout_gpu);
   cu_mem_free(d_pool);
-  cu_event_destroy(pool_ready);
   cu_stream_destroy(h2d);
   cu_stream_destroy(compute);
 
@@ -215,7 +210,6 @@ test_ingest_incremental(void)
   struct tile_stream_layout_gpu layout_gpu = { 0 };
   CUstream h2d = 0, compute = 0;
   CUdeviceptr d_pool = 0;
-  CUevent pool_ready = 0;
   void* h_pool = NULL;
   uint16_t* h_src = NULL;
   int ok = 0;
@@ -229,8 +223,6 @@ test_ingest_incremental(void)
 
   CU(Fail, cuMemAlloc(&d_pool, pool_bytes));
   CU(Fail, cuMemsetD8(d_pool, 0, pool_bytes));
-  CU(Fail, cuEventCreate(&pool_ready, CU_EVENT_DEFAULT));
-  CU(Fail, cuEventRecord(pool_ready, compute));
 
   layout.lifted_rank = lifted_rank;
   memcpy(layout.lifted_shape, lifted_shape, lifted_rank * sizeof(uint64_t));
@@ -258,7 +250,6 @@ test_ingest_incremental(void)
                                   &layout,
                                   &layout_gpu,
                                   (void*)d_pool,
-                                  pool_ready,
                                   &cursor,
                                   bytes_per_element,
                                   h2d,
@@ -275,7 +266,6 @@ test_ingest_incremental(void)
                                   &layout,
                                   &layout_gpu,
                                   (void*)d_pool,
-                                  pool_ready,
                                   &cursor,
                                   bytes_per_element,
                                   h2d,
@@ -321,7 +311,6 @@ Fail:
   gpu_ordering_destroy(&ord);
   destroy_layout_gpu(&layout_gpu);
   cu_mem_free(d_pool);
-  cu_event_destroy(pool_ready);
   cu_stream_destroy(h2d);
   cu_stream_destroy(compute);
 


### PR DESCRIPTION
Step 1 of the GPU orchestration migration described in
`docs/gpu-orchestration.md` (included as the first commit — read it first;
it is the spec for this and the four steps that follow).

## Why

#140 and #141 were both missing-ordering bugs that shipped silent
corruption. The rules existed only as `cuEventRecord`/`cuStreamWaitEvent`
pairs spread across six files plus undeclared host call-order assumptions;
several events were recorded and never waited (dead edges,
indistinguishable from load-bearing ones). #141's dependency was not even
expressible as an event. This PR makes every cross-stream and host→stream
ordering rule a named, declared, asserted, and metered entry in one table.

## What

- **`src/gpu/ordering.{h,c}`** — 13-edge declared table (the full table with
  producer/consumer streams, guarded resource, kind, and backing is in the
  design doc's appendix). Kinds: EVENT, GEN_COUNTER (#142's tail-generation
  gate, relocated behind this API with semantics preserved — including
  graceful degradation and teardown release), HOST_RULE (drain-before-rekick
  and oldest-first delivery, previously written nowhere, now debug-asserted).
  Timing-only events are excluded from the table — metrics can no longer
  masquerade as ordering.
- **Call-site migration** — every ordering record/wait/publish in `src/gpu/`
  and `src/multiarray/stream.gpu.c` goes through `edge_record` / `edge_wait`
  / `edge_publish` / `edge_release_all`. Behavior-neutral: same operations,
  same order, same streams.
- **Debug asserts** (zero release overhead): consumer-stream-matches-
  declaration; end-of-run dead-edge accounting. Mutation-tested on an L40: a
  deliberately removed wait → dead-edge warning at destroy; a wait on an
  undeclared stream → assert abort.
- **Per-edge stall metrics** for the host-poll edges: the bench's opaque
  `KickSync 45.7 ms` now decomposes (`ChunkIndex 41.7 + D2HDone 4.0`), and
  the previously unmetered staging busy-wait is visible (`StagingFree
  1.2 ms`).
- **Dead-edge deletion** (separate commit, −79/+16): `pool_state.ready[2]`,
  `aggregate_slot.ready` (only waiter was the abandoned #139 cap-stacking),
  and a never-polled passthrough-path record — each verified dead against
  current main before removal.

Test harnesses fake producers in one line via `gpu_ordering_bind` /
`edge_record` / `edge_publish` — the property the migration plan requires of
every stage boundary.

## Evidence (L40, sm_89)

- `ctest -E "(s3)"`: 46/46; `test_cross_validate` ×8 reps (covers the
  determinism, zstd round-trip, and page-aligned tail-carry race tests);
  `test_compress_agg` ×3; zero new build warnings (RelWithDebInfo and Debug).
- Mutation checks above (temporary patches, never committed).
- Bench sanity run shows the new stall rows; no throughput change expected
  or observed (release path adds no synchronization).

## Commit guide

- `Add GPU orchestration design doc` — the migration spec (steps 1–5, end
  state, escape hatch, non-goals).
- `Add gpu ordering edge table` — `ordering.{h,c}`: enum, descriptor table,
  runtime state, helpers.
- `Route ordering through edge table` — the call-site migration
  (behavior-neutral; suite green at this commit).
- `Add per-edge stall metrics` — host-poll blocked-time attribution,
  surfaced in the bench report.
- `Delete verified-dead ordering edges` — the three dead edges.
- `Record final edge table in design doc` — the as-implemented appendix.
