### PR TITLE
Move staging copies and sink delivery to worker threads

### DIFF
--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -501,7 +501,10 @@ run_bench(const struct bench_config* cfg)
 
   struct platform_clock clock = { 0 };
   platform_toc(&clock);
-  CHECK(Fail, pump_data(bench_writer(&h), total_elements, fill) == 0);
+  CHECK(Fail,
+        (cfg->prefill
+           ? pump_data_prefilled(bench_writer(&h), total_elements, fill)
+           : pump_data(bench_writer(&h), total_elements, fill)) == 0);
 
   size_t pending_bytes = bench_zarr_pending_bytes(&zarr);
 
@@ -607,6 +610,7 @@ struct bench_cli_args
   uint64_t io_latency_us;
   size_t backpressure_bytes;
   int max_threads;
+  int prefill;
 };
 
 // Parse the shared bench CLI flags into out. Unknown options print a usage
@@ -640,6 +644,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
   out->io_latency_us = 0;
   out->backpressure_bytes = 0;
   out->max_threads = 0;
+  out->prefill = 0;
 
   for (int i = 1; i < ac; ++i) {
     if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
@@ -688,6 +693,8 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
       out->backpressure_bytes = parse_bytes(av[++i]);
     } else if (strcmp(av[i], "--max-threads") == 0 && i + 1 < ac) {
       out->max_threads = (int)strtol(av[++i], NULL, 10);
+    } else if (strcmp(av[i], "--prefill") == 0) {
+      out->prefill = 1;
     } else {
       fprintf(stderr, "Unknown option: %s\n", av[i]);
       fprintf(stderr,
@@ -700,7 +707,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
               "[--s3-throughput-gbps N]] "
               "[--io-bw-mbps N (MiB/s)] [--io-latency-us N] "
               "[--backpressure N (bytes, e.g. 256M)] "
-              "[--max-threads N (0 = OpenMP default)]\n",
+              "[--max-threads N (0 = OpenMP default)] [--prefill]\n",
               av[0]);
       return 1;
     }
@@ -761,6 +768,7 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
     .io_latency_us = a.io_latency_us,
     .backpressure_bytes = a.backpressure_bytes,
     .max_threads = a.max_threads,
+    .prefill = a.prefill,
   };
   ecode = run_bench(&cfg);
 
@@ -786,13 +794,19 @@ pump_data_interleaved(struct writer* w0,
                       struct writer* w1,
                       size_t total_elements,
                       fill_fn fill,
-                      size_t bpe)
+                      size_t bpe,
+                      int prefill)
 {
   const size_t nelements = 32 * 1024 * 1024; // 32M elements per chunk
   size_t alloc = nelements * (bpe > 2 ? bpe : 2);
   uint16_t* data = (uint16_t*)malloc(alloc);
   if (!data)
     return 1;
+  if (prefill)
+    fill(data,
+         nelements < total_elements ? nelements : total_elements,
+         0,
+         total_elements);
 
   size_t off0 = 0, off1 = 0;
 
@@ -802,7 +816,8 @@ pump_data_interleaved(struct writer* w0,
       size_t n = nelements;
       if (off0 + n > total_elements)
         n = total_elements - off0;
-      fill(data, n, off0, total_elements);
+      if (!prefill)
+        fill(data, n, off0, total_elements);
       struct slice input = { .beg = data, .end = (char*)data + n * bpe };
       struct writer_result r = writer_append_wait(w0, input);
       if (r.error) {
@@ -818,7 +833,8 @@ pump_data_interleaved(struct writer* w0,
       size_t n = nelements;
       if (off1 + n > total_elements)
         n = total_elements - off1;
-      fill(data, n, off1, total_elements);
+      if (!prefill)
+        fill(data, n, off1, total_elements);
       struct slice input = { .beg = data, .end = (char*)data + n * bpe };
       struct writer_result r = writer_append_wait(w1, input);
       if (r.error) {
@@ -960,7 +976,9 @@ run_bench_two_streams(const struct bench_config* cfg)
   // Interleaved pump
   struct platform_clock clock = { 0 };
   platform_toc(&clock);
-  CHECK(Fail, pump_data_interleaved(w0, w1, total_elements, fill, bpe) == 0);
+  CHECK(Fail,
+        pump_data_interleaved(
+          w0, w1, total_elements, fill, bpe, cfg->prefill) == 0);
 
   // Flush zarr sinks before measuring wall time
   struct platform_clock flush_clock = { 0 };
@@ -1133,6 +1151,7 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
     .io_latency_us = a.io_latency_us,
     .backpressure_bytes = a.backpressure_bytes,
     .max_threads = a.max_threads,
+    .prefill = a.prefill,
   };
   int ecode = run_bench_two_streams(&cfg);
 

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -54,6 +54,7 @@ struct bench_config
   uint64_t io_latency_us;     // 0 = no fixed per-job latency
   size_t backpressure_bytes;  // 0 = disabled; >0 = stall when pending > N
   int max_threads;            // 0 = OpenMP default (omp_get_max_threads)
+  int prefill;                // fill the pump buffer once, append repeatedly
 };
 
 int

--- a/bench/sink_throttled.c
+++ b/bench/sink_throttled.c
@@ -48,7 +48,7 @@ throttled_post(struct throttled_shard_sink* s, size_t nbytes)
     free(j);
     goto Error;
   }
-  s->queued_bytes += nbytes;
+  atomic_fetch_add(&s->queued_bytes, nbytes);
   return 0;
 
 Error:
@@ -124,9 +124,10 @@ throttled_shard_pending_bytes(const struct shard_sink* self)
   const struct throttled_shard_sink* s =
     (const struct throttled_shard_sink*)self;
   uint64_t retired = atomic_load(&s->retired_bytes);
-  if (s->queued_bytes <= retired)
+  uint64_t queued = atomic_load(&s->queued_bytes);
+  if (queued <= retired)
     return 0;
-  return (size_t)(s->queued_bytes - retired);
+  return (size_t)(queued - retired);
 }
 
 int

--- a/bench/sink_throttled.h
+++ b/bench/sink_throttled.h
@@ -18,7 +18,7 @@ struct throttled_shard_sink
   struct shard_sink base;
   struct throttled_shard_writer writer; // single shared writer
   struct io_queue* queue;               // owned
-  uint64_t queued_bytes;                // main-thread only
+  _Atomic uint64_t queued_bytes;        // delivery thread posts, producer reads
   _Atomic uint64_t retired_bytes;       // worker, atomic
   _Atomic uint64_t total_bytes;         // reporting
   uint64_t latency_ns;                  // fixed per-job cost

--- a/docs/gpu-orchestration.md
+++ b/docs/gpu-orchestration.md
@@ -1,7 +1,10 @@
 # GPU stream orchestration: target design and migration plan
 
-Status: accepted direction, migration in progress (step 2).
-Base: main + #142. Related: #140, #141, PR #142, `gpu-output-slot-ledger.md`.
+Status: steps 1–4 merged (#143 edge table, #144 engine unification, #148
+resource pools, #149 scheduler); step 5 (workers) in review. The §5
+ambitions beyond data-movement workers (CPU/GPU sharing one orchestration,
+multiarray as composition) remain open follow-ups.
+Related: #140, #141, PR #142, `gpu-output-slot-ledger.md`.
 
 ## Why
 

--- a/src/gpu/CMakeLists.txt
+++ b/src/gpu/CMakeLists.txt
@@ -19,6 +19,6 @@ add_src_lib(stream
         flush.handoff.h flush.helpers.h
     LINKS
         transpose compress aggregate lod stream_config lod_plan index_ops
-        dimension crc32c shard_delivery writer platform chucky_log
+        dimension crc32c shard_delivery writer platform threadpool chucky_log
         CUDA::cuda_driver
 )

--- a/src/gpu/ordering.h
+++ b/src/gpu/ordering.h
@@ -221,5 +221,6 @@ gpu_edge_host_rule_check(struct gpu_ordering* ord,
 #define gpu_edge_host_rule(ord, e, cond)                                       \
   do {                                                                         \
     (void)(ord);                                                               \
+    (void)(cond);                                                              \
   } while (0)
 #endif

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -322,7 +322,9 @@ static void
 delivery_main(void* arg)
 {
   struct gpu_delivery* d = (struct gpu_delivery*)arg;
-  cuCtxSetCurrent(d->cuda);
+  // On failure the first drain's CUDA call fails and surfaces through the
+  // worker result at join; warn so the root cause is visible.
+  CUWARN(cuCtxSetCurrent(d->cuda));
   platform_mutex_lock(d->mu);
   for (;;) {
     int fc = -1;

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -494,7 +494,6 @@ Error:
   return 1;
 }
 
-// Joins the slot's queued delivery (or drains inline when none is queued).
 // The join wait is near-zero in steady state; the whole call accumulates
 // flush_stall.
 static struct writer_result

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -11,6 +11,7 @@
 #include "util/prelude.h"
 #include "zarr/shard_delivery.h"
 
+#include <assert.h>
 #include <string.h>
 
 // --- Streams ---
@@ -297,6 +298,144 @@ schedule_quiesce_output(struct stream_engine* e, struct shard_sink* sink)
   }
 }
 
+// --- Delivery worker ---
+
+// The whole drain for one kicked slot; runs on the worker when queued,
+// inline otherwise.
+static struct writer_result
+drain_payload(struct stream_engine* e, struct stream_context* ctx, int fc)
+{
+  return schedule_d2h_drain(&e->d2h_deliver,
+                            &e->sched.slot[fc].handoff,
+                            &ctx->levels,
+                            &ctx->dims,
+                            &ctx->layout,
+                            &ctx->config,
+                            ctx->sink,
+                            &e->lod,
+                            &e->lod_shared,
+                            &e->metrics,
+                            &e->metadata_update_clock);
+}
+
+static void
+delivery_main(void* arg)
+{
+  struct gpu_delivery* d = (struct gpu_delivery*)arg;
+  cuCtxSetCurrent(d->cuda);
+  platform_mutex_lock(d->mu);
+  for (;;) {
+    int fc = -1;
+    for (int i = 0; i < 2; ++i) {
+      struct delivery_job* j = &d->job[i];
+      if (j->queued && !j->done && (fc < 0 || j->seq < d->job[fc].seq))
+        fc = i;
+    }
+    if (fc < 0) {
+      if (d->stop)
+        break;
+      platform_cond_wait(d->cv, d->mu);
+      continue;
+    }
+    struct delivery_job* j = &d->job[fc];
+    const struct delivery_job* o = &d->job[fc ^ 1];
+    int oldest = !o->queued || o->done || j->seq < o->seq;
+    platform_mutex_unlock(d->mu);
+
+    gpu_edge_host_rule(&j->e->ord, GPU_EDGE_DELIVER_OLDEST_FIRST, oldest);
+    struct writer_result r = drain_payload(j->e, j->ctx, fc);
+
+    platform_mutex_lock(d->mu);
+    j->result = r;
+    j->done = 1;
+    platform_cond_broadcast(d->cv);
+  }
+  platform_mutex_unlock(d->mu);
+}
+
+int
+gpu_delivery_init(struct gpu_delivery* d)
+{
+  memset(d, 0, sizeof(*d));
+  if (cuCtxGetCurrent(&d->cuda) != CUDA_SUCCESS || !d->cuda)
+    return 1;
+  d->mu = platform_mutex_new();
+  d->cv = platform_cond_new();
+  CHECK(Fail, d->mu && d->cv);
+  d->thread = platform_thread_start(delivery_main, d);
+  CHECK(Fail, d->thread);
+  return 0;
+
+Fail:
+  platform_cond_free(d->cv);
+  platform_mutex_free(d->mu);
+  memset(d, 0, sizeof(*d));
+  return 1;
+}
+
+void
+gpu_delivery_enqueue(struct gpu_delivery* d,
+                     struct stream_engine* e,
+                     struct stream_context* ctx,
+                     int fc,
+                     uint64_t seq)
+{
+  if (!d->thread)
+    return;
+  platform_mutex_lock(d->mu);
+  // The drain-before-rekick rule keeps a slot's previous job joined before
+  // its next kick can enqueue here.
+  assert(!d->job[fc].queued);
+  d->job[fc] = (struct delivery_job){
+    .queued = 1,
+    .seq = seq,
+    .e = e,
+    .ctx = ctx,
+  };
+  platform_cond_broadcast(d->cv);
+  platform_mutex_unlock(d->mu);
+}
+
+int
+gpu_delivery_pending(struct gpu_delivery* d, int fc)
+{
+  if (!d->thread)
+    return 0;
+  platform_mutex_lock(d->mu);
+  int p = d->job[fc].queued;
+  platform_mutex_unlock(d->mu);
+  return p;
+}
+
+struct writer_result
+gpu_delivery_join(struct gpu_delivery* d, int fc)
+{
+  platform_mutex_lock(d->mu);
+  while (!d->job[fc].done)
+    platform_cond_wait(d->cv, d->mu);
+  struct writer_result r = d->job[fc].result;
+  d->job[fc] = (struct delivery_job){ 0 };
+  platform_mutex_unlock(d->mu);
+  return r;
+}
+
+void
+gpu_delivery_stop_join(struct gpu_delivery* d)
+{
+  if (!d->thread)
+    return;
+  platform_mutex_lock(d->mu);
+  d->stop = 1;
+  platform_cond_broadcast(d->cv);
+  platform_mutex_unlock(d->mu);
+  platform_thread_join(d->thread);
+  d->thread = NULL;
+  platform_cond_free(d->cv);
+  d->cv = NULL;
+  platform_mutex_free(d->mu);
+  d->mu = NULL;
+}
+
 // --- Helpers ---
 
 static struct compress_agg_input
@@ -355,8 +494,9 @@ Error:
   return 1;
 }
 
-// The handoff host-sync is near-zero in steady state; the whole call
-// accumulates flush_stall.
+// Joins the slot's queued delivery (or drains inline when none is queued).
+// The join wait is near-zero in steady state; the whole call accumulates
+// flush_stall.
 static struct writer_result
 drain_slot(struct stream_engine* e, struct stream_context* ctx, int fc)
 {
@@ -372,17 +512,9 @@ drain_slot(struct stream_engine* e, struct stream_context* ctx, int fc)
 
   struct platform_clock stall_clk = { 0 };
   platform_toc(&stall_clk);
-  struct writer_result r = schedule_d2h_drain(&e->d2h_deliver,
-                                              &s->handoff,
-                                              &ctx->levels,
-                                              &ctx->dims,
-                                              &ctx->layout,
-                                              &ctx->config,
-                                              ctx->sink,
-                                              &e->lod,
-                                              &e->lod_shared,
-                                              &e->metrics,
-                                              &e->metadata_update_clock);
+  struct writer_result r = gpu_delivery_pending(&e->delivery, fc)
+                             ? gpu_delivery_join(&e->delivery, fc)
+                             : drain_payload(e, ctx, fc);
   float ms = (float)(platform_toc(&stall_clk) * 1000.0);
   accumulate_metric_ms(&e->metrics.flush_stall, ms, 0, 0);
 
@@ -419,6 +551,12 @@ kick_batch(struct stream_engine* e,
   e->sched.slot[fc].handoff = handoff;
   e->sched.slot[fc].kick_seq = e->sched.next_seq++;
   e->sched.slot[fc].kicked = 1;
+
+  // Depth-1 schedules drain inline right after this kick; the host
+  // ordering they exist for must not move to another thread.
+  if (e->sched.depth == SCHEDULE_PIPELINED)
+    gpu_delivery_enqueue(
+      &e->delivery, e, ctx, fc, e->sched.slot[fc].kick_seq);
 
   return 0;
 

--- a/src/gpu/schedule.h
+++ b/src/gpu/schedule.h
@@ -13,6 +13,9 @@
 struct gpu_ordering;
 struct stream_engine;
 struct stream_context;
+struct platform_thread;
+struct platform_mutex;
+struct platform_cond;
 struct compress_agg_array;
 struct compress_agg_stage;
 struct compress_agg_input;
@@ -90,6 +93,61 @@ struct gpu_scheduler
   uint64_t next_seq;
   struct schedule_slot slot[2];
 };
+
+// Delivery worker: the pipelined schedule queues each kicked batch's drain
+// here at kick time and joins it before refilling the slot, so polls and
+// sink delivery run off the producer thread. One job slot per fc, queued in
+// kick order and run oldest-first (the tail gate's GEQ threshold and the
+// GPU_EDGE_DELIVER_OLDEST_FIRST rule). Ownership: the producer writes a job
+// between kick and enqueue and reads it after join; the worker owns it in
+// between — the same single-writer-per-generation discipline as the pools.
+// Engine/ctx pointers stay valid from enqueue to join (single-array only;
+// depth-1 schedules and multiarray drain inline and never queue here).
+struct delivery_job
+{
+  int queued;
+  int done;
+  uint64_t seq;
+  struct stream_engine* e;
+  struct stream_context* ctx;
+  struct writer_result result;
+};
+
+struct gpu_delivery
+{
+  struct platform_thread* thread; // NULL = drains run inline on the producer
+  struct platform_mutex* mu;
+  struct platform_cond* cv;
+  CUcontext cuda; // captured at init; made current on the worker
+  int stop;
+  struct delivery_job job[2]; // by fc
+};
+
+// Captures the calling thread's CUDA context and starts the worker.
+// Failure leaves the worker absent (drains run inline) — callers may
+// degrade rather than abort.
+int
+gpu_delivery_init(struct gpu_delivery* d);
+
+void
+gpu_delivery_enqueue(struct gpu_delivery* d,
+                     struct stream_engine* e,
+                     struct stream_context* ctx,
+                     int fc,
+                     uint64_t seq);
+
+int
+gpu_delivery_pending(struct gpu_delivery* d, int fc);
+
+struct writer_result
+gpu_delivery_join(struct gpu_delivery* d, int fc);
+
+// Runs every queued job to completion (each publishes its tail generation,
+// failure or not), then joins the thread. Idempotent; call before any
+// forced gate release — a worker publish after release_all would regress
+// the published count below parked thresholds.
+void
+gpu_delivery_stop_join(struct gpu_delivery* d);
 
 // Depth selection from the array's configuration. gate_ord NULL means
 // drains host-order the tail uploads (multiarray); call after the array's

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -163,12 +163,13 @@ stream_append_body(struct stream_engine* e,
           struct platform_clock mc = { 0 };
           platform_toc(&mc);
           // Same h_in generation as the bytes_written==0 acquire above.
-          memcpy(gpu_pool_at(&e->stage.h_pool,
-                             e->stage.current,
-                             e->stage.bytes_written)
-                   .p,
-                 src + written,
-                 payload);
+          ingest_copy(e->copy_pool,
+                      gpu_pool_at(&e->stage.h_pool,
+                                  e->stage.current,
+                                  e->stage.bytes_written)
+                        .p,
+                      src + written,
+                      payload);
           accumulate_metric_ms(&e->metrics.memcpy,
                                (float)(platform_toc(&mc) * 1000.0),
                                payload,

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -275,6 +275,7 @@ struct stream_engine
   struct lod_shared_state lod_shared; // engine-owned shared LOD resources
   struct lod_state lod;               // per-array; overwritten on array switch
   struct threadpool* copy_pool;       // staging-copy helpers (append body)
+  struct gpu_delivery delivery;       // drain worker (pipelined schedule)
   struct stream_metrics metrics;
   struct platform_clock metadata_update_clock;
 };

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -12,6 +12,8 @@
 #include "zarr/shard_delivery.h"
 #include <stddef.h>
 
+struct threadpool;
+
 // --- Sub-struct definitions (shared between engine and internal headers) ---
 
 struct pool_state
@@ -272,6 +274,7 @@ struct stream_engine
   struct d2h_deliver_stage d2h_deliver;
   struct lod_shared_state lod_shared; // engine-owned shared LOD resources
   struct lod_state lod;               // per-array; overwritten on array switch
+  struct threadpool* copy_pool;       // staging-copy helpers (append body)
   struct stream_metrics metrics;
   struct platform_clock metadata_update_clock;
 };
@@ -296,6 +299,7 @@ struct engine_limits
   size_t lod_linear_bytes;
   size_t lod_morton_bytes;
   int any_multiscale;
+  int max_threads; // max over arrays; 0 = platform default
 };
 
 // Fold one array's requirements into *lim (max per field). Call once per

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -2,9 +2,35 @@
 
 #include "gpu/prelude.cuda.h"
 #include "gpu/transpose.h"
+#include "threadpool/threadpool.h"
 #include "util/prelude.h"
 
 #include <string.h>
+
+struct copy_slices
+{
+  uint8_t* dst;
+  const uint8_t* src;
+};
+
+static void
+copy_slice(size_t beg, size_t end, int tid, void* vctx)
+{
+  (void)tid;
+  struct copy_slices* c = (struct copy_slices*)vctx;
+  memcpy(c->dst + beg, c->src + beg, end - beg);
+}
+
+void
+ingest_copy(struct threadpool* pool, void* dst, const void* src, size_t n)
+{
+  if (!pool || n < (2u << 20)) {
+    memcpy(dst, src, n);
+    return;
+  }
+  struct copy_slices c = { (uint8_t*)dst, (const uint8_t*)src };
+  threadpool_for_n(pool, n, copy_slice, &c);
+}
 
 int
 ingest_init(struct staging_state* stage,

--- a/src/gpu/stream.ingest.h
+++ b/src/gpu/stream.ingest.h
@@ -2,6 +2,14 @@
 
 #include "gpu/stream.internal.h"
 
+struct threadpool;
+
+// memcpy into pinned staging, split across the pool when the payload is
+// large enough to pay for the dispatch. The destination lies within one
+// acquired h_in generation owned by the caller, so no ordering is queued.
+void
+ingest_copy(struct threadpool* pool, void* dst, const void* src, size_t n);
+
 // Allocate double-buffered staging buffers and timing events; ordering
 // events live in ord. Returns 0 on success.
 int

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -8,6 +8,7 @@
 #include "lod/lod_plan.h"
 #include "platform/platform.h"
 #include "stream/config.h"
+#include "threadpool/threadpool.h"
 #include "util/prelude.h"
 #include "writer.h"
 
@@ -45,6 +46,8 @@ engine_limits_accumulate(struct engine_limits* lim,
   lim->buffer_capacity =
     max_sz(lim->buffer_capacity,
            (config->buffer_capacity_bytes + 4095) & ~(size_t)4095);
+  if (config->max_threads > lim->max_threads)
+    lim->max_threads = config->max_threads;
   lim->pool_bytes =
     max_sz(lim->pool_bytes, (size_t)K * total_chunks * chunk_stride * bpe);
   lim->chunk_bytes = max_sz(lim->chunk_bytes, chunk_stride * bpe);
@@ -123,6 +126,19 @@ stream_engine_init(struct stream_engine* e,
         ingest_init(
           &e->stage, lim->buffer_capacity, &e->ord, e->streams.compute) == 0);
 
+  {
+    // The staging copy is DRAM-bound; a few helpers saturate it. NULL pool
+    // means copies run serially on the producer.
+    int n = lim->max_threads > 0 ? lim->max_threads
+                                 : platform_default_thread_count();
+    int helpers = n - 1;
+    if (helpers > 3)
+      helpers = 3;
+    e->copy_pool = threadpool_new(helpers < 0 ? 0 : helpers);
+    if (!e->copy_pool)
+      log_warn("staging copy pool unavailable; copies run on the producer");
+  }
+
   e->pool_bytes = lim->pool_bytes;
   gpu_pool_init(
     &e->pools.p, &e->ord, GPU_EDGE_POOL_FILLED, GPU_EDGE_POOL_CONSUMED);
@@ -175,6 +191,8 @@ Fail:
 void
 stream_engine_destroy(struct stream_engine* e)
 {
+  threadpool_free(e->copy_pool);
+  e->copy_pool = NULL;
   d2h_deliver_destroy(&e->d2h_deliver);
   compress_agg_destroy_shared(&e->compress_agg);
   lod_shared_state_destroy(&e->lod_shared);

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -139,6 +139,9 @@ stream_engine_init(struct stream_engine* e,
       log_warn("staging copy pool unavailable; copies run on the producer");
   }
 
+  if (gpu_delivery_init(&e->delivery))
+    log_warn("delivery worker unavailable; drains run on the producer");
+
   e->pool_bytes = lim->pool_bytes;
   gpu_pool_init(
     &e->pools.p, &e->ord, GPU_EDGE_POOL_FILLED, GPU_EDGE_POOL_CONSUMED);
@@ -191,6 +194,8 @@ Fail:
 void
 stream_engine_destroy(struct stream_engine* e)
 {
+  // Before any stage teardown: queued jobs reference the stages and pools.
+  gpu_delivery_stop_join(&e->delivery);
   threadpool_free(e->copy_pool);
   e->copy_pool = NULL;
   d2h_deliver_destroy(&e->d2h_deliver);
@@ -333,6 +338,11 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
       log_error("GPU stream auto-flush failed during destroy");
     s->flushed = 1;
   }
+
+  // A failed flush can leave delivery jobs queued; run them out before the
+  // forced gate release below — a worker publish after release_all would
+  // regress the published count and re-park the gate.
+  gpu_delivery_stop_join(&s->engine.delivery);
 
   // A failed flush can leave a kick parked on the tail gate; release it or
   // the syncs below never return.

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -39,12 +39,13 @@ struct stream_metrics
   // flush_stall, kick_sync_stall, backpressure are GPU-only. io_fence_stall
   // is populated on both paths.
   //
-  // flush_stall is a SUPERSET: it wraps the entire schedule_d2h_drain call,
-  // which already times kick_sync_stall and sink internally. Summing
-  // flush_stall + kick_sync_stall + sink over-counts wall time. To isolate
-  // the drain-side overhead not already attributed elsewhere, compute
-  // flush_stall - kick_sync_stall - (sink portion inside drain).
-  struct stream_metric flush_stall;     // whole schedule_d2h_drain call
+  // On the pipelined schedule the drain runs on the delivery worker:
+  // kick_sync_stall and sink then accumulate worker-side and OVERLAP
+  // producer time — do not sum them with wall time. flush_stall is the
+  // producer's join wait in drain_slot (the producer-visible cost). On
+  // depth-1 schedules the drain runs inline and flush_stall is a superset
+  // of kick_sync_stall + sink, as before.
+  struct stream_metric flush_stall;     // producer join wait / inline drain
                                         // (drain_slot in schedule.c)
   // Passthrough: GPU_EDGE_D2H_DONE poll only. Compressed:
   // GPU_EDGE_CHUNK_INDEX_READY poll + per-LOD bulk D2H dispatch +

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -21,7 +21,9 @@ struct shard_pool_fs
   uint64_t nslots;
   int unbuffered;
   struct strbuf root; // owned
-  uint64_t queued_bytes;
+  // Writes land on whichever thread runs sink delivery while the producer
+  // samples pending_bytes for backpressure.
+  _Atomic uint64_t queued_bytes;
   _Atomic uint64_t retired_bytes;
   _Atomic int io_error;
 };
@@ -35,7 +37,7 @@ struct fs_slot
   struct io_queue* queue;
   size_t alignment; // 0 = normal malloc, >0 = page-aligned allocation
   _Atomic uint64_t* retired_bytes; // points to shard_pool_fs.retired_bytes
-  uint64_t* queued_bytes;          // points to shard_pool_fs.queued_bytes
+  _Atomic uint64_t* queued_bytes;  // points to shard_pool_fs.queued_bytes
   _Atomic int* io_error;           // points to shard_pool_fs.io_error
 };
 
@@ -102,7 +104,7 @@ fs_slot_write(struct shard_writer* self,
       job_free(j);
       goto Error;
     }
-    *w->queued_bytes += nbytes;
+    atomic_fetch_add(w->queued_bytes, nbytes);
   } else {
     CHECK(Error, platform_pwrite(w->fd, beg, nbytes, offset) == 0);
   }
@@ -159,7 +161,7 @@ fs_slot_write_direct(struct shard_writer* self,
       free(j);
       goto Error;
     }
-    *w->queued_bytes += nbytes;
+    atomic_fetch_add(w->queued_bytes, nbytes);
   } else {
     CHECK(Error, platform_pwrite(w->fd, beg, nbytes, offset) == 0);
   }
@@ -328,7 +330,7 @@ pool_fs_pending_bytes(const struct shard_pool* self)
 {
   const struct shard_pool_fs* p =
     container_of(self, struct shard_pool_fs, base);
-  return p->queued_bytes - atomic_load(&p->retired_bytes);
+  return atomic_load(&p->queued_bytes) - atomic_load(&p->retired_bytes);
 }
 
 static size_t

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -176,6 +176,7 @@ target_compile_definitions(
 add_gpu_test_exe(test_zarr_fs_sink   test_zarr_fs_sink.c   LINKS CUDA::cuda_driver CUDA::cudart_static test_zarr_helpers stream Zstd::Zstd test_platform test_shard_verify test_voxel_encode)
 add_gpu_test_exe(test_destroy_drain  test_destroy_drain.c  LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
 add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
+add_gpu_test_exe(test_destroy_midstream test_destroy_midstream.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
 add_test_exe(test_flush_drain_cpu test_flush_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
 add_gpu_test_exe(test_multiarray_flush_mock  test_multiarray_flush_mock.c  LINKS CUDA::cuda_driver CUDA::cudart_static multiarray_gpu stream writer chucky_log)
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   zarr_array ngff_multiscale zarr_group zarr_metadata store_s3 store_api lod_plan dimension platform_cmd chucky_log)

--- a/tests/test_batch.c
+++ b/tests/test_batch.c
@@ -118,7 +118,9 @@ test_batch_full_triggers_swap(void)
   struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
   CHECK(Fail2, r.error == 0);
 
-  // After full batch: accumulated reset, pool swapped, pending set
+  // After full batch: accumulated reset, pool swapped, pending set.
+  // Sink-side counts are not checked here: the delivery worker may have
+  // already drained the kicked batch.
   {
     struct tile_stream_status st = tile_stream_gpu_status(s);
     CHECK(Fail2, st.batch_accumulated == 0);
@@ -126,10 +128,7 @@ test_batch_full_triggers_swap(void)
     CHECK(Fail2, st.flush_pending == 1);
   }
 
-  // Kicked but NOT drained yet
-  CHECK(Fail2, css.finalize_count == 0);
-
-  // Flush drains the pending batch
+  // Flush joins the pending batch
   r = writer_flush(tile_stream_gpu_writer(s));
   CHECK(Fail2, r.error == 0);
 
@@ -175,9 +174,8 @@ test_batch_multi_cycle(void)
   struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
   CHECK(Fail2, r.error == 0);
 
-  // After 2 batches: swapped twice → back to pool 0, both pending (lazy
-  // delivery: pending[0] = batch 1, pending[1] = batch 2, until either
-  // a 3rd batch reuses fc=0 or the stream is flushed).
+  // After 2 batches: swapped twice → back to pool 0, both kicked and not
+  // yet joined (the delivery worker may already have drained either).
   {
     struct tile_stream_status st = tile_stream_gpu_status(s);
     CHECK(Fail2, st.pool_current == 0);
@@ -185,11 +183,10 @@ test_batch_multi_cycle(void)
     CHECK(Fail2, st.flush_pending == 1);
   }
 
-  // Flush drains both pending batches, finalizing their shards.
-  int pre_flush_finalize = css.finalize_count;
+  // Flush joins both batches; by then each has finalized its shards.
   r = writer_flush(tile_stream_gpu_writer(s));
   CHECK(Fail2, r.error == 0);
-  CHECK(Fail2, css.finalize_count >= pre_flush_finalize + 2);
+  CHECK(Fail2, css.finalize_count >= 2);
 
   free(src);
   tile_stream_gpu_destroy(s);

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -167,3 +167,32 @@ pump_data(struct writer* w, size_t total_elements, fill_fn fill)
 {
   return pump_data_bpe(w, total_elements, fill, sizeof(uint16_t));
 }
+
+int
+pump_data_prefilled(struct writer* w, size_t total_elements, fill_fn fill)
+{
+  const size_t bpe = sizeof(uint16_t);
+  const size_t nelements = 32 * 1024 * 1024; // 32M elements
+  uint16_t* data = (uint16_t*)malloc(nelements * bpe);
+  if (!data)
+    return 1;
+  fill(data, nelements < total_elements ? nelements : total_elements, 0,
+       total_elements);
+
+  for (size_t offset = 0; offset < total_elements; offset += nelements) {
+    size_t n = nelements;
+    if (offset + n > total_elements)
+      n = total_elements - offset;
+    struct slice input = { .beg = data, .end = (char*)data + n * bpe };
+    struct writer_result r = writer_append_wait(w, input);
+    if (r.error) {
+      log_error("  append failed at offset %zu", offset);
+      free(data);
+      return 1;
+    }
+  }
+
+  struct writer_result r = writer_flush(w);
+  free(data);
+  return r.error;
+}

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -42,3 +42,9 @@ pump_data_bpe(struct writer* w,
               size_t total_elements,
               fill_fn fill,
               size_t bpe);
+
+// Fill the pump buffer once and append it repeatedly. Isolates the writer's
+// cost from the per-iteration fill (perf benches only — chunk contents
+// repeat with the buffer period).
+int
+pump_data_prefilled(struct writer* w, size_t total_elements, fill_fn fill);

--- a/tests/test_destroy_midstream.c
+++ b/tests/test_destroy_midstream.c
@@ -1,0 +1,300 @@
+// Destroying a stream with a kicked, undelivered batch must drain the
+// delivery worker and the sink before freeing anything the queued work
+// references — including when sink IO is stalled at that moment.
+
+#include "gpu/prelude.cuda.h"
+#include "platform/platform.h"
+#include "store.h"
+#include "stream.gpu.h"
+#include "test_platform.h"
+#include "util/prelude.h"
+#include "writer.h"
+#include "zarr.h"
+#include "zarr/shard_pool.h"
+#include "zarr/shard_pool_fs.h"
+#include "zarr/zarr_array.h"
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <cuda.h>
+
+#define DRAIN_OBSERVE_MS 200
+#define POST_RELEASE_TIMEOUT_MS 10000
+#define POLL_STEP_MS 10
+
+struct destroy_args
+{
+  struct tile_stream_gpu* s;
+  _Atomic int done;
+};
+
+static void
+destroy_thread_fn(void* arg)
+{
+  struct destroy_args* da = (struct destroy_args*)arg;
+  tile_stream_gpu_destroy(da->s);
+  atomic_store(&da->done, 1);
+}
+
+static int
+wait_for_done(_Atomic int* done, int timeout_ms)
+{
+  int waited_ms = 0;
+  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
+    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
+    waited_ms += POLL_STEP_MS;
+  }
+  return atomic_load(done) != 0 ? 0 : -1;
+}
+
+// Append 1.5 batches (slot kicked, delivery in flight, partial batch
+// accumulated) and destroy immediately, without flushing.
+static int
+test_destroy_with_delivery_in_flight(const char* tmpdir, int rep)
+{
+  log_info("=== test_destroy_with_delivery_in_flight rep %d ===", rep);
+
+  struct dimension dims[3] = {
+    { .size = 12,
+      .chunk_size = 4,
+      .chunks_per_shard = 3,
+      .name = "z",
+      .storage_position = 0 },
+    { .size = 64,
+      .chunk_size = 16,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 64,
+      .chunk_size = 16,
+      .chunks_per_shard = 2,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  const size_t epoch_elements = 4 * 64 * 64;
+  const size_t append_elements = 3 * epoch_elements; // 1.5 batches at K=2
+
+  struct store* store = NULL;
+  struct shard_pool* pool = NULL;
+  struct zarr_array* arr = NULL;
+  struct tile_stream_gpu* s = NULL;
+  uint16_t* src = NULL;
+  int rc = 1;
+
+  store = store_fs_create(tmpdir, 1);
+  CHECK(Cleanup, store);
+  CHECK(Cleanup, store->mkdirs(store, ".") == 0);
+  CHECK(Cleanup, store->mkdirs(store, "0") == 0);
+
+  pool = store->create_pool(store, 8);
+  CHECK(Cleanup, pool);
+
+  struct zarr_array_config acfg = {
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_ZSTD },
+  };
+  arr = zarr_array_create_with_pool(store, pool, 0, "0", &acfg);
+  CHECK(Cleanup, arr);
+
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = epoch_elements * sizeof(uint16_t),
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_ZSTD },
+    .epochs_per_batch = 2,
+  };
+  s = tile_stream_gpu_create(&cfg, zarr_array_as_shard_sink(arr));
+  CHECK(Cleanup, s);
+
+  src = (uint16_t*)malloc(append_elements * sizeof(uint16_t));
+  CHECK(Cleanup, src);
+  for (size_t i = 0; i < append_elements; ++i)
+    src[i] = (uint16_t)(i * 31 + (size_t)rep);
+
+  {
+    struct slice input = { .beg = src, .end = src + append_elements };
+    struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
+    CHECK(Cleanup, r.error == 0);
+  }
+
+  tile_stream_gpu_destroy(s);
+  s = NULL;
+
+  CHECK(Cleanup, zarr_array_has_error(arr) == 0);
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  free(src);
+  tile_stream_gpu_destroy(s);
+  zarr_array_destroy(arr);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return rc;
+}
+
+// One full batch appended (slot kicked; its delivery ran on the worker and
+// queued sink IO), sink IO gated: destroy must block until the IO drains,
+// then finish clean.
+static int
+test_destroy_blocks_on_gated_sink(const char* tmpdir)
+{
+  log_info("=== test_destroy_blocks_on_gated_sink ===");
+
+  struct dimension dims[3] = {
+    { .size = 16,
+      .chunk_size = 4,
+      .chunks_per_shard = 4,
+      .name = "z",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 4,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 12,
+      .chunk_size = 3,
+      .chunks_per_shard = 2,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  const size_t epoch_elements = 4 * 8 * 12;
+  const size_t append_elements = 2 * epoch_elements; // one full batch at K=2
+
+  struct store* store = NULL;
+  struct shard_pool* pool = NULL;
+  struct zarr_array* arr = NULL;
+  struct tile_stream_gpu* s = NULL;
+  uint32_t* src = NULL;
+  test_thread* thr = NULL;
+  int rc = 1;
+  _Atomic int gate;
+  atomic_store(&gate, 0);
+
+  store = store_fs_create(tmpdir, 0);
+  CHECK(Cleanup, store);
+  CHECK(Cleanup, store->mkdirs(store, ".") == 0);
+  CHECK(Cleanup, store->mkdirs(store, "0") == 0);
+
+  pool = store->create_pool(store, 8);
+  CHECK(Cleanup, pool);
+
+  struct zarr_array_config acfg = {
+    .data_type = dtype_u32,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  arr = zarr_array_create_with_pool(store, pool, 0, "0", &acfg);
+  CHECK(Cleanup, arr);
+
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = epoch_elements * sizeof(uint32_t),
+    .dtype = dtype_u32,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .epochs_per_batch = 2,
+  };
+  s = tile_stream_gpu_create(&cfg, zarr_array_as_shard_sink(arr));
+  CHECK(Cleanup, s);
+
+  src = (uint32_t*)calloc(append_elements, sizeof(uint32_t));
+  CHECK(Cleanup, src);
+
+  {
+    struct slice input = { .beg = src, .end = src + append_elements };
+    struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
+    CHECK(Cleanup, r.error == 0);
+  }
+
+  CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+
+  struct destroy_args da = { .s = s };
+  atomic_store(&da.done, 0);
+  CHECK(Cleanup, test_thread_start(&thr, destroy_thread_fn, &da) == 0);
+  s = NULL;
+
+  platform_sleep_ns((int64_t)DRAIN_OBSERVE_MS * 1000000LL);
+  int destroy_returned_early = (atomic_load(&da.done) != 0);
+
+  atomic_store(&gate, 1);
+
+  if (wait_for_done(&da.done, POST_RELEASE_TIMEOUT_MS)) {
+    log_error("destroy did not finish within %d ms after gate release",
+              POST_RELEASE_TIMEOUT_MS);
+    goto Cleanup;
+  }
+
+  test_thread_join(thr);
+  thr = NULL;
+
+  if (destroy_returned_early) {
+    log_error("destroy returned before sink IO drained");
+    goto Cleanup;
+  }
+
+  CHECK(Cleanup, zarr_array_has_error(arr) == 0);
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  free(src);
+  tile_stream_gpu_destroy(s);
+  test_thread_join(thr);
+  zarr_array_destroy(arr);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return rc;
+}
+
+int
+main(int ac, char* av[])
+{
+  (void)ac;
+  (void)av;
+
+  int ecode = 0;
+  char tmpdir[4096];
+  CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  log_info("temp dir: %s", tmpdir);
+
+  CUcontext ctx = 0;
+  CUdevice dev;
+  CU(Cleanup, cuInit(0));
+  CU(Cleanup, cuDeviceGet(&dev, 0));
+  CU(Cleanup, cu_ctx_create(&ctx, 0, dev));
+
+  for (int rep = 0; rep < 5; ++rep) {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/midstream_%d", tmpdir, rep);
+    test_mkdir(sub);
+    ecode |= test_destroy_with_delivery_in_flight(sub, rep);
+  }
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/gated", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_destroy_blocks_on_gated_sink(sub);
+  }
+
+Cleanup:
+  if (ctx)
+    cuCtxDestroy(ctx);
+  test_tmpdir_remove(tmpdir);
+
+Fail:
+  return ecode;
+}


### PR DESCRIPTION
Step 5 — the last step — of the migration in `docs/gpu-orchestration.md`:
**move data movement off the producer thread**. The June L40 baseline showed
wall time is almost entirely host-side, with the staging copy as the
single biggest lever. Steps 1–4 (#143, #144, #148, #149) made the ordering
explicit and machine-checked so this step could add host threads without
re-creating the bug class behind #140/#141/#145.

## What

- **Staging copies run on a small helper pool** (`Parallelize staging copy
  in append`): the producer's user→pinned copy is split across helpers when
  the payload is large enough to pay for the dispatch. The copy is
  bandwidth-bound, so a few helpers saturate it. If the pool can't start,
  copies fall back to running serially on the producer.
- **Sink delivery runs on a worker** (`Queue sink delivery on a worker`):
  the pipelined schedule queues each kicked batch's delivery at kick time
  and joins it before refilling that slot, so the polls and the sink writes
  leave the producer thread. One job slot per pipeline slot, run strictly
  oldest-first (the tail counter's threshold and the declared
  deliver-oldest-first rule depend on that order). Ownership follows the
  same single-writer rule as the pools: the producer owns a job before
  enqueue and after join; the worker owns it in between. Depth-1 schedules
  and multiarray keep draining inline — the host ordering they exist for
  must not move to another thread.
- **Teardown**: destroy runs every queued delivery to completion (each
  publishes its tail generation, failure or not) before the forced gate
  release — a late publish after the release would re-park the gate. A new
  test (`Add mid-stream destroy abuse test`) destroys a stream with a
  kicked, undelivered batch while sink IO is stalled, in both build
  configurations.

Deliberately out of scope, per the plan: sharing one orchestration between
CPU and GPU backends, and multiarray-as-composition. Both remain follow-ups.

## Performance (L40, 5 runs per number, base = main before this PR)

`--prefill` is a new bench flag: fill the input buffer once instead of
regenerating synthetic data before every append. It separates the cost of
the writer (what this library does) from the cost of the benchmark's own
data generation, which the baseline measured at roughly half of wall time.

| scenario | uncompressed | uncompressed, prefill | zstd | zstd, prefill |
|---|---|---|---|---|
| 256cube_single | 6.41 → 9.07 (**+41%**) | 16.95 → 20.55 (+21%) | 6.23 → 7.37 (+18%) | 9.35 → 9.35 |
| medfmt_single | 5.43 → 7.03 (**+29%**) | 16.03 → 19.81 (+24%) | 4.01 → 3.30 (**−18%**, see below) | 4.39 → 4.40 |
| orca2_single | 6.53 → 9.06 (**+39%**) | 15.55 → 19.02 (+22%) | 4.76 → 4.83 | 4.82 → 4.85 |
| 256cube_two_streams | 6.59 → 9.13 (**+39%**) | — | 3.87 → 4.21 (+9%) | — |

The zstd columns sit at or near the compression ceiling (compress stage
time is unchanged), which is the expected next bottleneck.

**The one regression — medfmt zstd without prefill — is contention with
the benchmark's own data generation, not a pipeline defect.** The metrics
show the copy itself got twice as fast per operation, but on the most
bandwidth-hungry scenario the benchmark's fill thread, the copy helpers,
and compression all compete for memory bandwidth and everyone slows. With
prefill — closer to a real producer, whose data already exists — the same
scenario is dead even (4.39 → 4.40). The review re-ran this comparison on
two other nodes and measured flat (4.31 → 4.35) — the regression is
environment-dependent contention, not inherent. Benchmark methodology is
tracked in #150.

## Correctness evidence (L40, sm_89)

- Full test suite: **48/48** in both Release and Debug at the tip (a new
  test joins the suite), 47/47 at the copy-only commit; zero new build
  warnings; Debug runs clean of ordering asserts.
- `test_cross_validate` ×20 — twenty repetitions of the determinism,
  zstd round-trip, and page-aligned tail-carry tests under the new host
  concurrency (exactly the failure mode those tests exist to catch).
- Both ordering mutation checks re-run: removing the chunk-pool wait →
  determinism test fails 8/8; disabling the tail counter → tail-carry test
  fails 8/8. Restored: green.
- Mid-stream destroy abuse test passes in both configurations.
- `test_multiarray_gpu` + two_streams bench, both codecs.

## Commit guide

- `Parallelize staging copy in append` — the copy helper pool; suite green
  alone at this commit.
- `Queue sink delivery on a worker` — the delivery worker, oldest-first
  queue, teardown drain-and-join.
- `Add mid-stream destroy abuse test` — destroy with queued work and
  stalled sink IO.
- `Trim comments; update doc status` — comment pass; doc status now
  reflects steps 1–4 merged.
- `Make sink pending-byte counters atomic` — review finding: `queued_bytes`
  is now written by the delivery worker while the producer reads it for
  backpressure; `retired_bytes` was already atomic.
- `Add prefill option to stream benches` — the `--prefill` flag used by
  the table above, so those columns are reproducible from this branch.
- `Address worker review nits` — metric doc updated for worker-side
  overlap; worker context-set failure now warns.


