### PR TITLE
Carry buffer ordering in resource pools

### DIFF
--- a/src/gpu/CMakeLists.txt
+++ b/src/gpu/CMakeLists.txt
@@ -13,6 +13,7 @@ add_src_lib(stream
         stream.lod.c stream.lod.h
         stream.internal.h
         ordering.c ordering.h
+        pool.c pool.h
         flush.compress_agg.c flush.compress_agg.h
         flush.d2h_deliver.c flush.d2h_deliver.h
         flush.handoff.h flush.helpers.h

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -49,6 +49,16 @@ compress_agg_init_shared(struct compress_agg_stage* stage,
 {
   memset(stage, 0, sizeof(*stage));
   stage->ord = ord;
+  gpu_pool_init(
+    &stage->agg_pool, ord, GPU_EDGE_AGG_DONE, GPU_EDGE_SLOT_DRAINED);
+  gpu_pool_init(&stage->agg_host, ord, GPU_EDGE_D2H_DONE, GPU_EDGE_COUNT);
+  gpu_pool_init(
+    &stage->agg_index, ord, GPU_EDGE_CHUNK_INDEX_READY, GPU_EDGE_COUNT);
+  for (int fc = 0; fc < 2; ++fc) {
+    gpu_pool_bind(&stage->agg_pool, fc, &stage->agg[fc]);
+    gpu_pool_bind(&stage->agg_host, fc, &stage->agg[fc]);
+    gpu_pool_bind(&stage->agg_index, fc, &stage->agg[fc]);
+  }
 
   const uint32_t K = lim->epochs_per_batch;
   const uint64_t M = lim->codec_batch;
@@ -589,13 +599,14 @@ Error:
   return 1;
 }
 
-// GPU_EDGE_SLOT_DRAINED: aggregate must not overwrite agg[fc].d_aggregated
-// before the prior D2H on the same fc has read it (seeded at init).
+// The aggregate slot's produce-acquire (SLOT_DRAINED): aggregate must not
+// overwrite agg[fc] before the prior D2H on the same fc has read it.
 static int
 acquire_inputs(struct compress_agg_stage* stage,
                const struct compress_agg_input* in,
                CUstream compress_stream,
-               struct gpu_pool_view* pool_buf)
+               struct gpu_pool_view* pool_buf,
+               struct aggregate_slot** slot)
 {
   CHECK(Error,
         gpu_pool_acquire_consume(in->pool, in->fc, compress_stream, pool_buf) ==
@@ -605,9 +616,11 @@ acquire_inputs(struct compress_agg_stage* stage,
     CHECK(Error,
           gpu_edge_wait(
             stage->ord, GPU_EDGE_LOD_DONE, in->fc, compress_stream) == 0);
+  struct gpu_pool_view v;
   CHECK(Error,
-        gpu_edge_wait(
-          stage->ord, GPU_EDGE_SLOT_DRAINED, in->fc, compress_stream) == 0);
+        gpu_pool_acquire_produce(
+          &stage->agg_pool, in->fc, compress_stream, &v) == 0);
+  *slot = v.p;
   return 0;
 
 Error:
@@ -669,6 +682,7 @@ static int
 dispatch_aggregate(struct compress_agg_stage* stage,
                    const struct batch_aggregate_layout* layout,
                    int fc,
+                   struct aggregate_slot* slot,
                    CUdeviceptr d_aggregate_src,
                    CUstream compress_stream)
 {
@@ -684,7 +698,7 @@ dispatch_aggregate(struct compress_agg_stage* stage,
             layout->total_batch_covering,
             stage->ar.nlod,
             stage->codec.max_output_size,
-            &stage->agg[fc],
+            slot,
             stage->shards.d_base_offsets,
             stage->shards.d_shard_capacity,
             stage->shards.d_tps_group,
@@ -699,8 +713,7 @@ dispatch_aggregate(struct compress_agg_stage* stage,
   // Also releases the chunk pool for re-zero: POOL_CONSUMED aliases this
   // record (#140).
   CHECK(Error,
-        gpu_edge_record(stage->ord, GPU_EDGE_AGG_DONE, fc, compress_stream) ==
-          0);
+        gpu_pool_release_produce(&stage->agg_pool, fc, compress_stream) == 0);
   return 0;
 
 Error:
@@ -728,7 +741,9 @@ fill_handoff(struct compress_agg_stage* stage,
   out->t_compress_end = stage->t_compress_end[fc];
   out->max_output_size = stage->codec.max_output_size;
   out->passthrough = (stage->codec.type == CODEC_NONE);
-  out->agg = &stage->agg[fc];
+  out->agg_pool = &stage->agg_pool;
+  out->agg_host = &stage->agg_host;
+  out->agg_index = &stage->agg_index;
   out->layout = *layout;
   out->per_lod_agg_layouts = stage->ar.per_lod_agg_layouts;
   out->shards = &stage->ar;
@@ -759,7 +774,9 @@ compress_agg_kick(struct compress_agg_stage* stage,
   CHECK(Error,
         build_and_upload_shard_tables(stage, &layout, compress_stream) == 0);
   struct gpu_pool_view pool_buf;
-  CHECK(Error, acquire_inputs(stage, in, compress_stream, &pool_buf) == 0);
+  struct aggregate_slot* slot = NULL;
+  CHECK(Error,
+        acquire_inputs(stage, in, compress_stream, &pool_buf, &slot) == 0);
 
   CUdeviceptr d_aggregate_src = 0;
   CHECK(Error,
@@ -768,7 +785,7 @@ compress_agg_kick(struct compress_agg_stage* stage,
   CHECK(Error, arm_tail_gate(stage, &layout, compress_stream) == 0);
   CHECK(Error,
         dispatch_aggregate(
-          stage, &layout, in->fc, d_aggregate_src, compress_stream) == 0);
+          stage, &layout, in->fc, slot, d_aggregate_src, compress_stream) == 0);
   fill_handoff(stage, in, &layout, per_lod_n_active, out);
   return 0;
 

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -59,6 +59,9 @@ compress_agg_init_shared(struct compress_agg_stage* stage,
     gpu_pool_bind(&stage->agg_host, fc, &stage->agg[fc]);
     gpu_pool_bind(&stage->agg_index, fc, &stage->agg[fc]);
   }
+  gpu_pool_init(&stage->tail, ord, GPU_EDGE_TAIL_PUBLISHED, GPU_EDGE_COUNT);
+  // &stage->ar is stable across multiarray binds (swapped by value).
+  gpu_pool_bind(&stage->tail, 0, &stage->ar);
 
   const uint32_t K = lim->epochs_per_batch;
   const uint64_t M = lim->codec_batch;
@@ -169,7 +172,7 @@ compress_agg_destroy_shared(struct compress_agg_stage* stage)
   if (stage->ord && gpu_ordering_gate_active(stage->ord)) {
     // An undrained kick (failed flush) parks work on the compress stream;
     // the frees below can block on pending work, so release first.
-    gpu_edge_release_all(stage->ord);
+    gpu_pool_release_all(&stage->tail);
     CUWARN(cuCtxSynchronize());
   }
   codec_free(&stage->codec);
@@ -674,8 +677,7 @@ arm_tail_gate(struct compress_agg_stage* stage,
   const size_t page_size = stage->ar.per_lod_agg_layouts[0].page_size;
   const int enable = layout->total_batch_chunks > 0 &&
                      stage->ar.total_shards > 0 && page_size > 0;
-  return gpu_edge_wait_gen(
-    stage->ord, GPU_EDGE_TAIL_PUBLISHED, compress_stream, enable);
+  return gpu_pool_acquire_consume_gen(&stage->tail, compress_stream, enable);
 }
 
 static int
@@ -744,9 +746,9 @@ fill_handoff(struct compress_agg_stage* stage,
   out->agg_pool = &stage->agg_pool;
   out->agg_host = &stage->agg_host;
   out->agg_index = &stage->agg_index;
+  out->tail = &stage->tail;
   out->layout = *layout;
   out->per_lod_agg_layouts = stage->ar.per_lod_agg_layouts;
-  out->shards = &stage->ar;
   for (uint8_t lv = 0; lv < nlod; ++lv)
     out->shards_by_lod[lv] = &stage->ar.shard[lv];
 }

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -592,13 +592,15 @@ Error:
 // GPU_EDGE_SLOT_DRAINED: aggregate must not overwrite agg[fc].d_aggregated
 // before the prior D2H on the same fc has read it (seeded at init).
 static int
-wait_upstream_events(struct compress_agg_stage* stage,
-                     const struct compress_agg_input* in,
-                     CUstream compress_stream)
+acquire_inputs(struct compress_agg_stage* stage,
+               const struct compress_agg_input* in,
+               CUstream compress_stream,
+               struct gpu_pool_view* pool_buf)
 {
   CHECK(Error,
-        gpu_edge_wait(
-          stage->ord, GPU_EDGE_POOL_FILLED, 0, compress_stream) == 0);
+        gpu_pool_acquire_consume(in->pool, in->fc, compress_stream, pool_buf) ==
+          0);
+  // LOD chunks land in the pool through a second producer edge.
   if (in->lod_active)
     CHECK(Error,
           gpu_edge_wait(
@@ -618,12 +620,14 @@ static int
 kick_compress_phase(struct compress_agg_stage* stage,
                     const struct compress_agg_input* in,
                     const struct level_geometry* levels,
+                    struct gpu_pool_view pool_buf,
                     CUstream compress_stream,
                     CUdeviceptr* d_aggregate_src)
 {
   const int fc = in->fc;
   const int skip_compress = (stage->codec.type == CODEC_NONE);
-  *d_aggregate_src = skip_compress ? in->pool_buf : stage->d_compressed[fc];
+  *d_aggregate_src =
+    skip_compress ? gpu_pool_view_d(pool_buf) : stage->d_compressed[fc];
 
   if (skip_compress) {
     CU(Error, cuEventRecord(stage->t_compress_start[fc], compress_stream));
@@ -634,7 +638,7 @@ kick_compress_phase(struct compress_agg_stage* stage,
     CHECK(Error,
           kick_compress(stage,
                         fc,
-                        (void*)in->pool_buf,
+                        pool_buf.p,
                         batch_chunks,
                         stage->codec.chunk_bytes,
                         compress_stream) == 0);
@@ -692,6 +696,8 @@ dispatch_aggregate(struct compress_agg_stage* stage,
             compress_stream) == 0);
   }
 
+  // Also releases the chunk pool for re-zero: POOL_CONSUMED aliases this
+  // record (#140).
   CHECK(Error,
         gpu_edge_record(stage->ord, GPU_EDGE_AGG_DONE, fc, compress_stream) ==
           0);
@@ -752,12 +758,13 @@ compress_agg_kick(struct compress_agg_stage* stage,
                               compress_stream) == 0);
   CHECK(Error,
         build_and_upload_shard_tables(stage, &layout, compress_stream) == 0);
-  CHECK(Error, wait_upstream_events(stage, in, compress_stream) == 0);
+  struct gpu_pool_view pool_buf;
+  CHECK(Error, acquire_inputs(stage, in, compress_stream, &pool_buf) == 0);
 
   CUdeviceptr d_aggregate_src = 0;
   CHECK(Error,
         kick_compress_phase(
-          stage, in, levels, compress_stream, &d_aggregate_src) == 0);
+          stage, in, levels, pool_buf, compress_stream, &d_aggregate_src) == 0);
   CHECK(Error, arm_tail_gate(stage, &layout, compress_stream) == 0);
   CHECK(Error,
         dispatch_aggregate(

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -602,8 +602,8 @@ Error:
   return 1;
 }
 
-// The aggregate slot's produce-acquire (SLOT_DRAINED): aggregate must not
-// overwrite agg[fc] before the prior D2H on the same fc has read it.
+// Aggregate must not overwrite agg[fc] before the prior D2H on the same fc
+// has read it.
 static int
 acquire_inputs(struct compress_agg_stage* stage,
                const struct compress_agg_input* in,

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -315,9 +315,9 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     struct platform_clock sink_clock = { 0 };
     platform_toc(&sink_clock);
     size_t sink_bytes = 0;
-    // Tail-state produce-acquire: the consumed direction is the
-    // deliver-oldest-first host rule, so nothing is waited; the acquire
-    // hands out the array whose tail buffers this delivery uploads.
+    // The consumed direction is the deliver-oldest-first host rule, so no
+    // device wait is queued; the acquire hands out the array whose tail
+    // buffers this delivery uploads.
     struct gpu_pool_view tv = { 0 };
     if (gpu_pool_host_acquire_produce(handoff->tail, 0, &tv))
       goto Error;

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -200,14 +200,14 @@ Error:
   return 1;
 }
 
-// Publishes the drained kick's tail generation; must run exactly once per
+// Releases the drained kick's tail generation; must run exactly once per
 // drain, on failure exits too — the gate threshold counts kicks, so a
-// skipped publish leaves the gate unsatisfiable and destroy's auto-flush
+// skipped release leaves the gate unsatisfiable and destroy's auto-flush
 // hangs polling. Tail-state content is moot once the drain has failed.
 static struct writer_result
-finish_drain(struct gpu_ordering* ord, int err)
+finish_drain(struct gpu_pool* tail, int err)
 {
-  gpu_edge_publish(ord, GPU_EDGE_TAIL_PUBLISHED);
+  gpu_pool_release_produce_gen(tail);
   return err ? writer_error() : writer_ok();
 }
 
@@ -315,7 +315,13 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     struct platform_clock sink_clock = { 0 };
     platform_toc(&sink_clock);
     size_t sink_bytes = 0;
-    struct compress_agg_array* shards = handoff->shards;
+    // Tail-state produce-acquire: the consumed direction is the
+    // deliver-oldest-first host rule, so nothing is waited; the acquire
+    // hands out the array whose tail buffers this delivery uploads.
+    struct gpu_pool_view tv = { 0 };
+    if (gpu_pool_host_acquire_produce(handoff->tail, 0, &tv))
+      goto Error;
+    struct compress_agg_array* shards = tv.p;
     const size_t page_size = shards ? shards->page_size : 0;
 
     // In carry-over mode the bias kernel places each LOD at
@@ -407,10 +413,10 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     accumulate_metric_ms(&metrics->sink, sink_ms, sink_bytes, sink_bytes);
   }
 
-  return finish_drain(stage->ord, 0);
+  return finish_drain(handoff->tail, 0);
 
 Error:
-  return finish_drain(stage->ord, 1);
+  return finish_drain(handoff->tail, 1);
 }
 
 // Periodic metadata update (append-dim extents per level).

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -81,6 +81,7 @@ wait_io_fences(struct aggregate_slot* slot,
 
 static void
 record_flush_metrics(const struct flush_handoff* handoff,
+                     const struct aggregate_slot* slot,
                      const struct level_geometry* levels,
                      const struct dim_info* dims,
                      const struct tile_stream_layout* layout,
@@ -140,7 +141,7 @@ record_flush_metrics(const struct flush_handoff* handoff,
     size_t agg_bytes = 0;
     const size_t n_perm = handoff->layout.total_batch_covering + handoff->nlod;
     for (size_t i = 0; i < n_perm; ++i)
-      agg_bytes += handoff->agg->h_permuted_sizes[i];
+      agg_bytes += slot->h_permuted_sizes[i];
 
     accumulate_metric_cu(&metrics->compress,
                          handoff->t_compress_start,
@@ -161,10 +162,12 @@ record_flush_metrics(const struct flush_handoff* handoff,
 // chunk lives. In carry-over mode that is seg->data_segment_offset; in
 // contiguous mode it is the cumulative actual bytes of prior LODs.
 static struct aggregate_result
-lod_view(const struct flush_handoff* handoff, uint8_t lv, size_t data_base)
+lod_view(const struct flush_handoff* handoff,
+         struct aggregate_slot* slot,
+         uint8_t lv,
+         size_t data_base)
 {
   const struct lod_segment* seg = &handoff->layout.lods[lv];
-  struct aggregate_slot* slot = handoff->agg;
   struct aggregate_result ar = {
     .data = (uint8_t*)slot->h_aggregated + data_base,
     .offsets = slot->h_offsets + seg->batch_covering_offset + lv,
@@ -176,6 +179,7 @@ lod_view(const struct flush_handoff* handoff, uint8_t lv, size_t data_base)
 // h_offsets must be pre-rebase (absolute, slot-relative) values here.
 static int
 lod_actual_bytes(const struct flush_handoff* handoff,
+                 const struct aggregate_slot* slot,
                  uint8_t lv,
                  size_t* out_bytes)
 {
@@ -183,7 +187,6 @@ lod_actual_bytes(const struct flush_handoff* handoff,
   const struct lod_segment* seg = &handoff->layout.lods[lv];
   if (seg->n_active == 0)
     return 0;
-  const struct aggregate_slot* slot = handoff->agg;
   const uint64_t total = (uint64_t)seg->n_active * seg->covering_count;
   const size_t last = seg->batch_covering_offset + (size_t)lv + total - 1;
   const size_t end = slot->h_offsets[last] + slot->h_permuted_sizes[last];
@@ -221,7 +224,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
                  struct stream_metrics* metrics)
 {
   const int fc = handoff->fc;
-  struct aggregate_slot* slot = handoff->agg;
+  struct aggregate_slot* slot = NULL;
   const struct batch_aggregate_layout* alayout = &handoff->layout;
 
   if (sink->has_error && sink->has_error(sink))
@@ -232,11 +235,15 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     platform_toc(&kick_clk);
 
     if (handoff->passthrough) {
-      if (gpu_edge_host_wait(stage->ord, GPU_EDGE_D2H_DONE, fc))
+      struct gpu_pool_view hv;
+      if (gpu_pool_host_acquire_consume(handoff->agg_host, fc, &hv))
         goto Error;
+      slot = hv.p;
     } else {
-      if (gpu_edge_host_wait(stage->ord, GPU_EDGE_CHUNK_INDEX_READY, fc))
+      struct gpu_pool_view iv;
+      if (gpu_pool_host_acquire_consume(handoff->agg_index, fc, &iv))
         goto Error;
+      slot = iv.p;
 
       // Bulk copies go on drain_stream, never d2h_stream — sharing
       // deadlocks against the tail gate (see d2h_deliver_stage).
@@ -247,7 +254,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
             continue;
           const struct lod_segment* seg = &alayout->lods[lv];
           size_t actual = 0;
-          if (lod_actual_bytes(handoff, lv, &actual))
+          if (lod_actual_bytes(handoff, slot, lv, &actual))
             goto Error;
           if (actual == 0)
             continue;
@@ -272,19 +279,18 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
                                     stage->drain_stream));
       }
 
-      // Always record the slot-drained edge, even if the D2H dispatch above
-      // failed: the host poll below and the next kick's wait block on it
-      // and would hang otherwise. Record-on-error is harmless because the
-      // stream is already in an error state and the next op will
-      // short-circuit.
+      // Always release the slot (SLOT_DRAINED), even if the D2H dispatch
+      // above failed: the host poll below and the next kick's acquire block
+      // on it and would hang otherwise. Release-on-error is harmless
+      // because the stream is already in an error state and the next op
+      // will short-circuit.
       CHECK(Error,
-            gpu_edge_record(
-              stage->ord, GPU_EDGE_SLOT_DRAINED, fc, stage->drain_stream) ==
-              0);
+            gpu_pool_release_consume(
+              handoff->agg_pool, fc, stage->drain_stream) == 0);
 
       if (dispatch_err)
         goto Error;
-      if (gpu_edge_host_wait(stage->ord, GPU_EDGE_D2H_DONE, fc))
+      if (gpu_pool_host_acquire_consume(handoff->agg_host, fc, NULL))
         goto Error;
     }
 
@@ -293,6 +299,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
   }
 
   record_flush_metrics(handoff,
+                       slot,
                        levels,
                        dims,
                        layout,
@@ -323,8 +330,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
       if (handoff->layout.page_size > 0)
         data_base[lv] = seg->data_segment_offset;
       else
-        data_base[lv] =
-          handoff->agg->h_offsets[seg->batch_covering_offset + lv];
+        data_base[lv] = slot->h_offsets[seg->batch_covering_offset + lv];
     }
 
     // Rebase per-LOD offsets to be segment-relative. GPU produces absolute
@@ -339,7 +345,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
       if (handoff->per_lod_n_active[lv] == 0 || data_base[lv] == 0)
         continue;
       const struct lod_segment* seg = &handoff->layout.lods[lv];
-      size_t* off = handoff->agg->h_offsets + seg->batch_covering_offset + lv;
+      size_t* off = slot->h_offsets + seg->batch_covering_offset + lv;
       const uint64_t n = (uint64_t)seg->n_active * seg->covering_count + 1;
       for (uint64_t i = 0; i < n; ++i)
         off[i] -= data_base[lv];
@@ -349,7 +355,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
       if (handoff->per_lod_n_active[lv] == 0)
         continue;
 
-      struct aggregate_result ar = lod_view(handoff, lv, data_base[lv]);
+      struct aggregate_result ar = lod_view(handoff, slot, lv, data_base[lv]);
       // Per-LOD slice of the unified host tail-bytes scratch.
       size_t* h_tail_lv = NULL;
       if (shards && shards->h_tail_bytes && page_size > 0)
@@ -395,7 +401,7 @@ sync_and_deliver(struct d2h_deliver_stage* stage,
     // Record an aggregate IO fence on the unified slot. wait_io_fences()
     // checks slot->io_done at the next kick.
     if (sink->record_fence)
-      handoff->agg->io_done = sink->record_fence(sink);
+      slot->io_done = sink->record_fence(sink);
 
     float sink_ms = platform_toc(&sink_clock) * 1000.0f;
     accumulate_metric_ms(&metrics->sink, sink_ms, sink_bytes, sink_bytes);
@@ -449,13 +455,16 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                  CUstream d2h_stream)
 {
   const int fc = handoff->fc;
-  struct aggregate_slot* slot = handoff->agg;
   const struct batch_aggregate_layout* layout = &handoff->layout;
 
-  wait_io_fences(slot, sink, stage->metrics);
+  // io_done is host-owned slot bookkeeping; its fence must retire before
+  // any device acquire, so peek rather than acquire here.
+  wait_io_fences(gpu_pool_at(handoff->agg_host, fc, 0).p, sink, stage->metrics);
 
+  struct gpu_pool_view v;
   CHECK(Error,
-        gpu_edge_wait(stage->ord, GPU_EDGE_AGG_DONE, fc, d2h_stream) == 0);
+        gpu_pool_acquire_consume(handoff->agg_pool, fc, d2h_stream, &v) == 0);
+  struct aggregate_slot* slot = v.p;
   CU(Error, cuEventRecord(stage->t_d2h_start[fc], d2h_stream));
 
   // Compressed codecs use these in drain to size exact per-LOD transfers;
@@ -480,7 +489,7 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
   // Passthrough never polls the chunk index (its drain waits on the
   // slot-drained edge recorded after the bulk copy below).
   if (!dispatch_err && !handoff->passthrough &&
-      gpu_edge_record(stage->ord, GPU_EDGE_CHUNK_INDEX_READY, fc, d2h_stream))
+      gpu_pool_release_produce(handoff->agg_index, fc, d2h_stream))
     dispatch_err = 1;
 
   // Compressed defers bulk D2H to sync_and_deliver once the chunk index lands.
@@ -492,12 +501,11 @@ d2h_deliver_kick(struct d2h_deliver_stage* stage,
                               layout->total_data_bytes,
                               d2h_stream));
 
-  // Always record the passthrough slot-drained edge even on dispatch
+  // Always release the passthrough slot (SLOT_DRAINED) even on dispatch
   // error: the drain's host poll blocks on it and would hang otherwise.
   if (handoff->passthrough) {
     CHECK(Error,
-          gpu_edge_record(stage->ord, GPU_EDGE_SLOT_DRAINED, fc, d2h_stream) ==
-            0);
+          gpu_pool_release_consume(handoff->agg_pool, fc, d2h_stream) == 0);
   }
 
   return dispatch_err;

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "gpu/aggregate.h"
+#include "gpu/pool.h"
 #include "lod/lod_plan.h"
 #include "stream/types.aggregate.h"
 
@@ -34,7 +35,11 @@ struct flush_handoff
   CUevent t_compress_start; // for metrics
   CUevent t_compress_end;   // for metrics
 
-  struct aggregate_slot* agg;           // borrowed: unified slot for fc
+  // The unified slot for fc travels as pool handles, never a raw pointer;
+  // delivery acquires the facet it consumes (stream.engine.h).
+  struct gpu_pool* agg_pool;            // borrowed
+  struct gpu_pool* agg_host;            // borrowed
+  struct gpu_pool* agg_index;           // borrowed
   struct batch_aggregate_layout layout; // owned (by-value snapshot)
   const struct aggregate_layout* per_lod_agg_layouts; // borrowed [nlod]
   struct shard_state* shards_by_lod[LOD_MAX_LEVELS];  // borrowed

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -42,8 +42,10 @@ struct flush_handoff
   struct gpu_pool* agg_index;           // borrowed
   struct batch_aggregate_layout layout; // owned (by-value snapshot)
   const struct aggregate_layout* per_lod_agg_layouts; // borrowed [nlod]
-  struct shard_state* shards_by_lod[LOD_MAX_LEVELS];  // borrowed
-  struct compress_agg_array* shards; // borrowed (for tail HtoD)
+  struct shard_state* shards_by_lod[LOD_MAX_LEVELS]; // borrowed
+  struct gpu_pool* tail; // tail-state pool (#142); the drain's produce-
+                         // acquire yields the compress_agg_array whose
+                         // d_tail_bytes/d_tail_carry the delivery uploads
   size_t max_output_size;      // codec bound
 
   // Pass-through codec (CODEC_NONE): per-LOD bytes equal worst-case, so

--- a/src/gpu/pool.c
+++ b/src/gpu/pool.c
@@ -1,0 +1,122 @@
+#include "gpu/pool.h"
+
+#include <assert.h>
+#include <string.h>
+
+// Edge instances are declared in the table (per_fc), not chosen by callers:
+// single-instance edges fold every slot onto instance 0.
+static int
+inst(enum gpu_edge e, int slot)
+{
+  return gpu_edge_describe(e)->per_fc ? slot : 0;
+}
+
+void
+gpu_pool_init(struct gpu_pool* p,
+              struct gpu_ordering* ord,
+              enum gpu_edge ready,
+              enum gpu_edge consumed)
+{
+  memset(p, 0, sizeof(*p));
+  p->ord = ord;
+  p->ready = ready;
+  p->consumed = consumed;
+}
+
+void
+gpu_pool_bind(struct gpu_pool* p, int slot, void* payload)
+{
+  p->payload[slot] = payload;
+}
+
+int
+gpu_pool_acquire_produce(struct gpu_pool* p,
+                         int slot,
+                         CUstream stream,
+                         struct gpu_pool_view* out)
+{
+  if (p->consumed != GPU_EDGE_COUNT &&
+      gpu_edge_wait(p->ord, p->consumed, inst(p->consumed, slot), stream))
+    return 1;
+  if (out)
+    out->p = p->payload[slot];
+  return 0;
+}
+
+int
+gpu_pool_release_produce(struct gpu_pool* p, int slot, CUstream stream)
+{
+  assert(p->ready != GPU_EDGE_COUNT);
+  return gpu_edge_record(p->ord, p->ready, inst(p->ready, slot), stream);
+}
+
+int
+gpu_pool_acquire_consume(struct gpu_pool* p,
+                         int slot,
+                         CUstream stream,
+                         struct gpu_pool_view* out)
+{
+  if (p->ready != GPU_EDGE_COUNT &&
+      gpu_edge_wait(p->ord, p->ready, inst(p->ready, slot), stream))
+    return 1;
+  if (out)
+    out->p = p->payload[slot];
+  return 0;
+}
+
+int
+gpu_pool_release_consume(struct gpu_pool* p, int slot, CUstream stream)
+{
+  assert(p->consumed != GPU_EDGE_COUNT);
+  return gpu_edge_record(p->ord, p->consumed, inst(p->consumed, slot), stream);
+}
+
+int
+gpu_pool_host_acquire_produce(struct gpu_pool* p,
+                              int slot,
+                              struct gpu_pool_view* out)
+{
+  if (p->consumed != GPU_EDGE_COUNT &&
+      gpu_edge_host_wait(p->ord, p->consumed, inst(p->consumed, slot)))
+    return 1;
+  if (out)
+    out->p = p->payload[slot];
+  return 0;
+}
+
+int
+gpu_pool_host_acquire_consume(struct gpu_pool* p,
+                              int slot,
+                              struct gpu_pool_view* out)
+{
+  if (p->ready != GPU_EDGE_COUNT &&
+      gpu_edge_host_wait(p->ord, p->ready, inst(p->ready, slot)))
+    return 1;
+  if (out)
+    out->p = p->payload[slot];
+  return 0;
+}
+
+struct gpu_pool_view
+gpu_pool_at(struct gpu_pool* p, int slot, size_t byte_offset)
+{
+  return (struct gpu_pool_view){ .p = (char*)p->payload[slot] + byte_offset };
+}
+
+int
+gpu_pool_acquire_consume_gen(struct gpu_pool* p, CUstream stream, int enable)
+{
+  return gpu_edge_wait_gen(p->ord, p->ready, stream, enable);
+}
+
+void
+gpu_pool_release_produce_gen(struct gpu_pool* p)
+{
+  gpu_edge_publish(p->ord, p->ready);
+}
+
+void
+gpu_pool_release_all(struct gpu_pool* p)
+{
+  gpu_edge_release_all(p->ord);
+}

--- a/src/gpu/pool.c
+++ b/src/gpu/pool.c
@@ -118,5 +118,7 @@ gpu_pool_release_produce_gen(struct gpu_pool* p)
 void
 gpu_pool_release_all(struct gpu_pool* p)
 {
-  gpu_edge_release_all(p->ord);
+  // Callable on a never-initialized pool (failed engine init teardown).
+  if (p->ord)
+    gpu_edge_release_all(p->ord);
 }

--- a/src/gpu/pool.h
+++ b/src/gpu/pool.h
@@ -1,0 +1,100 @@
+#pragma once
+
+// Slotted resource pools with generation-carried ordering
+// (docs/gpu-orchestration.md §1). A pool binds a cycled resource's per-slot
+// payload to the declared edges that order its generations:
+//   ready    — producer -> consumer: slot contents valid
+//   consumed — consumer -> producer: slot reusable
+// Acquire queues the wait that makes the payload safe in that role before
+// handing the pointer out; release records that role's completion. Edge
+// identity, instancing, debug asserts, and stall metrics stay in
+// gpu_ordering — pools draw edges from the table, never own events.
+// GPU_EDGE_COUNT in either direction means host call order covers it (a
+// declared HOST_RULE), not a GPU primitive.
+
+#include "gpu/ordering.h"
+
+#include <stddef.h>
+
+struct gpu_pool
+{
+  struct gpu_ordering* ord; // borrowed
+  enum gpu_edge ready;
+  enum gpu_edge consumed;
+  void* payload[2]; // borrowed; device payloads stored as (void*)(uintptr_t)
+};
+
+// Pointer minted by the pool API. Stage boundaries take views (or pool +
+// slot handles), never raw pointers to pooled resources.
+struct gpu_pool_view
+{
+  void* p;
+};
+
+static inline CUdeviceptr
+gpu_pool_view_d(struct gpu_pool_view v)
+{
+  return (CUdeviceptr)(uintptr_t)v.p;
+}
+
+void
+gpu_pool_init(struct gpu_pool* p,
+              struct gpu_ordering* ord,
+              enum gpu_edge ready,
+              enum gpu_edge consumed);
+
+void
+gpu_pool_bind(struct gpu_pool* p, int slot, void* payload);
+
+// Producer role: acquire waits the slot's previous generation's consumed
+// release on `stream`; release records this generation's ready edge.
+// Aliased edges are released through their owner pool's record only.
+// `out` may be NULL when only the ordering is needed.
+int
+gpu_pool_acquire_produce(struct gpu_pool* p,
+                         int slot,
+                         CUstream stream,
+                         struct gpu_pool_view* out);
+int
+gpu_pool_release_produce(struct gpu_pool* p, int slot, CUstream stream);
+
+// Consumer role.
+int
+gpu_pool_acquire_consume(struct gpu_pool* p,
+                         int slot,
+                         CUstream stream,
+                         struct gpu_pool_view* out);
+int
+gpu_pool_release_consume(struct gpu_pool* p, int slot, CUstream stream);
+
+// Host-poll acquires (the backing edge's declared consumer is HOST).
+// Blocked time accrues to the edge's stall metric.
+int
+gpu_pool_host_acquire_produce(struct gpu_pool* p,
+                              int slot,
+                              struct gpu_pool_view* out);
+int
+gpu_pool_host_acquire_consume(struct gpu_pool* p,
+                              int slot,
+                              struct gpu_pool_view* out);
+
+// Payload offset with no ordering queued. Only for host-ordered paths
+// (sync flush, bind, teardown) and offsets within a generation this caller
+// already acquired on the same stream.
+struct gpu_pool_view
+gpu_pool_at(struct gpu_pool* p, int slot, size_t byte_offset);
+
+// GEN_COUNTER ready edge (#142 host-published generations) behind the same
+// API. Consumer acquire arms the gate; the threshold advances even when
+// enable is 0 — every kick drains exactly once. Producer release publishes
+// the drained generation and must run exactly once per drain, on failure
+// paths too.
+int
+gpu_pool_acquire_consume_gen(struct gpu_pool* p, CUstream stream, int enable);
+void
+gpu_pool_release_produce_gen(struct gpu_pool* p);
+
+// Force-satisfy every parked acquire. Required before any blocking stream/
+// context sync when a generation may be undrained (#142 teardown).
+void
+gpu_pool_release_all(struct gpu_pool* p);

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -55,15 +55,16 @@ stream_engine_attach_edge_stalls(struct stream_engine* e)
     &e->ord, GPU_EDGE_D2H_DONE, &e->metrics.edge_stall[2]);
 }
 
-void*
+struct gpu_pool_view
 stream_engine_pool_epoch(struct stream_engine* e,
                          struct stream_context* ctx,
                          uint32_t epoch_in_batch)
 {
   const size_t bpe = dtype_bpe(ctx->config.dtype);
-  return (char*)e->pools.buf[e->pools.current] +
-         (uint64_t)epoch_in_batch * ctx->levels.total_chunks *
-           ctx->layout.chunk_stride * bpe;
+  return gpu_pool_at(&e->pools.p,
+                     e->pools.current,
+                     (uint64_t)epoch_in_batch * ctx->levels.total_chunks *
+                       ctx->layout.chunk_stride * bpe);
 }
 
 static int

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -139,7 +139,7 @@ stream_append_body(struct stream_engine* e,
           struct staging_slot* ss = &e->stage.slot[si];
           // Poll instead of cuEventSynchronize to keep the producer thread
           // hot — it has memcpy work queued up immediately after.
-          if (gpu_edge_host_wait(&e->ord, GPU_EDGE_STAGING_FREE, si))
+          if (gpu_pool_host_acquire_produce(&e->stage.h_pool, si, NULL))
             goto Error;
 
           if (ctx->cursor_elements > 0) {
@@ -161,8 +161,11 @@ stream_append_body(struct stream_engine* e,
         {
           struct platform_clock mc = { 0 };
           platform_toc(&mc);
-          memcpy((uint8_t*)e->stage.slot[e->stage.current].h_in +
-                   e->stage.bytes_written,
+          // Same h_in generation as the bytes_written==0 acquire above.
+          memcpy(gpu_pool_at(&e->stage.h_pool,
+                             e->stage.current,
+                             e->stage.bytes_written)
+                   .p,
                  src + written,
                  payload);
           accumulate_metric_ms(&e->metrics.memcpy,

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -206,7 +206,15 @@ struct compress_agg_stage
   //   d_aggregated:     max_batch_layout.total_data_bytes
   //   d_offsets/sizes:  total_batch_covering + LOD_MAX_LEVELS (+ 1 for offsets)
   //   plus pinned host shadows of matching size.
+  // Non-init code reaches a slot through the pools below; each guards a
+  // different facet of the same payload for a different consumer.
   struct aggregate_slot agg[2];
+  struct gpu_pool agg_pool;  // device facet: ready=AGG_DONE,
+                             //               consumed=SLOT_DRAINED
+  struct gpu_pool agg_host;  // h_aggregated facet: ready=D2H_DONE (alias);
+                             // consumed is the drain-before-rekick host rule
+  struct gpu_pool agg_index; // h_offsets/h_permuted_sizes facet:
+                             // ready=CHUNK_INDEX_READY (compressed only)
   size_t max_total_batch_chunks;
   size_t max_total_batch_covering;
   size_t max_total_data_bytes;

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -215,6 +215,10 @@ struct compress_agg_stage
                              // consumed is the drain-before-rekick host rule
   struct gpu_pool agg_index; // h_offsets/h_permuted_sizes facet:
                              // ready=CHUNK_INDEX_READY (compressed only)
+  struct gpu_pool tail; // d_tail_bytes/d_tail_carry generations (#142):
+                        // ready=TAIL_PUBLISHED (GEN_COUNTER); consumed is
+                        // the deliver-oldest-first host rule. Payload is
+                        // the bound compress_agg_array (ar below).
   size_t max_total_batch_chunks;
   size_t max_total_batch_covering;
   size_t max_total_data_bytes;

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -16,8 +16,10 @@
 
 struct pool_state
 {
-  CUdeviceptr buf[2];
-  int current; // 0 or 1
+  struct gpu_pool p;  // buf generations: ready=POOL_FILLED,
+                      //                  consumed=POOL_CONSUMED (#140)
+  CUdeviceptr buf[2]; // payloads; non-init code goes through p
+  int current;        // 0 or 1
 };
 
 // Ordering events (h2d-done, scatter-done) live in gpu_ordering, instanced
@@ -129,7 +131,7 @@ struct compress_agg_input
   uint32_t n_epochs;
   uint32_t active_levels_mask;
   const uint32_t* batch_active_masks; // borrowed from flush_slot_gpu [K]
-  CUdeviceptr pool_buf;
+  struct gpu_pool* pool; // chunk pool; the kick acquires slot fc's batch
   int lod_active; // wait GPU_EDGE_LOD_DONE (multiscale with bound edge only)
   uint32_t epochs_per_batch;
 };
@@ -384,8 +386,9 @@ stream_engine_bind_array(struct stream_engine* e,
 
 // --- Engine operations ---
 
-// Pointer to the given epoch's chunk region in the current pool.
-void*
+// View of the given epoch's chunk region in the current pool — within the
+// produce generation acquired at the last swap.
+struct gpu_pool_view
 stream_engine_pool_epoch(struct stream_engine* e,
                          struct stream_context* ctx,
                          uint32_t epoch_in_batch);

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -4,6 +4,7 @@
 #include "gpu/compress.h"
 #include "gpu/flush.handoff.h"
 #include "gpu/ordering.h"
+#include "gpu/pool.h"
 #include "gpu/reduce_csr_gpu.h"
 #include "platform/platform.h"
 #include "stream.gpu.h"
@@ -20,7 +21,8 @@ struct pool_state
 };
 
 // Ordering events (h2d-done, scatter-done) live in gpu_ordering, instanced
-// by staging slot; only timing-interval starts stay here.
+// by staging slot; only timing-interval starts stay here. h_in/d_in are the
+// pool payloads — non-init code reaches them through d_pool/h_pool only.
 struct staging_slot
 {
   void* h_in;              // pinned host WC, size = buffer_capacity_bytes
@@ -33,9 +35,12 @@ struct staging_slot
 struct staging_state
 {
   struct staging_slot slot[2];
-  int current;          // 0 or 1: which buffer the host is filling
-  size_t bytes_written; // bytes written to current slot's h_in so far
-  struct gpu_ordering* ord; // borrowed
+  struct gpu_pool d_pool; // d_in: ready=STAGING_H2D_DONE,
+                          //       consumed=STAGING_SCATTER_DONE
+  struct gpu_pool h_pool; // h_in: consumed=STAGING_FREE; ready is host call
+                          //       order (fill precedes dispatch)
+  int current;            // 0 or 1: which buffer the host is filling
+  size_t bytes_written;   // bytes written to current slot's h_in so far
 };
 
 // Per flush-slot: mutable batch state (masks + epoch count).

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -219,8 +219,8 @@ flush_accumulate_epoch(struct stream_engine* e, struct stream_context* ctx)
     // Used by multiarray where double-buffered pipeline state doesn't
     // compose across array switches.
     struct writer_result r = flush_accumulated_sync(e, ctx);
-    // Zero pool for next batch. Host-ordered re-acquire: the sync drain
-    // above host-completed this fc's D2H, so no device wait is queued.
+    // Host-ordered re-acquire: the sync drain above host-completed this
+    // fc's D2H, so no device wait is queued.
     if (!r.error) {
       size_t bpe = dtype_bpe(ctx->config.dtype);
       size_t pool_bytes = (uint64_t)e->batch.epochs_per_batch *

--- a/src/gpu/stream.flush.c
+++ b/src/gpu/stream.flush.c
@@ -27,7 +27,7 @@ make_compress_input(struct stream_engine* e,
     .n_epochs = n_epochs,
     .active_levels_mask = fs->active_levels_mask,
     .batch_active_masks = fs->batch_active_masks,
-    .pool_buf = e->pools.buf[fc],
+    .pool = &e->pools.p,
     .lod_active = ctx->levels.enable_multiscale &&
                   gpu_ordering_event(&e->ord, GPU_EDGE_LOD_DONE, fc) != NULL,
     .epochs_per_batch = e->batch.epochs_per_batch,
@@ -173,16 +173,14 @@ drain_kick_and_swap(struct stream_engine* e, struct stream_context* ctx)
   e->pools.current ^= 1;
   // The aggregate's last pool read gates reuse; re-zeroing any earlier
   // corrupts the in-flight batch (#140).
+  struct gpu_pool_view fresh;
   CHECK(Error,
-        gpu_edge_wait(&e->ord,
-                      GPU_EDGE_POOL_CONSUMED,
-                      e->pools.current,
-                      e->streams.compute) == 0);
+        gpu_pool_acquire_produce(
+          &e->pools.p, e->pools.current, e->streams.compute, &fresh) == 0);
   size_t pool_bytes = (uint64_t)K * ctx->levels.total_chunks *
                       ctx->layout.chunk_stride * dtype_bpe(ctx->config.dtype);
   CU(Error,
-     cuMemsetD8Async(
-       e->pools.buf[e->pools.current], 0, pool_bytes, e->streams.compute));
+     cuMemsetD8Async(gpu_pool_view_d(fresh), 0, pool_bytes, e->streams.compute));
 
   // Reset batch accumulation.
   e->batch.accumulated = 0;
@@ -210,18 +208,19 @@ flush_accumulate_epoch(struct stream_engine* e, struct stream_context* ctx)
   if (e->batch.accumulated < e->batch.epochs_per_batch)
     return writer_ok();
 
-  // Record pool-filled once after the last epoch's scatter; compute-stream
+  // Release pool-filled once after the last epoch's scatter; compute-stream
   // ordering means this subsumes per-epoch ready signals.
   CHECK(Error,
-        gpu_edge_record(
-          &e->ord, GPU_EDGE_POOL_FILLED, 0, e->streams.compute) == 0);
+        gpu_pool_release_produce(
+          &e->pools.p, e->pools.current, e->streams.compute) == 0);
 
   if (e->sync_flush) {
     // Synchronous path: flush the full batch immediately (no pool swap).
     // Used by multiarray where double-buffered pipeline state doesn't
     // compose across array switches.
     struct writer_result r = flush_accumulated_sync(e, ctx);
-    // Zero pool for next batch.
+    // Zero pool for next batch. Host-ordered re-acquire: the sync drain
+    // above host-completed this fc's D2H, so no device wait is queued.
     if (!r.error) {
       size_t bpe = dtype_bpe(ctx->config.dtype);
       size_t pool_bytes = (uint64_t)e->batch.epochs_per_batch *
@@ -229,7 +228,10 @@ flush_accumulate_epoch(struct stream_engine* e, struct stream_context* ctx)
                           bpe;
       CU(SyncError,
          cuMemsetD8Async(
-           e->pools.buf[e->pools.current], 0, pool_bytes, e->streams.compute));
+           gpu_pool_view_d(gpu_pool_at(&e->pools.p, e->pools.current, 0)),
+           0,
+           pool_bytes,
+           e->streams.compute));
     }
     return r;
   SyncError:
@@ -318,9 +320,9 @@ flush_accumulated_sync(struct stream_engine* e, struct stream_context* ctx)
 
   fs->batch_epoch_count = (int)e->batch.accumulated;
 
-  // Record pool-filled after all scatter ops for this (possibly partial)
+  // Release pool-filled after all scatter ops for this (possibly partial)
   // batch.
-  if (gpu_edge_record(&e->ord, GPU_EDGE_POOL_FILLED, 0, e->streams.compute))
+  if (gpu_pool_release_produce(&e->pools.p, e->pools.current, e->streams.compute))
     return writer_error();
 
   if (flush_kick_batch(e, ctx, fc, e->batch.accumulated))
@@ -395,9 +397,14 @@ flush_partial_append(struct stream_engine* e, struct stream_context* ctx)
 
     e->lod.append_accum.counts[lv] = 0;
 
-    CUdeviceptr dst = e->pools.buf[e->pools.current] +
-                      ctx->levels.level[lv].chunk_offset *
-                        ctx->layout.chunk_stride * bytes_per_element;
+    // Produce-phase write within the generation acquired at the last swap
+    // (the current pool is still being filled).
+    CUdeviceptr dst =
+      gpu_pool_view_d(gpu_pool_at(&e->pools.p,
+                                  e->pools.current,
+                                  ctx->levels.level[lv].chunk_offset *
+                                    ctx->layout.chunk_stride *
+                                    bytes_per_element));
     size_t lv_pool_bytes = ctx->levels.level[lv].chunk_count *
                            ctx->layout.chunk_stride * bytes_per_element;
     CU(Error, cuMemsetD8Async(dst, 0, lv_pool_bytes, e->streams.compute));
@@ -419,8 +426,8 @@ flush_partial_append(struct stream_engine* e, struct stream_context* ctx)
             &e->ord, GPU_EDGE_LOD_DONE, fc, e->streams.compute) == 0);
 
   CHECK(Error,
-        gpu_edge_record(
-          &e->ord, GPU_EDGE_POOL_FILLED, 0, e->streams.compute) == 0);
+        gpu_pool_release_produce(
+          &e->pools.p, e->pools.current, e->streams.compute) == 0);
   if (flush_kick_batch(e, ctx, fc, 1))
     return writer_error();
   return drain_fc(e, ctx, fc);

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -76,7 +76,7 @@ int
 ingest_dispatch_scatter(struct staging_state* stage,
                         const struct tile_stream_layout* layout,
                         const struct tile_stream_layout_gpu* layout_gpu,
-                        void* pool_epoch,
+                        struct gpu_pool_view pool_epoch,
                         uint64_t* cursor,
                         size_t bpe,
                         CUstream h2d,
@@ -101,7 +101,7 @@ ingest_dispatch_scatter(struct staging_state* stage,
   CHECK(Error,
         gpu_pool_acquire_consume(&stage->d_pool, idx, compute, &d_in) == 0);
   CU(Error, cuEventRecord(ss->t_scatter_start, compute));
-  transpose((CUdeviceptr)pool_epoch,
+  transpose(gpu_pool_view_d(pool_epoch),
             gpu_pool_view_d(d_in),
             stage->bytes_written,
             (uint8_t)bpe,

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -13,12 +13,18 @@ ingest_init(struct staging_state* stage,
             CUstream compute)
 {
   memset(stage, 0, sizeof(*stage));
-  stage->ord = ord;
   // Ordering events (h2d-done, scatter-done) are owned and seeded by ord;
   // only the timing-interval starts are created here.
+  gpu_pool_init(&stage->d_pool,
+                ord,
+                GPU_EDGE_STAGING_H2D_DONE,
+                GPU_EDGE_STAGING_SCATTER_DONE);
+  gpu_pool_init(&stage->h_pool, ord, GPU_EDGE_COUNT, GPU_EDGE_STAGING_FREE);
   for (int i = 0; i < 2; ++i) {
     CU(Fail, cuMemHostAlloc(&stage->slot[i].h_in, buffer_capacity_bytes, 0));
     CU(Fail, cuMemAlloc(&stage->slot[i].d_in, buffer_capacity_bytes));
+    gpu_pool_bind(&stage->h_pool, i, stage->slot[i].h_in);
+    gpu_pool_bind(&stage->d_pool, i, (void*)(uintptr_t)stage->slot[i].d_in);
     CU(Fail, cuEventCreate(&stage->slot[i].t_h2d_start, CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->slot[i].t_scatter_start, CU_EVENT_DEFAULT));
     CU(Fail, cuEventRecord(stage->slot[i].t_h2d_start, compute));
@@ -40,6 +46,30 @@ ingest_destroy(struct staging_state* stage)
     cu_event_destroy(ss->t_h2d_start);
     cu_event_destroy(ss->t_scatter_start);
   }
+}
+
+// H2D into the slot's d_in. The produce-acquire keeps the copy from
+// overwriting d_in while the prior generation's scatter still reads it; the
+// release also frees h_in for host refill (STAGING_FREE aliases it).
+static int
+dispatch_h2d(struct staging_state* stage,
+             int idx,
+             CUstream h2d,
+             struct gpu_pool_view* d_in)
+{
+  struct gpu_pool_view h_in;
+  // h_in consume: ready is host call order (filled before this dispatch).
+  CHECK(Error, gpu_pool_acquire_consume(&stage->h_pool, idx, h2d, &h_in) == 0);
+  CHECK(Error, gpu_pool_acquire_produce(&stage->d_pool, idx, h2d, d_in) == 0);
+  CU(Error, cuEventRecord(stage->slot[idx].t_h2d_start, h2d));
+  CU(Error,
+     cuMemcpyHtoDAsync(
+       gpu_pool_view_d(*d_in), h_in.p, stage->bytes_written, h2d));
+  CHECK(Error, gpu_pool_release_produce(&stage->d_pool, idx, h2d) == 0);
+  return 0;
+
+Error:
+  return 1;
 }
 
 int
@@ -64,22 +94,15 @@ ingest_dispatch_scatter(struct staging_state* stage,
 
   ss->dispatched_bytes = stage->bytes_written;
 
-  // H2D — wait for prior scatter to finish reading d_in before overwriting
-  CHECK(Error,
-        gpu_edge_wait(
-          stage->ord, GPU_EDGE_STAGING_SCATTER_DONE, idx, h2d) == 0);
-  CU(Error, cuEventRecord(ss->t_h2d_start, h2d));
-  CU(Error, cuMemcpyHtoDAsync(ss->d_in, ss->h_in, stage->bytes_written, h2d));
-  CHECK(Error,
-        gpu_edge_record(stage->ord, GPU_EDGE_STAGING_H2D_DONE, idx, h2d) == 0);
+  struct gpu_pool_view d_in;
+  CHECK(Error, dispatch_h2d(stage, idx, h2d, &d_in) == 0);
 
   // Scatter into chunk pool
   CHECK(Error,
-        gpu_edge_wait(
-          stage->ord, GPU_EDGE_STAGING_H2D_DONE, idx, compute) == 0);
+        gpu_pool_acquire_consume(&stage->d_pool, idx, compute, &d_in) == 0);
   CU(Error, cuEventRecord(ss->t_scatter_start, compute));
   transpose((CUdeviceptr)pool_epoch,
-            ss->d_in,
+            gpu_pool_view_d(d_in),
             stage->bytes_written,
             (uint8_t)bpe,
             *cursor,
@@ -87,9 +110,7 @@ ingest_dispatch_scatter(struct staging_state* stage,
             layout_gpu->d_lifted_shape,
             layout_gpu->d_lifted_strides,
             compute);
-  CHECK(Error,
-        gpu_edge_record(
-          stage->ord, GPU_EDGE_STAGING_SCATTER_DONE, idx, compute) == 0);
+  CHECK(Error, gpu_pool_release_consume(&stage->d_pool, idx, compute) == 0);
 
   *cursor += elements;
   stage->current ^= 1;
@@ -120,29 +141,22 @@ ingest_dispatch_multiscale(struct staging_state* stage,
 
   ss->dispatched_bytes = stage->bytes_written;
 
-  // H2D — wait for prior d_linear copy to finish reading d_in
-  CHECK(Error,
-        gpu_edge_wait(
-          stage->ord, GPU_EDGE_STAGING_SCATTER_DONE, idx, h2d) == 0);
-  CU(Error, cuEventRecord(ss->t_h2d_start, h2d));
-  CU(Error, cuMemcpyHtoDAsync(ss->d_in, ss->h_in, stage->bytes_written, h2d));
-  CHECK(Error,
-        gpu_edge_record(stage->ord, GPU_EDGE_STAGING_H2D_DONE, idx, h2d) == 0);
+  struct gpu_pool_view d_in;
+  CHECK(Error, dispatch_h2d(stage, idx, h2d, &d_in) == 0);
 
   // Copy raw input to linear epoch buffer for LOD downsampling
   CHECK(Error,
-        gpu_edge_wait(
-          stage->ord, GPU_EDGE_STAGING_H2D_DONE, idx, compute) == 0);
+        gpu_pool_acquire_consume(&stage->d_pool, idx, compute, &d_in) == 0);
   CU(Error, cuEventRecord(ss->t_scatter_start, compute));
   {
     uint64_t epoch_offset = (*cursor % epoch_elements) * bpe;
     CU(Error,
-       cuMemcpyDtoDAsync(
-         d_linear + epoch_offset, ss->d_in, elements * bpe, compute));
+       cuMemcpyDtoDAsync(d_linear + epoch_offset,
+                         gpu_pool_view_d(d_in),
+                         elements * bpe,
+                         compute));
   }
-  CHECK(Error,
-        gpu_edge_record(
-          stage->ord, GPU_EDGE_STAGING_SCATTER_DONE, idx, compute) == 0);
+  CHECK(Error, gpu_pool_release_consume(&stage->d_pool, idx, compute) == 0);
 
   *cursor += elements;
   stage->current ^= 1;

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -48,9 +48,9 @@ ingest_destroy(struct staging_state* stage)
   }
 }
 
-// H2D into the slot's d_in. The produce-acquire keeps the copy from
-// overwriting d_in while the prior generation's scatter still reads it; the
-// release also frees h_in for host refill (STAGING_FREE aliases it).
+// The produce-acquire keeps the H2D copy from overwriting d_in while the
+// prior generation's scatter still reads it; the release also frees h_in
+// for host refill (STAGING_FREE aliases it).
 static int
 dispatch_h2d(struct staging_state* stage,
              int idx,

--- a/src/gpu/stream.ingest.h
+++ b/src/gpu/stream.ingest.h
@@ -15,14 +15,14 @@ void
 ingest_destroy(struct staging_state* stage);
 
 // H2D transfer + scatter into chunk pool.
-// pool_epoch: pointer to the target epoch's chunk region in the pool.
+// pool_epoch: acquired view of the target epoch's chunk region in the pool.
 // cursor: in/out, incremented by elements transferred.
 // Returns 0 on success, non-zero on error.
 int
 ingest_dispatch_scatter(struct staging_state* stage,
                         const struct tile_stream_layout* layout,
                         const struct tile_stream_layout_gpu* layout_gpu,
-                        void* pool_epoch,
+                        struct gpu_pool_view pool_epoch,
                         uint64_t* cursor,
                         size_t bpe,
                         CUstream h2d,

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -151,8 +151,11 @@ stream_engine_init(struct stream_engine* e,
           &e->stage, lim->buffer_capacity, &e->ord, e->streams.compute) == 0);
 
   e->pool_bytes = lim->pool_bytes;
+  gpu_pool_init(
+    &e->pools.p, &e->ord, GPU_EDGE_POOL_FILLED, GPU_EDGE_POOL_CONSUMED);
   for (int i = 0; i < 2; ++i) {
     CU(Fail, cuMemAlloc(&e->pools.buf[i], lim->pool_bytes));
+    gpu_pool_bind(&e->pools.p, i, (void*)(uintptr_t)e->pools.buf[i]);
     CU(Fail,
        cuMemsetD8Async(e->pools.buf[i], 0, lim->pool_bytes, e->streams.compute));
   }

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -341,7 +341,7 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
 
   // A failed flush can leave a kick parked on the tail gate; release it or
   // the syncs below never return.
-  gpu_edge_release_all(&s->engine.ord);
+  gpu_pool_release_all(&s->engine.compress_agg.tail);
 
   // Ensure all GPU work completes before tearing down events/memory.
   sync(s->engine.streams.h2d);

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -691,7 +691,7 @@ static int
 scatter_morton_to_chunks(struct lod_state* lod,
                          struct lod_shared_state* sh,
                          const struct level_geometry* levels,
-                         void* pool_epoch,
+                         struct gpu_pool_view pool_epoch,
                          enum dtype dtype,
                          uint32_t active_levels_mask,
                          CUstream compute)
@@ -705,9 +705,9 @@ scatter_morton_to_chunks(struct lod_state* lod,
       continue;
 
     struct lod_span lev = lod_spans_at(&p->level_spans, lv);
-    CUdeviceptr dst = (CUdeviceptr)pool_epoch + levels->level[lv].chunk_offset *
-                                                  chunk_stride *
-                                                  bytes_per_element;
+    CUdeviceptr dst = gpu_pool_view_d(pool_epoch) +
+                      levels->level[lv].chunk_offset * chunk_stride *
+                        bytes_per_element;
 
     CHECK(Error,
           lod_morton_to_chunks_lut(dst,
@@ -732,7 +732,7 @@ lod_run_epoch(struct lod_state* lod,
               struct gpu_ordering* ord,
               int fc,
               const struct level_geometry* levels,
-              void* pool_epoch,
+              struct gpu_pool_view pool_epoch,
               enum dtype dtype,
               enum lod_reduce_method reduce_method,
               enum lod_reduce_method append_reduce_method,

--- a/src/gpu/stream.lod.h
+++ b/src/gpu/stream.lod.h
@@ -54,16 +54,16 @@ lod_state_device_bytes(const struct computed_stream_layouts* cl,
                        const struct tile_stream_configuration* config);
 
 // Run LOD pipeline for one epoch: gather -> reduce -> append fold ->
-// morton-to-chunks. pool_epoch: pointer to this epoch's chunk pool region (all
-// levels). *out_active_mask: set to bitmask of active LOD levels for this
-// epoch. Returns 0 on success, non-zero on error.
+// morton-to-chunks. pool_epoch: acquired view of this epoch's chunk pool
+// region (all levels). *out_active_mask: set to bitmask of active LOD levels
+// for this epoch. Returns 0 on success, non-zero on error.
 int
 lod_run_epoch(struct lod_state* lod,
               struct lod_shared_state* sh,
               struct gpu_ordering* ord,
               int fc,
               const struct level_geometry* levels,
-              void* pool_epoch,
+              struct gpu_pool_view pool_epoch,
               enum dtype dtype,
               enum lod_reduce_method reduce_method,
               enum lod_reduce_method append_reduce_method,

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -180,9 +180,14 @@ switch_to_array(struct multiarray_tile_stream_gpu* ms, int array_index)
   // the per-array portion of the current pool as an optimization for the
   // common batch-boundary case, but that only covers one pool and only the
   // per-array size — this full zero covers both pools at the max size.)
+  // Host-ordered access: the departing array's sync flush drained every
+  // batch, so no produce wait is queued.
   for (int i = 0; i < 2; ++i)
     CU(Fail,
-       cuMemsetD8Async(e->pools.buf[i], 0, e->pool_bytes, e->streams.compute));
+       cuMemsetD8Async(gpu_pool_view_d(gpu_pool_at(&e->pools.p, i, 0)),
+                       0,
+                       e->pool_bytes,
+                       e->streams.compute));
 
   return 0;
 

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -66,9 +66,9 @@ drain_d2h_for_array(struct stream_engine* e, struct array_descriptor_gpu* desc)
   cuStreamSynchronize(e->streams.d2h);
   // Drain the unified slot's io_done fence with the departing array's sink
   // so the next-bound array doesn't wait on a fence that was issued by a
-  // different sink.
+  // different sink. Host-ordered access: the sync above quiesced the slot.
   for (int fc = 0; fc < 2; ++fc) {
-    struct aggregate_slot* agg = &e->compress_agg.agg[fc];
+    struct aggregate_slot* agg = gpu_pool_at(&e->compress_agg.agg_host, fc, 0).p;
     if (agg->io_done.seq > 0 && desc->ctx.sink->wait_fence)
       desc->ctx.sink->wait_fence(desc->ctx.sink, agg->io_done);
     agg->io_done.seq = 0;

--- a/tests/test_compress_agg.c
+++ b/tests/test_compress_agg.c
@@ -161,6 +161,14 @@ Fail:
   return 1;
 }
 
+// Tests host-sync the compute stream before reading slot contents, so the
+// host-ordered peek is the right acquire.
+static struct aggregate_slot*
+handoff_slot(const struct flush_handoff* handoff)
+{
+  return gpu_pool_at(handoff->agg_host, handoff->fc, 0).p;
+}
+
 // D2H aggregate offsets and data for level 0. Caller frees *out_agg_data.
 // Copies the full d_aggregated pool because the new tail-carryover layout
 // places each shard's chunks at fixed `s * shard_capacity` offsets — not
@@ -175,7 +183,7 @@ ca_ctx_fetch_agg(struct flush_handoff* handoff,
                  uint64_t n_covering,
                  void** out_agg_data)
 {
-  struct aggregate_slot* agg = handoff->agg;
+  struct aggregate_slot* agg = handoff_slot(handoff);
   const struct lod_segment* seg = &handoff->layout.lods[0];
   const uint64_t base = seg->batch_covering_offset + 0; // lv=0
 
@@ -215,7 +223,7 @@ verify_tiles_none(const struct flush_handoff* handoff,
                   uint16_t (*fill_fn)(uint64_t))
 {
   const struct aggregate_layout* al = &handoff->per_lod_agg_layouts[0];
-  const struct aggregate_slot* agg = handoff->agg;
+  const struct aggregate_slot* agg = handoff_slot(handoff);
   const struct lod_segment* seg = &handoff->layout.lods[0];
   const size_t* lv_offsets = agg->h_offsets + seg->batch_covering_offset + 0;
   const uint64_t total_chunks = c->cl.levels.total_chunks;
@@ -286,13 +294,13 @@ test_compress_agg_single_epoch(void)
   CHECK(Fail, handoff.t_compress_start != 0);
   CHECK(Fail, handoff.t_compress_end != 0);
   CHECK(Fail, handoff.max_output_size == chunk_bytes);
-  CHECK(Fail, handoff.agg != NULL);
+  CHECK(Fail, handoff.agg_pool != NULL);
   CHECK(Fail, handoff.per_lod_agg_layouts != NULL);
 
   // D2H and verify
   const struct lod_segment* seg0 = &handoff.layout.lods[0];
   const size_t* lv_offsets =
-    handoff.agg->h_offsets + seg0->batch_covering_offset + 0;
+    handoff_slot(&handoff)->h_offsets + seg0->batch_covering_offset + 0;
   uint64_t C = handoff.per_lod_agg_layouts[0].covering_count;
   CHECK(Fail, ca_ctx_fetch_agg(&handoff, C, &h_agg) == 0);
   CHECK(Fail, verify_offsets_monotonic(lv_offsets, C) == 0);
@@ -352,7 +360,7 @@ test_compress_agg_batch(void)
   const struct aggregate_layout* al = &handoff.per_lod_agg_layouts[0];
   const struct lod_segment* seg = &handoff.layout.lods[0];
   const size_t* lv_offsets =
-    handoff.agg->h_offsets + seg->batch_covering_offset + 0;
+    handoff_slot(&handoff)->h_offsets + seg->batch_covering_offset + 0;
   uint64_t C = al->covering_count;
   uint32_t batch_count = c.stage.ar.per_lod_agg_layouts[0].active_count_max;
   uint64_t batch_covering = (uint64_t)batch_count * C;
@@ -454,7 +462,7 @@ test_compress_agg_partial_batch(void)
     c.cl.layouts[0].chunk_stride * dtype_bpe(c.config.dtype);
   const struct lod_segment* seg = &handoff.layout.lods[0];
   const size_t* lv_offsets =
-    handoff.agg->h_offsets + seg->batch_covering_offset + 0;
+    handoff_slot(&handoff)->h_offsets + seg->batch_covering_offset + 0;
   uint64_t C = handoff.per_lod_agg_layouts[0].covering_count;
   CHECK(Fail, ca_ctx_fetch_agg(&handoff, C, &h_agg) == 0);
   CHECK(Fail, verify_offsets_monotonic(lv_offsets, C) == 0);
@@ -510,9 +518,9 @@ test_compress_agg_zstd_single_epoch(void)
   const struct aggregate_layout* al = &handoff.per_lod_agg_layouts[0];
   const struct lod_segment* seg = &handoff.layout.lods[0];
   const size_t* lv_offsets =
-    handoff.agg->h_offsets + seg->batch_covering_offset + 0;
+    handoff_slot(&handoff)->h_offsets + seg->batch_covering_offset + 0;
   const size_t* lv_sizes =
-    handoff.agg->h_permuted_sizes + seg->batch_covering_offset + 0;
+    handoff_slot(&handoff)->h_permuted_sizes + seg->batch_covering_offset + 0;
   uint64_t C = al->covering_count;
   CHECK(Fail, ca_ctx_fetch_agg(&handoff, C, &h_agg) == 0);
   CHECK(Fail, verify_offsets_monotonic(lv_offsets, C) == 0);
@@ -596,7 +604,7 @@ test_compress_agg_zstd_batch(void)
   const struct aggregate_layout* al = &handoff.per_lod_agg_layouts[0];
   const struct lod_segment* seg = &handoff.layout.lods[0];
   const size_t* lv_offsets =
-    handoff.agg->h_offsets + seg->batch_covering_offset + 0;
+    handoff_slot(&handoff)->h_offsets + seg->batch_covering_offset + 0;
   uint64_t C = al->covering_count;
   uint32_t batch_count = c.stage.ar.per_lod_agg_layouts[0].active_count_max;
   uint64_t batch_covering = (uint64_t)batch_count * C;

--- a/tests/test_compress_agg.c
+++ b/tests/test_compress_agg.c
@@ -117,13 +117,13 @@ Fail:
   return 1;
 }
 
-// Stand in for delivery's tail publish (flush.d2h_deliver.c): tests drive
-// compress_agg_kick without the delivery loop, and an unpublished
+// Stand in for delivery's tail release (flush.d2h_deliver.c): tests drive
+// compress_agg_kick without the delivery loop, and an unreleased
 // generation parks the next kick's tail gate forever.
 static void
 ca_ctx_publish_tail(struct ca_test_ctx* c)
 {
-  gpu_edge_publish(&c->ord, GPU_EDGE_TAIL_PUBLISHED);
+  gpu_pool_release_produce_gen(&c->stage.tail);
 }
 
 // Build input, kick compress_agg, sync.

--- a/tests/test_compress_agg.c
+++ b/tests/test_compress_agg.c
@@ -26,7 +26,8 @@ struct ca_test_ctx
   struct compress_agg_stage stage;
   CUstream compute;
   CUdeviceptr d_pool;
-  struct gpu_ordering ord;      // pool-filled record stands in for the engine
+  struct gpu_ordering ord; // edge registry the harness pools draw from
+  struct gpu_pool pool;    // chunk pool faked over d_pool (both slots)
   uint32_t* batch_active_masks; // [K] owned scratch for tests
   int ord_inited;
   int stage_inited;
@@ -78,6 +79,9 @@ ca_ctx_setup(struct ca_test_ctx* c,
                       c->cl.layouts[0].chunk_stride *
                       dtype_bpe(c->config.dtype);
   CU(Fail, cuMemAlloc(&c->d_pool, pool_bytes));
+  gpu_pool_init(&c->pool, &c->ord, GPU_EDGE_POOL_FILLED, GPU_EDGE_POOL_CONSUMED);
+  for (int fc = 0; fc < 2; ++fc)
+    gpu_pool_bind(&c->pool, fc, (void*)(uintptr_t)c->d_pool);
 
   c->batch_active_masks =
     (uint32_t*)calloc(c->cl.epochs_per_batch, sizeof(uint32_t));
@@ -104,10 +108,9 @@ ca_ctx_fill_epoch(struct ca_test_ctx* c,
           epoch_ptr, total_chunks, chunk_stride, bytes_per_element, fill_fn) ==
           0);
 
-  // Re-record pool-filled on the compute stream after every fill so the
-  // kick's wait sees batch-level readiness.
-  CHECK(Fail,
-        gpu_edge_record(&c->ord, GPU_EDGE_POOL_FILLED, 0, c->compute) == 0);
+  // Re-release pool-filled on the compute stream after every fill so the
+  // kick's acquire sees batch-level readiness.
+  CHECK(Fail, gpu_pool_release_produce(&c->pool, 0, c->compute) == 0);
   return 0;
 
 Fail:
@@ -137,7 +140,7 @@ ca_ctx_kick(struct ca_test_ctx* c,
     .n_epochs = n_epochs,
     .active_levels_mask = 0x1,
     .batch_active_masks = c->batch_active_masks,
-    .pool_buf = c->d_pool,
+    .pool = &c->pool,
     .lod_active = 0,
     .epochs_per_batch = c->cl.epochs_per_batch,
   };
@@ -759,7 +762,7 @@ test_compress_agg_lut_cache_position_shift(void)
       .n_epochs = 2,
       .active_levels_mask = 0x1,
       .batch_active_masks = c.batch_active_masks,
-      .pool_buf = c.d_pool,
+      .pool = &c.pool,
       .lod_active = 0,
       .epochs_per_batch = c.cl.epochs_per_batch,
     };
@@ -789,7 +792,7 @@ test_compress_agg_lut_cache_position_shift(void)
       .n_epochs = 2,
       .active_levels_mask = 0x1,
       .batch_active_masks = c.batch_active_masks,
-      .pool_buf = c.d_pool,
+      .pool = &c.pool,
       .lod_active = 0,
       .epochs_per_batch = c.cl.epochs_per_batch,
     };

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -28,7 +28,8 @@ struct test_ctx
   CUstream compute;
   CUstream d2h_stream;
   CUdeviceptr d_pool;
-  struct gpu_ordering ord; // pool-filled record stands in for the engine
+  struct gpu_ordering ord; // edge registry the harness pools draw from
+  struct gpu_pool pool;    // chunk pool; slots rebound per kick's pool_buf
   uint32_t* batch_active_masks;
   struct stream_metrics metrics;
   struct lod_state lod;
@@ -95,6 +96,7 @@ test_ctx_setup(struct test_ctx* c,
   size_t pool_bytes = (uint64_t)n_pool_epochs * c->cl.levels.total_chunks *
                       c->cl.layouts[0].chunk_stride * dtype_bpe(config->dtype);
   CU(Fail, cuMemAlloc(&c->d_pool, pool_bytes));
+  gpu_pool_init(&c->pool, &c->ord, GPU_EDGE_POOL_FILLED, GPU_EDGE_POOL_CONSUMED);
 
   c->batch_active_masks =
     (uint32_t*)calloc(c->cl.epochs_per_batch, sizeof(uint32_t));
@@ -130,12 +132,13 @@ test_ctx_kick_and_drain(struct test_ctx* c,
   for (uint32_t i = 0; i < n_epochs; ++i)
     c->batch_active_masks[i] = 0x1;
 
+  gpu_pool_bind(&c->pool, fc, (void*)(uintptr_t)pool_buf);
   struct compress_agg_input in = {
     .fc = fc,
     .n_epochs = n_epochs,
     .active_levels_mask = 0x1,
     .batch_active_masks = c->batch_active_masks,
-    .pool_buf = pool_buf,
+    .pool = &c->pool,
     .lod_active = 0,
     .epochs_per_batch = c->cl.epochs_per_batch,
   };
@@ -211,8 +214,7 @@ test_d2h_single_epoch_none(void)
       0);
 
   // Record pool-filled after the fill
-  CHECK(Fail,
-        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
+  CHECK(Fail, gpu_pool_release_produce(&c.pool, 0, c.compute) == 0);
 
   // Kick compress_agg + D2H + drain
   struct flush_handoff handoff;
@@ -281,8 +283,7 @@ test_d2h_batch_none(void)
                         bytes_per_element,
                         fill_epoch1) == 0);
 
-  CHECK(Fail,
-        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
+  CHECK(Fail, gpu_pool_release_produce(&c.pool, 0, c.compute) == 0);
 
   // Kick with 2 epochs
   struct flush_handoff handoff;
@@ -426,8 +427,7 @@ test_d2h_zstd_single_epoch(void)
                         bytes_per_element,
                         fill_epoch0) == 0);
 
-  CHECK(Fail,
-        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
+  CHECK(Fail, gpu_pool_release_produce(&c.pool, 0, c.compute) == 0);
 
   struct flush_handoff handoff;
   CHECK(Fail,
@@ -539,8 +539,7 @@ test_d2h_double_buffer(void)
     fill_pool_epoch(
       c.d_pool, total_chunks, chunk_stride, bytes_per_element, fill_epoch0) ==
       0);
-  CHECK(Fail,
-        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
+  CHECK(Fail, gpu_pool_release_produce(&c.pool, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
@@ -558,8 +557,7 @@ test_d2h_double_buffer(void)
                         chunk_stride,
                         bytes_per_element,
                         fill_epoch1) == 0);
-  CHECK(Fail,
-        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
+  CHECK(Fail, gpu_pool_release_produce(&c.pool, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
@@ -673,8 +671,7 @@ test_d2h_zstd_double_buffer(void)
     fill_pool_epoch(
       c.d_pool, total_chunks, chunk_stride, bytes_per_element, fill_epoch0) ==
       0);
-  CHECK(Fail,
-        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
+  CHECK(Fail, gpu_pool_release_produce(&c.pool, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
@@ -691,8 +688,7 @@ test_d2h_zstd_double_buffer(void)
                         chunk_stride,
                         bytes_per_element,
                         fill_epoch1) == 0);
-  CHECK(Fail,
-        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
+  CHECK(Fail, gpu_pool_release_produce(&c.pool, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
@@ -715,8 +711,7 @@ test_d2h_zstd_double_buffer(void)
     fill_pool_epoch(
       c.d_pool, total_chunks, chunk_stride, bytes_per_element, fill_epoch2) ==
       0);
-  CHECK(Fail,
-        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
+  CHECK(Fail, gpu_pool_release_produce(&c.pool, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;
@@ -735,8 +730,7 @@ test_d2h_zstd_double_buffer(void)
                         chunk_stride,
                         bytes_per_element,
                         fill_epoch3) == 0);
-  CHECK(Fail,
-        gpu_edge_record(&c.ord, GPU_EDGE_POOL_FILLED, 0, c.compute) == 0);
+  CHECK(Fail, gpu_pool_release_produce(&c.pool, 0, c.compute) == 0);
 
   {
     struct flush_handoff handoff;

--- a/tests/test_flush_orchestration.c
+++ b/tests/test_flush_orchestration.c
@@ -124,8 +124,15 @@ orch_ctx_setup(struct orch_ctx* c,
                          c->s->engine.streams.compute) == 0);
 
   // Double-buffered chunk pools
+  gpu_pool_init(&c->s->engine.pools.p,
+                &c->s->engine.ord,
+                GPU_EDGE_POOL_FILLED,
+                GPU_EDGE_POOL_CONSUMED);
   for (int i = 0; i < 2; ++i) {
     CU(Fail, cuMemAlloc(&c->s->engine.pools.buf[i], pool_bytes));
+    gpu_pool_bind(&c->s->engine.pools.p,
+                  i,
+                  (void*)(uintptr_t)c->s->engine.pools.buf[i]);
     CU(Fail,
        cuMemsetD8Async(c->s->engine.pools.buf[i],
                        0,

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -110,7 +110,7 @@ test_ingest_single_epoch(void)
   for (uint64_t i = 0; i < epoch_elements; ++i)
     h_src[i] = (uint16_t)(i & 0xFFFF);
 
-  memcpy(stage.slot[0].h_in, h_src, src_bytes);
+  memcpy(gpu_pool_at(&stage.h_pool, 0, 0).p, h_src, src_bytes);
   stage.bytes_written = src_bytes;
 
   {
@@ -243,7 +243,7 @@ test_ingest_incremental(void)
   {
     uint64_t cursor = 0;
 
-    memcpy(stage.slot[stage.current].h_in, h_src, half);
+    memcpy(gpu_pool_at(&stage.h_pool, stage.current, 0).p, h_src, half);
     stage.bytes_written = half;
     CHECK(Fail,
           ingest_dispatch_scatter(&stage,
@@ -256,10 +256,11 @@ test_ingest_incremental(void)
                                   compute) == 0);
     CHECK(Fail, cursor == epoch_elements / 2);
 
-    CU(Fail,
-       cuEventSynchronize(gpu_ordering_event(
-         &ord, GPU_EDGE_STAGING_H2D_DONE, stage.current)));
-    memcpy(stage.slot[stage.current].h_in, (uint8_t*)h_src + half, half);
+    struct gpu_pool_view h_in;
+    CHECK(Fail,
+          gpu_pool_host_acquire_produce(&stage.h_pool, stage.current, &h_in) ==
+            0);
+    memcpy(h_in.p, (uint8_t*)h_src + half, half);
     stage.bytes_written = half;
     CHECK(Fail,
           ingest_dispatch_scatter(&stage,
@@ -351,7 +352,7 @@ test_ingest_multiscale(void)
   for (uint64_t i = 0; i < epoch_elements; ++i)
     h_src[i] = (uint16_t)(i + 1);
 
-  memcpy(stage.slot[0].h_in, h_src, src_bytes);
+  memcpy(gpu_pool_at(&stage.h_pool, 0, 0).p, h_src, src_bytes);
   stage.bytes_written = src_bytes;
 
   {

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -119,7 +119,8 @@ test_ingest_single_epoch(void)
           ingest_dispatch_scatter(&stage,
                                   &layout,
                                   &layout_gpu,
-                                  (void*)d_pool,
+                                  (struct gpu_pool_view){
+                                    .p = (void*)(uintptr_t)d_pool },
                                   &cursor,
                                   bytes_per_element,
                                   h2d,
@@ -249,7 +250,8 @@ test_ingest_incremental(void)
           ingest_dispatch_scatter(&stage,
                                   &layout,
                                   &layout_gpu,
-                                  (void*)d_pool,
+                                  (struct gpu_pool_view){
+                                    .p = (void*)(uintptr_t)d_pool },
                                   &cursor,
                                   bytes_per_element,
                                   h2d,
@@ -266,7 +268,8 @@ test_ingest_incremental(void)
           ingest_dispatch_scatter(&stage,
                                   &layout,
                                   &layout_gpu,
-                                  (void*)d_pool,
+                                  (struct gpu_pool_view){
+                                    .p = (void*)(uintptr_t)d_pool },
                                   &cursor,
                                   bytes_per_element,
                                   h2d,


### PR DESCRIPTION
Step 3 of the migration in `docs/gpu-orchestration.md` — **resource pools
with generation-carried ordering** — following #143 (edge table) and #144
(engine unification). This is the step the plan exists for: after it, a
stage cannot observe a pointer to a cycled buffer without the
synchronization that makes it safe.

## What

`src/gpu/pool.{h,c}` (226 LOC): a pool binds a cycled resource's per-slot
payload to the two declared edges that order its generations (`ready`:
producer→consumer; `consumed`: consumer→producer). `acquire` queues the
wait that makes the payload safe in that role before handing the pointer
out; `release` records that role's completion. Pointers are minted only by
the pool API (`gpu_pool_view`); `gpu_pool_at` exists solely for documented
host-ordered paths (sync flush, bind, teardown). Edge identity, instancing,
debug asserts, and stall metrics stay in `gpu_ordering` — pools draw edges
from the table and never own events. Host-published generations (#142's
tail gate) are the same API with a `GEN_COUNTER` ready edge; teardown is
`gpu_pool_release_all` (preserving #142's release-before-blocking-sync and
memops degradation exactly).

Four resource families migrated, one commit each, suite green at every
commit:

1. **Staging slots** — ingest's four cross-stream waits/records become
   produce/consume acquire/release; the append loop's previously-unmetered
   busy-poll is a host acquire.
2. **Chunk pool** — the #140 edge is now structural: `drain_kick_and_swap`
   must `gpu_pool_acquire_produce` before re-zeroing.
3. **Aggregate slots** — three facets (device slot, host mirror, chunk
   index) over the same payload, each guarding a different consumer;
   `flush_handoff` carries pool handles instead of a raw slot pointer.
4. **Tail state** — `arm_tail_gate` → consumer acquire (threshold advances
   even when disabled, so every kick drains exactly once); `finish_drain` →
   producer release, on failure exits too.

`GPU_EDGE_LOD_DONE` deliberately remains a plain edge (dual-use timing
event; a second producer into the chunk pool).

## Boundary proof

Direct edge operations outside `ordering.c`/`pool.c`: **three**, all the
deliberate LOD_DONE sites. No stage signature takes a raw device pointer
for a pooled resource (`compress_agg_input.pool_buf` is a `gpu_pool*`;
ingest/LOD take `gpu_pool_view`); payload field access outside init/destroy
/bind is gone.

## Mutation checks (the step's exit criterion)

Temporary, never-committed mutations on the final commit:

- Chunk-pool acquire dropped (re-zero without waiting POOL_CONSUMED — the
  #140 bug reintroduced): `gpu_zstd_determinism` fails **8/8 reps**.
- Tail generation wait dropped (gate never armed — the #141 bug
  reintroduced): `gpu_page_aligned_tail_carry` fails **8/8 reps**.

Both restored: green. The pools demonstrably carry the ordering, and the
regression tests stand guard.

## Validation (L40, sm_89)

- Full `ctest -E "(s3)"` green in RelWithDebInfo **and** Debug at each of
  the four family commits; zero new build warnings; Debug runs clean of
  ordering asserts.
- `test_cross_validate` 8/8 reps (determinism, zstd round-trip,
  page-aligned tail-carry); `test_multiarray_gpu` + two_streams bench both
  codecs.
- Perf, base vs PR, same node, interleaved 3 reps × 5 scenarios × 2 codecs:
  zstd within 0.3% everywhere; codec=none within run noise (worst first-rep
  outlier re-tested with warmup: −0.9%). No standing regression.

## Commit guide

- `Add resource pool API; migrate staging` — pool.{h,c} + first family.
- `Migrate chunk pool to pool API` — #140's edge becomes structural.
- `Migrate aggregate slots to pool API` — the three facets + handoff
  change.
- `Migrate tail state to pool API` — #142's gate behind the GEN_COUNTER
  kind.
- `Trim comments to why-only` — comment hygiene pass.
