### PR TITLE
Drain sink IO in CPU writer_flush

### DIFF
--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -322,9 +322,6 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
       }
     }
 
-    // finalize_shards queues footer write_direct jobs that reference
-    // stream-owned footer_buf memory; stream destroy frees it, so flush
-    // must not return while those jobs are pending. Mirrors the GPU body.
     if (shard_sink_drain(v->sink))
       return writer_error();
 

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -322,6 +322,12 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
       }
     }
 
+    // finalize_shards queues footer write_direct jobs that reference
+    // stream-owned footer_buf memory; stream destroy frees it, so flush
+    // must not return while those jobs are pending. Mirrors the GPU body.
+    if (shard_sink_drain(v->sink))
+      return writer_error();
+
     float emit_ms = (float)(platform_toc(&emit_clk) * 1000.0);
     if (v->metrics)
       accumulate_metric_ms(&v->metrics->sink, emit_ms, 0, 0);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -176,6 +176,7 @@ target_compile_definitions(
 add_gpu_test_exe(test_zarr_fs_sink   test_zarr_fs_sink.c   LINKS CUDA::cuda_driver CUDA::cudart_static test_zarr_helpers stream Zstd::Zstd test_platform test_shard_verify test_voxel_encode)
 add_gpu_test_exe(test_destroy_drain  test_destroy_drain.c  LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
 add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
+add_test_exe(test_flush_drain_cpu test_flush_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
 add_gpu_test_exe(test_multiarray_flush_mock  test_multiarray_flush_mock.c  LINKS CUDA::cuda_driver CUDA::cudart_static multiarray_gpu stream writer chucky_log)
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   zarr_array ngff_multiscale zarr_group zarr_metadata store_s3 store_api lod_plan dimension platform_cmd chucky_log)
 add_test_exe(test_store_s3       test_store_s3.c       store_s3 store_api platform_cmd chucky_log)

--- a/tests/test_flush_drain_cpu.c
+++ b/tests/test_flush_drain_cpu.c
@@ -1,0 +1,199 @@
+// Regression test: writer_flush() on the CPU stream must drain sink IO
+// before returning. finalize_shards queues footer write_direct jobs that
+// reference stream-owned footer_buf memory; without the drain, stream
+// destroy frees that memory while the IO worker may still read it.
+
+#include "platform/platform.h"
+#include "store.h"
+#include "stream.cpu.h"
+#include "test_platform.h"
+#include "util/prelude.h"
+#include "writer.h"
+#include "zarr/shard_pool.h"
+#include "zarr/shard_pool_fs.h"
+#include "zarr/zarr_array.h"
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DRAIN_OBSERVE_MS 200
+#define POST_RELEASE_TIMEOUT_MS 5000
+#define POLL_STEP_MS 10
+
+struct flush_args
+{
+  struct writer* w;
+  _Atomic int done;
+  int error;
+};
+
+static void
+flush_thread_fn(void* arg)
+{
+  struct flush_args* fa = (struct flush_args*)arg;
+  struct writer_result r = writer_flush(fa->w);
+  fa->error = r.error;
+  atomic_store(&fa->done, 1);
+}
+
+static int
+wait_for_done(_Atomic int* done, int timeout_ms)
+{
+  int waited_ms = 0;
+  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
+    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
+    waited_ms += POLL_STEP_MS;
+  }
+  return atomic_load(done) != 0 ? 0 : -1;
+}
+
+static int
+test_flush_waits_for_sink_io(const char* tmpdir)
+{
+  log_info("=== test_flush_waits_for_sink_io (cpu) ===");
+
+  // Unbounded append dim with chunks_per_shard=2 and one appended epoch:
+  // the shard is partial at flush time, so writer_flush's finalize_shards
+  // queues the footer write_direct behind the injected gate.
+  struct dimension dims[3] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 2,
+      .name = "t",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  const size_t epoch_elements = 8 * 8;
+
+  struct store* store = NULL;
+  struct shard_pool* pool = NULL;
+  struct zarr_array* arr = NULL;
+  struct tile_stream_cpu* s = NULL;
+  uint16_t* src = NULL;
+  test_thread* thr = NULL;
+  int rc = 1;
+  _Atomic int gate;
+  atomic_store(&gate, 0);
+
+  store = store_fs_create(tmpdir, /*unbuffered=*/1);
+  CHECK(Cleanup, store);
+  CHECK(Cleanup, store->mkdirs(store, ".") == 0);
+  CHECK(Cleanup, store->mkdirs(store, "0") == 0);
+
+  pool = store->create_pool(store, 8);
+  CHECK(Cleanup, pool);
+
+  struct zarr_array_config acfg = {
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  arr = zarr_array_create_with_pool(store, pool, 0, "0", &acfg);
+  CHECK(Cleanup, arr);
+
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = epoch_elements * sizeof(uint16_t),
+    .epochs_per_batch = 1,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  s = tile_stream_cpu_create(&cfg, zarr_array_as_shard_sink(arr));
+  CHECK(Cleanup, s);
+
+  src = (uint16_t*)calloc(epoch_elements, sizeof(uint16_t));
+  CHECK(Cleanup, src);
+
+  {
+    struct slice input = { .beg = src, .end = src + epoch_elements };
+    struct writer_result r = writer_append(tile_stream_cpu_writer(s), input);
+    CHECK(Cleanup, r.error == 0);
+  }
+
+  // Gate sits in the io_queue ahead of the footer jobs the flush will queue
+  // behind it.
+  CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+
+  struct flush_args fa = { .w = tile_stream_cpu_writer(s) };
+  atomic_store(&fa.done, 0);
+  CHECK(Cleanup, test_thread_start(&thr, flush_thread_fn, &fa) == 0);
+
+  platform_sleep_ns((int64_t)DRAIN_OBSERVE_MS * 1000000LL);
+  int flush_returned_early = (atomic_load(&fa.done) != 0);
+
+  atomic_store(&gate, 1);
+
+  if (wait_for_done(&fa.done, POST_RELEASE_TIMEOUT_MS)) {
+    log_error("flush did not finish within %d ms after gate release",
+              POST_RELEASE_TIMEOUT_MS);
+    goto Cleanup;
+  }
+
+  test_thread_join(thr);
+  thr = NULL;
+
+  if (flush_returned_early) {
+    log_error("flush returned before sink IO drained — fix is not in place");
+    goto Cleanup;
+  }
+
+  if (fa.error) {
+    log_error("flush returned error %d", fa.error);
+    goto Cleanup;
+  }
+
+  if (zarr_array_has_error(arr)) {
+    log_error("zarr_array reported IO error after drain");
+    goto Cleanup;
+  }
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  free(src);
+  tile_stream_cpu_destroy(s);
+  test_thread_join(thr);
+  zarr_array_destroy(arr);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return rc;
+}
+
+int
+main(int ac, char* av[])
+{
+  (void)ac;
+  (void)av;
+
+  int ecode = 0;
+  char tmpdir[4096];
+  CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  log_info("temp dir: %s", tmpdir);
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/flush_drain_cpu", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_flush_waits_for_sink_io(sub);
+  }
+
+  test_tmpdir_remove(tmpdir);
+
+Fail:
+  return ecode;
+}


### PR DESCRIPTION
Closes #145.

## What

`cpu_stream_flush_body` returned with the final-flush shard footers still
queued in the sink's IO queue. Those footer writes are `write_direct` jobs
that *reference* the stream-owned `footer_buf`; a subsequent
`tile_stream_cpu_destroy` freed that memory while the IO worker could still
be parked before the write — a use-after-free whose freed bytes land on
disk in the footer region (leading bytes = the last chunk's sub-page tail,
which is why #145's CI failure corrupted exactly one chunk while index/CRC
stayed intact).

Fix mirrors the GPU body (`shard_sink_drain` after the `finalize_shards`
loop — the GPU got this in #115/#111; the CPU body never did, and #125's
switch to buffer-referencing footers turned the missing drain from a
durability gap into corruption). This also makes CPU `writer_flush` a
commit point (parity with #115) and covers the multiarray CPU path, which
flushes per-array through the same body.

## Proof (full matrix on #145)

With a 20 ms worker delay at upstream/main: ASAN reports the
use-after-free deterministically (3/3); delay + `MALLOC_PERTURB_=85` →
**0/30 pass**, all failures in final-flush footers. With the fix: 100/100
under both amplifications, ASAN clean.

## Regression test

`tests/test_flush_drain_cpu.c` — CPU twin of `test_flush_drain_gpu.c`
(#115): injects a gated blocking job into the pool's io_queue, runs
`writer_flush` on a second thread, and asserts it does not return before
the gate releases (geometry leaves a partial shard so a footer is queued
behind the gate). Deterministically red on unfixed main, green with the
fix — no timing-luck dependence.

## Validation

- CPU-only build: full ctest 29/29 (incl. the new test); 200/200 loops of
  `test_cpu_zarr_fs`.
- Full GPU build (sm_89, L40): ctest 47/47; build warnings identical to
  main.

The error-path variant (flush failing between queueing a footer and the
drain, both backends) is tracked separately — see follow-up issue.
