### PR TITLE
Unify GPU engine init, teardown, and binding

### DIFF
--- a/docs/gpu-orchestration.md
+++ b/docs/gpu-orchestration.md
@@ -1,6 +1,6 @@
 # GPU stream orchestration: target design and migration plan
 
-Status: accepted direction, migration in progress (step 1).
+Status: accepted direction, migration in progress (step 2).
 Base: main + #142. Related: #140, #141, PR #142, `gpu-output-slot-ledger.md`.
 
 ## Why

--- a/src/gpu/aggregate.cu
+++ b/src/gpu/aggregate.cu
@@ -188,6 +188,38 @@ gather_batch_k(const void* __restrict__ d_compressed,
 }
 
 // ---------------------------------------------------------------------------
+// Sizing (must mirror aggregate_layout_upload / aggregate_batch_slot_init
+// exactly — tile_stream_gpu_memory_estimate sums these)
+// ---------------------------------------------------------------------------
+
+extern "C" size_t
+aggregate_layout_device_bytes(const struct aggregate_layout* layout)
+{
+  if (layout->lifted_rank == 0)
+    return 0;
+  return layout->lifted_rank * (sizeof(uint64_t) + sizeof(int64_t));
+}
+
+extern "C" int
+aggregate_batch_slot_memory(uint64_t batch_covering_count,
+                            size_t comp_pool_bytes,
+                            size_t* device_bytes,
+                            size_t* host_bytes)
+{
+  const uint64_t C = batch_covering_count;
+  size_t temp = 0;
+  if (aggregate_cub_temp_bytes(C, &temp))
+    return 1;
+  *device_bytes = 2 * (C + 1) * sizeof(size_t) // d_permuted_sizes + d_offsets
+                  + comp_pool_bytes            // d_aggregated
+                  + temp;                      // d_temp
+  *host_bytes = comp_pool_bytes                // h_aggregated
+                + (C + 1) * sizeof(size_t)     // h_offsets
+                + C * sizeof(size_t);          // h_permuted_sizes
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
 // aggregate_batch_slot_init
 // ---------------------------------------------------------------------------
 

--- a/src/gpu/aggregate.h
+++ b/src/gpu/aggregate.h
@@ -41,6 +41,15 @@ extern "C"
                                 uint64_t batch_covering_count,
                                 size_t comp_pool_bytes);
 
+  // Sizing mirrors of aggregate_layout_upload / aggregate_batch_slot_init,
+  // for the memory estimate.
+  size_t aggregate_layout_device_bytes(const struct aggregate_layout* layout);
+
+  int aggregate_batch_slot_memory(uint64_t batch_covering_count,
+                                  size_t comp_pool_bytes,
+                                  size_t* device_bytes,
+                                  size_t* host_bytes);
+
   // d_tail_bytes: persistent per-LOD device array of size_t[num_shards]; read
   //   by add_shard_bias_k for this batch's leading-tail accounting. The host
   //   uploads the post-delivery values after every batch.

--- a/src/gpu/compress.cu
+++ b/src/gpu/compress.cu
@@ -152,6 +152,23 @@ Fail:
   return 0;
 }
 
+// --- codec_device_bytes ---
+
+// Device bytes codec_init allocates for this configuration. Must mirror the
+// allocations below exactly — tile_stream_gpu_memory_estimate sums this.
+extern "C" size_t
+codec_device_bytes(enum compression_codec type,
+                   size_t chunk_bytes,
+                   size_t batch_size)
+{
+  size_t bytes = batch_size * sizeof(size_t); // d_comp_sizes
+  bytes += batch_size * sizeof(size_t);       // d_uncomp_sizes
+  if (type != CODEC_NONE)
+    bytes += 2 * batch_size * sizeof(void*); // d_ptrs
+  bytes += codec_temp_bytes(type, chunk_bytes, batch_size); // d_temp
+  return bytes;
+}
+
 // --- codec_init ---
 
 extern "C" int

--- a/src/gpu/compress.h
+++ b/src/gpu/compress.h
@@ -31,7 +31,8 @@ extern "C"
   // Query max compressed output size per chunk (no GPU allocation).
   size_t codec_max_output_size(enum compression_codec type, size_t chunk_bytes);
 
-  // Query nvcomp workspace temp bytes (no GPU allocation).
+  // Total device bytes codec_init allocates (size arrays, ptr table, nvcomp
+  // temp) — sizing mirror for the memory estimate (no GPU allocation).
   size_t codec_device_bytes(enum compression_codec type,
                             size_t chunk_bytes,
                             size_t batch_size);

--- a/src/gpu/compress.h
+++ b/src/gpu/compress.h
@@ -32,6 +32,10 @@ extern "C"
   size_t codec_max_output_size(enum compression_codec type, size_t chunk_bytes);
 
   // Query nvcomp workspace temp bytes (no GPU allocation).
+  size_t codec_device_bytes(enum compression_codec type,
+                            size_t chunk_bytes,
+                            size_t batch_size);
+
   size_t codec_temp_bytes(enum compression_codec type,
                           size_t chunk_bytes,
                           size_t batch_size);

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -89,32 +89,31 @@ compress_agg_init(struct compress_agg_stage* stage,
   // --- Unified across-LODs aggregate state ---------------------------------
   // Mirrors the CPU pipeline (src/cpu/pipeline.c + src/cpu/aggregate.c).
 
-  stage->nlod = (uint8_t)cl->levels.nlod;
+  stage->ar.nlod = (uint8_t)cl->levels.nlod;
 
   // Per-LOD aggregate_layouts: own copy so multiarray bind/unbind can swap
   // them per-array. Each layout's GPU-side d_lifted_shape/strides are uploaded.
   for (int lv = 0; lv < cl->levels.nlod; ++lv) {
-    stage->per_lod_agg_layouts[lv] = cl->per_level[lv].agg_layout;
-    CHECK(Fail, aggregate_layout_upload(&stage->per_lod_agg_layouts[lv]) == 0);
+    stage->ar.per_lod_agg_layouts[lv] = cl->per_level[lv].agg_layout;
+    CHECK(Fail, aggregate_layout_upload(&stage->ar.per_lod_agg_layouts[lv]) == 0);
   }
 
-  // Cached max batch layout assuming each LOD fires its worst-case active
-  // count.
+  // Max batch layout assuming each LOD fires its worst-case active count.
   {
+    struct batch_aggregate_layout max_layout;
     uint32_t per_lod_max[LOD_MAX_LEVELS] = { 0 };
     for (int lv = 0; lv < cl->levels.nlod; ++lv)
       per_lod_max[lv] = cl->per_level[lv].batch_active_count;
     const size_t page_size = cl->per_level[0].agg_layout.page_size;
     CHECK(Fail,
-          batch_aggregate_layout_init(&stage->max_batch_layout,
-                                      stage->per_lod_agg_layouts,
+          batch_aggregate_layout_init(&max_layout,
+                                      stage->ar.per_lod_agg_layouts,
                                       per_lod_max,
-                                      stage->nlod,
+                                      stage->ar.nlod,
                                       page_size) == 0);
-    stage->max_total_batch_chunks = stage->max_batch_layout.total_batch_chunks;
-    stage->max_total_batch_covering =
-      stage->max_batch_layout.total_batch_covering;
-    stage->max_total_data_bytes = stage->max_batch_layout.total_data_bytes;
+    stage->max_total_batch_chunks = max_layout.total_batch_chunks;
+    stage->max_total_batch_covering = max_layout.total_batch_covering;
+    stage->max_total_data_bytes = max_layout.total_data_bytes;
   }
 
   // Unified aggregate slot per fc. Sized for the max-batch case:
@@ -125,7 +124,7 @@ compress_agg_init(struct compress_agg_stage* stage,
   //     sentinel positions, so no per-LOD write_total fixup is needed.
   if (stage->max_total_batch_chunks > 0) {
     const uint64_t C_max =
-      stage->max_total_batch_covering + (uint64_t)stage->nlod;
+      stage->max_total_batch_covering + (uint64_t)stage->ar.nlod;
     for (int fc = 0; fc < 2; ++fc) {
       CHECK(Fail,
             aggregate_batch_slot_init(&stage->agg[fc],
@@ -153,34 +152,34 @@ compress_agg_init(struct compress_agg_stage* stage,
   {
     uint64_t total_shards = 0;
     for (int lv = 0; lv < cl->levels.nlod; ++lv) {
-      stage->shards.shards_begin[lv] = (uint32_t)total_shards;
-      stage->shards.n_shards[lv] =
+      stage->ar.shards_begin[lv] = (uint32_t)total_shards;
+      stage->ar.n_shards[lv] =
         (uint32_t)cl->per_level[lv].agg_layout.num_shards;
       total_shards += cl->per_level[lv].agg_layout.num_shards;
     }
-    stage->shards.total_shards = total_shards;
-    stage->shards.page_size = cl->per_level[0].agg_layout.page_size;
+    stage->ar.total_shards = total_shards;
+    stage->ar.page_size = cl->per_level[0].agg_layout.page_size;
 
     if (total_shards > 0) {
       stage->shards.h_base_offsets =
         (size_t*)malloc(total_shards * sizeof(size_t));
-      stage->shards.h_shard_capacity =
+      stage->ar.h_shard_capacity =
         (size_t*)malloc(total_shards * sizeof(size_t));
       stage->shards.h_tps_group =
         (uint64_t*)malloc(total_shards * sizeof(uint64_t));
       stage->shards.h_offsets_base =
         (uint64_t*)malloc(total_shards * sizeof(uint64_t));
-      stage->shards.h_tail_bytes =
+      stage->ar.h_tail_bytes =
         (size_t*)calloc(total_shards, sizeof(size_t));
       CHECK(Fail,
-            stage->shards.h_base_offsets && stage->shards.h_shard_capacity &&
+            stage->shards.h_base_offsets && stage->ar.h_shard_capacity &&
               stage->shards.h_tps_group && stage->shards.h_offsets_base &&
-              stage->shards.h_tail_bytes);
+              stage->ar.h_tail_bytes);
       for (uint64_t i = 0; i < total_shards; ++i) {
         for (int lv = 0; lv < cl->levels.nlod; ++lv) {
-          if (i >= stage->shards.shards_begin[lv] &&
-              i < stage->shards.shards_begin[lv] + stage->shards.n_shards[lv]) {
-            stage->shards.h_shard_capacity[i] =
+          if (i >= stage->ar.shards_begin[lv] &&
+              i < stage->ar.shards_begin[lv] + stage->ar.n_shards[lv]) {
+            stage->ar.h_shard_capacity[i] =
               cl->per_level[lv].agg_layout.shard_capacity;
             break;
           }
@@ -200,10 +199,10 @@ compress_agg_init(struct compress_agg_stage* stage,
          cuMemAlloc((CUdeviceptr*)&stage->shards.d_offsets_base,
                     total_shards * sizeof(uint64_t)));
       CU(Fail,
-         cuMemAlloc((CUdeviceptr*)&stage->shards.d_tail_bytes,
+         cuMemAlloc((CUdeviceptr*)&stage->ar.d_tail_bytes,
                     total_shards * sizeof(size_t)));
       CU(Fail,
-         cuMemsetD8((CUdeviceptr)stage->shards.d_tail_bytes,
+         cuMemsetD8((CUdeviceptr)stage->ar.d_tail_bytes,
                     0,
                     total_shards * sizeof(size_t)));
 
@@ -216,7 +215,7 @@ compress_agg_init(struct compress_agg_stage* stage,
         CU(Fail,
            cuPointerSetAttribute(&sync_memops,
                                  CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                 (CUdeviceptr)stage->shards.d_tail_bytes));
+                                 (CUdeviceptr)stage->ar.d_tail_bytes));
       }
 
       // d_shard_capacity stays constant across batches in steady state; upload
@@ -224,26 +223,26 @@ compress_agg_init(struct compress_agg_stage* stage,
       // per-batch active counts and are uploaded by the kick.
       CU(Fail,
          cuMemcpyHtoD((CUdeviceptr)stage->shards.d_shard_capacity,
-                      stage->shards.h_shard_capacity,
+                      stage->ar.h_shard_capacity,
                       total_shards * sizeof(size_t)));
 
       // Tail-carry buffer: total_shards * page_size bytes; uniform layout
       // across LODs (sink page size is uniform).
-      if (stage->shards.page_size > 0) {
-        stage->shards.tail_carry_bytes = total_shards * stage->shards.page_size;
+      if (stage->ar.page_size > 0) {
+        stage->ar.tail_carry_bytes = total_shards * stage->ar.page_size;
         CU(Fail,
-           cuMemAlloc(&stage->shards.d_tail_carry,
-                      stage->shards.tail_carry_bytes));
+           cuMemAlloc(&stage->ar.d_tail_carry,
+                      stage->ar.tail_carry_bytes));
         CU(Fail,
            cuMemsetD8(
-             stage->shards.d_tail_carry, 0, stage->shards.tail_carry_bytes));
+             stage->ar.d_tail_carry, 0, stage->ar.tail_carry_bytes));
         // Same pageable-HtoD constraint as d_tail_bytes above.
         {
           unsigned int sync_memops = 1;
           CU(Fail,
              cuPointerSetAttribute(&sync_memops,
                                    CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                   stage->shards.d_tail_carry));
+                                   stage->ar.d_tail_carry));
         }
 
         // Tail-generation gate (shard_tables in stream.engine.h). Without
@@ -260,7 +259,7 @@ compress_agg_init(struct compress_agg_stage* stage,
   // Per-LOD shard_state (writers + tail/footer pools + generation
   // bookkeeping). The unified kick/D2H path iterates this directly.
   for (int lv = 0; lv < cl->levels.nlod; ++lv)
-    CHECK(Fail, init_shard_state(&stage->shard[lv], &cl->per_level[lv]) == 0);
+    CHECK(Fail, init_shard_state(&stage->ar.shard[lv], &cl->per_level[lv]) == 0);
 
   // Seed timing events so the first metric reads see a valid interval.
   for (int fc = 0; fc < 2; ++fc) {
@@ -271,12 +270,12 @@ compress_agg_init(struct compress_agg_stage* stage,
   return 0;
 
 Fail:
-  compress_agg_destroy(stage, cl->levels.nlod);
+  compress_agg_destroy(stage);
   return 1;
 }
 
 void
-compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
+compress_agg_destroy(struct compress_agg_stage* stage)
 {
   if (!stage)
     return;
@@ -312,22 +311,23 @@ compress_agg_destroy(struct compress_agg_stage* stage, int nlod)
   free(stage->h_lut_perm_scratch);
   stage->h_lut_gather_scratch = NULL;
   stage->h_lut_perm_scratch = NULL;
-  for (int lv = 0; lv < nlod; ++lv) {
-    aggregate_layout_destroy(&stage->per_lod_agg_layouts[lv]);
-    shard_state_destroy(&stage->shard[lv]);
+  for (int lv = 0; lv < stage->ar.nlod; ++lv) {
+    aggregate_layout_destroy(&stage->ar.per_lod_agg_layouts[lv]);
+    shard_state_destroy(&stage->ar.shard[lv]);
   }
   free(stage->shards.h_base_offsets);
-  free(stage->shards.h_shard_capacity);
+  free(stage->ar.h_shard_capacity);
   free(stage->shards.h_tps_group);
   free(stage->shards.h_offsets_base);
-  free(stage->shards.h_tail_bytes);
+  free(stage->ar.h_tail_bytes);
   cu_mem_free((CUdeviceptr)stage->shards.d_base_offsets);
   cu_mem_free((CUdeviceptr)stage->shards.d_shard_capacity);
   cu_mem_free((CUdeviceptr)stage->shards.d_tps_group);
   cu_mem_free((CUdeviceptr)stage->shards.d_offsets_base);
-  cu_mem_free((CUdeviceptr)stage->shards.d_tail_bytes);
-  cu_mem_free(stage->shards.d_tail_carry);
+  cu_mem_free((CUdeviceptr)stage->ar.d_tail_bytes);
+  cu_mem_free(stage->ar.d_tail_carry);
   memset(&stage->shards, 0, sizeof(stage->shards));
+  memset(&stage->ar, 0, sizeof(stage->ar));
 }
 
 // --- Kick ---
@@ -342,14 +342,15 @@ build_and_upload_shard_tables(struct compress_agg_stage* stage,
                               CUstream stream)
 {
   struct shard_tables* t = &stage->shards;
-  if (t->total_shards == 0)
+  const struct compress_agg_array* ar = &stage->ar;
+  if (ar->total_shards == 0)
     return 0;
 
   for (uint8_t lv = 0; lv < layout->nlod; ++lv) {
     const struct lod_segment* seg = &layout->lods[lv];
-    const struct aggregate_layout* al = &stage->per_lod_agg_layouts[lv];
-    const uint32_t begin = t->shards_begin[lv];
-    const uint32_t n = t->n_shards[lv];
+    const struct aggregate_layout* al = &stage->ar.per_lod_agg_layouts[lv];
+    const uint32_t begin = ar->shards_begin[lv];
+    const uint32_t n = ar->n_shards[lv];
     const uint64_t cps_inner = al->cps_inner;
     const uint64_t tps_group_lv = (uint64_t)seg->n_active * cps_inner;
     // Each LOD's offsets range starts at seg->batch_covering_offset + lv
@@ -368,17 +369,17 @@ build_and_upload_shard_tables(struct compress_agg_stage* stage,
   CU(Error,
      cuMemcpyHtoDAsync((CUdeviceptr)t->d_base_offsets,
                        t->h_base_offsets,
-                       t->total_shards * sizeof(size_t),
+                       ar->total_shards * sizeof(size_t),
                        stream));
   CU(Error,
      cuMemcpyHtoDAsync((CUdeviceptr)t->d_tps_group,
                        t->h_tps_group,
-                       t->total_shards * sizeof(uint64_t),
+                       ar->total_shards * sizeof(uint64_t),
                        stream));
   CU(Error,
      cuMemcpyHtoDAsync((CUdeviceptr)t->d_offsets_base,
                        t->h_offsets_base,
-                       t->total_shards * sizeof(uint64_t),
+                       ar->total_shards * sizeof(uint64_t),
                        stream));
 
   return 0;
@@ -394,7 +395,7 @@ scan_active_masks(struct compress_agg_stage* stage,
                   const uint32_t** per_lod_pool_epochs)
 {
   const uint32_t stride = stage->pool_epochs_stride;
-  for (uint8_t lv = 0; lv < stage->nlod; ++lv) {
+  for (uint8_t lv = 0; lv < stage->ar.nlod; ++lv) {
     uint32_t* dst = stage->pool_epochs_scratch + (size_t)lv * stride;
     uint32_t k = 0;
     for (uint32_t e = 0; e < in->n_epochs; ++e)
@@ -411,12 +412,12 @@ build_batch_layout(struct compress_agg_stage* stage,
                    struct batch_aggregate_layout* layout)
 {
   // Page size is uniform across LODs (sink-driven); read from LOD 0.
-  const size_t page_size = stage->per_lod_agg_layouts[0].page_size;
+  const size_t page_size = stage->ar.per_lod_agg_layouts[0].page_size;
   CHECK(Error,
         batch_aggregate_layout_init(layout,
-                                    stage->per_lod_agg_layouts,
+                                    stage->ar.per_lod_agg_layouts,
                                     per_lod_n_active,
-                                    stage->nlod,
+                                    stage->ar.nlod,
                                     page_size) == 0);
 
   CHECK(Error, layout->total_data_bytes <= stage->max_total_data_bytes);
@@ -442,7 +443,7 @@ build_and_upload_luts(struct compress_agg_stage* stage,
                       const uint32_t* const* per_lod_pool_epochs,
                       CUstream compress_stream)
 {
-  const uint8_t nlod = stage->nlod;
+  const uint8_t nlod = stage->ar.nlod;
   const uint32_t stride = stage->pool_epochs_stride;
 
   int lut_steady =
@@ -466,7 +467,7 @@ build_and_upload_luts(struct compress_agg_stage* stage,
   stage->lut_recompute_count++;
   if (layout->total_batch_chunks > 0) {
     aggregate_batch_luts_unified(layout,
-                                 stage->per_lod_agg_layouts,
+                                 stage->ar.per_lod_agg_layouts,
                                  levels,
                                  per_lod_pool_epochs,
                                  stage->h_lut_gather_scratch,
@@ -563,9 +564,9 @@ arm_tail_gate(struct compress_agg_stage* stage,
               const struct batch_aggregate_layout* layout,
               CUstream compress_stream)
 {
-  const size_t page_size = stage->per_lod_agg_layouts[0].page_size;
+  const size_t page_size = stage->ar.per_lod_agg_layouts[0].page_size;
   const int enable = layout->total_batch_chunks > 0 &&
-                     stage->shards.total_shards > 0 && page_size > 0;
+                     stage->ar.total_shards > 0 && page_size > 0;
   return gpu_edge_wait_gen(
     stage->ord, GPU_EDGE_TAIL_PUBLISHED, compress_stream, enable);
 }
@@ -578,7 +579,7 @@ dispatch_aggregate(struct compress_agg_stage* stage,
                    CUstream compress_stream)
 {
   if (layout->total_batch_chunks > 0) {
-    const size_t page_size = stage->per_lod_agg_layouts[0].page_size;
+    const size_t page_size = stage->ar.per_lod_agg_layouts[0].page_size;
     CHECK(Error,
           aggregate_batch_unified_async(
             (const void*)d_aggregate_src,
@@ -587,17 +588,17 @@ dispatch_aggregate(struct compress_agg_stage* stage,
             (const uint32_t*)(uintptr_t)stage->d_batch_perm,
             layout->total_batch_chunks,
             layout->total_batch_covering,
-            stage->nlod,
+            stage->ar.nlod,
             stage->codec.max_output_size,
             &stage->agg[fc],
             stage->shards.d_base_offsets,
             stage->shards.d_shard_capacity,
             stage->shards.d_tps_group,
             stage->shards.d_offsets_base,
-            stage->shards.d_tail_bytes,
-            stage->shards.d_tail_carry,
+            stage->ar.d_tail_bytes,
+            stage->ar.d_tail_carry,
             page_size,
-            stage->shards.total_shards,
+            stage->ar.total_shards,
             compress_stream) == 0);
   }
 
@@ -618,7 +619,7 @@ fill_handoff(struct compress_agg_stage* stage,
              struct flush_handoff* out)
 {
   const int fc = in->fc;
-  const uint8_t nlod = stage->nlod;
+  const uint8_t nlod = stage->ar.nlod;
   out->fc = fc;
   out->n_epochs = in->n_epochs;
   out->active_levels_mask = in->active_levels_mask;
@@ -633,10 +634,10 @@ fill_handoff(struct compress_agg_stage* stage,
   out->passthrough = (stage->codec.type == CODEC_NONE);
   out->agg = &stage->agg[fc];
   out->layout = *layout;
-  out->per_lod_agg_layouts = stage->per_lod_agg_layouts;
-  out->shards = &stage->shards;
+  out->per_lod_agg_layouts = stage->ar.per_lod_agg_layouts;
+  out->shards = &stage->ar;
   for (uint8_t lv = 0; lv < nlod; ++lv)
-    out->shards_by_lod[lv] = &stage->shard[lv];
+    out->shards_by_lod[lv] = &stage->ar.shard[lv];
 }
 
 int

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -656,8 +656,9 @@ Error:
 }
 
 // Page-aligned path only. The aggregate dispatch reads tail state that the
-// previous kick's delivery uploads AFTER this enqueue (shard_tables in
-// stream.engine.h). The wait goes after compress, which reads no tail state.
+// previous kick's delivery uploads AFTER this enqueue (gate state in
+// gpu_ordering, src/gpu/ordering.h). The wait goes after compress, which
+// reads no tail state.
 static int
 arm_tail_gate(struct compress_agg_stage* stage,
               const struct batch_aggregate_layout* layout,

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -361,6 +361,74 @@ compress_agg_destroy(struct compress_agg_stage* stage)
   compress_agg_array_destroy(&stage->ar);
 }
 
+// --- Memory estimate ---
+
+// Mirrors compress_agg_init_shared + compress_agg_array_init for one array:
+// every term below corresponds to an allocation above, derived from the same
+// engine_limits the real init consumes.
+int
+compress_agg_memory_estimate(const struct engine_limits* lim,
+                             const struct computed_stream_layouts* cl,
+                             enum compression_codec codec_id,
+                             size_t* compressed_pool_bytes,
+                             size_t* codec_bytes,
+                             size_t* aggregate_device_bytes,
+                             size_t* aggregate_host_bytes)
+{
+  // d_compressed[2]; skipped for CODEC_NONE (kick aggregates from the pool).
+  *compressed_pool_bytes =
+    (codec_id == CODEC_NONE)
+      ? 0
+      : 2 * (size_t)lim->codec_batch * cl->max_output_size;
+
+  *codec_bytes =
+    codec_device_bytes(codec_id, lim->chunk_bytes, lim->codec_batch);
+
+  size_t dev = 0;
+  size_t host = 0;
+
+  if (lim->max_total_batch_chunks > 0) {
+    const uint64_t C_max =
+      lim->max_total_batch_covering + (uint64_t)lim->max_nlod;
+    size_t slot_dev = 0;
+    size_t slot_host = 0;
+    CHECK(Error,
+          aggregate_batch_slot_memory(
+            C_max, lim->max_total_data_bytes, &slot_dev, &slot_host) == 0);
+    dev += 2 * slot_dev;  // agg[2]
+    host += 2 * slot_host;
+    dev += 2 * lim->max_total_batch_chunks *
+           sizeof(uint32_t); // d_batch_gather + d_batch_perm
+  }
+
+  // Shared per-shard device tables: d_base_offsets, d_shard_capacity,
+  // d_tps_group, d_offsets_base.
+  dev +=
+    lim->max_total_shards * (2 * sizeof(size_t) + 2 * sizeof(uint64_t));
+
+  // Per-array slice (compress_agg_array_init).
+  {
+    uint64_t total_shards = 0;
+    for (int lv = 0; lv < cl->levels.nlod; ++lv) {
+      dev += aggregate_layout_device_bytes(&cl->per_level[lv].agg_layout);
+      total_shards += cl->per_level[lv].agg_layout.num_shards;
+    }
+    if (total_shards > 0) {
+      dev += total_shards * sizeof(size_t); // d_tail_bytes
+      const size_t page_size = cl->per_level[0].agg_layout.page_size;
+      if (page_size > 0)
+        dev += total_shards * page_size; // d_tail_carry
+    }
+  }
+
+  *aggregate_device_bytes = dev;
+  *aggregate_host_bytes = host;
+  return 0;
+
+Error:
+  return 1;
+}
+
 // --- Kick ---
 
 // Build per-shard tables for this batch's `layout`. Populates host shadows

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -101,7 +101,6 @@ compress_agg_init_shared(struct compress_agg_stage* stage,
                                       stage->max_total_data_bytes) == 0);
     }
 
-    // Unified LUT buffers + host scratch.
     CU(Fail,
        cuMemAlloc(&stage->d_batch_gather,
                   stage->max_total_batch_chunks * sizeof(uint32_t)));
@@ -115,8 +114,8 @@ compress_agg_init_shared(struct compress_agg_stage* stage,
     CHECK(Fail, stage->h_lut_gather_scratch && stage->h_lut_perm_scratch);
   }
 
-  // Shared per-shard tables, sized to the max total_shards. The active
-  // array's slice is rebuilt and re-uploaded by every kick.
+  // Sized to the max total_shards; the active array's slice is re-uploaded
+  // by every kick.
   if (lim->max_total_shards > 0) {
     const uint64_t ts = lim->max_total_shards;
     stage->shards.h_base_offsets = (size_t*)malloc(ts * sizeof(size_t));
@@ -217,15 +216,12 @@ compress_agg_array_init(struct compress_agg_array* ar,
 
   ar->nlod = (uint8_t)cl->levels.nlod;
 
-  // Per-LOD aggregate_layouts: own copy so multiarray bind/unbind can swap
-  // them per-array. Each layout's GPU-side d_lifted_shape/strides are
-  // uploaded.
+  // Own copy so multiarray bind/unbind can swap them per-array.
   for (int lv = 0; lv < cl->levels.nlod; ++lv) {
     ar->per_lod_agg_layouts[lv] = cl->per_level[lv].agg_layout;
     CHECK(Fail, aggregate_layout_upload(&ar->per_lod_agg_layouts[lv]) == 0);
   }
 
-  // Per-shard tables. total_shards = sum_lv num_shards[lv].
   uint64_t total_shards = 0;
   for (int lv = 0; lv < cl->levels.nlod; ++lv) {
     ar->shards_begin[lv] = (uint32_t)total_shards;
@@ -268,8 +264,7 @@ compress_agg_array_init(struct compress_agg_array* ar,
                                (CUdeviceptr)ar->d_tail_bytes));
     }
 
-    // Tail-carry buffer: total_shards * page_size bytes; uniform layout
-    // across LODs (sink page size is uniform).
+    // One layout across LODs: the sink page size is uniform.
     if (ar->page_size > 0) {
       ar->tail_carry_bytes = total_shards * ar->page_size;
       CU(Fail, cuMemAlloc(&ar->d_tail_carry, ar->tail_carry_bytes));
@@ -283,7 +278,6 @@ compress_agg_array_init(struct compress_agg_array* ar,
                                  ar->d_tail_carry));
       }
 
-      // Tail-generation gate (compress_agg_array in stream.engine.h).
       // Without stream memops — or when the counter can't be allocated or
       // mapped — the lazy path host-drains instead (stream.flush.c).
       if (gate_ord) {
@@ -295,8 +289,6 @@ compress_agg_array_init(struct compress_agg_array* ar,
     }
   }
 
-  // Per-LOD shard_state (writers + tail/footer pools + generation
-  // bookkeeping). The unified kick/D2H path iterates this directly.
   for (int lv = 0; lv < cl->levels.nlod; ++lv)
     CHECK(Fail, init_shard_state(&ar->shard[lv], &cl->per_level[lv]) == 0);
 
@@ -337,9 +329,8 @@ compress_agg_init(struct compress_agg_stage* stage,
         compress_agg_init_shared(stage, &lim, config->codec.id, ord, compute) ==
           0);
   CHECK(Fail, compress_agg_array_init(&stage->ar, cl, ord, compute) == 0);
-  // d_shard_capacity stays constant across batches in steady state; upload
-  // it once now. d_base_offsets / d_tps_group / d_offsets_base depend on
-  // per-batch active counts and are uploaded by the kick.
+  // d_shard_capacity is constant per array — upload once; the other shard
+  // tables depend on per-batch active counts and are uploaded by the kick.
   if (stage->ar.total_shards > 0)
     CU(Fail,
        cuMemcpyHtoD((CUdeviceptr)stage->shards.d_shard_capacity,
@@ -363,9 +354,8 @@ compress_agg_destroy(struct compress_agg_stage* stage)
 
 // --- Memory estimate ---
 
-// Mirrors compress_agg_init_shared + compress_agg_array_init for one array:
-// every term below corresponds to an allocation above, derived from the same
-// engine_limits the real init consumes.
+// Mirrors compress_agg_init_shared + compress_agg_array_init for one array,
+// from the same engine_limits the real init consumes.
 int
 compress_agg_memory_estimate(const struct engine_limits* lim,
                              const struct computed_stream_layouts* cl,

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -41,25 +41,20 @@ Error:
 // --- Init / Destroy ---
 
 int
-compress_agg_init(struct compress_agg_stage* stage,
-                  const struct computed_stream_layouts* cl,
-                  const struct tile_stream_configuration* config,
-                  struct gpu_ordering* ord,
-                  CUstream compute)
+compress_agg_init_shared(struct compress_agg_stage* stage,
+                         const struct engine_limits* lim,
+                         enum compression_codec codec_id,
+                         struct gpu_ordering* ord,
+                         CUstream compute)
 {
   memset(stage, 0, sizeof(*stage));
   stage->ord = ord;
 
-  const size_t bytes_per_element = dtype_bpe(config->dtype);
-  const uint32_t K = cl->epochs_per_batch;
-  const uint64_t total_chunks = cl->levels.total_chunks;
-  const uint64_t chunk_stride = cl->layouts[0].chunk_stride;
-  CHECK_MUL_OVERFLOW(Fail, K, total_chunks, UINT64_MAX);
-  const uint64_t M = (uint64_t)K * total_chunks;
-  const size_t chunk_bytes = chunk_stride * bytes_per_element;
+  const uint32_t K = lim->epochs_per_batch;
+  const uint64_t M = lim->codec_batch;
 
   // Codec
-  CHECK(Fail, codec_init(&stage->codec, config->codec.id, chunk_bytes, M) == 0);
+  CHECK(Fail, codec_init(&stage->codec, codec_id, lim->chunk_bytes, M) == 0);
 
   // Per-LOD scratch for mask-scan results, plus the previous-kick cache used
   // for steady-state LUT-cache validation. Both are sized to
@@ -86,55 +81,27 @@ compress_agg_init(struct compress_agg_stage* stage,
     CU(Fail, cuEventCreate(&stage->t_compress_end[fc], CU_EVENT_DEFAULT));
   }
 
-  // --- Unified across-LODs aggregate state ---------------------------------
-  // Mirrors the CPU pipeline (src/cpu/pipeline.c + src/cpu/aggregate.c).
-
-  stage->ar.nlod = (uint8_t)cl->levels.nlod;
-
-  // Per-LOD aggregate_layouts: own copy so multiarray bind/unbind can swap
-  // them per-array. Each layout's GPU-side d_lifted_shape/strides are uploaded.
-  for (int lv = 0; lv < cl->levels.nlod; ++lv) {
-    stage->ar.per_lod_agg_layouts[lv] = cl->per_level[lv].agg_layout;
-    CHECK(Fail, aggregate_layout_upload(&stage->ar.per_lod_agg_layouts[lv]) == 0);
-  }
-
-  // Max batch layout assuming each LOD fires its worst-case active count.
-  {
-    struct batch_aggregate_layout max_layout;
-    uint32_t per_lod_max[LOD_MAX_LEVELS] = { 0 };
-    for (int lv = 0; lv < cl->levels.nlod; ++lv)
-      per_lod_max[lv] = cl->per_level[lv].batch_active_count;
-    const size_t page_size = cl->per_level[0].agg_layout.page_size;
-    CHECK(Fail,
-          batch_aggregate_layout_init(&max_layout,
-                                      stage->ar.per_lod_agg_layouts,
-                                      per_lod_max,
-                                      stage->ar.nlod,
-                                      page_size) == 0);
-    stage->max_total_batch_chunks = max_layout.total_batch_chunks;
-    stage->max_total_batch_covering = max_layout.total_batch_covering;
-    stage->max_total_data_bytes = max_layout.total_data_bytes;
-  }
+  stage->max_total_batch_chunks = lim->max_total_batch_chunks;
+  stage->max_total_batch_covering = lim->max_total_batch_covering;
+  stage->max_total_data_bytes = lim->max_total_data_bytes;
 
   // Unified aggregate slot per fc. Sized for the max-batch case:
   //   d_aggregated: max_total_data_bytes (page-aligned across LOD segments)
-  //   d_offsets/d_permuted_sizes/h_*: max_total_batch_covering + nlod
+  //   d_offsets/d_permuted_sizes/h_*: max_total_batch_covering + max_nlod
   //     entries each (one sentinel slot per LOD for the +lv shift in
   //     aggregate_batch_luts_unified). The CUB exclusive scan fills all
   //     sentinel positions, so no per-LOD write_total fixup is needed.
   if (stage->max_total_batch_chunks > 0) {
     const uint64_t C_max =
-      stage->max_total_batch_covering + (uint64_t)stage->ar.nlod;
+      stage->max_total_batch_covering + (uint64_t)lim->max_nlod;
     for (int fc = 0; fc < 2; ++fc) {
       CHECK(Fail,
             aggregate_batch_slot_init(&stage->agg[fc],
                                       C_max,
                                       stage->max_total_data_bytes) == 0);
     }
-  }
 
-  // Unified LUT buffers + host scratch.
-  if (stage->max_total_batch_chunks > 0) {
+    // Unified LUT buffers + host scratch.
     CU(Fail,
        cuMemAlloc(&stage->d_batch_gather,
                   stage->max_total_batch_chunks * sizeof(uint32_t)));
@@ -148,118 +115,29 @@ compress_agg_init(struct compress_agg_stage* stage,
     CHECK(Fail, stage->h_lut_gather_scratch && stage->h_lut_perm_scratch);
   }
 
-  // Per-shard tables. total_shards = sum_lv num_shards[lv].
-  {
-    uint64_t total_shards = 0;
-    for (int lv = 0; lv < cl->levels.nlod; ++lv) {
-      stage->ar.shards_begin[lv] = (uint32_t)total_shards;
-      stage->ar.n_shards[lv] =
-        (uint32_t)cl->per_level[lv].agg_layout.num_shards;
-      total_shards += cl->per_level[lv].agg_layout.num_shards;
-    }
-    stage->ar.total_shards = total_shards;
-    stage->ar.page_size = cl->per_level[0].agg_layout.page_size;
-
-    if (total_shards > 0) {
-      stage->shards.h_base_offsets =
-        (size_t*)malloc(total_shards * sizeof(size_t));
-      stage->ar.h_shard_capacity =
-        (size_t*)malloc(total_shards * sizeof(size_t));
-      stage->shards.h_tps_group =
-        (uint64_t*)malloc(total_shards * sizeof(uint64_t));
-      stage->shards.h_offsets_base =
-        (uint64_t*)malloc(total_shards * sizeof(uint64_t));
-      stage->ar.h_tail_bytes =
-        (size_t*)calloc(total_shards, sizeof(size_t));
-      CHECK(Fail,
-            stage->shards.h_base_offsets && stage->ar.h_shard_capacity &&
-              stage->shards.h_tps_group && stage->shards.h_offsets_base &&
-              stage->ar.h_tail_bytes);
-      for (uint64_t i = 0; i < total_shards; ++i) {
-        for (int lv = 0; lv < cl->levels.nlod; ++lv) {
-          if (i >= stage->ar.shards_begin[lv] &&
-              i < stage->ar.shards_begin[lv] + stage->ar.n_shards[lv]) {
-            stage->ar.h_shard_capacity[i] =
-              cl->per_level[lv].agg_layout.shard_capacity;
-            break;
-          }
-        }
-      }
-
-      CU(Fail,
-         cuMemAlloc((CUdeviceptr*)&stage->shards.d_base_offsets,
-                    total_shards * sizeof(size_t)));
-      CU(Fail,
-         cuMemAlloc((CUdeviceptr*)&stage->shards.d_shard_capacity,
-                    total_shards * sizeof(size_t)));
-      CU(Fail,
-         cuMemAlloc((CUdeviceptr*)&stage->shards.d_tps_group,
-                    total_shards * sizeof(uint64_t)));
-      CU(Fail,
-         cuMemAlloc((CUdeviceptr*)&stage->shards.d_offsets_base,
-                    total_shards * sizeof(uint64_t)));
-      CU(Fail,
-         cuMemAlloc((CUdeviceptr*)&stage->ar.d_tail_bytes,
-                    total_shards * sizeof(size_t)));
-      CU(Fail,
-         cuMemsetD8((CUdeviceptr)stage->ar.d_tail_bytes,
-                    0,
-                    total_shards * sizeof(size_t)));
-
-      // Delivery's tail upload is a synchronous HtoD from pageable memory,
-      // which may return before the DMA reaches the device; SYNC_MEMOPS
-      // makes it complete at the device first, so the tail-gate publish
-      // that follows it cannot outrun the copy (flush.d2h_deliver.c).
-      {
-        unsigned int sync_memops = 1;
-        CU(Fail,
-           cuPointerSetAttribute(&sync_memops,
-                                 CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                 (CUdeviceptr)stage->ar.d_tail_bytes));
-      }
-
-      // d_shard_capacity stays constant across batches in steady state; upload
-      // it once now. d_base_offsets / d_tps_group / d_offsets_base depend on
-      // per-batch active counts and are uploaded by the kick.
-      CU(Fail,
-         cuMemcpyHtoD((CUdeviceptr)stage->shards.d_shard_capacity,
-                      stage->ar.h_shard_capacity,
-                      total_shards * sizeof(size_t)));
-
-      // Tail-carry buffer: total_shards * page_size bytes; uniform layout
-      // across LODs (sink page size is uniform).
-      if (stage->ar.page_size > 0) {
-        stage->ar.tail_carry_bytes = total_shards * stage->ar.page_size;
-        CU(Fail,
-           cuMemAlloc(&stage->ar.d_tail_carry,
-                      stage->ar.tail_carry_bytes));
-        CU(Fail,
-           cuMemsetD8(
-             stage->ar.d_tail_carry, 0, stage->ar.tail_carry_bytes));
-        // Same pageable-HtoD constraint as d_tail_bytes above.
-        {
-          unsigned int sync_memops = 1;
-          CU(Fail,
-             cuPointerSetAttribute(&sync_memops,
-                                   CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                   stage->ar.d_tail_carry));
-        }
-
-        // Tail-generation gate (shard_tables in stream.engine.h). Without
-        // stream memops — or when the counter can't be allocated or mapped
-        // — the lazy path host-drains instead (stream.flush.c).
-        CHECK(Fail, gpu_ordering_gate_init(ord, compute) == 0);
-        if (!gpu_ordering_gate_supported(ord))
-          log_warn("compress_agg: tail gate unavailable; page-aligned "
-                   "pipeline degrades to host-ordered tail uploads");
-      }
-    }
+  // Shared per-shard tables, sized to the max total_shards. The active
+  // array's slice is rebuilt and re-uploaded by every kick.
+  if (lim->max_total_shards > 0) {
+    const uint64_t ts = lim->max_total_shards;
+    stage->shards.h_base_offsets = (size_t*)malloc(ts * sizeof(size_t));
+    stage->shards.h_tps_group = (uint64_t*)malloc(ts * sizeof(uint64_t));
+    stage->shards.h_offsets_base = (uint64_t*)malloc(ts * sizeof(uint64_t));
+    CHECK(Fail,
+          stage->shards.h_base_offsets && stage->shards.h_tps_group &&
+            stage->shards.h_offsets_base);
+    CU(Fail,
+       cuMemAlloc((CUdeviceptr*)&stage->shards.d_base_offsets,
+                  ts * sizeof(size_t)));
+    CU(Fail,
+       cuMemAlloc((CUdeviceptr*)&stage->shards.d_shard_capacity,
+                  ts * sizeof(size_t)));
+    CU(Fail,
+       cuMemAlloc((CUdeviceptr*)&stage->shards.d_tps_group,
+                  ts * sizeof(uint64_t)));
+    CU(Fail,
+       cuMemAlloc((CUdeviceptr*)&stage->shards.d_offsets_base,
+                  ts * sizeof(uint64_t)));
   }
-
-  // Per-LOD shard_state (writers + tail/footer pools + generation
-  // bookkeeping). The unified kick/D2H path iterates this directly.
-  for (int lv = 0; lv < cl->levels.nlod; ++lv)
-    CHECK(Fail, init_shard_state(&stage->ar.shard[lv], &cl->per_level[lv]) == 0);
 
   // Seed timing events so the first metric reads see a valid interval.
   for (int fc = 0; fc < 2; ++fc) {
@@ -270,12 +148,12 @@ compress_agg_init(struct compress_agg_stage* stage,
   return 0;
 
 Fail:
-  compress_agg_destroy(stage);
+  compress_agg_destroy_shared(stage);
   return 1;
 }
 
 void
-compress_agg_destroy(struct compress_agg_stage* stage)
+compress_agg_destroy_shared(struct compress_agg_stage* stage)
 {
   if (!stage)
     return;
@@ -294,6 +172,9 @@ compress_agg_destroy(struct compress_agg_stage* stage)
     cu_mem_free(stage->d_compressed[fc]);
     cu_event_destroy(stage->t_compress_start[fc]);
     cu_event_destroy(stage->t_compress_end[fc]);
+    stage->d_compressed[fc] = 0;
+    stage->t_compress_start[fc] = NULL;
+    stage->t_compress_end[fc] = NULL;
   }
   if (stage->lut_steady_count + stage->lut_recompute_count > 0) {
     const uint64_t tot = stage->lut_steady_count + stage->lut_recompute_count;
@@ -307,27 +188,177 @@ compress_agg_destroy(struct compress_agg_stage* stage)
     aggregate_slot_destroy(&stage->agg[fc]);
   cu_mem_free(stage->d_batch_gather);
   cu_mem_free(stage->d_batch_perm);
+  stage->d_batch_gather = 0;
+  stage->d_batch_perm = 0;
   free(stage->h_lut_gather_scratch);
   free(stage->h_lut_perm_scratch);
   stage->h_lut_gather_scratch = NULL;
   stage->h_lut_perm_scratch = NULL;
-  for (int lv = 0; lv < stage->ar.nlod; ++lv) {
-    aggregate_layout_destroy(&stage->ar.per_lod_agg_layouts[lv]);
-    shard_state_destroy(&stage->ar.shard[lv]);
-  }
   free(stage->shards.h_base_offsets);
-  free(stage->ar.h_shard_capacity);
   free(stage->shards.h_tps_group);
   free(stage->shards.h_offsets_base);
-  free(stage->ar.h_tail_bytes);
   cu_mem_free((CUdeviceptr)stage->shards.d_base_offsets);
   cu_mem_free((CUdeviceptr)stage->shards.d_shard_capacity);
   cu_mem_free((CUdeviceptr)stage->shards.d_tps_group);
   cu_mem_free((CUdeviceptr)stage->shards.d_offsets_base);
-  cu_mem_free((CUdeviceptr)stage->ar.d_tail_bytes);
-  cu_mem_free(stage->ar.d_tail_carry);
   memset(&stage->shards, 0, sizeof(stage->shards));
-  memset(&stage->ar, 0, sizeof(stage->ar));
+}
+
+int
+compress_agg_array_init(struct compress_agg_array* ar,
+                        const struct computed_stream_layouts* cl,
+                        struct gpu_ordering* gate_ord,
+                        CUstream gate_stream)
+{
+  memset(ar, 0, sizeof(*ar));
+
+  // --- Unified across-LODs aggregate state ---------------------------------
+  // Mirrors the CPU pipeline (src/cpu/pipeline.c + src/cpu/aggregate.c).
+
+  ar->nlod = (uint8_t)cl->levels.nlod;
+
+  // Per-LOD aggregate_layouts: own copy so multiarray bind/unbind can swap
+  // them per-array. Each layout's GPU-side d_lifted_shape/strides are
+  // uploaded.
+  for (int lv = 0; lv < cl->levels.nlod; ++lv) {
+    ar->per_lod_agg_layouts[lv] = cl->per_level[lv].agg_layout;
+    CHECK(Fail, aggregate_layout_upload(&ar->per_lod_agg_layouts[lv]) == 0);
+  }
+
+  // Per-shard tables. total_shards = sum_lv num_shards[lv].
+  uint64_t total_shards = 0;
+  for (int lv = 0; lv < cl->levels.nlod; ++lv) {
+    ar->shards_begin[lv] = (uint32_t)total_shards;
+    ar->n_shards[lv] = (uint32_t)cl->per_level[lv].agg_layout.num_shards;
+    total_shards += cl->per_level[lv].agg_layout.num_shards;
+  }
+  ar->total_shards = total_shards;
+  ar->page_size = cl->per_level[0].agg_layout.page_size;
+
+  if (total_shards > 0) {
+    ar->h_shard_capacity = (size_t*)malloc(total_shards * sizeof(size_t));
+    ar->h_tail_bytes = (size_t*)calloc(total_shards, sizeof(size_t));
+    CHECK(Fail, ar->h_shard_capacity && ar->h_tail_bytes);
+    for (uint64_t i = 0; i < total_shards; ++i) {
+      for (int lv = 0; lv < cl->levels.nlod; ++lv) {
+        if (i >= ar->shards_begin[lv] &&
+            i < ar->shards_begin[lv] + ar->n_shards[lv]) {
+          ar->h_shard_capacity[i] = cl->per_level[lv].agg_layout.shard_capacity;
+          break;
+        }
+      }
+    }
+
+    CU(Fail,
+       cuMemAlloc((CUdeviceptr*)&ar->d_tail_bytes,
+                  total_shards * sizeof(size_t)));
+    CU(Fail,
+       cuMemsetD8(
+         (CUdeviceptr)ar->d_tail_bytes, 0, total_shards * sizeof(size_t)));
+
+    // Delivery's tail upload is a synchronous HtoD from pageable memory,
+    // which may return before the DMA reaches the device; SYNC_MEMOPS
+    // makes it complete at the device first, so the tail-gate publish
+    // that follows it cannot outrun the copy (flush.d2h_deliver.c).
+    {
+      unsigned int sync_memops = 1;
+      CU(Fail,
+         cuPointerSetAttribute(&sync_memops,
+                               CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                               (CUdeviceptr)ar->d_tail_bytes));
+    }
+
+    // Tail-carry buffer: total_shards * page_size bytes; uniform layout
+    // across LODs (sink page size is uniform).
+    if (ar->page_size > 0) {
+      ar->tail_carry_bytes = total_shards * ar->page_size;
+      CU(Fail, cuMemAlloc(&ar->d_tail_carry, ar->tail_carry_bytes));
+      CU(Fail, cuMemsetD8(ar->d_tail_carry, 0, ar->tail_carry_bytes));
+      // Same pageable-HtoD constraint as d_tail_bytes above.
+      {
+        unsigned int sync_memops = 1;
+        CU(Fail,
+           cuPointerSetAttribute(&sync_memops,
+                                 CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                                 ar->d_tail_carry));
+      }
+
+      // Tail-generation gate (compress_agg_array in stream.engine.h).
+      // Without stream memops — or when the counter can't be allocated or
+      // mapped — the lazy path host-drains instead (stream.flush.c).
+      if (gate_ord) {
+        CHECK(Fail, gpu_ordering_gate_init(gate_ord, gate_stream) == 0);
+        if (!gpu_ordering_gate_supported(gate_ord))
+          log_warn("compress_agg: tail gate unavailable; page-aligned "
+                   "pipeline degrades to host-ordered tail uploads");
+      }
+    }
+  }
+
+  // Per-LOD shard_state (writers + tail/footer pools + generation
+  // bookkeeping). The unified kick/D2H path iterates this directly.
+  for (int lv = 0; lv < cl->levels.nlod; ++lv)
+    CHECK(Fail, init_shard_state(&ar->shard[lv], &cl->per_level[lv]) == 0);
+
+  return 0;
+
+Fail:
+  compress_agg_array_destroy(ar);
+  return 1;
+}
+
+void
+compress_agg_array_destroy(struct compress_agg_array* ar)
+{
+  if (!ar)
+    return;
+  for (int lv = 0; lv < ar->nlod; ++lv) {
+    aggregate_layout_destroy(&ar->per_lod_agg_layouts[lv]);
+    shard_state_destroy(&ar->shard[lv]);
+  }
+  free(ar->h_shard_capacity);
+  free(ar->h_tail_bytes);
+  cu_mem_free((CUdeviceptr)ar->d_tail_bytes);
+  cu_mem_free(ar->d_tail_carry);
+  memset(ar, 0, sizeof(*ar));
+}
+
+int
+compress_agg_init(struct compress_agg_stage* stage,
+                  const struct computed_stream_layouts* cl,
+                  const struct tile_stream_configuration* config,
+                  struct gpu_ordering* ord,
+                  CUstream compute)
+{
+  struct engine_limits lim;
+  memset(&lim, 0, sizeof(lim));
+  CHECK(Fail, engine_limits_accumulate(&lim, cl, config) == 0);
+  CHECK(Fail,
+        compress_agg_init_shared(stage, &lim, config->codec.id, ord, compute) ==
+          0);
+  CHECK(Fail, compress_agg_array_init(&stage->ar, cl, ord, compute) == 0);
+  // d_shard_capacity stays constant across batches in steady state; upload
+  // it once now. d_base_offsets / d_tps_group / d_offsets_base depend on
+  // per-batch active counts and are uploaded by the kick.
+  if (stage->ar.total_shards > 0)
+    CU(Fail,
+       cuMemcpyHtoD((CUdeviceptr)stage->shards.d_shard_capacity,
+                    stage->ar.h_shard_capacity,
+                    stage->ar.total_shards * sizeof(size_t)));
+  return 0;
+
+Fail:
+  compress_agg_destroy(stage);
+  return 1;
+}
+
+void
+compress_agg_destroy(struct compress_agg_stage* stage)
+{
+  if (!stage)
+    return;
+  compress_agg_destroy_shared(stage);
+  compress_agg_array_destroy(&stage->ar);
 }
 
 // --- Kick ---

--- a/src/gpu/flush.compress_agg.h
+++ b/src/gpu/flush.compress_agg.h
@@ -3,7 +3,34 @@
 #include "gpu/stream.internal.h"
 
 struct computed_stream_layouts;
+struct engine_limits;
 
+// Shared (maxima-sized) stage resources: codec, compressed buffers, unified
+// aggregate slots, LUTs, per-shard device tables.
+int
+compress_agg_init_shared(struct compress_agg_stage* stage,
+                         const struct engine_limits* lim,
+                         enum compression_codec codec_id,
+                         struct gpu_ordering* ord,
+                         CUstream compute);
+
+void
+compress_agg_destroy_shared(struct compress_agg_stage* stage);
+
+// Per-array slice: aggregate layouts, shard_state, tail buffers. gate_ord
+// arms the tail-generation gate when page-aligned; NULL skips it (multiarray
+// sync-flush path host-orders the tail uploads via immediate drains).
+int
+compress_agg_array_init(struct compress_agg_array* ar,
+                        const struct computed_stream_layouts* cl,
+                        struct gpu_ordering* gate_ord,
+                        CUstream gate_stream);
+
+void
+compress_agg_array_destroy(struct compress_agg_array* ar);
+
+// Single-array convenience: shared + array init from one layout, with the
+// tail gate armed and the shard-capacity table uploaded.
 int
 compress_agg_init(struct compress_agg_stage* stage,
                   const struct computed_stream_layouts* cl,

--- a/src/gpu/flush.compress_agg.h
+++ b/src/gpu/flush.compress_agg.h
@@ -12,7 +12,7 @@ compress_agg_init(struct compress_agg_stage* stage,
                   CUstream compute);
 
 void
-compress_agg_destroy(struct compress_agg_stage* stage, int nlod);
+compress_agg_destroy(struct compress_agg_stage* stage);
 
 int
 compress_agg_kick(struct compress_agg_stage* stage,

--- a/src/gpu/flush.compress_agg.h
+++ b/src/gpu/flush.compress_agg.h
@@ -41,6 +41,17 @@ compress_agg_init(struct compress_agg_stage* stage,
 void
 compress_agg_destroy(struct compress_agg_stage* stage);
 
+// Sizing mirror of compress_agg_init_shared + compress_agg_array_init for
+// one array, for the memory estimate.
+int
+compress_agg_memory_estimate(const struct engine_limits* lim,
+                             const struct computed_stream_layouts* cl,
+                             enum compression_codec codec_id,
+                             size_t* compressed_pool_bytes,
+                             size_t* codec_bytes,
+                             size_t* aggregate_device_bytes,
+                             size_t* aggregate_host_bytes);
+
 int
 compress_agg_kick(struct compress_agg_stage* stage,
                   const struct compress_agg_input* in,

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -308,7 +308,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     struct platform_clock sink_clock = { 0 };
     platform_toc(&sink_clock);
     size_t sink_bytes = 0;
-    struct shard_tables* shards = handoff->shards;
+    struct compress_agg_array* shards = handoff->shards;
     const size_t page_size = shards ? shards->page_size : 0;
 
     // In carry-over mode the bias kernel places each LOD at

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -8,7 +8,7 @@
 #include <stdint.h>
 
 struct shard_state;
-struct shard_tables;
+struct compress_agg_array;
 
 // Handoff from compress+aggregate to D2H+deliver.
 //
@@ -38,7 +38,7 @@ struct flush_handoff
   struct batch_aggregate_layout layout; // owned (by-value snapshot)
   const struct aggregate_layout* per_lod_agg_layouts; // borrowed [nlod]
   struct shard_state* shards_by_lod[LOD_MAX_LEVELS];  // borrowed
-  struct shard_tables* shards; // borrowed (for tail HtoD)
+  struct compress_agg_array* shards; // borrowed (for tail HtoD)
   size_t max_output_size;      // codec bound
 
   // Pass-through codec (CODEC_NONE): per-LOD bytes equal worst-case, so

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -264,9 +264,9 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
   // Emit partial shards for all levels (unified path: shard[lv] is the
   // shard_state read by the new kick/D2H code).
   for (int lv = 0; lv < ctx->levels.nlod; ++lv) {
-    if (e->compress_agg.shard[lv].epoch_in_shard > 0) {
+    if (e->compress_agg.ar.shard[lv].epoch_in_shard > 0) {
       if (finalize_shards(
-            &e->compress_agg.shard[lv], ctx->sink, ctx->shard_alignment))
+            &e->compress_agg.ar.shard[lv], ctx->sink, ctx->shard_alignment))
         return writer_error();
     }
   }

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -321,6 +321,73 @@ struct stream_engine
   struct platform_clock metadata_update_clock;
 };
 
+// --- Engine init / teardown (shared by single-array and multiarray) ---
+
+// Sizing for the engine's shared resources. Single-array fills this from its
+// one layout; multiarray accumulates the max across arrays — shared buffers
+// are sized to the maxima while each array still runs at its own geometry.
+struct engine_limits
+{
+  size_t buffer_capacity; // page-aligned staging slot size
+  size_t pool_bytes;      // one chunk-pool buffer
+  size_t chunk_bytes;     // codec chunk stride in bytes
+  uint64_t codec_batch;   // K * total_chunks
+  uint32_t epochs_per_batch;
+  int max_nlod;
+  uint64_t max_total_batch_chunks;
+  uint64_t max_total_batch_covering;
+  size_t max_total_data_bytes;
+  uint64_t max_total_shards;
+  size_t lod_linear_bytes;
+  size_t lod_morton_bytes;
+  int any_multiscale;
+};
+
+// Fold one array's requirements into *lim (max per field). Call once per
+// array on a zeroed struct before stream_engine_init.
+int
+engine_limits_accumulate(struct engine_limits* lim,
+                         const struct computed_stream_layouts* cl,
+                         const struct tile_stream_configuration* config);
+
+// Allocate all shared engine resources (streams, ordering, staging, pools,
+// compress/aggregate shared buffers, d2h, shared LOD buffers, metrics).
+// scatter_is_copy selects the ingest metric label only. On failure the
+// engine is left partially initialized; stream_engine_destroy handles it.
+int
+stream_engine_init(struct stream_engine* e,
+                   const struct engine_limits* lim,
+                   enum compression_codec codec_id,
+                   int scatter_is_copy);
+
+// Free shared engine resources. Per-array state (engine_array_state) is
+// destroyed separately by its owner. Caller must have synchronized all
+// engine streams first.
+void
+stream_engine_destroy(struct stream_engine* e);
+
+// Initialize one array's engine state. ctx->config/sink/shard_alignment
+// must be set; fills the remaining ctx fields and takes ownership of
+// cl->plan. gate_ord arms the tail-generation gate (pipelined single-array
+// path); pass NULL on the multiarray sync-flush path, whose immediate
+// drains host-order the tail uploads instead.
+int
+engine_array_state_init(struct engine_array_state* st,
+                        struct stream_context* ctx,
+                        struct computed_stream_layouts* cl,
+                        struct gpu_ordering* gate_ord,
+                        CUstream gate_stream);
+
+void
+engine_array_state_destroy(struct engine_array_state* st);
+
+// Make *st the engine's active array (whole-struct handoff + per-array
+// shard-capacity upload + LUT-cache invalidation).
+int
+stream_engine_bind_array(struct stream_engine* e,
+                         const struct engine_array_state* st,
+                         const struct stream_context* ctx);
+
 // --- Engine operations ---
 
 // Pointer to the given epoch's chunk region in the current pool.

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -129,20 +129,18 @@ struct compress_agg_input
   uint32_t epochs_per_batch;
 };
 
-// Per-shard layout tables, sized to total_shards = sum(num_shards_lv) across
-// all LODs. These collapse what was N per-LOD shard-bias/leading-tail launches
-// into a single launch over the flat shard list. d_base_offsets / d_tps_group
-// / d_offsets_base are rebuilt and re-uploaded every kick (depends on
-// per_lod_n_active); d_shard_capacity is constant per array and uploaded once
-// at init (or on multiarray bind).
+// Per-shard layout tables shared across arrays, sized to the max
+// total_shards = sum(num_shards_lv). These collapse what was N per-LOD
+// shard-bias/leading-tail launches into a single launch over the flat shard
+// list. d_base_offsets / d_tps_group / d_offsets_base are rebuilt and
+// re-uploaded every kick (depends on per_lod_n_active); d_shard_capacity is
+// constant per array and uploaded at bind.
 struct shard_tables
 {
-  uint64_t total_shards;
   // Per-shard parameters used by add_shard_bias_unified_k and
   // copy_leading_tail_unified_k. Host shadows are owned; device buffers are
   // allocated at init sized to the max across arrays.
   size_t* h_base_offsets;   // base byte offset in d_aggregated
-  size_t* h_shard_capacity; // per shard
   uint64_t* h_tps_group;    // chunks-per-shard within a batch
   uint64_t* h_offsets_base; // base index in d_offsets / d_permuted_sizes
 
@@ -150,6 +148,28 @@ struct shard_tables
   size_t* d_shard_capacity;
   uint64_t* d_tps_group;
   uint64_t* d_offsets_base;
+};
+
+// Per-array slice of compress+aggregate state. Multiarray swaps this into
+// the engine wholesale on array switch; any new per-array field added here
+// rides along with that single assignment.
+struct compress_agg_array
+{
+  // Per-LOD aggregate layouts (immutable per array). One per LOD; carries
+  // shard_capacity, num_shards, cps_inner, page_size, etc. Read by host LUT
+  // builder and at delivery time.
+  struct aggregate_layout per_lod_agg_layouts[LOD_MAX_LEVELS];
+  uint8_t nlod;
+
+  // Per-LOD shard_state (one shard_state per LOD, mirrors CPU). Carries
+  // per-shard writers, tail/footer pools, generation-boundary bookkeeping.
+  // The shard_state itself stays per-LOD because deliver_to_shards_batch and
+  // finalize_shards iterate it; the per-shard tail/carry bytes consumed by
+  // the GPU kernels live below instead.
+  struct shard_state shard[LOD_MAX_LEVELS];
+
+  uint64_t total_shards;    // sum_lv num_shards[lv]
+  size_t* h_shard_capacity; // per shard; uploaded to shards.d_shard_capacity
 
   // Persistent across-batch tail state, unified across all shards. Sized to
   // total_shards / total_shards * page_size. d_* uploaded by host after each
@@ -209,25 +229,11 @@ struct compress_agg_stage
   uint64_t lut_steady_count;
   uint64_t lut_recompute_count;
 
-  // Per-LOD aggregate layouts (immutable per array; switched on multiarray
-  // bind). One per LOD; carries shard_capacity, num_shards, cps_inner,
-  // page_size, etc. Read by host LUT builder and at delivery time.
-  struct aggregate_layout per_lod_agg_layouts[LOD_MAX_LEVELS];
-  uint8_t nlod;
-
-  // Cached "max" batch layout — segment offsets / total sizes assuming the
-  // worst-case active_count_max per LOD. Buffers are sized from this.
-  struct batch_aggregate_layout max_batch_layout;
-
-  // Per-shard tables (replaces per-LOD d_tail_*, d_batch_gather/perm).
+  // Per-shard tables shared across arrays (sized to maxima).
   struct shard_tables shards;
 
-  // Per-LOD shard_state (one shard_state per LOD, mirrors CPU). Carries
-  // per-shard writers, tail/footer pools, generation-boundary bookkeeping.
-  // The shard_state itself stays per-LOD because deliver_to_shards_batch and
-  // finalize_shards iterate it; the per-shard tail/carry bytes consumed by
-  // the GPU kernels live in shard_tables instead.
-  struct shard_state shard[LOD_MAX_LEVELS];
+  // Per-array state; swapped on multiarray bind.
+  struct compress_agg_array ar;
 };
 
 struct d2h_deliver_stage
@@ -263,6 +269,17 @@ struct flush_pipeline
 
 _Static_assert(LOD_MAX_LEVELS <= 32,
                "active_levels_mask is uint32_t; LOD_MAX_LEVELS > 32 overflows");
+
+// All per-array mutable engine state, grouped so a multiarray array switch
+// is whole-struct assignment in each direction — never a field checklist.
+struct engine_array_state
+{
+  struct batch_state batch;
+  int pool_current;
+  struct flush_pipeline flush;
+  struct lod_state lod;
+  struct compress_agg_array agg;
+};
 
 // --- Engine / Context ---
 

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -130,16 +130,11 @@ struct compress_agg_input
 };
 
 // Per-shard layout tables shared across arrays, sized to the max
-// total_shards = sum(num_shards_lv). These collapse what was N per-LOD
-// shard-bias/leading-tail launches into a single launch over the flat shard
-// list. d_base_offsets / d_tps_group / d_offsets_base are rebuilt and
-// re-uploaded every kick (depends on per_lod_n_active); d_shard_capacity is
-// constant per array and uploaded at bind.
+// total_shards. d_base_offsets / d_tps_group / d_offsets_base depend on
+// per-batch active counts and are re-uploaded every kick; d_shard_capacity
+// is constant per array and uploaded at bind.
 struct shard_tables
 {
-  // Per-shard parameters used by add_shard_bias_unified_k and
-  // copy_leading_tail_unified_k. Host shadows are owned; device buffers are
-  // allocated at init sized to the max across arrays.
   size_t* h_base_offsets;   // base byte offset in d_aggregated
   uint64_t* h_tps_group;    // chunks-per-shard within a batch
   uint64_t* h_offsets_base; // base index in d_offsets / d_permuted_sizes
@@ -155,17 +150,13 @@ struct shard_tables
 // rides along with that single assignment.
 struct compress_agg_array
 {
-  // Per-LOD aggregate layouts (immutable per array). One per LOD; carries
-  // shard_capacity, num_shards, cps_inner, page_size, etc. Read by host LUT
-  // builder and at delivery time.
+  // Immutable per array; read by the host LUT builder and at delivery.
   struct aggregate_layout per_lod_agg_layouts[LOD_MAX_LEVELS];
   uint8_t nlod;
 
-  // Per-LOD shard_state (one shard_state per LOD, mirrors CPU). Carries
-  // per-shard writers, tail/footer pools, generation-boundary bookkeeping.
-  // The shard_state itself stays per-LOD because deliver_to_shards_batch and
-  // finalize_shards iterate it; the per-shard tail/carry bytes consumed by
-  // the GPU kernels live below instead.
+  // Stays per-LOD because deliver_to_shards_batch and finalize_shards
+  // iterate it; the per-shard tail/carry bytes the GPU kernels consume
+  // live below instead.
   struct shard_state shard[LOD_MAX_LEVELS];
 
   uint64_t total_shards;    // sum_lv num_shards[lv]
@@ -350,8 +341,6 @@ engine_limits_accumulate(struct engine_limits* lim,
                          const struct computed_stream_layouts* cl,
                          const struct tile_stream_configuration* config);
 
-// Allocate all shared engine resources (streams, ordering, staging, pools,
-// compress/aggregate shared buffers, d2h, shared LOD buffers, metrics).
 // scatter_is_copy selects the ingest metric label only. On failure the
 // engine is left partially initialized; stream_engine_destroy handles it.
 int

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -132,9 +132,10 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
 
   // Tail-gate fallback: without the gate (stream memops unsupported, or
   // the counter failed to map at init) the tail upload cannot be ordered
-  // device-side (shard_tables in stream.engine.h), so also drain the
-  // other, newer pending batch — order stays oldest-first, pipeline
-  // degrades to depth 1 — and the kick below sees published tail state.
+  // device-side (gate state in gpu_ordering, src/gpu/ordering.h), so also
+  // drain the other, newer pending batch — order stays oldest-first,
+  // pipeline degrades to depth 1 — and the kick below sees published tail
+  // state.
   if (e->compress_agg.ar.page_size > 0 &&
       e->compress_agg.ar.total_shards > 0 &&
       !gpu_ordering_gate_supported(&e->ord)) {

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -135,8 +135,8 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
   // device-side (shard_tables in stream.engine.h), so also drain the
   // other, newer pending batch — order stays oldest-first, pipeline
   // degrades to depth 1 — and the kick below sees published tail state.
-  if (e->compress_agg.shards.page_size > 0 &&
-      e->compress_agg.shards.total_shards > 0 &&
+  if (e->compress_agg.ar.page_size > 0 &&
+      e->compress_agg.ar.total_shards > 0 &&
       !gpu_ordering_gate_supported(&e->ord)) {
     struct writer_result r = drain_fc(e, ctx, completed_pool ^ 1);
     if (r.error)

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -70,7 +70,7 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
 
   destroy_flush_pipeline(&s->engine.flush);
   d2h_deliver_destroy(&s->engine.d2h_deliver);
-  compress_agg_destroy(&s->engine.compress_agg, s->ctx.levels.nlod);
+  compress_agg_destroy(&s->engine.compress_agg);
   destroy_chunk_pools(&s->engine.pools);
   lod_state_destroy(&s->engine.lod);
   lod_shared_state_destroy(&s->engine.lod_shared);

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -454,6 +454,10 @@ tile_stream_gpu_status(const struct tile_stream_gpu* s)
 
 // --- Memory estimate ---
 
+// Derived, not duplicated: every term comes from the same engine_limits and
+// per-module sizing mirrors (compress_agg_memory_estimate,
+// lod_state_device_bytes, shard_state_heap_bytes) that the real init
+// consumes, so the estimate tracks the allocations by construction.
 int
 tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
                                 size_t shard_alignment,
@@ -472,173 +476,55 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
                              &cl))
     return 1;
 
-  const uint8_t rank = config->rank;
-  const size_t bytes_per_element = dtype_bpe(config->dtype);
-  const size_t buffer_capacity_bytes =
-    (config->buffer_capacity_bytes + 4095) & ~(size_t)4095;
-  const uint64_t chunk_stride = cl.layouts[0].chunk_stride;
-  const uint64_t chunks_per_epoch = cl.layouts[0].chunks_per_epoch;
-  const uint64_t total_chunks = cl.levels.total_chunks;
-  const uint32_t K = cl.epochs_per_batch;
-  const int nlod = cl.levels.nlod;
-  const size_t max_output_size = cl.max_output_size;
+  struct engine_limits lim;
+  memset(&lim, 0, sizeof(lim));
+  if (engine_limits_accumulate(&lim, &cl, config))
+    goto Fail;
 
-  const size_t chunk_bytes = chunk_stride * bytes_per_element;
-  const uint64_t codec_batch = (uint64_t)K * total_chunks;
-  const size_t nvcomp_temp =
-    codec_temp_bytes(config->codec.id, chunk_bytes, codec_batch);
+  // Staging (ingest_init): 2 slots, device + pinned host each.
+  info->staging_bytes = 2 * lim.buffer_capacity;
+  const size_t staging_host = 2 * lim.buffer_capacity;
 
-  const size_t staging_bytes = 2 * buffer_capacity_bytes;
-  const size_t staging_host = 2 * buffer_capacity_bytes;
+  // Chunk pools (stream_engine_init): 2 buffers.
+  info->chunk_pool_bytes = 2 * lim.pool_bytes;
 
-  const size_t chunk_pool_bytes =
-    2 * (uint64_t)K * total_chunks * chunk_stride * bytes_per_element;
-
-  // CODEC_NONE skips the d_compressed[fc] allocation (aggregate reads pool
-  // directly); see compress_agg_init / compress_agg_kick.
-  const size_t compressed_pool_bytes =
-    (config->codec.id == CODEC_NONE)
-      ? 0
-      : 2 * (uint64_t)K * total_chunks * max_output_size;
-
-  size_t codec_bytes = 0;
-  codec_bytes += codec_batch * sizeof(size_t); // d_comp_sizes
-  codec_bytes += codec_batch * sizeof(size_t); // d_uncomp_sizes
-  if (config->codec.id != CODEC_NONE)
-    codec_bytes += 2 * codec_batch * sizeof(void*); // d_ptrs
-  codec_bytes += nvcomp_temp;
-
-  size_t aggregate_device = 0;
+  // Compress + aggregate stage (shared + per-array slices).
   size_t aggregate_host = 0;
+  if (compress_agg_memory_estimate(&lim,
+                                   &cl,
+                                   config->codec.id,
+                                   &info->compressed_pool_bytes,
+                                   &info->codec_bytes,
+                                   &info->aggregate_bytes,
+                                   &aggregate_host))
+    goto Fail;
 
-  for (int lv = 0; lv < nlod; ++lv) {
-    const struct level_layout_info* li = &cl.per_level[lv];
-    uint64_t covering_count = li->agg_layout.covering_count;
-    uint64_t cps_inner_lv = li->agg_layout.cps_inner;
+  // LOD: per-array state plus the engine-shared linear/morton buffers.
+  info->lod_bytes = lod_state_device_bytes(&cl, config);
+  if (cl.levels.enable_multiscale)
+    info->lod_bytes += lim.lod_linear_bytes + lim.lod_morton_bytes;
 
-    uint32_t batch_count = li->batch_active_count;
-    if (batch_count == 0)
-      batch_count = 1;
+  // Shard state: host heap (init_shard_state per level).
+  for (int lv = 0; lv < cl.levels.nlod; ++lv)
+    info->shard_bytes += shard_state_heap_bytes(&cl.per_level[lv]);
 
-    uint64_t batch_chunks =
-      (uint64_t)batch_count * cl.levels.level[lv].chunk_count;
-    uint64_t batch_covering = (uint64_t)batch_count * covering_count;
-    size_t batch_agg_bytes = agg_pool_bytes(batch_chunks,
-                                            max_output_size,
-                                            covering_count,
-                                            cps_inner_lv,
-                                            shard_alignment);
-
-    size_t agg_layout_dev =
-      2 * (rank - 1) * sizeof(uint64_t) + 2 * (rank - 1) * sizeof(int64_t);
-
-    size_t cub_temp = 0;
-    aggregate_cub_temp_bytes(batch_covering, &cub_temp);
-
-    size_t slot_dev = (batch_covering + 1) * sizeof(size_t) +
-                      (batch_covering + 1) * sizeof(size_t) +
-                      batch_chunks * sizeof(uint32_t) + batch_agg_bytes +
-                      cub_temp;
-
-    size_t slot_host = batch_agg_bytes + (batch_covering + 1) * sizeof(size_t) +
-                       batch_covering * sizeof(size_t);
-
-    size_t lut_dev = 0;
-    if (K > 1)
-      lut_dev = batch_chunks * sizeof(uint32_t) * 2;
-
-    aggregate_device += agg_layout_dev + 2 * slot_dev + lut_dev;
-    aggregate_host += 2 * slot_host;
-  }
-
-  // Shard state: active_shard arrays + index buffers (host heap).
-  size_t shard_heap = 0;
-  for (int lv = 0; lv < nlod; ++lv) {
-    const struct level_layout_info* li = &cl.per_level[lv];
-    shard_heap += li->shard_inner_count *
-                  (sizeof(struct active_shard) +
-                   2 * li->chunks_per_shard_total * sizeof(uint64_t));
-  }
-
-  size_t lod_device = 0;
-
-  lod_device += 2 * rank * sizeof(uint64_t);
-  lod_device += 2 * rank * sizeof(int64_t);
-
-  if (cl.levels.enable_multiscale) {
-    const struct lod_plan* plan = &cl.plan;
-
-    lod_device += cl.layouts[0].epoch_elements * bytes_per_element;
-    uint64_t total_lod_vals = plan->level_spans.ends[plan->levels.nlod - 1];
-    lod_device += total_lod_vals * bytes_per_element;
-
-    lod_device += rank * sizeof(uint64_t);
-    if (plan->lod_ndim > 0)
-      lod_device += plan->lod_ndim * sizeof(uint64_t);
-
-    if (plan->lod_ndim > 0) {
-      lod_device += plan->levels.level[0].lod_nelem * sizeof(uint32_t);
-      lod_device += plan->fixed_dims_count * sizeof(uint32_t);
-    }
-
-    for (int l = 0; l < plan->levels.nlod - 1; ++l) {
-      // CSR reduce LUTs (computed from level_dims; actual alloc happens later
-      // via reduce_csr_gpu_alloc).
-      const struct level_dims* src_ld = &plan->levels.level[l];
-      const struct level_dims* dst_ld = &plan->levels.level[l + 1];
-      uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
-      uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
-      if (src_total == 0 || dst_total == 0)
-        continue;
-      lod_device += (dst_total + 1) * sizeof(uint64_t);
-      lod_device += src_total * sizeof(uint64_t);
-    }
-
-    for (int lv = 1; lv < plan->levels.nlod; ++lv) {
-      // Per-level morton scatter LUTs (level 0 already counted above)
-      lod_device += plan->levels.level[lv].lod_nelem * sizeof(uint32_t);
-      lod_device += plan->levels.level[lv].fixed_dims_count * sizeof(uint32_t);
-    }
-
-    for (int lv = 1; lv < plan->levels.nlod; ++lv) {
-      lod_device += 2 * rank * sizeof(uint64_t);
-      lod_device += 2 * rank * sizeof(int64_t);
-    }
-
-    if (cl.dims.append_downsample) {
-      size_t accum_bpe = dtype_bpe(config->dtype);
-      uint64_t total_elems = 0;
-      for (int lv = 1; lv < plan->levels.nlod; ++lv)
-        total_elems += plan->levels.level[lv].fixed_dims_count *
-                       plan->levels.level[lv].lod_nelem;
-      lod_device += total_elems * accum_bpe;
-      lod_device += total_elems;
-      lod_device += (uint64_t)plan->levels.nlod * sizeof(uint32_t);
-    }
-  }
-
-  // FIXME: use designated initializers here
-  info->staging_bytes = staging_bytes;
-  info->chunk_pool_bytes = chunk_pool_bytes;
-  info->compressed_pool_bytes = compressed_pool_bytes;
-  info->aggregate_bytes = aggregate_device;
-  info->lod_bytes = lod_device;
-  info->codec_bytes = codec_bytes;
-  info->shard_bytes = shard_heap;
-
-  info->device_bytes = staging_bytes + chunk_pool_bytes +
-                       compressed_pool_bytes + aggregate_device + lod_device +
-                       codec_bytes;
+  info->device_bytes = info->staging_bytes + info->chunk_pool_bytes +
+                       info->compressed_pool_bytes + info->aggregate_bytes +
+                       info->lod_bytes + info->codec_bytes;
   info->host_pinned_bytes = staging_host + aggregate_host;
 
-  info->chunks_per_epoch = chunks_per_epoch;
-  info->total_chunks = total_chunks;
-  info->max_output_size = max_output_size;
-  info->nlod = nlod;
-  info->epochs_per_batch = K;
+  info->chunks_per_epoch = cl.layouts[0].chunks_per_epoch;
+  info->total_chunks = cl.levels.total_chunks;
+  info->max_output_size = cl.max_output_size;
+  info->nlod = cl.levels.nlod;
+  info->epochs_per_batch = cl.epochs_per_batch;
 
   computed_stream_layouts_free(&cl);
   return 0;
+
+Fail:
+  computed_stream_layouts_free(&cl);
+  return 1;
 }
 
 int

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -234,13 +234,13 @@ engine_array_state_init(struct engine_array_state* st,
     st->lod.layouts[lv] = cl->layouts[lv];
 
   CHECK(Fail, lod_state_init(&st->lod, &ctx->levels, &ctx->config) == 0);
-  // Alias L0 layout GPU pointers from LOD state into context (for scatter).
+  // View, not owned — freed with st->lod.
   ctx->layout_gpu = st->lod.layout_gpu[0];
 
   if (ctx->levels.enable_multiscale && ctx->dims.append_downsample)
     CHECK(Fail, lod_state_init_accumulators(&st->lod, &ctx->config) == 0);
 
-  // Per-slot batch_active_masks sized to this array's K.
+  // Sized to this array's K, not the shared maxima.
   for (int fc = 0; fc < 2; ++fc) {
     st->flush.slot[fc].batch_active_masks =
       (uint32_t*)calloc(cl->epochs_per_batch, sizeof(uint32_t));
@@ -376,7 +376,6 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
                                shard_sink_required_shard_alignment(sink),
                                &cl) == 0);
 
-  // Phase 2: allocate engine (shared) + array state, then bind.
   struct tile_stream_gpu* out =
     (struct tile_stream_gpu*)calloc(1, sizeof(*out));
   CHECK(FailPhase1b, out);

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -16,6 +16,106 @@
 #include <stdlib.h>
 #include <string.h>
 
+// --- Engine limits ---
+
+static inline size_t
+max_sz(size_t a, size_t b)
+{
+  return a > b ? a : b;
+}
+
+static inline uint64_t
+max_u64(uint64_t a, uint64_t b)
+{
+  return a > b ? a : b;
+}
+
+int
+engine_limits_accumulate(struct engine_limits* lim,
+                         const struct computed_stream_layouts* cl,
+                         const struct tile_stream_configuration* config)
+{
+  const uint32_t K = cl->epochs_per_batch;
+  const size_t bpe = dtype_bpe(config->dtype);
+  const uint64_t total_chunks = cl->levels.total_chunks;
+  const uint64_t chunk_stride = cl->layouts[0].chunk_stride;
+
+  CHECK(Fail, K >= 1);
+  CHECK_MUL_OVERFLOW(Fail, K, total_chunks, UINT64_MAX);
+
+  lim->buffer_capacity =
+    max_sz(lim->buffer_capacity,
+           (config->buffer_capacity_bytes + 4095) & ~(size_t)4095);
+  lim->pool_bytes =
+    max_sz(lim->pool_bytes, (size_t)K * total_chunks * chunk_stride * bpe);
+  lim->chunk_bytes = max_sz(lim->chunk_bytes, chunk_stride * bpe);
+  lim->codec_batch = max_u64(lim->codec_batch, (uint64_t)K * total_chunks);
+  if (K > lim->epochs_per_batch)
+    lim->epochs_per_batch = K;
+  if (cl->levels.nlod > lim->max_nlod)
+    lim->max_nlod = cl->levels.nlod;
+
+  if (cl->levels.enable_multiscale) {
+    lim->any_multiscale = 1;
+    lim->lod_linear_bytes =
+      max_sz(lim->lod_linear_bytes, cl->layouts[0].epoch_elements * bpe);
+    const uint64_t morton_vals =
+      cl->plan.level_spans.ends[cl->plan.levels.nlod - 1];
+    lim->lod_morton_bytes = max_sz(lim->lod_morton_bytes, morton_vals * bpe);
+  }
+
+  // Max batch layout assuming each LOD fires its worst-case active count.
+  {
+    struct batch_aggregate_layout ml;
+    struct aggregate_layout per_lod_layouts[LOD_MAX_LEVELS];
+    uint32_t per_lod_max[LOD_MAX_LEVELS] = { 0 };
+    for (int lv = 0; lv < cl->levels.nlod; ++lv) {
+      per_lod_layouts[lv] = cl->per_level[lv].agg_layout;
+      per_lod_max[lv] = cl->per_level[lv].batch_active_count;
+    }
+    CHECK(Fail,
+          batch_aggregate_layout_init(&ml,
+                                      per_lod_layouts,
+                                      per_lod_max,
+                                      (uint8_t)cl->levels.nlod,
+                                      cl->per_level[0].agg_layout.page_size) ==
+            0);
+    lim->max_total_batch_chunks =
+      max_u64(lim->max_total_batch_chunks, ml.total_batch_chunks);
+    lim->max_total_batch_covering =
+      max_u64(lim->max_total_batch_covering, ml.total_batch_covering);
+    lim->max_total_data_bytes =
+      max_sz(lim->max_total_data_bytes, ml.total_data_bytes);
+  }
+
+  {
+    uint64_t total_shards = 0;
+    for (int lv = 0; lv < cl->levels.nlod; ++lv)
+      total_shards += cl->per_level[lv].agg_layout.num_shards;
+    lim->max_total_shards = max_u64(lim->max_total_shards, total_shards);
+  }
+
+  return 0;
+
+Fail:
+  return 1;
+}
+
+// --- Shared engine init / teardown ---
+
+static int
+init_cuda_streams(struct gpu_streams* streams)
+{
+  CU(Fail, cuStreamCreate(&streams->h2d, CU_STREAM_NON_BLOCKING));
+  CU(Fail, cuStreamCreate(&streams->compute, CU_STREAM_NON_BLOCKING));
+  CU(Fail, cuStreamCreate(&streams->compress, CU_STREAM_NON_BLOCKING));
+  CU(Fail, cuStreamCreate(&streams->d2h, CU_STREAM_NON_BLOCKING));
+
+  return 0;
+Fail:
+  return 1;
+}
+
 static void
 destroy_cuda_streams(struct gpu_streams* streams)
 {
@@ -32,8 +132,186 @@ destroy_chunk_pools(struct pool_state* pools)
     cu_mem_free(pools->buf[i]);
 }
 
-static void
-destroy_flush_pipeline(struct flush_pipeline* fp);
+int
+stream_engine_init(struct stream_engine* e,
+                   const struct engine_limits* lim,
+                   enum compression_codec codec_id,
+                   int scatter_is_copy)
+{
+  CHECK(Fail, init_cuda_streams(&e->streams) == 0);
+  CHECK(Fail, gpu_ordering_init(&e->ord, e->streams.compute) == 0);
+  gpu_ordering_register_stream(&e->ord, GPU_STREAM_H2D, e->streams.h2d);
+  gpu_ordering_register_stream(&e->ord, GPU_STREAM_COMPUTE, e->streams.compute);
+  gpu_ordering_register_stream(
+    &e->ord, GPU_STREAM_COMPRESS, e->streams.compress);
+  gpu_ordering_register_stream(&e->ord, GPU_STREAM_D2H, e->streams.d2h);
+
+  CHECK(Fail,
+        ingest_init(
+          &e->stage, lim->buffer_capacity, &e->ord, e->streams.compute) == 0);
+
+  e->pool_bytes = lim->pool_bytes;
+  for (int i = 0; i < 2; ++i) {
+    CU(Fail, cuMemAlloc(&e->pools.buf[i], lim->pool_bytes));
+    CU(Fail,
+       cuMemsetD8Async(e->pools.buf[i], 0, lim->pool_bytes, e->streams.compute));
+  }
+
+  e->batch.epochs_per_batch = lim->epochs_per_batch;
+
+  CHECK(Fail,
+        compress_agg_init_shared(
+          &e->compress_agg, lim, codec_id, &e->ord, e->streams.compute) == 0);
+
+  // shard_alignment is per-array; set by stream_engine_bind_array.
+  CHECK(Fail,
+        d2h_deliver_init(&e->d2h_deliver, 0, &e->ord, e->streams.compute) == 0);
+
+  // Shared LOD buffers (sized to the max across arrays).
+  if (lim->any_multiscale) {
+    CHECK(Fail,
+          lod_shared_state_init(&e->lod_shared,
+                                lim->lod_linear_bytes,
+                                lim->lod_morton_bytes,
+                                e->streams.compute) == 0);
+    // t_end doubles as GPU_EDGE_LOD_DONE; already seeded by the init above.
+    for (int fc = 0; fc < 2; ++fc)
+      gpu_ordering_bind(
+        &e->ord, GPU_EDGE_LOD_DONE, fc, e->lod_shared.timing[fc].t_end);
+  }
+
+  CU(Fail, cuStreamSynchronize(e->streams.compute));
+
+  e->metrics = stream_engine_init_metrics(scatter_is_copy);
+  e->d2h_deliver.metrics = &e->metrics;
+  stream_engine_attach_edge_stalls(e);
+  e->metadata_update_clock = (struct platform_clock){ 0 };
+  platform_toc(&e->metadata_update_clock);
+
+  return 0;
+
+Fail:
+  return 1; // caller tears down via stream_engine_destroy
+}
+
+void
+stream_engine_destroy(struct stream_engine* e)
+{
+  d2h_deliver_destroy(&e->d2h_deliver);
+  compress_agg_destroy_shared(&e->compress_agg);
+  lod_shared_state_destroy(&e->lod_shared);
+  destroy_chunk_pools(&e->pools);
+  ingest_destroy(&e->stage);
+  gpu_ordering_destroy(&e->ord);
+  destroy_cuda_streams(&e->streams);
+}
+
+// --- Per-array state ---
+
+int
+engine_array_state_init(struct engine_array_state* st,
+                        struct stream_context* ctx,
+                        struct computed_stream_layouts* cl,
+                        struct gpu_ordering* gate_ord,
+                        CUstream gate_stream)
+{
+  memset(st, 0, sizeof(*st));
+
+  ctx->layout = cl->layouts[0]; // host fields; d_* still NULL
+  ctx->levels = cl->levels;
+  ctx->dims = cl->dims;
+  ctx->config.buffer_capacity_bytes =
+    (ctx->config.buffer_capacity_bytes + 4095) & ~(size_t)4095;
+
+  st->batch.epochs_per_batch = cl->epochs_per_batch;
+
+  // Move LOD plan and level layouts (always, including L0). st->lod owns
+  // plan, layouts[], layout_gpu[], CSRs, accumulators, and LOD LUTs — but
+  // NOT d_linear/d_morton/timing, which are engine-owned shared resources.
+  st->lod.plan = cl->plan;
+  cl->plan = (struct lod_plan){ 0 }; // ownership transferred
+  for (int lv = 0; lv < cl->levels.nlod; ++lv)
+    st->lod.layouts[lv] = cl->layouts[lv];
+
+  CHECK(Fail, lod_state_init(&st->lod, &ctx->levels, &ctx->config) == 0);
+  // Alias L0 layout GPU pointers from LOD state into context (for scatter).
+  ctx->layout_gpu = st->lod.layout_gpu[0];
+
+  if (ctx->levels.enable_multiscale && ctx->dims.append_downsample)
+    CHECK(Fail, lod_state_init_accumulators(&st->lod, &ctx->config) == 0);
+
+  // Per-slot batch_active_masks sized to this array's K.
+  for (int fc = 0; fc < 2; ++fc) {
+    st->flush.slot[fc].batch_active_masks =
+      (uint32_t*)calloc(cl->epochs_per_batch, sizeof(uint32_t));
+    CHECK(Fail, st->flush.slot[fc].batch_active_masks);
+  }
+
+  CHECK(Fail, compress_agg_array_init(&st->agg, cl, gate_ord, gate_stream) == 0);
+
+  // total_element_limit: configured stream length (0 = unbounded). Lets the
+  // append body detect the at-capacity case without recomputing each call.
+  {
+    const struct dimension* dims = ctx->config.dimensions;
+    const uint8_t na = dim_info_n_append(&ctx->dims);
+    if (dims[0].size > 0) {
+      ctx->total_element_limit = ctx->layout.epoch_elements;
+      for (int d = 0; d < na; ++d)
+        ctx->total_element_limit *= ceildiv(dims[d].size, dims[d].chunk_size);
+    }
+  }
+
+  return 0;
+
+Fail:
+  engine_array_state_destroy(st);
+  return 1;
+}
+
+void
+engine_array_state_destroy(struct engine_array_state* st)
+{
+  if (!st)
+    return;
+  for (int fc = 0; fc < 2; ++fc) {
+    free(st->flush.slot[fc].batch_active_masks);
+    st->flush.slot[fc].batch_active_masks = NULL;
+  }
+  compress_agg_array_destroy(&st->agg);
+  lod_state_destroy(&st->lod);
+}
+
+int
+stream_engine_bind_array(struct stream_engine* e,
+                         const struct engine_array_state* st,
+                         const struct stream_context* ctx)
+{
+  e->batch = st->batch;
+  e->pools.current = st->pool_current;
+  e->flush = st->flush;
+  e->lod = st->lod;
+  e->compress_agg.ar = st->agg;
+  e->d2h_deliver.shard_alignment = ctx->shard_alignment;
+
+  // Per-array shard_capacity table is constant; upload on bind so the
+  // device-side d_shard_capacity reflects the active array's shard sizes.
+  // (h_base_offsets / h_tps_group / h_offsets_base are per-batch scratch,
+  // refreshed by the kick.)
+  if (st->agg.total_shards > 0 && st->agg.h_shard_capacity)
+    CU(Fail,
+       cuMemcpyHtoD((CUdeviceptr)e->compress_agg.shards.d_shard_capacity,
+                    st->agg.h_shard_capacity,
+                    st->agg.total_shards * sizeof(size_t)));
+
+  // Invalidate the LUT cache: per-array layouts differ.
+  e->compress_agg.lut_cache_valid = 0;
+  return 0;
+
+Fail:
+  return 1;
+}
+
+// --- Create / Destroy ---
 
 static void
 sync(CUstream stream)
@@ -68,73 +346,12 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.compress);
   sync(s->engine.streams.d2h);
 
-  destroy_flush_pipeline(&s->engine.flush);
-  d2h_deliver_destroy(&s->engine.d2h_deliver);
-  compress_agg_destroy(&s->engine.compress_agg);
-  destroy_chunk_pools(&s->engine.pools);
-  lod_state_destroy(&s->engine.lod);
-  lod_shared_state_destroy(&s->engine.lod_shared);
-  ingest_destroy(&s->engine.stage);
-  gpu_ordering_destroy(&s->engine.ord);
-  destroy_cuda_streams(&s->engine.streams);
+  // s->ar owns the per-array allocations; the engine holds a bound copy of
+  // the same pointers, so destroy strictly after engine teardown would
+  // double-free — free once, here.
+  engine_array_state_destroy(&s->ar);
+  stream_engine_destroy(&s->engine);
   free(s);
-}
-
-// --- Create ---
-
-static int
-init_cuda_streams(struct gpu_streams* streams)
-{
-  CU(Fail, cuStreamCreate(&streams->h2d, CU_STREAM_NON_BLOCKING));
-  CU(Fail, cuStreamCreate(&streams->compute, CU_STREAM_NON_BLOCKING));
-  CU(Fail, cuStreamCreate(&streams->compress, CU_STREAM_NON_BLOCKING));
-  CU(Fail, cuStreamCreate(&streams->d2h, CU_STREAM_NON_BLOCKING));
-
-  return 0;
-Fail:
-  return 1;
-}
-
-static int
-init_chunk_pools(struct pool_state* pools,
-                 const struct level_geometry* levels,
-                 uint64_t chunk_stride,
-                 size_t bytes_per_element,
-                 uint32_t epochs_per_batch,
-                 CUstream compute)
-{
-  const size_t pool_bytes = (uint64_t)epochs_per_batch * levels->total_chunks *
-                            chunk_stride * bytes_per_element;
-
-  for (int i = 0; i < 2; ++i) {
-    CU(Fail, cuMemAlloc(&pools->buf[i], pool_bytes));
-    CU(Fail, cuMemsetD8Async(pools->buf[i], 0, pool_bytes, compute));
-  }
-
-  return 0;
-Fail:
-  return 1;
-}
-
-// Allocate per-slot batch_active_masks for the flush pipeline. K entries each.
-static int
-init_flush_pipeline(struct flush_pipeline* fp, uint32_t K)
-{
-  for (int fc = 0; fc < 2; ++fc) {
-    fp->slot[fc].batch_active_masks = (uint32_t*)calloc(K, sizeof(uint32_t));
-    if (!fp->slot[fc].batch_active_masks)
-      return 1;
-  }
-  return 0;
-}
-
-static void
-destroy_flush_pipeline(struct flush_pipeline* fp)
-{
-  for (int fc = 0; fc < 2; ++fc) {
-    free(fp->slot[fc].batch_active_masks);
-    fp->slot[fc].batch_active_masks = NULL;
-  }
 }
 
 struct tile_stream_gpu*
@@ -159,7 +376,7 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
                                shard_sink_required_shard_alignment(sink),
                                &cl) == 0);
 
-  // Phase 2: Allocate and initialize tile_stream_gpu.
+  // Phase 2: allocate engine (shared) + array state, then bind.
   struct tile_stream_gpu* out =
     (struct tile_stream_gpu*)calloc(1, sizeof(*out));
   CHECK(FailPhase1b, out);
@@ -167,120 +384,25 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
   out->ctx.config = *config;
   out->ctx.sink = sink;
   out->ctx.shard_alignment = shard_sink_required_shard_alignment(sink);
-  out->ctx.levels = cl.levels;
-  out->ctx.dims = cl.dims;
   tile_stream_gpu_init_writer(out);
 
-  out->ctx.config.buffer_capacity_bytes =
-    (config->buffer_capacity_bytes + 4095) & ~(size_t)4095;
-
-  // Copy L0 layout (host fields; d_* still NULL).
-  out->ctx.layout = cl.layouts[0];
-
-  // Move LOD plan and level layouts (always, including L0).
-  out->engine.lod.plan = cl.plan;
-  cl.plan = (struct lod_plan){ 0 }; // ownership transferred
-  for (int lv = 0; lv < cl.levels.nlod; ++lv)
-    out->engine.lod.layouts[lv] = cl.layouts[lv];
-
-  // Copy batch info.
-  CHECK(FailPhase2, cl.epochs_per_batch >= 1);
-  out->engine.batch.epochs_per_batch = cl.epochs_per_batch;
-  out->engine.batch.accumulated = 0;
-
-  // Allocate per-slot batch_active_masks sized to K.
+  struct engine_limits lim;
+  memset(&lim, 0, sizeof(lim));
+  CHECK(FailPhase2, engine_limits_accumulate(&lim, &cl, config) == 0);
   CHECK(FailPhase2,
-        init_flush_pipeline(&out->engine.flush, cl.epochs_per_batch) == 0);
-
-  // GPU allocation and init.
-  CHECK(FailPhase2, init_cuda_streams(&out->engine.streams) == 0);
+        stream_engine_init(&out->engine,
+                           &lim,
+                           config->codec.id,
+                           cl.levels.enable_multiscale) == 0);
+  // The pipelined (non-sync-flush) path arms the tail gate.
   CHECK(FailPhase2,
-        gpu_ordering_init(&out->engine.ord, out->engine.streams.compute) == 0);
-  gpu_ordering_register_stream(
-    &out->engine.ord, GPU_STREAM_H2D, out->engine.streams.h2d);
-  gpu_ordering_register_stream(
-    &out->engine.ord, GPU_STREAM_COMPUTE, out->engine.streams.compute);
-  gpu_ordering_register_stream(
-    &out->engine.ord, GPU_STREAM_COMPRESS, out->engine.streams.compress);
-  gpu_ordering_register_stream(
-    &out->engine.ord, GPU_STREAM_D2H, out->engine.streams.d2h);
-  CHECK(FailPhase2,
-        ingest_init(&out->engine.stage,
-                    out->ctx.config.buffer_capacity_bytes,
-                    &out->engine.ord,
-                    out->engine.streams.compute) == 0);
-  CHECK(FailPhase2,
-        lod_state_init(&out->engine.lod, &out->ctx.levels, &out->ctx.config) ==
-          0);
-  // Alias L0 layout GPU pointers from LOD state into context.
-  out->ctx.layout_gpu = out->engine.lod.layout_gpu[0];
-  CHECK(FailPhase2,
-        init_chunk_pools(&out->engine.pools,
-                         &out->ctx.levels,
-                         out->ctx.layout.chunk_stride,
-                         dtype_bpe(config->dtype),
-                         out->engine.batch.epochs_per_batch,
-                         out->engine.streams.compute) == 0);
-
-  // Initialize the two pipeline stages.
-  CHECK(FailPhase2,
-        compress_agg_init(&out->engine.compress_agg,
-                          &cl,
-                          config,
-                          &out->engine.ord,
-                          out->engine.streams.compute) == 0);
-  CHECK(FailPhase2,
-        d2h_deliver_init(&out->engine.d2h_deliver,
-                         out->ctx.shard_alignment,
-                         &out->engine.ord,
-                         out->engine.streams.compute) == 0);
-
-  if (out->ctx.levels.enable_multiscale) {
-    const size_t bpe = dtype_bpe(out->ctx.config.dtype);
-    const size_t linear_bytes = out->engine.lod.layouts[0].epoch_elements * bpe;
-    const uint64_t morton_total_vals =
-      out->engine.lod.plan.level_spans
-        .ends[out->engine.lod.plan.levels.nlod - 1];
-    const size_t morton_bytes = morton_total_vals * bpe;
-    CHECK(FailPhase2,
-          lod_shared_state_init(&out->engine.lod_shared,
-                                linear_bytes,
-                                morton_bytes,
+        engine_array_state_init(&out->ar,
+                                &out->ctx,
+                                &cl,
+                                &out->engine.ord,
                                 out->engine.streams.compute) == 0);
-    // t_end doubles as GPU_EDGE_LOD_DONE; already seeded by the init above.
-    for (int fc = 0; fc < 2; ++fc)
-      gpu_ordering_bind(&out->engine.ord,
-                        GPU_EDGE_LOD_DONE,
-                        fc,
-                        out->engine.lod_shared.timing[fc].t_end);
-    if (out->ctx.dims.append_downsample)
-      CHECK(FailPhase2,
-            lod_state_init_accumulators(&out->engine.lod, &out->ctx.config) ==
-              0);
-  }
-  CU(FailPhase2, cuStreamSynchronize(out->engine.streams.compute));
-
-  // Precompute total_element_limit (configured stream length) so the body can
-  // detect the at-capacity case without recomputing each call.
-  {
-    const struct dimension* dims = config->dimensions;
-    const uint8_t na = dim_info_n_append(&out->ctx.dims);
-    if (dims[0].size > 0) {
-      out->ctx.total_element_limit = out->ctx.layout.epoch_elements;
-      for (int d = 0; d < na; ++d)
-        out->ctx.total_element_limit *=
-          ceildiv(dims[d].size, dims[d].chunk_size);
-    }
-  }
-
-  out->engine.metrics =
-    stream_engine_init_metrics(out->ctx.levels.enable_multiscale);
-  out->engine.d2h_deliver.metrics = &out->engine.metrics;
-  stream_engine_attach_edge_stalls(&out->engine);
-
-  // Initialize metadata update timer
-  out->engine.metadata_update_clock = (struct platform_clock){ 0 };
-  platform_toc(&out->engine.metadata_update_clock);
+  CHECK(FailPhase2,
+        stream_engine_bind_array(&out->engine, &out->ar, &out->ctx) == 0);
 
   computed_stream_layouts_free(&cl);
   return out;

--- a/src/gpu/stream.internal.h
+++ b/src/gpu/stream.internal.h
@@ -7,6 +7,8 @@ struct tile_stream_gpu
   struct writer writer;
   struct stream_engine engine;
   struct stream_context ctx;
+  // Owner of the per-array allocations; the engine holds the bound copy.
+  struct engine_array_state ar;
   int flushed; // 1 after flush; reset by append for idempotency
 };
 

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -597,6 +597,9 @@ lod_state_destroy(struct lod_state* lod)
     CUWARN(cuMemFree((CUdeviceptr)lod->layout_gpu[i].d_lifted_strides));
   }
   lod_plan_free(&lod->plan);
+  // Zero so a second destroy (init-failure cleanup, then owner teardown)
+  // can't re-free stale device handles.
+  *lod = (struct lod_state){ 0 };
 }
 
 // --- LOD runtime ---

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -498,6 +498,75 @@ Fail:
   return 1;
 }
 
+// --- Memory estimate ---
+
+// Device bytes lod_state_init + lod_state_init_accumulators allocate for
+// this layout (build-time temporaries, freed before return, excluded). Must
+// mirror the allocations above exactly — tile_stream_gpu_memory_estimate
+// sums this.
+size_t
+lod_state_device_bytes(const struct computed_stream_layouts* cl,
+                       const struct tile_stream_configuration* config)
+{
+  const struct lod_plan* p = &cl->plan;
+  size_t bytes = 0;
+
+  // upload_lod_level_layouts: every level, L0 included.
+  for (int lv = 0; lv < p->levels.nlod; ++lv)
+    bytes += cl->layouts[lv].lifted_rank * (sizeof(uint64_t) + sizeof(int64_t));
+
+  if (!cl->levels.enable_multiscale)
+    return bytes;
+
+  const struct level_dims* l0 = &p->levels.level[0];
+
+  // upload_plan_shapes
+  bytes += config->rank * sizeof(uint64_t); // d_full_shape
+  if (l0->lod_ndim > 0)
+    bytes += l0->lod_ndim * sizeof(uint64_t); // d_lod_shape
+
+  // init_gather_lut
+  if (l0->lod_ndim > 0) {
+    bytes += l0->lod_nelem * sizeof(uint32_t);       // d_gather_lut
+    bytes += p->fixed_dims_count * sizeof(uint32_t); // d_fixed_dims_offsets
+  }
+
+  // init_csr_reduce_luts (reduce_csr_gpu_alloc per level transition)
+  for (int l = 0; l < p->levels.nlod - 1; ++l) {
+    const struct level_dims* src = &p->levels.level[l];
+    const struct level_dims* dst = &p->levels.level[l + 1];
+    const uint64_t src_total = src->fixed_dims_count * src->lod_nelem;
+    const uint64_t dst_total = dst->fixed_dims_count * dst->lod_nelem;
+    if (src_total == 0 || dst_total == 0)
+      continue;
+    bytes += (dst_total + 1) * sizeof(uint64_t); // csr starts
+    bytes += src_total * sizeof(uint64_t);       // csr indices
+  }
+
+  // init_morton_scatter_luts: every level, L0 included.
+  if (p->lod_ndim > 0) {
+    for (int lv = 0; lv < p->levels.nlod; ++lv) {
+      bytes += p->levels.level[lv].lod_nelem * sizeof(uint32_t);
+      bytes += p->levels.level[lv].fixed_dims_count * sizeof(uint32_t);
+    }
+  }
+
+  // lod_state_init_accumulators
+  if (cl->dims.append_downsample) {
+    uint64_t total = 0;
+    for (int lv = 1; lv < p->levels.nlod; ++lv)
+      total += p->levels.level[lv].fixed_dims_count * p->levels.level[lv].lod_nelem;
+    if (total > 0) {
+      const size_t bpe = dtype_bpe(config->dtype);
+      bytes += total * bpe;                                  // d_accum
+      bytes += total;                                        // d_level_ids
+      bytes += (uint64_t)p->levels.nlod * sizeof(uint32_t);  // d_counts
+    }
+  }
+
+  return bytes;
+}
+
 // --- LOD destroy ---
 
 void

--- a/src/gpu/stream.lod.h
+++ b/src/gpu/stream.lod.h
@@ -45,6 +45,14 @@ lod_state_init_accumulators(struct lod_state* lod,
 void
 lod_state_destroy(struct lod_state* lod);
 
+struct computed_stream_layouts;
+
+// Sizing mirror of lod_state_init + lod_state_init_accumulators, for the
+// memory estimate.
+size_t
+lod_state_device_bytes(const struct computed_stream_layouts* cl,
+                       const struct tile_stream_configuration* config);
+
 // Run LOD pipeline for one epoch: gather -> reduce -> append fold ->
 // morton-to-chunks. pool_epoch: pointer to this epoch's chunk pool region (all
 // levels). *out_active_mask: set to bitmask of active LOD levels for this

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -34,29 +34,6 @@ struct array_descriptor_gpu
   int flushed; // 1 once flush body has run for this array
 };
 
-// ---- Pool maxima (computed across all arrays) ----
-
-struct pool_maxima
-{
-  size_t pool_bytes;
-  size_t buffer_capacity;
-  size_t compressed_bytes;
-  uint64_t codec_batch;
-  size_t chunk_bytes;
-  uint32_t epochs_per_batch;
-  int max_nlod;
-  size_t max_output_size;
-  size_t lod_linear_bytes; // max across arrays
-  size_t lod_morton_bytes; // max across arrays
-  int any_multiscale;      // 1 if any array uses multiscale
-
-  // Unified-pipeline maxima (max across arrays).
-  uint64_t u_max_total_batch_chunks;
-  uint64_t u_max_total_batch_covering;
-  size_t u_max_total_data_bytes;
-  uint64_t u_max_total_shards;
-};
-
 // ---- Main struct ----
 
 struct multiarray_tile_stream_gpu
@@ -65,7 +42,6 @@ struct multiarray_tile_stream_gpu
   struct stream_engine engine;
   int n_arrays;
   int active; // -1 = none
-  int max_nlod;
   struct array_descriptor_gpu* arrays;
 };
 
@@ -75,26 +51,6 @@ static struct multiarray_writer_result
 update_impl(struct multiarray_writer* self, int array_index, struct slice data);
 static struct multiarray_writer_result
 flush_impl(struct multiarray_writer* self);
-
-// ---- Helpers ----
-
-static inline size_t
-max_sz(size_t a, size_t b)
-{
-  return a > b ? a : b;
-}
-
-static inline uint64_t
-max_u64(uint64_t a, uint64_t b)
-{
-  return a > b ? a : b;
-}
-
-static inline uint32_t
-max_u32(uint32_t a, uint32_t b)
-{
-  return a > b ? a : b;
-}
 
 // ---- Bind / Unbind ----
 // Copy per-array mutable state between descriptor and engine sub-structs.
@@ -122,28 +78,10 @@ drain_d2h_for_array(struct stream_engine* e, struct array_descriptor_gpu* desc)
 static void
 bind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
 {
-  // Whole-struct handoff. Shared engine resources (pools.buf, staging,
-  // agg[2], d_batch_gather/perm, lut scratch, shards.*, lod_shared) are
-  // sized to maxima and untouched. st.batch carries the array's own K so
-  // each array fills/flushes at its own batch size.
-  e->batch = desc->st.batch;
-  e->pools.current = desc->st.pool_current;
-  e->flush = desc->st.flush;
-  e->lod = desc->st.lod;
-  e->compress_agg.ar = desc->st.agg;
-  e->d2h_deliver.shard_alignment = desc->ctx.shard_alignment;
-
-  // Per-array shard_capacity table is constant; re-upload on bind so the
-  // device-side d_shard_capacity reflects the active array's shard sizes.
-  // (h_base_offsets / h_tps_group / h_offsets_base are per-batch scratch,
-  // refreshed by the kick.)
-  if (desc->st.agg.total_shards > 0 && desc->st.agg.h_shard_capacity) {
-    cuMemcpyHtoD((CUdeviceptr)e->compress_agg.shards.d_shard_capacity,
-                 desc->st.agg.h_shard_capacity,
-                 desc->st.agg.total_shards * sizeof(size_t));
-  }
-  // Invalidate the LUT cache: per-array layouts differ.
-  e->compress_agg.lut_cache_valid = 0;
+  // Whole-struct handoff; shared engine resources (sized to maxima) are
+  // untouched. The bind upload failing leaves the engine no worse than the
+  // current array's first kick failing, which the writer paths report.
+  (void)stream_engine_bind_array(e, &desc->st, &desc->ctx);
 }
 
 static void
@@ -171,7 +109,7 @@ static int
 init_array_descriptor(struct array_descriptor_gpu* desc,
                       const struct tile_stream_configuration* config,
                       struct shard_sink* sink,
-                      struct pool_maxima* mx)
+                      struct engine_limits* lim)
 {
   if (!codec_is_gpu_supported(config->codec.id))
     return 1;
@@ -187,188 +125,15 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
                              &desc->cl))
     return 1;
 
-  desc->ctx.layout = desc->cl.layouts[0];
-  desc->ctx.levels = desc->cl.levels;
-  desc->ctx.dims = desc->cl.dims;
-
-  // Initialize per-array LOD state: transfer plan from cl, copy layouts,
-  // upload level layouts + LUTs + CSRs. Does NOT allocate d_linear/d_morton
-  // or timing events — those are engine-owned shared resources.
-  desc->st.lod.plan = desc->cl.plan;
-  desc->cl.plan = (struct lod_plan){ 0 }; // ownership transferred
-  for (int lv = 0; lv < desc->cl.levels.nlod; ++lv)
-    desc->st.lod.layouts[lv] = desc->cl.layouts[lv];
-
-  if (lod_state_init(&desc->st.lod, &desc->ctx.levels, &desc->ctx.config))
+  // Fold this array into the shared-resource maxima before
+  // engine_array_state_init moves cl->plan out.
+  if (engine_limits_accumulate(lim, &desc->cl, config))
     return 1;
 
-  // Alias L0 layout GPU pointers from st.lod into ctx (for scatter).
-  desc->ctx.layout_gpu = desc->st.lod.layout_gpu[0];
-
-  if (desc->ctx.levels.enable_multiscale && desc->ctx.dims.append_downsample) {
-    if (lod_state_init_accumulators(&desc->st.lod, &desc->ctx.config))
-      return 1;
-  }
-
-  const uint32_t K = desc->cl.epochs_per_batch;
-  const size_t bpe = dtype_bpe(config->dtype);
-  const uint64_t total_chunks = desc->ctx.levels.total_chunks;
-  const uint64_t chunk_stride = desc->ctx.layout.chunk_stride;
-
-  // Batch K from the array's own config, not the engine max. Shared buffers
-  // are sized to max K, but each array fills/flushes at its own K so that
-  // batch_active_count and active_count agree.
-  desc->st.batch.epochs_per_batch = K;
-  desc->st.agg.nlod = (uint8_t)desc->ctx.levels.nlod;
-
-  // Per-array, per-slot batch_active_masks. Bind/unbind copies the pointer
-  // into the engine's flush slots; the storage lives here for the array's
-  // lifetime.
-  for (int fc = 0; fc < 2; ++fc) {
-    desc->st.flush.slot[fc].batch_active_masks =
-      (uint32_t*)calloc(K, sizeof(uint32_t));
-    if (!desc->st.flush.slot[fc].batch_active_masks)
-      return 1;
-  }
-
-  // total_element_limit: configured stream length (0 = unbounded)
-  {
-    const struct dimension* dims = config->dimensions;
-    const uint8_t na = dim_info_n_append(&desc->ctx.dims);
-    if (dims[0].size > 0) {
-      desc->ctx.total_element_limit = desc->ctx.layout.epoch_elements;
-      for (int d = 0; d < na; ++d)
-        desc->ctx.total_element_limit *=
-          ceildiv(dims[d].size, dims[d].chunk_size);
-    }
-  }
-
-  // Buffer capacity (page-aligned)
-  desc->ctx.config.buffer_capacity_bytes =
-    (config->buffer_capacity_bytes + 4095) & ~(size_t)4095;
-
-  // Update pool maxima
-  mx->pool_bytes =
-    max_sz(mx->pool_bytes, (size_t)K * total_chunks * chunk_stride * bpe);
-  mx->buffer_capacity =
-    max_sz(mx->buffer_capacity, desc->ctx.config.buffer_capacity_bytes);
-  mx->compressed_bytes = max_sz(
-    mx->compressed_bytes, (size_t)K * total_chunks * desc->cl.max_output_size);
-  mx->codec_batch = max_u64(mx->codec_batch, (uint64_t)K * total_chunks);
-  mx->chunk_bytes = max_sz(mx->chunk_bytes, chunk_stride * bpe);
-  mx->epochs_per_batch = max_u32(mx->epochs_per_batch, K);
-  mx->max_output_size = max_sz(mx->max_output_size, desc->cl.max_output_size);
-
-  if (desc->ctx.levels.nlod > mx->max_nlod)
-    mx->max_nlod = desc->ctx.levels.nlod;
-
-  // LOD buffer sizes (for engine's shared d_linear / d_morton).
-  if (desc->ctx.levels.enable_multiscale) {
-    mx->any_multiscale = 1;
-    size_t linear_bytes = desc->ctx.layout.epoch_elements * bpe;
-    mx->lod_linear_bytes = max_sz(mx->lod_linear_bytes, linear_bytes);
-    uint64_t total_vals = desc->st.lod.plan.level_spans
-                            .ends[desc->st.lod.plan.levels.nlod - 1];
-    size_t morton_bytes = total_vals * bpe;
-    mx->lod_morton_bytes = max_sz(mx->lod_morton_bytes, morton_bytes);
-  }
-
-  // Unified-pipeline per-array sizing.
-  desc->st.agg.total_shards = 0;
-  desc->st.agg.page_size = desc->cl.per_level[0].agg_layout.page_size;
-  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-    desc->st.agg.shards_begin[lv] = (uint32_t)desc->st.agg.total_shards;
-    desc->st.agg.n_shards[lv] =
-      (uint32_t)desc->cl.per_level[lv].agg_layout.num_shards;
-    desc->st.agg.total_shards += desc->cl.per_level[lv].agg_layout.num_shards;
-  }
-  if (desc->st.agg.total_shards > 0) {
-    desc->st.agg.h_shard_capacity =
-      (size_t*)malloc(desc->st.agg.total_shards * sizeof(size_t));
-    desc->st.agg.h_tail_bytes =
-      (size_t*)calloc(desc->st.agg.total_shards, sizeof(size_t));
-    if (!desc->st.agg.h_shard_capacity || !desc->st.agg.h_tail_bytes)
-      return 1;
-    for (uint64_t i = 0; i < desc->st.agg.total_shards; ++i) {
-      for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-        if (i >= desc->st.agg.shards_begin[lv] &&
-            i < desc->st.agg.shards_begin[lv] + desc->st.agg.n_shards[lv]) {
-          desc->st.agg.h_shard_capacity[i] =
-            desc->cl.per_level[lv].agg_layout.shard_capacity;
-          break;
-        }
-      }
-    }
-    if (cuMemAlloc((CUdeviceptr*)&desc->st.agg.d_tail_bytes,
-                   desc->st.agg.total_shards * sizeof(size_t)) != CUDA_SUCCESS)
-      return 1;
-    if (cuMemsetD8((CUdeviceptr)desc->st.agg.d_tail_bytes,
-                   0,
-                   desc->st.agg.total_shards * sizeof(size_t)) != CUDA_SUCCESS)
-      return 1;
-    // Delivery's tail upload is a synchronous HtoD from pageable memory,
-    // which may return before the DMA reaches the device; SYNC_MEMOPS makes
-    // it complete at the device first, so work enqueued after the drain
-    // cannot read a stale tail (flush.d2h_deliver.c).
-    unsigned int sync_memops = 1;
-    if (cuPointerSetAttribute(&sync_memops,
-                              CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                              (CUdeviceptr)desc->st.agg.d_tail_bytes) !=
-        CUDA_SUCCESS)
-      return 1;
-    if (desc->st.agg.page_size > 0) {
-      desc->st.agg.tail_carry_bytes =
-        desc->st.agg.total_shards * desc->st.agg.page_size;
-      if (cuMemAlloc(&desc->st.agg.d_tail_carry, desc->st.agg.tail_carry_bytes) !=
-          CUDA_SUCCESS)
-        return 1;
-      if (cuMemsetD8(
-            desc->st.agg.d_tail_carry, 0, desc->st.agg.tail_carry_bytes) != CUDA_SUCCESS)
-        return 1;
-      // Same pageable-HtoD constraint as d_tail_bytes above.
-      if (cuPointerSetAttribute(&sync_memops,
-                                CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                desc->st.agg.d_tail_carry) != CUDA_SUCCESS)
-        return 1;
-    }
-  }
-
-  // Pool-maxima inputs for the unified pipeline. Compute this array's
-  // max-batch layout and feed the maxima accumulator below.
-  struct batch_aggregate_layout array_max_layout;
-  {
-    struct aggregate_layout per_lod_layouts[LOD_MAX_LEVELS];
-    uint32_t per_lod_max[LOD_MAX_LEVELS] = { 0 };
-    for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-      per_lod_layouts[lv] = desc->cl.per_level[lv].agg_layout;
-      per_lod_max[lv] = desc->cl.per_level[lv].batch_active_count;
-    }
-    if (batch_aggregate_layout_init(&array_max_layout,
-                                    per_lod_layouts,
-                                    per_lod_max,
-                                    (uint8_t)desc->ctx.levels.nlod,
-                                    desc->st.agg.page_size))
-      return 1;
-  }
-  mx->u_max_total_batch_chunks =
-    max_u64(mx->u_max_total_batch_chunks, array_max_layout.total_batch_chunks);
-  mx->u_max_total_batch_covering =
-    max_u64(mx->u_max_total_batch_covering,
-            array_max_layout.total_batch_covering);
-  mx->u_max_total_data_bytes =
-    max_sz(mx->u_max_total_data_bytes, array_max_layout.total_data_bytes);
-  mx->u_max_total_shards =
-    max_u64(mx->u_max_total_shards, desc->st.agg.total_shards);
-
-  // Per-LOD shard_state + agg_layout snapshot.
-  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-    const struct level_layout_info* li = &desc->cl.per_level[lv];
-    desc->st.agg.per_lod_agg_layouts[lv] = li->agg_layout;
-    if (init_shard_state(&desc->st.agg.shard[lv], li))
-      return 1;
-  }
-
-  return 0;
+  // No tail gate on the multiarray sync-flush path: every kick drains
+  // immediately, so tail uploads are host-ordered.
+  return engine_array_state_init(
+    &desc->st, &desc->ctx, &desc->cl, NULL, NULL);
 }
 
 static void
@@ -376,182 +141,8 @@ destroy_array_descriptor(struct array_descriptor_gpu* desc)
 {
   if (!desc)
     return;
-  for (int fc = 0; fc < 2; ++fc) {
-    free(desc->st.flush.slot[fc].batch_active_masks);
-    desc->st.flush.slot[fc].batch_active_masks = NULL;
-  }
-  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-    shard_state_destroy(&desc->st.agg.shard[lv]);
-    aggregate_layout_destroy(&desc->st.agg.per_lod_agg_layouts[lv]);
-  }
-  free(desc->st.agg.h_shard_capacity);
-  free(desc->st.agg.h_tail_bytes);
-  cu_mem_free((CUdeviceptr)desc->st.agg.d_tail_bytes);
-  cu_mem_free(desc->st.agg.d_tail_carry);
-  // st.lod owns everything except d_linear/d_morton/timing (which stay 0
-  // in the per-array struct). ctx.layout_gpu aliases st.lod.layout_gpu[0]
-  // and is freed via st.lod destroy.
-  lod_state_destroy(&desc->st.lod);
+  engine_array_state_destroy(&desc->st);
   computed_stream_layouts_free(&desc->cl);
-}
-
-// ---- Shared resource allocation ----
-
-static int
-init_shared_resources(struct multiarray_tile_stream_gpu* ms,
-                      const struct pool_maxima* mx)
-{
-  struct stream_engine* e = &ms->engine;
-
-  // CUDA streams
-  CU(Fail, cuStreamCreate(&e->streams.h2d, CU_STREAM_NON_BLOCKING));
-  CU(Fail, cuStreamCreate(&e->streams.compute, CU_STREAM_NON_BLOCKING));
-  CU(Fail, cuStreamCreate(&e->streams.compress, CU_STREAM_NON_BLOCKING));
-  CU(Fail, cuStreamCreate(&e->streams.d2h, CU_STREAM_NON_BLOCKING));
-
-  CHECK(Fail, gpu_ordering_init(&e->ord, e->streams.compute) == 0);
-  gpu_ordering_register_stream(&e->ord, GPU_STREAM_H2D, e->streams.h2d);
-  gpu_ordering_register_stream(&e->ord, GPU_STREAM_COMPUTE, e->streams.compute);
-  gpu_ordering_register_stream(
-    &e->ord, GPU_STREAM_COMPRESS, e->streams.compress);
-  gpu_ordering_register_stream(&e->ord, GPU_STREAM_D2H, e->streams.d2h);
-  e->compress_agg.ord = &e->ord;
-
-  CHECK(Fail,
-        ingest_init(&e->stage, mx->buffer_capacity, &e->ord,
-                    e->streams.compute) == 0);
-
-  e->pool_bytes = mx->pool_bytes;
-  for (int i = 0; i < 2; ++i) {
-    CU(Fail, cuMemAlloc(&e->pools.buf[i], mx->pool_bytes));
-    CU(Fail,
-       cuMemsetD8Async(e->pools.buf[i], 0, mx->pool_bytes, e->streams.compute));
-  }
-
-  e->batch.epochs_per_batch = mx->epochs_per_batch;
-
-  // Per-slot batch_active_masks live on each array descriptor (bind/unbind
-  // copies them in). Stage scratch is shared and sized to the max K.
-  e->compress_agg.pool_epochs_scratch =
-    (uint32_t*)malloc((size_t)mx->epochs_per_batch * sizeof(uint32_t));
-  CHECK(Fail, e->compress_agg.pool_epochs_scratch);
-
-  CHECK(Fail,
-        codec_init(&e->compress_agg.codec,
-                   ms->arrays[0].ctx.config.codec.id,
-                   mx->chunk_bytes,
-                   mx->codec_batch) == 0);
-
-  for (int fc = 0; fc < 2; ++fc) {
-    size_t comp_sz = mx->codec_batch * e->compress_agg.codec.max_output_size;
-    if (comp_sz > 0)
-      CU(Fail, cuMemAlloc(&e->compress_agg.d_compressed[fc], comp_sz));
-    CU(Fail,
-       cuEventCreate(&e->compress_agg.t_compress_start[fc], CU_EVENT_DEFAULT));
-    CU(Fail,
-       cuEventCreate(&e->compress_agg.t_compress_end[fc], CU_EVENT_DEFAULT));
-  }
-
-  CHECK(Fail,
-        d2h_deliver_init(&e->d2h_deliver, 0, &e->ord, e->streams.compute) ==
-          0);
-  e->d2h_deliver.metrics = &e->metrics;
-
-  // Unified-pipeline shared resources. Sized to maxima across arrays.
-  e->compress_agg.max_total_batch_chunks = mx->u_max_total_batch_chunks;
-  e->compress_agg.max_total_batch_covering = mx->u_max_total_batch_covering;
-  e->compress_agg.max_total_data_bytes = mx->u_max_total_data_bytes;
-  if (mx->u_max_total_batch_chunks > 0) {
-    const uint64_t C_max =
-      mx->u_max_total_batch_covering + (uint64_t)ms->max_nlod;
-    for (int fc = 0; fc < 2; ++fc) {
-      CHECK(Fail,
-            aggregate_batch_slot_init(&e->compress_agg.agg[fc],
-                                      C_max,
-                                      mx->u_max_total_data_bytes) == 0);
-    }
-    CU(Fail,
-       cuMemAlloc(&e->compress_agg.d_batch_gather,
-                  mx->u_max_total_batch_chunks * sizeof(uint32_t)));
-    CU(Fail,
-       cuMemAlloc(&e->compress_agg.d_batch_perm,
-                  mx->u_max_total_batch_chunks * sizeof(uint32_t)));
-    e->compress_agg.h_lut_gather_scratch =
-      (uint32_t*)malloc(mx->u_max_total_batch_chunks * sizeof(uint32_t));
-    e->compress_agg.h_lut_perm_scratch =
-      (uint32_t*)malloc(mx->u_max_total_batch_chunks * sizeof(uint32_t));
-    CHECK(Fail,
-          e->compress_agg.h_lut_gather_scratch &&
-            e->compress_agg.h_lut_perm_scratch);
-  }
-  // Engine-shared per-shard scratch + device buffers, sized to max shards.
-  if (mx->u_max_total_shards > 0) {
-    e->compress_agg.shards.h_base_offsets =
-      (size_t*)malloc(mx->u_max_total_shards * sizeof(size_t));
-    e->compress_agg.shards.h_tps_group =
-      (uint64_t*)malloc(mx->u_max_total_shards * sizeof(uint64_t));
-    e->compress_agg.shards.h_offsets_base =
-      (uint64_t*)malloc(mx->u_max_total_shards * sizeof(uint64_t));
-    CHECK(Fail,
-          e->compress_agg.shards.h_base_offsets &&
-            e->compress_agg.shards.h_tps_group &&
-            e->compress_agg.shards.h_offsets_base);
-    CU(Fail,
-       cuMemAlloc((CUdeviceptr*)&e->compress_agg.shards.d_base_offsets,
-                  mx->u_max_total_shards * sizeof(size_t)));
-    CU(Fail,
-       cuMemAlloc((CUdeviceptr*)&e->compress_agg.shards.d_shard_capacity,
-                  mx->u_max_total_shards * sizeof(size_t)));
-    CU(Fail,
-       cuMemAlloc((CUdeviceptr*)&e->compress_agg.shards.d_tps_group,
-                  mx->u_max_total_shards * sizeof(uint64_t)));
-    CU(Fail,
-       cuMemAlloc((CUdeviceptr*)&e->compress_agg.shards.d_offsets_base,
-                  mx->u_max_total_shards * sizeof(uint64_t)));
-  }
-  // Override the shared scratch sized at engine-init: the unified kick
-  // needs LOD_MAX_LEVELS * max_K entries to carve per-LOD pool_epochs slices.
-  // Allocate the cache to the same shape so the LUT-steady check can compare
-  // each LOD's slice at a stable stride.
-  free(e->compress_agg.pool_epochs_scratch);
-  e->compress_agg.pool_epochs_stride = mx->epochs_per_batch;
-  e->compress_agg.pool_epochs_scratch = (uint32_t*)malloc(
-    (size_t)LOD_MAX_LEVELS * mx->epochs_per_batch * sizeof(uint32_t));
-  e->compress_agg.cached_pool_epochs = (uint32_t*)malloc(
-    (size_t)LOD_MAX_LEVELS * mx->epochs_per_batch * sizeof(uint32_t));
-  CHECK(Fail,
-        e->compress_agg.pool_epochs_scratch &&
-          e->compress_agg.cached_pool_epochs);
-
-  for (int fc = 0; fc < 2; ++fc) {
-    CU(Fail,
-       cuEventRecord(e->compress_agg.t_compress_start[fc], e->streams.compute));
-    CU(Fail,
-       cuEventRecord(e->compress_agg.t_compress_end[fc], e->streams.compute));
-  }
-
-  // Shared LOD buffers (sized to max across arrays). Only allocated if any
-  // array uses multiscale.  The struct lod_shared_state / lod_state split
-  // keeps engine-owned resources separate from per-array state, so bind/unbind
-  // never touches these fields.
-  if (mx->any_multiscale) {
-    CHECK(Fail,
-          lod_shared_state_init(&e->lod_shared,
-                                mx->lod_linear_bytes,
-                                mx->lod_morton_bytes,
-                                e->streams.compute) == 0);
-    // t_end doubles as GPU_EDGE_LOD_DONE; already seeded by the init above.
-    for (int fc = 0; fc < 2; ++fc)
-      gpu_ordering_bind(
-        &e->ord, GPU_EDGE_LOD_DONE, fc, e->lod_shared.timing[fc].t_end);
-  }
-
-  CU(Fail, cuStreamSynchronize(e->streams.compute));
-
-  return 0;
-
-Fail:
-  return 1;
 }
 
 // ---- Array switching ----
@@ -723,53 +314,9 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
     free(ms->arrays);
   }
 
-  struct stream_engine* e = &ms->engine;
-
-  d2h_deliver_destroy(&e->d2h_deliver);
-
-  codec_free(&e->compress_agg.codec);
-  free(e->compress_agg.pool_epochs_scratch);
-  free(e->compress_agg.cached_pool_epochs);
-  e->compress_agg.pool_epochs_scratch = NULL;
-  e->compress_agg.cached_pool_epochs = NULL;
-  for (int fc = 0; fc < 2; ++fc) {
-    cu_mem_free(e->compress_agg.d_compressed[fc]);
-    cu_event_destroy(e->compress_agg.t_compress_start[fc]);
-    cu_event_destroy(e->compress_agg.t_compress_end[fc]);
-  }
-
-  // Unified-pipeline shared resources (allocated in init_shared_resources).
-  for (int fc = 0; fc < 2; ++fc)
-    aggregate_slot_destroy(&e->compress_agg.agg[fc]);
-  cu_mem_free(e->compress_agg.d_batch_gather);
-  cu_mem_free(e->compress_agg.d_batch_perm);
-  free(e->compress_agg.h_lut_gather_scratch);
-  free(e->compress_agg.h_lut_perm_scratch);
-  free(e->compress_agg.shards.h_base_offsets);
-  free(e->compress_agg.shards.h_tps_group);
-  free(e->compress_agg.shards.h_offsets_base);
-  cu_mem_free((CUdeviceptr)e->compress_agg.shards.d_base_offsets);
-  cu_mem_free((CUdeviceptr)e->compress_agg.shards.d_shard_capacity);
-  cu_mem_free((CUdeviceptr)e->compress_agg.shards.d_tps_group);
-  cu_mem_free((CUdeviceptr)e->compress_agg.shards.d_offsets_base);
-  memset(&e->compress_agg.shards, 0, sizeof(e->compress_agg.shards));
-
-  // The per-array fields of e->lod are views of the last-bound descriptor
-  // (freed above by destroy_array_descriptor).  Engine-owned shared LOD
-  // resources live in e->lod_shared.
-  lod_shared_state_destroy(&e->lod_shared);
-
-  for (int i = 0; i < 2; ++i)
-    cu_mem_free(e->pools.buf[i]);
-
-  ingest_destroy(&e->stage);
-
-  gpu_ordering_destroy(&e->ord);
-
-  cu_stream_destroy(e->streams.h2d);
-  cu_stream_destroy(e->streams.compute);
-  cu_stream_destroy(e->streams.compress);
-  cu_stream_destroy(e->streams.d2h);
+  // The per-array fields of e->lod / e->compress_agg.ar are views of the
+  // last-bound descriptor (freed above by destroy_array_descriptor).
+  stream_engine_destroy(&ms->engine);
 
   free(ms);
 }
@@ -803,16 +350,15 @@ multiarray_tile_stream_gpu_create(
     n_arrays, sizeof(struct array_descriptor_gpu));
   CHECK(Fail, ms->arrays);
 
-  // Phase 1: compute per-array layouts and pool maxima
-  struct pool_maxima mx;
-  memset(&mx, 0, sizeof(mx));
+  // Phase 1: per-array layouts, LOD state, shard state, and the
+  // shared-resource maxima.
+  struct engine_limits lim;
+  memset(&lim, 0, sizeof(lim));
 
   for (int a = 0; a < n_arrays; ++a)
     CHECK(Fail,
-          init_array_descriptor(&ms->arrays[a], &configs[a], sinks[a], &mx) ==
+          init_array_descriptor(&ms->arrays[a], &configs[a], sinks[a], &lim) ==
             0);
-
-  ms->max_nlod = mx.max_nlod;
 
   // Validate: all arrays must use the same codec (shared codec instance).
   for (int a = 1; a < n_arrays; ++a) {
@@ -822,22 +368,6 @@ multiarray_tile_stream_gpu_create(
       goto Fail;
     }
   }
-
-  // Phase 2: upload per-array aggregate layouts to GPU
-  for (int a = 0; a < n_arrays; ++a) {
-    struct array_descriptor_gpu* desc = &ms->arrays[a];
-    for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv)
-      CHECK(Fail, aggregate_layout_upload(&desc->st.agg.per_lod_agg_layouts[lv]) == 0);
-  }
-
-  // Phase 3: allocate shared GPU resources
-  // (Per-array L0 layout_gpu is aliased from array_lod.layout_gpu[0], which
-  // was uploaded during lod_state_init in init_array_descriptor.)
-  CHECK(Fail, init_shared_resources(ms, &mx) == 0);
-
-  // Use synchronous flush path — the double-buffered pipeline doesn't
-  // compose across array switches.
-  ms->engine.sync_flush = 1;
 
   // Label scatter as "Copy" only when every array uses multiscale (matches
   // single-array GPU).  When any array is non-multiscale, the scatter kernel
@@ -849,10 +379,17 @@ multiarray_tile_stream_gpu_create(
       break;
     }
   }
-  ms->engine.metrics = stream_engine_init_metrics(all_multiscale);
-  stream_engine_attach_edge_stalls(&ms->engine);
-  ms->engine.metadata_update_clock = (struct platform_clock){ 0 };
-  platform_toc(&ms->engine.metadata_update_clock);
+
+  // Phase 2: allocate shared engine resources at the accumulated maxima.
+  CHECK(Fail,
+        stream_engine_init(&ms->engine,
+                           &lim,
+                           ms->arrays[0].ctx.config.codec.id,
+                           all_multiscale) == 0);
+
+  // Use synchronous flush path — the double-buffered pipeline doesn't
+  // compose across array switches.
+  ms->engine.sync_flush = 1;
 
   return ms;
 

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -89,9 +89,8 @@ unbind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
 {
   drain_d2h_for_array(e, desc);
 
-  // Snapshot the per-array state back wholesale (shard_state, append
-  // accumulator counts, flush pipeline, and batch bookkeeping all mutate
-  // over a batch).
+  // Wholesale: shard_state, accumulator counts, flush pipeline, and batch
+  // bookkeeping all mutate over a batch.
   desc->st.batch = e->batch;
   desc->st.pool_current = e->pools.current;
   desc->st.flush = e->flush;
@@ -350,8 +349,6 @@ multiarray_tile_stream_gpu_create(
     n_arrays, sizeof(struct array_descriptor_gpu));
   CHECK(Fail, ms->arrays);
 
-  // Phase 1: per-array layouts, LOD state, shard state, and the
-  // shared-resource maxima.
   struct engine_limits lim;
   memset(&lim, 0, sizeof(lim));
 
@@ -380,7 +377,6 @@ multiarray_tile_stream_gpu_create(
     }
   }
 
-  // Phase 2: allocate shared engine resources at the accumulated maxima.
   CHECK(Fail,
         stream_engine_init(&ms->engine,
                            &lim,

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -17,7 +17,7 @@
 #include <string.h>
 
 // ---- Per-array descriptor ----
-// Extends stream_context with mutable per-array state that is swapped
+// Extends stream_context with the per-array engine state that is swapped
 // into/out of the engine on array switch.
 
 struct array_descriptor_gpu
@@ -25,35 +25,11 @@ struct array_descriptor_gpu
   struct stream_context ctx;
   struct computed_stream_layouts cl; // owned, freed on destroy
 
-  // Per-array LOD state (owns plan, layouts[], layout_gpu[], CSRs, append
-  // accumulator device memory, and LOD LUTs — but NOT d_linear/d_morton/timing,
-  // which are shared and owned by the engine).
-  struct lod_state array_lod;
-
-  // Mutable per-array state (saved/restored via bind/unbind)
-  uint32_t batch_accumulated;
-  int pools_current;
-  struct flush_slot_gpu flush_slots[2];
-  int flush_pending[2];
-  uint64_t flush_pending_seq[2];
-  uint64_t flush_next_seq;
-  struct flush_handoff flush_pending_handoff[2];
-  struct aggregate_layout agg_layout[LOD_MAX_LEVELS];
-  uint32_t batch_active_count[LOD_MAX_LEVELS];
-
-  // Per-array unified state. total_shards = sum_lv num_shards[lv]; tail
-  // buffers contiguous over all shards in this array. Bind swaps these
-  // into compress_agg_stage.{per_lod_agg_layouts, shard, shards}.
-  uint64_t u_total_shards;
-  uint32_t u_shards_begin[LOD_MAX_LEVELS];
-  uint32_t u_n_shards[LOD_MAX_LEVELS];
-  size_t u_page_size;
-  size_t u_tail_carry_bytes;
-  size_t* u_d_tail_bytes;
-  CUdeviceptr u_d_tail_carry;
-  size_t* u_h_tail_bytes;
-  size_t* u_h_shard_capacity;
-  struct shard_state u_shard[LOD_MAX_LEVELS];
+  // Whole-struct swapped on bind/unbind. st.lod owns plan, layouts[],
+  // layout_gpu[], CSRs, append accumulator device memory, and LOD LUTs — but
+  // NOT d_linear/d_morton/timing, which are shared and owned by the engine.
+  // st.agg owns per-LOD layouts, shard_state, and the per-array tail buffers.
+  struct engine_array_state st;
 
   int flushed; // 1 once flush body has run for this array
 };
@@ -146,55 +122,28 @@ drain_d2h_for_array(struct stream_engine* e, struct array_descriptor_gpu* desc)
 static void
 bind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
 {
-  // Set batch K from the array's own config, not the engine max.
-  // Shared buffers are sized to max K, but each array should fill/flush at
-  // its own K so that batch_active_count and active_count agree.
-  e->batch.epochs_per_batch = desc->cl.epochs_per_batch;
-  e->batch.accumulated = desc->batch_accumulated;
-  e->pools.current = desc->pools_current;
-  for (int i = 0; i < 2; ++i) {
-    e->flush.slot[i] = desc->flush_slots[i];
-    e->flush.pending[i] = desc->flush_pending[i];
-    e->flush.pending_seq[i] = desc->flush_pending_seq[i];
-    e->flush.pending_handoff[i] = desc->flush_pending_handoff[i];
-  }
-  e->flush.next_seq = desc->flush_next_seq;
+  // Whole-struct handoff. Shared engine resources (pools.buf, staging,
+  // agg[2], d_batch_gather/perm, lut scratch, shards.*, lod_shared) are
+  // sized to maxima and untouched. st.batch carries the array's own K so
+  // each array fills/flushes at its own batch size.
+  e->batch = desc->st.batch;
+  e->pools.current = desc->st.pool_current;
+  e->flush = desc->st.flush;
+  e->lod = desc->st.lod;
+  e->compress_agg.ar = desc->st.agg;
   e->d2h_deliver.shard_alignment = desc->ctx.shard_alignment;
 
-  // Unified-pipeline bind: swap per-array state into the engine. Engine
-  // buffers (agg[2], d_batch_gather/perm, h_lut_* scratch,
-  // d_*_offsets/_tps_group/_capacity) are sized to max and shared.
-  e->compress_agg.nlod = (uint8_t)desc->ctx.levels.nlod;
-  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-    e->compress_agg.per_lod_agg_layouts[lv] = desc->agg_layout[lv];
-    e->compress_agg.shard[lv] = desc->u_shard[lv];
-  }
-  e->compress_agg.shards.total_shards = desc->u_total_shards;
-  e->compress_agg.shards.page_size = desc->u_page_size;
-  e->compress_agg.shards.tail_carry_bytes = desc->u_tail_carry_bytes;
-  for (int lv = 0; lv < LOD_MAX_LEVELS; ++lv) {
-    e->compress_agg.shards.shards_begin[lv] = desc->u_shards_begin[lv];
-    e->compress_agg.shards.n_shards[lv] = desc->u_n_shards[lv];
-  }
-  e->compress_agg.shards.h_tail_bytes = desc->u_h_tail_bytes;
-  e->compress_agg.shards.d_tail_bytes = desc->u_d_tail_bytes;
-  e->compress_agg.shards.d_tail_carry = desc->u_d_tail_carry;
   // Per-array shard_capacity table is constant; re-upload on bind so the
   // device-side d_shard_capacity reflects the active array's shard sizes.
   // (h_base_offsets / h_tps_group / h_offsets_base are per-batch scratch,
   // refreshed by the kick.)
-  if (desc->u_total_shards > 0 && desc->u_h_shard_capacity) {
+  if (desc->st.agg.total_shards > 0 && desc->st.agg.h_shard_capacity) {
     cuMemcpyHtoD((CUdeviceptr)e->compress_agg.shards.d_shard_capacity,
-                 desc->u_h_shard_capacity,
-                 desc->u_total_shards * sizeof(size_t));
+                 desc->st.agg.h_shard_capacity,
+                 desc->st.agg.total_shards * sizeof(size_t));
   }
   // Invalidate the LUT cache: per-array layouts differ.
   e->compress_agg.lut_cache_valid = 0;
-
-  // Per-array LOD state is now a single struct assignment.  Shared LOD
-  // resources (d_linear, d_morton, timing) live in e->lod_shared and are
-  // untouched by bind/unbind — the type system enforces this.
-  e->lod = desc->array_lod;
 }
 
 static void
@@ -202,51 +151,18 @@ unbind_context(struct stream_engine* e, struct array_descriptor_gpu* desc)
 {
   drain_d2h_for_array(e, desc);
 
-  desc->batch_accumulated = e->batch.accumulated;
-  desc->pools_current = e->pools.current;
-  for (int i = 0; i < 2; ++i) {
-    desc->flush_slots[i] = e->flush.slot[i];
-    desc->flush_pending[i] = e->flush.pending[i];
-    desc->flush_pending_seq[i] = e->flush.pending_seq[i];
-    desc->flush_pending_handoff[i] = e->flush.pending_handoff[i];
-  }
-  desc->flush_next_seq = e->flush.next_seq;
-  // Snapshot per-array state back into the descriptor. shard_state mutates
-  // over a batch (epoch_in_shard, shard_epoch, writer pointers); preserve it.
-  for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv)
-    desc->u_shard[lv] = e->compress_agg.shard[lv];
-  // Clear engine-side per-array pointers so the next bind establishes them
-  // unambiguously. We zero everything that bind_context fills in so a stale
-  // pointer can't survive an unbind/destroy that isn't followed by a bind.
-  e->compress_agg.shards.d_tail_bytes = NULL;
-  e->compress_agg.shards.d_tail_carry = 0;
-  e->compress_agg.shards.h_tail_bytes = NULL;
-  e->compress_agg.shards.total_shards = 0;
-  e->compress_agg.shards.tail_carry_bytes = 0;
-  e->compress_agg.shards.page_size = 0;
-  memset(e->compress_agg.shards.shards_begin,
-         0,
-         sizeof(e->compress_agg.shards.shards_begin));
-  memset(e->compress_agg.shards.n_shards,
-         0,
-         sizeof(e->compress_agg.shards.n_shards));
-  for (int lv = 0; lv < LOD_MAX_LEVELS; ++lv) {
-    memset(&e->compress_agg.per_lod_agg_layouts[lv],
-           0,
-           sizeof(e->compress_agg.per_lod_agg_layouts[lv]));
-  }
-  e->compress_agg.nlod = 0;
+  // Snapshot the per-array state back wholesale (shard_state, append
+  // accumulator counts, flush pipeline, and batch bookkeeping all mutate
+  // over a batch).
+  desc->st.batch = e->batch;
+  desc->st.pool_current = e->pools.current;
+  desc->st.flush = e->flush;
+  desc->st.lod = e->lod;
+  desc->st.agg = e->compress_agg.ar;
 
-  // Save per-array LOD state. counts[] tracks running append-accumulator
-  // state across epochs; element_capacity is the fixed accumulator buffer
-  // size set at init.
-  if (desc->ctx.levels.enable_multiscale) {
-    memcpy(desc->array_lod.append_accum.counts,
-           e->lod.append_accum.counts,
-           sizeof(desc->array_lod.append_accum.counts));
-    desc->array_lod.append_accum.element_capacity =
-      e->lod.append_accum.element_capacity;
-  }
+  // Clear the engine-side per-array slice so a stale pointer can't survive
+  // an unbind/destroy that isn't followed by a bind.
+  memset(&e->compress_agg.ar, 0, sizeof(e->compress_agg.ar));
 }
 
 // ---- Per-array init ----
@@ -278,19 +194,19 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
   // Initialize per-array LOD state: transfer plan from cl, copy layouts,
   // upload level layouts + LUTs + CSRs. Does NOT allocate d_linear/d_morton
   // or timing events — those are engine-owned shared resources.
-  desc->array_lod.plan = desc->cl.plan;
+  desc->st.lod.plan = desc->cl.plan;
   desc->cl.plan = (struct lod_plan){ 0 }; // ownership transferred
   for (int lv = 0; lv < desc->cl.levels.nlod; ++lv)
-    desc->array_lod.layouts[lv] = desc->cl.layouts[lv];
+    desc->st.lod.layouts[lv] = desc->cl.layouts[lv];
 
-  if (lod_state_init(&desc->array_lod, &desc->ctx.levels, &desc->ctx.config))
+  if (lod_state_init(&desc->st.lod, &desc->ctx.levels, &desc->ctx.config))
     return 1;
 
-  // Alias L0 layout GPU pointers from array_lod into ctx (for scatter).
-  desc->ctx.layout_gpu = desc->array_lod.layout_gpu[0];
+  // Alias L0 layout GPU pointers from st.lod into ctx (for scatter).
+  desc->ctx.layout_gpu = desc->st.lod.layout_gpu[0];
 
   if (desc->ctx.levels.enable_multiscale && desc->ctx.dims.append_downsample) {
-    if (lod_state_init_accumulators(&desc->array_lod, &desc->ctx.config))
+    if (lod_state_init_accumulators(&desc->st.lod, &desc->ctx.config))
       return 1;
   }
 
@@ -299,13 +215,19 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
   const uint64_t total_chunks = desc->ctx.levels.total_chunks;
   const uint64_t chunk_stride = desc->ctx.layout.chunk_stride;
 
+  // Batch K from the array's own config, not the engine max. Shared buffers
+  // are sized to max K, but each array fills/flushes at its own K so that
+  // batch_active_count and active_count agree.
+  desc->st.batch.epochs_per_batch = K;
+  desc->st.agg.nlod = (uint8_t)desc->ctx.levels.nlod;
+
   // Per-array, per-slot batch_active_masks. Bind/unbind copies the pointer
   // into the engine's flush slots; the storage lives here for the array's
   // lifetime.
   for (int fc = 0; fc < 2; ++fc) {
-    desc->flush_slots[fc].batch_active_masks =
+    desc->st.flush.slot[fc].batch_active_masks =
       (uint32_t*)calloc(K, sizeof(uint32_t));
-    if (!desc->flush_slots[fc].batch_active_masks)
+    if (!desc->st.flush.slot[fc].batch_active_masks)
       return 1;
   }
 
@@ -345,44 +267,44 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
     mx->any_multiscale = 1;
     size_t linear_bytes = desc->ctx.layout.epoch_elements * bpe;
     mx->lod_linear_bytes = max_sz(mx->lod_linear_bytes, linear_bytes);
-    uint64_t total_vals = desc->array_lod.plan.level_spans
-                            .ends[desc->array_lod.plan.levels.nlod - 1];
+    uint64_t total_vals = desc->st.lod.plan.level_spans
+                            .ends[desc->st.lod.plan.levels.nlod - 1];
     size_t morton_bytes = total_vals * bpe;
     mx->lod_morton_bytes = max_sz(mx->lod_morton_bytes, morton_bytes);
   }
 
   // Unified-pipeline per-array sizing.
-  desc->u_total_shards = 0;
-  desc->u_page_size = desc->cl.per_level[0].agg_layout.page_size;
+  desc->st.agg.total_shards = 0;
+  desc->st.agg.page_size = desc->cl.per_level[0].agg_layout.page_size;
   for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-    desc->u_shards_begin[lv] = (uint32_t)desc->u_total_shards;
-    desc->u_n_shards[lv] =
+    desc->st.agg.shards_begin[lv] = (uint32_t)desc->st.agg.total_shards;
+    desc->st.agg.n_shards[lv] =
       (uint32_t)desc->cl.per_level[lv].agg_layout.num_shards;
-    desc->u_total_shards += desc->cl.per_level[lv].agg_layout.num_shards;
+    desc->st.agg.total_shards += desc->cl.per_level[lv].agg_layout.num_shards;
   }
-  if (desc->u_total_shards > 0) {
-    desc->u_h_shard_capacity =
-      (size_t*)malloc(desc->u_total_shards * sizeof(size_t));
-    desc->u_h_tail_bytes =
-      (size_t*)calloc(desc->u_total_shards, sizeof(size_t));
-    if (!desc->u_h_shard_capacity || !desc->u_h_tail_bytes)
+  if (desc->st.agg.total_shards > 0) {
+    desc->st.agg.h_shard_capacity =
+      (size_t*)malloc(desc->st.agg.total_shards * sizeof(size_t));
+    desc->st.agg.h_tail_bytes =
+      (size_t*)calloc(desc->st.agg.total_shards, sizeof(size_t));
+    if (!desc->st.agg.h_shard_capacity || !desc->st.agg.h_tail_bytes)
       return 1;
-    for (uint64_t i = 0; i < desc->u_total_shards; ++i) {
+    for (uint64_t i = 0; i < desc->st.agg.total_shards; ++i) {
       for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-        if (i >= desc->u_shards_begin[lv] &&
-            i < desc->u_shards_begin[lv] + desc->u_n_shards[lv]) {
-          desc->u_h_shard_capacity[i] =
+        if (i >= desc->st.agg.shards_begin[lv] &&
+            i < desc->st.agg.shards_begin[lv] + desc->st.agg.n_shards[lv]) {
+          desc->st.agg.h_shard_capacity[i] =
             desc->cl.per_level[lv].agg_layout.shard_capacity;
           break;
         }
       }
     }
-    if (cuMemAlloc((CUdeviceptr*)&desc->u_d_tail_bytes,
-                   desc->u_total_shards * sizeof(size_t)) != CUDA_SUCCESS)
+    if (cuMemAlloc((CUdeviceptr*)&desc->st.agg.d_tail_bytes,
+                   desc->st.agg.total_shards * sizeof(size_t)) != CUDA_SUCCESS)
       return 1;
-    if (cuMemsetD8((CUdeviceptr)desc->u_d_tail_bytes,
+    if (cuMemsetD8((CUdeviceptr)desc->st.agg.d_tail_bytes,
                    0,
-                   desc->u_total_shards * sizeof(size_t)) != CUDA_SUCCESS)
+                   desc->st.agg.total_shards * sizeof(size_t)) != CUDA_SUCCESS)
       return 1;
     // Delivery's tail upload is a synchronous HtoD from pageable memory,
     // which may return before the DMA reaches the device; SYNC_MEMOPS makes
@@ -391,22 +313,22 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
     unsigned int sync_memops = 1;
     if (cuPointerSetAttribute(&sync_memops,
                               CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                              (CUdeviceptr)desc->u_d_tail_bytes) !=
+                              (CUdeviceptr)desc->st.agg.d_tail_bytes) !=
         CUDA_SUCCESS)
       return 1;
-    if (desc->u_page_size > 0) {
-      desc->u_tail_carry_bytes =
-        desc->u_total_shards * desc->u_page_size;
-      if (cuMemAlloc(&desc->u_d_tail_carry, desc->u_tail_carry_bytes) !=
+    if (desc->st.agg.page_size > 0) {
+      desc->st.agg.tail_carry_bytes =
+        desc->st.agg.total_shards * desc->st.agg.page_size;
+      if (cuMemAlloc(&desc->st.agg.d_tail_carry, desc->st.agg.tail_carry_bytes) !=
           CUDA_SUCCESS)
         return 1;
       if (cuMemsetD8(
-            desc->u_d_tail_carry, 0, desc->u_tail_carry_bytes) != CUDA_SUCCESS)
+            desc->st.agg.d_tail_carry, 0, desc->st.agg.tail_carry_bytes) != CUDA_SUCCESS)
         return 1;
-      // Same pageable-HtoD constraint as u_d_tail_bytes above.
+      // Same pageable-HtoD constraint as d_tail_bytes above.
       if (cuPointerSetAttribute(&sync_memops,
                                 CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                desc->u_d_tail_carry) != CUDA_SUCCESS)
+                                desc->st.agg.d_tail_carry) != CUDA_SUCCESS)
         return 1;
     }
   }
@@ -425,7 +347,7 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
                                     per_lod_layouts,
                                     per_lod_max,
                                     (uint8_t)desc->ctx.levels.nlod,
-                                    desc->u_page_size))
+                                    desc->st.agg.page_size))
       return 1;
   }
   mx->u_max_total_batch_chunks =
@@ -436,14 +358,13 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
   mx->u_max_total_data_bytes =
     max_sz(mx->u_max_total_data_bytes, array_max_layout.total_data_bytes);
   mx->u_max_total_shards =
-    max_u64(mx->u_max_total_shards, desc->u_total_shards);
+    max_u64(mx->u_max_total_shards, desc->st.agg.total_shards);
 
   // Per-LOD shard_state + agg_layout snapshot.
   for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
     const struct level_layout_info* li = &desc->cl.per_level[lv];
-    desc->agg_layout[lv] = li->agg_layout;
-    desc->batch_active_count[lv] = li->batch_active_count;
-    if (init_shard_state(&desc->u_shard[lv], li))
+    desc->st.agg.per_lod_agg_layouts[lv] = li->agg_layout;
+    if (init_shard_state(&desc->st.agg.shard[lv], li))
       return 1;
   }
 
@@ -456,21 +377,21 @@ destroy_array_descriptor(struct array_descriptor_gpu* desc)
   if (!desc)
     return;
   for (int fc = 0; fc < 2; ++fc) {
-    free(desc->flush_slots[fc].batch_active_masks);
-    desc->flush_slots[fc].batch_active_masks = NULL;
+    free(desc->st.flush.slot[fc].batch_active_masks);
+    desc->st.flush.slot[fc].batch_active_masks = NULL;
   }
   for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv) {
-    shard_state_destroy(&desc->u_shard[lv]);
-    aggregate_layout_destroy(&desc->agg_layout[lv]);
+    shard_state_destroy(&desc->st.agg.shard[lv]);
+    aggregate_layout_destroy(&desc->st.agg.per_lod_agg_layouts[lv]);
   }
-  free(desc->u_h_shard_capacity);
-  free(desc->u_h_tail_bytes);
-  cu_mem_free((CUdeviceptr)desc->u_d_tail_bytes);
-  cu_mem_free(desc->u_d_tail_carry);
-  // array_lod owns everything except d_linear/d_morton/timing (which stay 0
-  // in the per-array struct). ctx.layout_gpu aliases array_lod.layout_gpu[0]
-  // and is freed via array_lod destroy.
-  lod_state_destroy(&desc->array_lod);
+  free(desc->st.agg.h_shard_capacity);
+  free(desc->st.agg.h_tail_bytes);
+  cu_mem_free((CUdeviceptr)desc->st.agg.d_tail_bytes);
+  cu_mem_free(desc->st.agg.d_tail_carry);
+  // st.lod owns everything except d_linear/d_morton/timing (which stay 0
+  // in the per-array struct). ctx.layout_gpu aliases st.lod.layout_gpu[0]
+  // and is freed via st.lod destroy.
+  lod_state_destroy(&desc->st.lod);
   computed_stream_layouts_free(&desc->cl);
 }
 
@@ -734,7 +655,7 @@ flush_impl(struct multiarray_writer* self)
     // arrives.
     if (desc->flushed)
       continue;
-    if (desc->ctx.cursor_elements == 0 && desc->batch_accumulated == 0) {
+    if (desc->ctx.cursor_elements == 0 && desc->st.batch.accumulated == 0) {
       desc->flushed = 1;
       continue;
     }
@@ -906,7 +827,7 @@ multiarray_tile_stream_gpu_create(
   for (int a = 0; a < n_arrays; ++a) {
     struct array_descriptor_gpu* desc = &ms->arrays[a];
     for (int lv = 0; lv < desc->ctx.levels.nlod; ++lv)
-      CHECK(Fail, aggregate_layout_upload(&desc->agg_layout[lv]) == 0);
+      CHECK(Fail, aggregate_layout_upload(&desc->st.agg.per_lod_agg_layouts[lv]) == 0);
   }
 
   // Phase 3: allocate shared GPU resources

--- a/src/zarr/shard_delivery.c
+++ b/src/zarr/shard_delivery.c
@@ -54,6 +54,23 @@ init_shard_state(struct shard_state* ss, const struct level_layout_info* li)
   return 0;
 }
 
+// Host heap bytes init_shard_state allocates for this level. Must mirror
+// the allocations above exactly — tile_stream_gpu_memory_estimate sums this.
+size_t
+shard_state_heap_bytes(const struct level_layout_info* li)
+{
+  size_t bytes = li->shard_inner_count * sizeof(struct active_shard);
+  const size_t page = li->agg_layout.page_size;
+  if (page > 0 && li->shard_inner_count > 0) {
+    bytes += (size_t)li->shard_inner_count * page; // tail_buf_pool
+    bytes += (size_t)li->shard_inner_count *
+             footer_capacity_for(li->chunks_per_shard_total, page);
+  }
+  bytes +=
+    li->shard_inner_count * (li->chunks_per_shard_total * 2 * sizeof(uint64_t));
+  return bytes;
+}
+
 void
 shard_state_destroy(struct shard_state* ss)
 {

--- a/src/zarr/shard_delivery.h
+++ b/src/zarr/shard_delivery.h
@@ -59,6 +59,10 @@ init_shard_state(struct shard_state* ss, const struct level_layout_info* li);
 void
 shard_state_destroy(struct shard_state* ss);
 
+// Sizing mirror of init_shard_state, for the memory estimate.
+size_t
+shard_state_heap_bytes(const struct level_layout_info* li);
+
 // Best-effort finalize of every shard with an open writer. Returns 0 on
 // success. Calls sink->wait_fence/record_fence on each shard's footer to
 // keep the footer_buf reuse cycle correct.

--- a/tests/test_compress_agg.c
+++ b/tests/test_compress_agg.c
@@ -42,7 +42,7 @@ static void
 ca_ctx_destroy(struct ca_test_ctx* c)
 {
   if (c->stage_inited)
-    compress_agg_destroy(&c->stage, c->cl.levels.nlod);
+    compress_agg_destroy(&c->stage);
   if (c->ord_inited)
     gpu_ordering_destroy(&c->ord);
   computed_stream_layouts_free(&c->cl);
@@ -300,7 +300,7 @@ test_compress_agg_single_epoch(void)
     // Each shard's data starts at s * shard_capacity in h_agg.
     const struct aggregate_layout* al = &handoff.per_lod_agg_layouts[0];
     uint64_t num_shards = C / al->cps_inner;
-    uint64_t N = (uint64_t)c.stage.per_lod_agg_layouts[0].active_count_max *
+    uint64_t N = (uint64_t)c.stage.ar.per_lod_agg_layouts[0].active_count_max *
                  c.cl.levels.level[0].chunk_count;
     CHECK(Fail, lv_offsets[C] == N * chunk_bytes);
     for (uint64_t s = 0; s < num_shards; ++s)
@@ -351,7 +351,7 @@ test_compress_agg_batch(void)
   const size_t* lv_offsets =
     handoff.agg->h_offsets + seg->batch_covering_offset + 0;
   uint64_t C = al->covering_count;
-  uint32_t batch_count = c.stage.per_lod_agg_layouts[0].active_count_max;
+  uint32_t batch_count = c.stage.ar.per_lod_agg_layouts[0].active_count_max;
   uint64_t batch_covering = (uint64_t)batch_count * C;
 
   CHECK(Fail, ca_ctx_fetch_agg(&handoff, batch_covering, &h_agg) == 0);
@@ -595,7 +595,7 @@ test_compress_agg_zstd_batch(void)
   const size_t* lv_offsets =
     handoff.agg->h_offsets + seg->batch_covering_offset + 0;
   uint64_t C = al->covering_count;
-  uint32_t batch_count = c.stage.per_lod_agg_layouts[0].active_count_max;
+  uint32_t batch_count = c.stage.ar.per_lod_agg_layouts[0].active_count_max;
   uint64_t batch_covering = (uint64_t)batch_count * C;
 
   CHECK(Fail, ca_ctx_fetch_agg(&handoff, batch_covering, &h_agg) == 0);

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -51,7 +51,7 @@ test_ctx_destroy(struct test_ctx* c)
   if (c->d2h_inited)
     d2h_deliver_destroy(&c->d2h);
   if (c->ca_inited)
-    compress_agg_destroy(&c->ca, c->cl.levels.nlod);
+    compress_agg_destroy(&c->ca);
   if (c->ord_inited)
     gpu_ordering_destroy(&c->ord);
   computed_stream_layouts_free(&c->cl);
@@ -296,7 +296,7 @@ test_d2h_batch_none(void)
   // Parse finalized shard: index block at end
   // chunks_per_shard_total = 8, index = 8 * 16 bytes + 4 byte CRC
   {
-    struct shard_state* ss = &c.ca.shard[0];
+    struct shard_state* ss = &c.ca.ar.shard[0];
     uint64_t tps_total = ss->chunks_per_shard_total;
     size_t index_data_bytes = tps_total * 2 * sizeof(uint64_t);
     size_t index_total_bytes = index_data_bytes + 4;
@@ -309,8 +309,8 @@ test_d2h_batch_none(void)
 
     // Shard output layout: [num_shards, batch_count, cps_inner] row-major.
     // Slot → (si, epoch, ci) via unravel, then perm_pos = si * cps_inner + ci.
-    const struct aggregate_layout* al = &c.ca.per_lod_agg_layouts[0];
-    uint32_t batch_count = c.ca.per_lod_agg_layouts[0].active_count_max;
+    const struct aggregate_layout* al = &c.ca.ar.per_lod_agg_layouts[0];
+    uint32_t batch_count = c.ca.ar.per_lod_agg_layouts[0].active_count_max;
     uint32_t cps_inner = (uint32_t)al->cps_inner;
     uint32_t num_shards = (uint32_t)(al->covering_count / cps_inner);
     uint64_t chunks_lv = c.cl.levels.level[0].chunk_count;
@@ -439,7 +439,7 @@ test_d2h_zstd_single_epoch(void)
 
   // Decompress and verify chunk data via the on-disk index.
   {
-    struct shard_state* ss = &c.ca.shard[0];
+    struct shard_state* ss = &c.ca.ar.shard[0];
     uint64_t tps_total = ss->chunks_per_shard_total;
     size_t index_data_bytes = tps_total * 2 * sizeof(uint64_t);
     size_t index_total_bytes = index_data_bytes + 4;
@@ -449,7 +449,7 @@ test_d2h_zstd_single_epoch(void)
     const uint64_t* idx =
       (const uint64_t*)(sink.writers[0][0].buf + index_start);
 
-    const struct aggregate_layout* al = &c.ca.per_lod_agg_layouts[0];
+    const struct aggregate_layout* al = &c.ca.ar.per_lod_agg_layouts[0];
     uint64_t cps_inner = ss->chunks_per_shard_inner;
 
     decomp_buf = (uint8_t*)malloc(chunk_bytes);
@@ -577,7 +577,7 @@ test_d2h_double_buffer(void)
 
   // Parse finalized shard and verify both epochs' data
   {
-    struct shard_state* ss = &c.ca.shard[0];
+    struct shard_state* ss = &c.ca.ar.shard[0];
     uint64_t tps_total = ss->chunks_per_shard_total;
     size_t index_data_bytes = tps_total * 2 * sizeof(uint64_t);
     size_t index_total_bytes = index_data_bytes + 4;
@@ -587,7 +587,7 @@ test_d2h_double_buffer(void)
     const uint64_t* idx =
       (const uint64_t*)(sink.writers[0][0].buf + index_start);
 
-    const struct aggregate_layout* al = &c.ca.per_lod_agg_layouts[0];
+    const struct aggregate_layout* al = &c.ca.ar.per_lod_agg_layouts[0];
     uint64_t cps_inner = ss->chunks_per_shard_inner;
 
     int errors = 0;
@@ -753,12 +753,12 @@ test_d2h_zstd_double_buffer(void)
   CHECK(Fail, sink.finalize_count == 2);
 
   {
-    struct shard_state* ss = &c.ca.shard[0];
+    struct shard_state* ss = &c.ca.ar.shard[0];
     uint64_t tps_total = ss->chunks_per_shard_total;
     size_t index_data_bytes = tps_total * 2 * sizeof(uint64_t);
     size_t index_total_bytes = index_data_bytes + 4;
 
-    const struct aggregate_layout* al = &c.ca.per_lod_agg_layouts[0];
+    const struct aggregate_layout* al = &c.ca.ar.per_lod_agg_layouts[0];
     uint64_t cps_inner = ss->chunks_per_shard_inner;
 
     decomp_buf = (uint8_t*)malloc(chunk_bytes);

--- a/tests/test_flush_orchestration.c
+++ b/tests/test_flush_orchestration.c
@@ -42,7 +42,7 @@ orch_ctx_destroy(struct orch_ctx* c)
     }
 
     d2h_deliver_destroy(&c->s->engine.d2h_deliver);
-    compress_agg_destroy(&c->s->engine.compress_agg, c->cl.levels.nlod);
+    compress_agg_destroy(&c->s->engine.compress_agg);
 
     // Pools
     for (int i = 0; i < 2; ++i)
@@ -383,7 +383,7 @@ test_accumulated_sync_partial(void)
   // rather than on-disk size.
   CHECK(Fail, sink.open_count >= 1);
   {
-    struct shard_state* ss = &c.s->engine.compress_agg.shard[0];
+    struct shard_state* ss = &c.s->engine.compress_agg.ar.shard[0];
     struct active_shard* sh = &ss->shards[0];
     CHECK(Fail, sh->tail_bytes > 0);
   }


### PR DESCRIPTION
Step 2 of the migration in `docs/gpu-orchestration.md` ("Unify init/teardown
and multiarray binding"), following #143. Behavior-neutral; net −150 LOC
(+1021/−1171 across 21 files).

## Why

The single-array engine and the multiarray path built the same engine three
ways: multiarray hand-reimplemented stage allocation (including a
field-by-field near-copy of `compress_agg_destroy`), context-switched arrays
through a ~45-assignment bind/unbind checklist that taxed every engine
change, and `tile_stream_gpu_memory_estimate` re-stated every allocation by
hand — and had drifted.

## What

- **Group per-array engine state** — per-array state becomes
  `struct compress_agg_array` + `struct engine_array_state` {batch,
  pool_current, flush, lod, agg}. Bind/unbind drops from the ~45-assignment
  two-way checklist (~105 lines) to five whole-struct assignments plus two
  fixups (capacity upload, LUT-cache invalidate); multiarray's
  `bind_context` is now 7 lines. New per-array fields ride the swap
  automatically.
- **Unify engine init and teardown** — shared `stream_engine_init/destroy`,
  `engine_array_state_init/destroy`, and split
  `compress_agg_init_shared/array_init` used by both paths.
  `src/multiarray/stream.gpu.c`: 956 → 414 lines. The genuine single-vs-
  multiarray differences survive as five explicit parameters (sizing source
  via `engine_limits_accumulate`, tail-gate on/off, `sync_flush`, scatter
  metric label, per-array capacity upload at bind); everything else was
  accidental duplication. One real waste removed: multiarray allocated
  `d_compressed` even for CODEC_NONE (never read — aggregate reads the pool
  directly); both paths now skip it.
- **Derive gpu memory estimate from init** — the 190-line hand mirror is
  replaced by sums of the same sizing functions the allocator calls
  (`codec_device_bytes`, `aggregate_batch_slot_memory`,
  `compress_agg_memory_estimate`, `lod_state_device_bytes`,
  `shard_state_heap_bytes`, …), each placed next to its allocation.

## Estimate drift found (and fixed by derivation)

The old estimate modeled a previous generation of the allocator: it omitted
all five per-shard device tables, `d_tail_carry`, and the L0 morton-chunk
LUT; gated LUT sizing on K>1 (the buffers always exist); and hardcoded
`2*(rank−1)` where the actual lifted rank is `2*(rank−n_append)`.
Measured: `256cube_multiscale` device estimate 10.27 → 10.34 GiB and
`orca2_multiscale` 6.67 → 6.69 GiB (same LOD-block root cause); other
bench scenarios unchanged at display precision. Bench-chosen configurations
are identical before/after — reporting accuracy only.

## Evidence (L40, sm_89)

- `ctest -E "(s3)"`: 46/46 in RelWithDebInfo **and** Debug;
  `test_cross_validate` ×8 (determinism, zstd round-trip, page-aligned
  tail-carry all 8/8).
- Multiarray explicitly: `test_multiarray_gpu` both configs;
  `bench_stream_256cube_two_streams` zstd + none; Debug run clean of
  ordering asserts.
- Zero new build warnings.

## Commit guide

- `Group per-array engine state` — the one-struct bind.
- `Unify engine init and teardown` — shared construction; multiarray's
  duplicate init/destroy deleted.
- `Derive gpu memory estimate from init` — single source of truth for
  sizing; deletes the drifted mirror.

