### PR TITLE
Record L40 benchmark baseline

### DIFF
--- a/bench/results/reef-l40-5af7ead-20260613.json
+++ b/bench/results/reef-l40-5af7ead-20260613.json
@@ -1,0 +1,24275 @@
+{
+  "version": 1,
+  "machine": {
+    "hostname": "cw-us-e4a2-l40-234-159",
+    "gpu": "NVIDIA L40",
+    "commit": "5af7ead",
+    "date": "2026-06-13T15:55:02"
+  },
+  "runs": [
+    {
+      "id": "orca2_single__none__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 4.51,
+      "status": "pass",
+      "throughput_in_gibs": 2.23939,
+      "throughput_out_gibs": 2.24085,
+      "compression_fold": 0.999349,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51791,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 1.5699,
+      "init_s": 0.423562,
+      "flush_s": 6.54e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.65517,
+          "best_ms": 0.324262,
+          "best_in_gibs": 48.1863,
+          "best_out_gibs": 48.1863,
+          "in_gibs": 17.6542,
+          "out_gibs": 17.6542
+        },
+        "h2d": {
+          "avg_ms": 1.96527,
+          "best_ms": 0.62464,
+          "best_in_gibs": 25.0144,
+          "best_out_gibs": 25.0144,
+          "in_gibs": 23.9606,
+          "out_gibs": 23.9606
+        },
+        "scatter": {
+          "avg_ms": 0.274526,
+          "best_ms": 0.099776,
+          "best_in_gibs": 156.601,
+          "best_out_gibs": 156.601,
+          "in_gibs": 171.529,
+          "out_gibs": 171.529
+        },
+        "aggregate": {
+          "avg_ms": 4.42907,
+          "best_ms": 0.569536,
+          "best_in_gibs": 246.912,
+          "best_out_gibs": 246.912,
+          "in_gibs": 113.394,
+          "out_gibs": 113.394
+        },
+        "d2h": {
+          "avg_ms": 24.6204,
+          "best_ms": 24.0761,
+          "best_in_gibs": 23.3634,
+          "best_out_gibs": 23.3634,
+          "in_gibs": 20.399,
+          "out_gibs": 20.399
+        },
+        "sink": {
+          "avg_ms": 0.000774,
+          "best_ms": 5.7e-05,
+          "best_in_gibs": 668174,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21643.4,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 115.918,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 187.431,
+        "kick_sync_count": 7,
+        "io_fence_ms": 510.468,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 135.912,
+        "peak_pending_mib": 1074.47
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 4.41,
+      "status": "pass",
+      "throughput_in_gibs": 1.50059,
+      "throughput_out_gibs": 1.50157,
+      "compression_fold": 0.999349,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51791,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 2.34283,
+      "init_s": 0.00433073,
+      "flush_s": 5.87e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.6789,
+          "best_ms": 7.30135,
+          "best_in_gibs": 2.14002,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.81044,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.2149,
+          "best_ms": 9.77481,
+          "best_in_gibs": 14.3865,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.918,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 31.0759,
+          "best_ms": 7.97147,
+          "best_in_gibs": 71.6739,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.3855,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000639405,
+          "best_ms": 5.4e-05,
+          "best_in_gibs": 352648,
+          "best_out_gibs": 0.0,
+          "in_gibs": 26199.3,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.017713,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 3.76,
+      "status": "pass",
+      "throughput_in_gibs": 3.87029,
+      "throughput_out_gibs": 0.501332,
+      "compression_fold": 7.72002,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.455391,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.908362,
+      "init_s": 0.430888,
+      "flush_s": 8.12e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.05833,
+          "best_ms": 0.322788,
+          "best_in_gibs": 48.4064,
+          "best_out_gibs": 48.4064,
+          "in_gibs": 44.2913,
+          "out_gibs": 44.2913
+        },
+        "h2d": {
+          "avg_ms": 1.959,
+          "best_ms": 0.632064,
+          "best_in_gibs": 24.7206,
+          "best_out_gibs": 24.7206,
+          "in_gibs": 24.0373,
+          "out_gibs": 24.0373
+        },
+        "scatter": {
+          "avg_ms": 1.08772,
+          "best_ms": 0.100576,
+          "best_in_gibs": 155.355,
+          "best_out_gibs": 155.355,
+          "in_gibs": 41.0054,
+          "out_gibs": 41.0054
+        },
+        "compress": {
+          "avg_ms": 95.4664,
+          "best_ms": 26.7732,
+          "best_in_gibs": 5.25245,
+          "best_out_gibs": 0.678884,
+          "in_gibs": 5.26083,
+          "out_gibs": 0.6781
+        },
+        "aggregate": {
+          "avg_ms": 0.267557,
+          "best_ms": 0.063648,
+          "best_in_gibs": 285.569,
+          "best_out_gibs": 285.569,
+          "in_gibs": 241.952,
+          "out_gibs": 241.952
+        },
+        "d2h": {
+          "avg_ms": 26.1019,
+          "best_ms": 21.9813,
+          "best_in_gibs": 3.29806,
+          "best_out_gibs": 3.29806,
+          "in_gibs": 2.48012,
+          "out_gibs": 2.48012
+        },
+        "sink": {
+          "avg_ms": 0.219375,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 54931.6,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.88504,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 229.808,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 688.865,
+        "kick_sync_count": 7,
+        "io_fence_ms": 71.5176,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 94.9209,
+        "peak_pending_mib": 59.1289
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 5.62,
+      "status": "pass",
+      "throughput_in_gibs": 0.957772,
+      "throughput_out_gibs": 0.098766,
+      "compression_fold": 9.69738,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.362534,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 3.67063,
+      "init_s": 0.00448675,
+      "flush_s": 4.75e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.8429,
+          "best_ms": 6.77062,
+          "best_in_gibs": 2.30776,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.95874,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 295.561,
+          "best_ms": 88.8455,
+          "best_in_gibs": 1.5828,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.69925,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.80413,
+          "best_ms": 4.04016,
+          "best_in_gibs": 142.182,
+          "best_out_gibs": 0.0,
+          "in_gibs": 84.4246,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.168257,
+          "best_ms": 6.4e-05,
+          "best_in_gibs": 56326.4,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.2602,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.016824,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 4.89,
+      "status": "pass",
+      "throughput_in_gibs": 1.23273,
+      "throughput_out_gibs": 0.708798,
+      "compression_fold": 1.73919,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.02142,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 2.8519,
+      "init_s": 0.0043154,
+      "flush_s": 5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.2869,
+          "best_ms": 7.16894,
+          "best_in_gibs": 2.17954,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.87808,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 114.138,
+          "best_ms": 35.5406,
+          "best_in_gibs": 3.95674,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.40021,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 19.7145,
+          "best_ms": 5.82073,
+          "best_in_gibs": 98.2062,
+          "best_out_gibs": 0.0,
+          "in_gibs": 28.9956,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 1.02952,
+          "best_ms": 6.1e-05,
+          "best_in_gibs": 500.288,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.34976,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.013063,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 4.39,
+      "status": "pass",
+      "throughput_in_gibs": 1.43918,
+      "throughput_out_gibs": 0.0293693,
+      "compression_fold": 49.003,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.071743,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 2.44279,
+      "init_s": 0.00430369,
+      "flush_s": 6.95e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.8329,
+          "best_ms": 6.80682,
+          "best_in_gibs": 2.29549,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.9606,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 131.266,
+          "best_ms": 38.6807,
+          "best_in_gibs": 3.63553,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.82606,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.18887,
+          "best_ms": 3.52455,
+          "best_in_gibs": 162.186,
+          "best_out_gibs": 0.0,
+          "in_gibs": 136.465,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0240018,
+          "best_ms": 6.4e-05,
+          "best_in_gibs": 5424.02,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.2337,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011963,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 4.56,
+      "status": "pass",
+      "throughput_in_gibs": 2.25938,
+      "throughput_out_gibs": 2.25957,
+      "compression_fold": 0.999913,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51593,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.55602,
+      "init_s": 0.460258,
+      "flush_s": 5.82e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.36496,
+          "best_ms": 0.319756,
+          "best_in_gibs": 48.8654,
+          "best_out_gibs": 48.8654,
+          "in_gibs": 19.8206,
+          "out_gibs": 19.8206
+        },
+        "h2d": {
+          "avg_ms": 1.96964,
+          "best_ms": 0.624608,
+          "best_in_gibs": 25.0157,
+          "best_out_gibs": 25.0157,
+          "in_gibs": 23.9074,
+          "out_gibs": 23.9074
+        },
+        "scatter": {
+          "avg_ms": 0.274936,
+          "best_ms": 0.099552,
+          "best_in_gibs": 156.953,
+          "best_out_gibs": 156.953,
+          "in_gibs": 171.273,
+          "out_gibs": 171.273
+        },
+        "aggregate": {
+          "avg_ms": 5.14783,
+          "best_ms": 0.659616,
+          "best_in_gibs": 213.192,
+          "best_out_gibs": 213.192,
+          "in_gibs": 97.562,
+          "out_gibs": 97.562
+        },
+        "d2h": {
+          "avg_ms": 26.8561,
+          "best_ms": 25.7931,
+          "best_in_gibs": 5.45204,
+          "best_out_gibs": 5.45204,
+          "in_gibs": 18.7008,
+          "out_gibs": 18.7008
+        },
+        "sink": {
+          "avg_ms": 0.000554598,
+          "best_ms": 4.6e-05,
+          "best_in_gibs": 82.9282,
+          "best_out_gibs": 0.0,
+          "in_gibs": 28301.8,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 119.962,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 203.401,
+        "kick_sync_count": 7,
+        "io_fence_ms": 542.907,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 148.945,
+        "peak_pending_mib": 1072.06
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 4.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.56071,
+      "throughput_out_gibs": 1.56084,
+      "compression_fold": 0.999913,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51593,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 2.25258,
+      "init_s": 0.00400271,
+      "flush_s": 5.78e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.7668,
+          "best_ms": 7.12153,
+          "best_in_gibs": 2.19405,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.17434,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.004,
+          "best_ms": 9.50732,
+          "best_in_gibs": 14.7912,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.3136,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 31.3922,
+          "best_ms": 7.82556,
+          "best_in_gibs": 79.8743,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.9113,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000638477,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 84.771,
+          "best_out_gibs": 0.0,
+          "in_gibs": 24583.7,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.010843,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 4.26,
+      "status": "pass",
+      "throughput_in_gibs": 2.55348,
+      "throughput_out_gibs": 0.324784,
+      "compression_fold": 7.86207,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.447163,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.3768,
+      "init_s": 0.510952,
+      "flush_s": 7.98e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.36348,
+          "best_ms": 0.317854,
+          "best_in_gibs": 49.1578,
+          "best_out_gibs": 49.1578,
+          "in_gibs": 34.3789,
+          "out_gibs": 34.3789
+        },
+        "h2d": {
+          "avg_ms": 1.94439,
+          "best_ms": 0.626784,
+          "best_in_gibs": 24.9288,
+          "best_out_gibs": 24.9288,
+          "in_gibs": 24.2179,
+          "out_gibs": 24.2179
+        },
+        "scatter": {
+          "avg_ms": 1.4552,
+          "best_ms": 0.09936,
+          "best_in_gibs": 157.256,
+          "best_out_gibs": 157.256,
+          "in_gibs": 30.3173,
+          "out_gibs": 30.3173
+        },
+        "compress": {
+          "avg_ms": 162.126,
+          "best_ms": 29.5917,
+          "best_in_gibs": 4.75218,
+          "best_out_gibs": 0.606484,
+          "in_gibs": 3.09779,
+          "out_gibs": 0.393641
+        },
+        "aggregate": {
+          "avg_ms": 0.337216,
+          "best_ms": 0.048992,
+          "best_in_gibs": 366.323,
+          "best_out_gibs": 366.323,
+          "in_gibs": 189.254,
+          "out_gibs": 189.254
+        },
+        "d2h": {
+          "avg_ms": 28.5516,
+          "best_ms": 24.0483,
+          "best_in_gibs": 2.97172,
+          "best_out_gibs": 2.97172,
+          "in_gibs": 2.23523,
+          "out_gibs": 2.23523
+        },
+        "sink": {
+          "avg_ms": 0.188802,
+          "best_ms": 4.4e-05,
+          "best_in_gibs": 56700.3,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.5733,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 366.968,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 1159.4,
+        "kick_sync_count": 7,
+        "io_fence_ms": 67.9169,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 189.425,
+        "peak_pending_mib": 62.9336
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 5.2,
+      "status": "pass",
+      "throughput_in_gibs": 1.08853,
+      "throughput_out_gibs": 0.109706,
+      "compression_fold": 9.92227,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.354317,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 3.2297,
+      "init_s": 0.00439808,
+      "flush_s": 6.02e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.722,
+          "best_ms": 6.28448,
+          "best_in_gibs": 2.48628,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.68456,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 266.324,
+          "best_ms": 77.8444,
+          "best_in_gibs": 1.80649,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.88579,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.09449,
+          "best_ms": 4.02121,
+          "best_in_gibs": 156.048,
+          "best_out_gibs": 0.0,
+          "in_gibs": 102.962,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.149851,
+          "best_ms": 4.6e-05,
+          "best_in_gibs": 165.856,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.5556,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.016665,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 4.94,
+      "status": "pass",
+      "throughput_in_gibs": 1.23227,
+      "throughput_out_gibs": 0.729665,
+      "compression_fold": 1.68882,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.0817,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 2.85296,
+      "init_s": 0.00461312,
+      "flush_s": 7.23e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.0124,
+          "best_ms": 6.57769,
+          "best_in_gibs": 2.37545,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.34526,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 123.329,
+          "best_ms": 36.7671,
+          "best_in_gibs": 3.82475,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.0723,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 20.743,
+          "best_ms": 11.2093,
+          "best_in_gibs": 55.7681,
+          "best_out_gibs": 0.0,
+          "in_gibs": 30.1366,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 1.10004,
+          "best_ms": 5.3e-05,
+          "best_in_gibs": 143.951,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.44815,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.009797,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 3.97,
+      "status": "pass",
+      "throughput_in_gibs": 1.86354,
+      "throughput_out_gibs": 0.0277105,
+      "compression_fold": 67.2504,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0522766,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.88653,
+      "init_s": 0.00458058,
+      "flush_s": 6.23e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.9922,
+          "best_ms": 6.11205,
+          "best_in_gibs": 2.55643,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.60794,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 80.7053,
+          "best_ms": 23.6433,
+          "best_in_gibs": 5.94778,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.22304,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.15448,
+          "best_ms": 3.46789,
+          "best_in_gibs": 180.26,
+          "best_out_gibs": 0.0,
+          "in_gibs": 150.469,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0113072,
+          "best_ms": 4.6e-05,
+          "best_in_gibs": 165.856,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.6398,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.010115,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 4.54,
+      "status": "pass",
+      "throughput_in_gibs": 2.2119,
+      "throughput_out_gibs": 2.30052,
+      "compression_fold": 0.999937,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65648,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.58942,
+      "init_s": 0.424245,
+      "flush_s": 6.94e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.722,
+          "best_ms": 0.633052,
+          "best_in_gibs": 49.364,
+          "best_out_gibs": 49.364,
+          "in_gibs": 20.5009,
+          "out_gibs": 20.5009
+        },
+        "h2d": {
+          "avg_ms": 2.33813,
+          "best_ms": 1.24483,
+          "best_in_gibs": 25.1038,
+          "best_out_gibs": 25.1038,
+          "in_gibs": 24.1015,
+          "out_gibs": 24.1015
+        },
+        "scatter": {
+          "avg_ms": 0.324238,
+          "best_ms": 0.18464,
+          "best_in_gibs": 169.248,
+          "best_out_gibs": 169.248,
+          "in_gibs": 173.8,
+          "out_gibs": 173.8
+        },
+        "aggregate": {
+          "avg_ms": 5.69216,
+          "best_ms": 2.76742,
+          "best_in_gibs": 101.629,
+          "best_out_gibs": 101.629,
+          "in_gibs": 91.7615,
+          "out_gibs": 91.7615
+        },
+        "d2h": {
+          "avg_ms": 24.0308,
+          "best_ms": 23.5823,
+          "best_in_gibs": 11.9263,
+          "best_out_gibs": 11.9263,
+          "in_gibs": 21.7355,
+          "out_gibs": 21.7355
+        },
+        "sink": {
+          "avg_ms": 0.000679143,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 520833,
+          "best_out_gibs": 0.0,
+          "in_gibs": 32047.4,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 111.642,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 185.876,
+        "kick_sync_count": 7,
+        "io_fence_ms": 501.395,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 135.589,
+        "peak_pending_mib": 1008.05
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 4.26,
+      "status": "pass",
+      "throughput_in_gibs": 1.58072,
+      "throughput_out_gibs": 1.64405,
+      "compression_fold": 0.999937,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65648,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 2.22407,
+      "init_s": 0.00414982,
+      "flush_s": 6.29e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.9721,
+          "best_ms": 8.75538,
+          "best_in_gibs": 1.78462,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.49381,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 21.2058,
+          "best_ms": 10.2908,
+          "best_in_gibs": 27.3302,
+          "best_out_gibs": 0.0,
+          "in_gibs": 24.6311,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 28.7138,
+          "best_ms": 10.6637,
+          "best_in_gibs": 52.7535,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.5915,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000694548,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 84.771,
+          "best_out_gibs": 0.0,
+          "in_gibs": 31336.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011745,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 3.95,
+      "status": "pass",
+      "throughput_in_gibs": 3.51275,
+      "throughput_out_gibs": 0.46555,
+      "compression_fold": 7.84719,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.465931,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.00082,
+      "init_s": 0.496096,
+      "flush_s": 7.74e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.1587,
+          "best_ms": 0.546403,
+          "best_in_gibs": 28.5961,
+          "best_out_gibs": 28.5961,
+          "in_gibs": 25.8506,
+          "out_gibs": 25.8506
+        },
+        "h2d": {
+          "avg_ms": 2.32603,
+          "best_ms": 1.2472,
+          "best_in_gibs": 25.0561,
+          "best_out_gibs": 25.0561,
+          "in_gibs": 24.2269,
+          "out_gibs": 24.2269
+        },
+        "scatter": {
+          "avg_ms": 0.546367,
+          "best_ms": 0.184768,
+          "best_in_gibs": 169.131,
+          "best_out_gibs": 169.131,
+          "in_gibs": 100.934,
+          "out_gibs": 100.934
+        },
+        "compress": {
+          "avg_ms": 101.9,
+          "best_ms": 55.2429,
+          "best_in_gibs": 5.09115,
+          "best_out_gibs": 0.340585,
+          "in_gibs": 5.12583,
+          "out_gibs": 0.652992
+        },
+        "aggregate": {
+          "avg_ms": 0.545993,
+          "best_ms": 0.106464,
+          "best_in_gibs": 176.725,
+          "best_out_gibs": 176.725,
+          "in_gibs": 121.869,
+          "out_gibs": 121.869
+        },
+        "d2h": {
+          "avg_ms": 25.0272,
+          "best_ms": 21.3496,
+          "best_in_gibs": 0.881276,
+          "best_out_gibs": 0.881276,
+          "in_gibs": 2.65869,
+          "out_gibs": 2.65869
+        },
+        "sink": {
+          "avg_ms": 0.308569,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 84.771,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.98793,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 236.691,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 730.533,
+        "kick_sync_count": 7,
+        "io_fence_ms": 96.8054,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 90.549,
+        "peak_pending_mib": 38.0625
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 5.16,
+      "status": "pass",
+      "throughput_in_gibs": 1.12384,
+      "throughput_out_gibs": 0.110946,
+      "compression_fold": 10.5348,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.347065,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 3.12822,
+      "init_s": 0.00433605,
+      "flush_s": 7.42e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.1112,
+          "best_ms": 6.87489,
+          "best_in_gibs": 2.27276,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.95455,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 255.914,
+          "best_ms": 142.085,
+          "best_in_gibs": 1.97944,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.041,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.8899,
+          "best_ms": 4.06906,
+          "best_in_gibs": 138.79,
+          "best_out_gibs": 0.0,
+          "in_gibs": 81.9668,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.187425,
+          "best_ms": 6.1e-05,
+          "best_in_gibs": 73542.4,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.0223,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0163,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 4.69,
+      "status": "pass",
+      "throughput_in_gibs": 1.33907,
+      "throughput_out_gibs": 0.740814,
+      "compression_fold": 1.87987,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.94495,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 2.62542,
+      "init_s": 0.00411991,
+      "flush_s": 4.8e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.7241,
+          "best_ms": 6.98918,
+          "best_in_gibs": 2.2356,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.78996,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 119.436,
+          "best_ms": 64.7545,
+          "best_in_gibs": 4.34333,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.37322,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 18.7066,
+          "best_ms": 9.94273,
+          "best_in_gibs": 56.5832,
+          "best_out_gibs": 0.0,
+          "in_gibs": 30.0745,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 1.23658,
+          "best_ms": 4.6e-05,
+          "best_in_gibs": 82.9282,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.36221,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014666,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 3.62,
+      "status": "pass",
+      "throughput_in_gibs": 2.13026,
+      "throughput_out_gibs": 0.0324533,
+      "compression_fold": 68.2667,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0535583,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.65032,
+      "init_s": 0.00436611,
+      "flush_s": 4.79e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.601,
+          "best_ms": 6.32696,
+          "best_in_gibs": 2.46959,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.1029,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 67.871,
+          "best_ms": 35.9823,
+          "best_in_gibs": 7.81634,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.6958,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.79196,
+          "best_ms": 3.52143,
+          "best_in_gibs": 159.762,
+          "best_out_gibs": 0.0,
+          "in_gibs": 148.364,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0103803,
+          "best_ms": 5.1e-05,
+          "best_in_gibs": 74.798,
+          "best_out_gibs": 0.0,
+          "in_gibs": 30.7121,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014689,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 14.6,
+      "status": "pass",
+      "throughput_in_gibs": 2.19944,
+      "throughput_out_gibs": 2.20059,
+      "compression_fold": 0.999479,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75195,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 1.70498,
+      "init_s": 0.435822,
+      "flush_s": 7.25e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.1464,
+          "best_ms": 1.25921,
+          "best_in_gibs": 49.6341,
+          "best_out_gibs": 49.6341,
+          "in_gibs": 19.864,
+          "out_gibs": 19.864
+        },
+        "h2d": {
+          "avg_ms": 2.56569,
+          "best_ms": 2.48854,
+          "best_in_gibs": 25.1151,
+          "best_out_gibs": 25.1151,
+          "in_gibs": 24.3599,
+          "out_gibs": 24.3599
+        },
+        "scatter": {
+          "avg_ms": 0.442382,
+          "best_ms": 0.437568,
+          "best_in_gibs": 142.835,
+          "best_out_gibs": 142.835,
+          "in_gibs": 141.281,
+          "out_gibs": 141.281
+        },
+        "aggregate": {
+          "avg_ms": 2.29527,
+          "best_ms": 1.39066,
+          "best_in_gibs": 269.657,
+          "best_out_gibs": 269.657,
+          "in_gibs": 233.399,
+          "out_gibs": 233.399
+        },
+        "d2h": {
+          "avg_ms": 23.7325,
+          "best_ms": 23.2281,
+          "best_in_gibs": 16.1442,
+          "best_out_gibs": 16.1442,
+          "in_gibs": 22.5731,
+          "out_gibs": 22.5731
+        },
+        "sink": {
+          "avg_ms": 0.000591841,
+          "best_ms": 4.9e-05,
+          "best_in_gibs": 478316,
+          "best_out_gibs": 0.0,
+          "in_gibs": 30478.2,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 28.7073,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 189.996,
+        "kick_sync_count": 7,
+        "io_fence_ms": 440.252,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 145.376,
+        "peak_pending_mib": 1080.5
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 14.34,
+      "status": "pass",
+      "throughput_in_gibs": 1.62586,
+      "throughput_out_gibs": 1.62671,
+      "compression_fold": 0.999479,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75195,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 2.30647,
+      "init_s": 0.00430819,
+      "flush_s": 3.43e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 18.5743,
+          "best_ms": 16.0504,
+          "best_in_gibs": 3.894,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.36487,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.5664,
+          "best_ms": 17.2058,
+          "best_in_gibs": 21.7949,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.4336,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 33.0291,
+          "best_ms": 18.2703,
+          "best_in_gibs": 30.791,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.0323,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000744183,
+          "best_ms": 6.1e-05,
+          "best_in_gibs": 576332,
+          "best_out_gibs": 0.0,
+          "in_gibs": 24239,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011235,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 13.82,
+      "status": "pass",
+      "throughput_in_gibs": 4.69311,
+      "throughput_out_gibs": 0.569147,
+      "compression_fold": 8.24587,
+      "input_gib": 3.75,
+      "compressed_gib": 0.454773,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.799043,
+      "init_s": 0.431662,
+      "flush_s": 7.42e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.0783,
+          "best_ms": 1.26452,
+          "best_in_gibs": 49.426,
+          "best_out_gibs": 49.426,
+          "in_gibs": 30.0726,
+          "out_gibs": 30.0726
+        },
+        "h2d": {
+          "avg_ms": 2.61084,
+          "best_ms": 2.49155,
+          "best_in_gibs": 25.0848,
+          "best_out_gibs": 25.0848,
+          "in_gibs": 23.9387,
+          "out_gibs": 23.9387
+        },
+        "scatter": {
+          "avg_ms": 1.5156,
+          "best_ms": 0.437952,
+          "best_in_gibs": 142.71,
+          "best_out_gibs": 142.71,
+          "in_gibs": 41.2379,
+          "out_gibs": 41.2379
+        },
+        "compress": {
+          "avg_ms": 51.3677,
+          "best_ms": 34.0788,
+          "best_in_gibs": 11.0039,
+          "best_out_gibs": 1.32995,
+          "in_gibs": 10.429,
+          "out_gibs": 1.25936
+        },
+        "aggregate": {
+          "avg_ms": 0.277682,
+          "best_ms": 0.172896,
+          "best_in_gibs": 262.14,
+          "best_out_gibs": 262.14,
+          "in_gibs": 232.965,
+          "out_gibs": 232.965
+        },
+        "d2h": {
+          "avg_ms": 23.2571,
+          "best_ms": 21.6987,
+          "best_in_gibs": 3.12941,
+          "best_out_gibs": 3.12941,
+          "in_gibs": 2.78153,
+          "out_gibs": 2.78153
+        },
+        "sink": {
+          "avg_ms": 0.212294,
+          "best_ms": 4.7e-05,
+          "best_in_gibs": 60223.5,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.299,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 94.6334,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 413.178,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.004072,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.96693,
+        "peak_pending_mib": 65.6836
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 15.57,
+      "status": "pass",
+      "throughput_in_gibs": 1.06801,
+      "throughput_out_gibs": 0.0982487,
+      "compression_fold": 10.8705,
+      "input_gib": 3.75,
+      "compressed_gib": 0.344971,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 3.5112,
+      "init_s": 0.0042996,
+      "flush_s": 3.82e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.1652,
+          "best_ms": 15.509,
+          "best_in_gibs": 4.02993,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.6411,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 292.291,
+          "best_ms": 205.63,
+          "best_in_gibs": 1.82366,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.83281,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.54999,
+          "best_ms": 4.95419,
+          "best_in_gibs": 114.169,
+          "best_out_gibs": 0.0,
+          "in_gibs": 86.3532,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.154652,
+          "best_ms": 6.4e-05,
+          "best_in_gibs": 33497.8,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.7242,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.010767,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 15.09,
+      "status": "pass",
+      "throughput_in_gibs": 1.2945,
+      "throughput_out_gibs": 0.774233,
+      "compression_fold": 1.67197,
+      "input_gib": 3.75,
+      "compressed_gib": 2.24286,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 2.89688,
+      "init_s": 0.00446839,
+      "flush_s": 3.86e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.7217,
+          "best_ms": 15.4487,
+          "best_in_gibs": 4.04566,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.52675,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 130.407,
+          "best_ms": 91.0968,
+          "best_in_gibs": 4.1165,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.10803,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 20.8005,
+          "best_ms": 11.3695,
+          "best_in_gibs": 49.5068,
+          "best_out_gibs": 0.0,
+          "in_gibs": 27.0602,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 1.18275,
+          "best_ms": 6.5e-05,
+          "best_in_gibs": 215384,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.11688,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.008919,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 14.96,
+      "status": "pass",
+      "throughput_in_gibs": 1.31339,
+      "throughput_out_gibs": 0.0295855,
+      "compression_fold": 44.3931,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0844727,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 2.8552,
+      "init_s": 0.00438535,
+      "flush_s": 4.88e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.9748,
+          "best_ms": 15.5035,
+          "best_in_gibs": 4.03134,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.68193,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 210.654,
+          "best_ms": 147.904,
+          "best_in_gibs": 2.53542,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.5431,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.21015,
+          "best_ms": 3.83217,
+          "best_in_gibs": 146.879,
+          "best_out_gibs": 0.0,
+          "in_gibs": 133.693,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.0278802,
+          "best_ms": 6.3e-05,
+          "best_in_gibs": 8174.35,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.5665,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.008575,
+        "io_fence_count": 7,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 14.99,
+      "status": "pass",
+      "throughput_in_gibs": 2.08041,
+      "throughput_out_gibs": 2.08058,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 1.80253,
+      "init_s": 0.551135,
+      "flush_s": 6.85e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.21336,
+          "best_ms": 1.26399,
+          "best_in_gibs": 49.4466,
+          "best_out_gibs": 49.4466,
+          "in_gibs": 19.45,
+          "out_gibs": 19.45
+        },
+        "h2d": {
+          "avg_ms": 2.54105,
+          "best_ms": 2.48736,
+          "best_in_gibs": 25.127,
+          "best_out_gibs": 25.127,
+          "in_gibs": 24.5961,
+          "out_gibs": 24.5961
+        },
+        "scatter": {
+          "avg_ms": 0.439408,
+          "best_ms": 0.436576,
+          "best_in_gibs": 143.159,
+          "best_out_gibs": 143.159,
+          "in_gibs": 142.237,
+          "out_gibs": 142.237
+        },
+        "aggregate": {
+          "avg_ms": 42.8949,
+          "best_ms": 4.17395,
+          "best_in_gibs": 179.686,
+          "best_out_gibs": 179.686,
+          "in_gibs": 17.4846,
+          "out_gibs": 17.4846
+        },
+        "d2h": {
+          "avg_ms": 31.1589,
+          "best_ms": 30.5112,
+          "best_in_gibs": 24.5811,
+          "best_out_gibs": 24.5811,
+          "in_gibs": 24.0702,
+          "out_gibs": 24.0702
+        },
+        "sink": {
+          "avg_ms": 0.000570937,
+          "best_ms": 5e-05,
+          "best_in_gibs": 76.2939,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41054.2,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 303.845,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 187.463,
+        "kick_sync_count": 5,
+        "io_fence_ms": 198.619,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 133.332,
+        "peak_pending_mib": 816.062
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 14.53,
+      "status": "pass",
+      "throughput_in_gibs": 1.56107,
+      "throughput_out_gibs": 1.56119,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 2.4022,
+      "init_s": 0.00427109,
+      "flush_s": 4.79e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 18.7157,
+          "best_ms": 16.2916,
+          "best_in_gibs": 3.83634,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.33945,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 39.7777,
+          "best_ms": 29.0337,
+          "best_in_gibs": 25.8321,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.8548,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 47.6013,
+          "best_ms": 29.7212,
+          "best_in_gibs": 25.2366,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.7571,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000404662,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 84.771,
+          "best_out_gibs": 0.0,
+          "in_gibs": 57923.4,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.011686,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 13.94,
+      "status": "pass",
+      "throughput_in_gibs": 4.42754,
+      "throughput_out_gibs": 0.509484,
+      "compression_fold": 8.69024,
+      "input_gib": 3.75,
+      "compressed_gib": 0.431519,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.846972,
+      "init_s": 0.544704,
+      "flush_s": 6.39e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.89798,
+          "best_ms": 1.25768,
+          "best_in_gibs": 49.6945,
+          "best_out_gibs": 49.6945,
+          "in_gibs": 32.9297,
+          "out_gibs": 32.9297
+        },
+        "h2d": {
+          "avg_ms": 2.59248,
+          "best_ms": 2.48822,
+          "best_in_gibs": 25.1183,
+          "best_out_gibs": 25.1183,
+          "in_gibs": 24.1082,
+          "out_gibs": 24.1082
+        },
+        "scatter": {
+          "avg_ms": 1.09203,
+          "best_ms": 0.436832,
+          "best_in_gibs": 143.076,
+          "best_out_gibs": 143.076,
+          "in_gibs": 57.2331,
+          "out_gibs": 57.2331
+        },
+        "compress": {
+          "avg_ms": 82.6099,
+          "best_ms": 74.3426,
+          "best_in_gibs": 10.0884,
+          "best_out_gibs": 1.15994,
+          "in_gibs": 9.07882,
+          "out_gibs": 1.04385
+        },
+        "aggregate": {
+          "avg_ms": 0.450349,
+          "best_ms": 0.360512,
+          "best_in_gibs": 239.195,
+          "best_out_gibs": 239.195,
+          "in_gibs": 191.48,
+          "out_gibs": 191.48
+        },
+        "d2h": {
+          "avg_ms": 30.5069,
+          "best_ms": 29.0593,
+          "best_in_gibs": 2.96748,
+          "best_out_gibs": 2.96748,
+          "in_gibs": 2.82666,
+          "out_gibs": 2.82666
+        },
+        "sink": {
+          "avg_ms": 0.00052835,
+          "best_ms": 4.7e-05,
+          "best_in_gibs": 162.328,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5104.55,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 119.104,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 471.742,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.001819,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 26.2624,
+        "peak_pending_mib": 82.8555
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 15.24,
+      "status": "pass",
+      "throughput_in_gibs": 1.14986,
+      "throughput_out_gibs": 0.100313,
+      "compression_fold": 11.4627,
+      "input_gib": 3.75,
+      "compressed_gib": 0.327148,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 3.26127,
+      "init_s": 0.00421372,
+      "flush_s": 4.04e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.9383,
+          "best_ms": 15.1625,
+          "best_in_gibs": 4.122,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.68986,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 370.589,
+          "best_ms": 366.906,
+          "best_in_gibs": 2.04412,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.02381,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.21667,
+          "best_ms": 5.02749,
+          "best_in_gibs": 149.775,
+          "best_out_gibs": 0.0,
+          "in_gibs": 104.34,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000401044,
+          "best_ms": 6.7e-05,
+          "best_in_gibs": 113.872,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5098.39,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.008092,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 14.97,
+      "status": "pass",
+      "throughput_in_gibs": 1.28466,
+      "throughput_out_gibs": 0.838113,
+      "compression_fold": 1.5328,
+      "input_gib": 3.75,
+      "compressed_gib": 2.4465,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 2.91906,
+      "init_s": 0.0042176,
+      "flush_s": 3.9e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.8009,
+          "best_ms": 15.8793,
+          "best_in_gibs": 3.93595,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.51106,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 202.139,
+          "best_ms": 194.486,
+          "best_in_gibs": 3.85631,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.71032,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 32.6662,
+          "best_ms": 19.7948,
+          "best_in_gibs": 37.895,
+          "best_out_gibs": 0.0,
+          "in_gibs": 22.9632,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000416138,
+          "best_ms": 7.7e-05,
+          "best_in_gibs": 99.083,
+          "best_out_gibs": 0.0,
+          "in_gibs": 36744.2,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.007092,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 14.55,
+      "status": "pass",
+      "throughput_in_gibs": 1.49599,
+      "throughput_out_gibs": 0.0335405,
+      "compression_fold": 44.6025,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0840759,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 2.5067,
+      "init_s": 0.00434146,
+      "flush_s": 4.39e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.9839,
+          "best_ms": 15.1553,
+          "best_in_gibs": 4.12397,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.67995,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 227.786,
+          "best_ms": 222.571,
+          "best_in_gibs": 3.36972,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.29257,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.95672,
+          "best_ms": 4.02663,
+          "best_in_gibs": 186.29,
+          "best_out_gibs": 0.0,
+          "in_gibs": 151.334,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000372319,
+          "best_ms": 6.3e-05,
+          "best_in_gibs": 60.5508,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1411.36,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.006002,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.98,
+      "status": "pass",
+      "throughput_in_gibs": 2.1294,
+      "throughput_out_gibs": 2.12957,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 1.76106,
+      "init_s": 0.702682,
+      "flush_s": 7.62e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.13828,
+          "best_ms": 1.25587,
+          "best_in_gibs": 49.7663,
+          "best_out_gibs": 49.7663,
+          "in_gibs": 19.9154,
+          "out_gibs": 19.9154
+        },
+        "h2d": {
+          "avg_ms": 2.56742,
+          "best_ms": 2.48704,
+          "best_in_gibs": 25.1303,
+          "best_out_gibs": 25.1303,
+          "in_gibs": 24.3435,
+          "out_gibs": 24.3435
+        },
+        "scatter": {
+          "avg_ms": 0.438884,
+          "best_ms": 0.436192,
+          "best_in_gibs": 143.286,
+          "best_out_gibs": 143.286,
+          "in_gibs": 142.407,
+          "out_gibs": 142.407
+        },
+        "aggregate": {
+          "avg_ms": 34.6641,
+          "best_ms": 4.86304,
+          "best_in_gibs": 154.225,
+          "best_out_gibs": 154.225,
+          "in_gibs": 21.6362,
+          "out_gibs": 21.6362
+        },
+        "d2h": {
+          "avg_ms": 41.5858,
+          "best_ms": 40.9345,
+          "best_in_gibs": 18.322,
+          "best_out_gibs": 18.322,
+          "in_gibs": 18.035,
+          "out_gibs": 18.035
+        },
+        "sink": {
+          "avg_ms": 0.000548831,
+          "best_ms": 7.5e-05,
+          "best_in_gibs": 50.8626,
+          "best_out_gibs": 0.0,
+          "in_gibs": 42707.8,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 289.095,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 241.385,
+        "kick_sync_count": 5,
+        "io_fence_ms": 154.378,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 98.676,
+        "peak_pending_mib": 832.062
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.33,
+      "status": "pass",
+      "throughput_in_gibs": 1.6704,
+      "throughput_out_gibs": 1.67054,
+      "compression_fold": 0.999919,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75031,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 2.24497,
+      "init_s": 0.00416213,
+      "flush_s": 6.18e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.8426,
+          "best_ms": 15.801,
+          "best_in_gibs": 3.95545,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.50286,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 30.3029,
+          "best_ms": 18.1605,
+          "best_in_gibs": 41.2983,
+          "best_out_gibs": 0.0,
+          "in_gibs": 24.7501,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 42.4741,
+          "best_ms": 18.5038,
+          "best_in_gibs": 54.0461,
+          "best_out_gibs": 0.0,
+          "in_gibs": 23.5452,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000653612,
+          "best_ms": 6.2e-05,
+          "best_in_gibs": 61.5274,
+          "best_out_gibs": 0.0,
+          "in_gibs": 35861.3,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.007465,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.29,
+      "status": "pass",
+      "throughput_in_gibs": 4.28444,
+      "throughput_out_gibs": 0.501364,
+      "compression_fold": 8.54557,
+      "input_gib": 3.75,
+      "compressed_gib": 0.438824,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.87526,
+      "init_s": 0.679743,
+      "flush_s": 5.43e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.98757,
+          "best_ms": 1.25892,
+          "best_in_gibs": 49.6455,
+          "best_out_gibs": 49.6455,
+          "in_gibs": 31.4454,
+          "out_gibs": 31.4454
+        },
+        "h2d": {
+          "avg_ms": 2.61583,
+          "best_ms": 2.48778,
+          "best_in_gibs": 25.1228,
+          "best_out_gibs": 25.1228,
+          "in_gibs": 23.8929,
+          "out_gibs": 23.8929
+        },
+        "scatter": {
+          "avg_ms": 1.03074,
+          "best_ms": 0.43696,
+          "best_in_gibs": 143.034,
+          "best_out_gibs": 143.034,
+          "in_gibs": 60.6362,
+          "out_gibs": 60.6362
+        },
+        "compress": {
+          "avg_ms": 86.8691,
+          "best_ms": 83.3509,
+          "best_in_gibs": 8.9981,
+          "best_out_gibs": 1.0525,
+          "in_gibs": 8.63368,
+          "out_gibs": 1.00988
+        },
+        "aggregate": {
+          "avg_ms": 0.712634,
+          "best_ms": 0.43216,
+          "best_in_gibs": 202.997,
+          "best_out_gibs": 202.997,
+          "in_gibs": 123.103,
+          "out_gibs": 123.103
+        },
+        "d2h": {
+          "avg_ms": 40.7165,
+          "best_ms": 38.6122,
+          "best_in_gibs": 2.272,
+          "best_out_gibs": 2.272,
+          "in_gibs": 2.15459,
+          "out_gibs": 2.15459
+        },
+        "sink": {
+          "avg_ms": 0.000359706,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 84.771,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7624.69,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 129.231,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 517.859,
+        "kick_sync_count": 5,
+        "io_fence_ms": 6.3696,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 35.4884,
+        "peak_pending_mib": 82.3867
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 15.19,
+      "status": "pass",
+      "throughput_in_gibs": 1.21496,
+      "throughput_out_gibs": 0.100326,
+      "compression_fold": 12.1101,
+      "input_gib": 3.75,
+      "compressed_gib": 0.309658,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 3.08651,
+      "init_s": 0.0042724,
+      "flush_s": 5.76e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.6749,
+          "best_ms": 14.9817,
+          "best_in_gibs": 4.17175,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.74816,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 340.96,
+          "best_ms": 332.689,
+          "best_in_gibs": 2.25436,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.19967,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.59474,
+          "best_ms": 4.89261,
+          "best_in_gibs": 205.201,
+          "best_out_gibs": 0.0,
+          "in_gibs": 152.238,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000301369,
+          "best_ms": 6.3e-05,
+          "best_in_gibs": 60.5508,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6421.91,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.006386,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.72,
+      "status": "pass",
+      "throughput_in_gibs": 1.38443,
+      "throughput_out_gibs": 0.780678,
+      "compression_fold": 1.77337,
+      "input_gib": 3.75,
+      "compressed_gib": 2.11462,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 2.7087,
+      "init_s": 0.00404141,
+      "flush_s": 7.96e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.6126,
+          "best_ms": 15.3987,
+          "best_in_gibs": 4.05878,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.54859,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 180.883,
+          "best_ms": 171.831,
+          "best_in_gibs": 4.36475,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.14632,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 27.5628,
+          "best_ms": 16.2156,
+          "best_in_gibs": 61.6765,
+          "best_out_gibs": 0.0,
+          "in_gibs": 36.2852,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00032585,
+          "best_ms": 6.3e-05,
+          "best_in_gibs": 60.5508,
+          "best_out_gibs": 0.0,
+          "in_gibs": 40559.7,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.006924,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 13.97,
+      "status": "pass",
+      "throughput_in_gibs": 1.86155,
+      "throughput_out_gibs": 0.0280282,
+      "compression_fold": 66.4171,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0564613,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 2.01445,
+      "init_s": 0.00406939,
+      "flush_s": 6.16e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.6129,
+          "best_ms": 15.1149,
+          "best_in_gibs": 4.13499,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.76213,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 136.645,
+          "best_ms": 132.027,
+          "best_in_gibs": 5.68066,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.48867,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.97803,
+          "best_ms": 3.62419,
+          "best_in_gibs": 275.957,
+          "best_out_gibs": 0.0,
+          "in_gibs": 251.411,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000324275,
+          "best_ms": 6.3e-05,
+          "best_in_gibs": 60.5508,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1088.22,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.007857,
+        "io_fence_count": 5,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 4.75,
+      "status": "pass",
+      "throughput_in_gibs": 1.92119,
+      "throughput_out_gibs": 2.21242,
+      "compression_fold": 1.16122,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04855,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 1.82992,
+      "init_s": 0.511236,
+      "flush_s": 7.36e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.2426,
+          "best_ms": 0.34949,
+          "best_in_gibs": 44.708,
+          "best_out_gibs": 44.708,
+          "in_gibs": 20.9021,
+          "out_gibs": 20.9021
+        },
+        "h2d": {
+          "avg_ms": 1.99023,
+          "best_ms": 0.626304,
+          "best_in_gibs": 24.9479,
+          "best_out_gibs": 24.9479,
+          "in_gibs": 23.6601,
+          "out_gibs": 23.6601
+        },
+        "scatter": {
+          "avg_ms": 0.151932,
+          "best_ms": 0.038336,
+          "best_in_gibs": 407.58,
+          "best_out_gibs": 407.58,
+          "in_gibs": 309.935,
+          "out_gibs": 309.935
+        },
+        "lod_gather": {
+          "avg_ms": 0.5608,
+          "best_ms": 0.544768,
+          "best_in_gibs": 258.137,
+          "best_out_gibs": 258.137,
+          "in_gibs": 250.758,
+          "out_gibs": 250.758
+        },
+        "lod_reduce": {
+          "avg_ms": 1.79077,
+          "best_ms": 1.78419,
+          "best_in_gibs": 78.8172,
+          "best_out_gibs": 105.098,
+          "in_gibs": 78.5278,
+          "out_gibs": 104.712
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.193824,
+          "best_ms": 0.13376,
+          "best_in_gibs": 350.555,
+          "best_out_gibs": 350.555,
+          "in_gibs": 241.922,
+          "out_gibs": 241.922
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 18.8747,
+          "best_ms": 0.440288,
+          "best_in_gibs": 425.892,
+          "best_out_gibs": 427.105,
+          "in_gibs": 9.93475,
+          "out_gibs": 9.96304
+        },
+        "aggregate": {
+          "avg_ms": 38.7231,
+          "best_ms": 0.281984,
+          "best_in_gibs": 168.181,
+          "best_out_gibs": 168.181,
+          "in_gibs": 10.4478,
+          "out_gibs": 10.4478
+        },
+        "d2h": {
+          "avg_ms": 24.4006,
+          "best_ms": 23.0983,
+          "best_in_gibs": 6.0881,
+          "best_out_gibs": 6.0881,
+          "in_gibs": 16.5804,
+          "out_gibs": 16.5804
+        },
+        "sink": {
+          "avg_ms": 0.000628136,
+          "best_ms": 4.7e-05,
+          "best_in_gibs": 81.1638,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19069,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 213.517,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 270.144,
+        "kick_sync_count": 10,
+        "io_fence_ms": 915.247,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 143.866,
+        "peak_pending_mib": 930.918
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 21.25,
+      "status": "pass",
+      "throughput_in_gibs": 0.473226,
+      "throughput_out_gibs": 0.54496,
+      "compression_fold": 1.16122,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04855,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 7.42907,
+      "init_s": 11.7709,
+      "flush_s": 3.06e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.08235,
+          "best_ms": 1.13534,
+          "best_in_gibs": 13.7624,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.2231,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 61.8697,
+          "best_ms": 57.5915,
+          "best_in_gibs": 2.44177,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.27292,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 61.7154,
+          "best_ms": 56.5445,
+          "best_in_gibs": 3.31624,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.03839,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 31.2443,
+          "best_ms": 21.3572,
+          "best_in_gibs": 2.19552,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.50076,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 69.5719,
+          "best_ms": 55.5722,
+          "best_in_gibs": 3.38387,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.70295,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 22.5193,
+          "best_ms": 8.65665,
+          "best_in_gibs": 21.7231,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.7116,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 33.6891,
+          "best_ms": 8.4958,
+          "best_in_gibs": 65.9842,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.64,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000355598,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 634766,
+          "best_out_gibs": 0.0,
+          "in_gibs": 33684,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.015858,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 4.04,
+      "status": "pass",
+      "throughput_in_gibs": 3.29838,
+      "throughput_out_gibs": 0.47625,
+      "compression_fold": 9.26136,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.507618,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 1.06587,
+      "init_s": 0.546134,
+      "flush_s": 4.65e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.47601,
+          "best_ms": 0.325345,
+          "best_in_gibs": 48.0259,
+          "best_out_gibs": 48.0259,
+          "in_gibs": 31.758,
+          "out_gibs": 31.758
+        },
+        "h2d": {
+          "avg_ms": 1.96952,
+          "best_ms": 0.62688,
+          "best_in_gibs": 24.925,
+          "best_out_gibs": 24.925,
+          "in_gibs": 23.9089,
+          "out_gibs": 23.9089
+        },
+        "scatter": {
+          "avg_ms": 0.263226,
+          "best_ms": 0.040032,
+          "best_in_gibs": 390.313,
+          "best_out_gibs": 390.313,
+          "in_gibs": 189.951,
+          "out_gibs": 189.951
+        },
+        "lod_gather": {
+          "avg_ms": 4.97924,
+          "best_ms": 0.576768,
+          "best_in_gibs": 243.816,
+          "best_out_gibs": 243.816,
+          "in_gibs": 28.2423,
+          "out_gibs": 28.2423
+        },
+        "lod_reduce": {
+          "avg_ms": 5.13329,
+          "best_ms": 1.78467,
+          "best_in_gibs": 78.796,
+          "best_out_gibs": 105.07,
+          "in_gibs": 27.3947,
+          "out_gibs": 36.5292
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.2953,
+          "best_ms": 0.14912,
+          "best_in_gibs": 314.446,
+          "best_out_gibs": 314.446,
+          "in_gibs": 36.2004,
+          "out_gibs": 36.2004
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 32.0948,
+          "best_ms": 0.443616,
+          "best_in_gibs": 422.697,
+          "best_out_gibs": 423.901,
+          "in_gibs": 5.84254,
+          "out_gibs": 5.85918
+        },
+        "compress": {
+          "avg_ms": 86.2508,
+          "best_ms": 27.8249,
+          "best_in_gibs": 6.7583,
+          "best_out_gibs": 0.653224,
+          "in_gibs": 5.66868,
+          "out_gibs": 0.585316
+        },
+        "aggregate": {
+          "avg_ms": 0.204573,
+          "best_ms": 0.033536,
+          "best_in_gibs": 175.194,
+          "best_out_gibs": 175.194,
+          "in_gibs": 246.777,
+          "out_gibs": 246.777
+        },
+        "d2h": {
+          "avg_ms": 20.7497,
+          "best_ms": 4.31498,
+          "best_in_gibs": 1.36161,
+          "best_out_gibs": 1.36161,
+          "in_gibs": 2.43299,
+          "out_gibs": 2.43299
+        },
+        "sink": {
+          "avg_ms": 0.000390021,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 21362.3,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3862.06,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 220.053,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 913.789,
+        "kick_sync_count": 10,
+        "io_fence_ms": 113.741,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 71.1241,
+        "peak_pending_mib": 40.4375
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 23.15,
+      "status": "pass",
+      "throughput_in_gibs": 0.383381,
+      "throughput_out_gibs": 0.0423475,
+      "compression_fold": 12.1063,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.388329,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 9.17005,
+      "init_s": 11.9665,
+      "flush_s": 4.49e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.49664,
+          "best_ms": 1.13805,
+          "best_in_gibs": 13.7296,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.4245,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 59.9828,
+          "best_ms": 58.1263,
+          "best_in_gibs": 2.4193,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.34442,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 58.4317,
+          "best_ms": 55.8334,
+          "best_in_gibs": 3.35848,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.20914,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 29.5519,
+          "best_ms": 20.9491,
+          "best_in_gibs": 2.23829,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.58671,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 69.8263,
+          "best_ms": 54.9273,
+          "best_in_gibs": 3.4236,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.6931,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 253.522,
+          "best_ms": 102.887,
+          "best_in_gibs": 1.82773,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.92854,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.9031,
+          "best_ms": 4.11171,
+          "best_in_gibs": 137.088,
+          "best_out_gibs": 0.0,
+          "in_gibs": 40.5425,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000316,
+          "best_ms": 6.2e-05,
+          "best_in_gibs": 246.11,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3646.55,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.012687,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 21.68,
+      "status": "pass",
+      "throughput_in_gibs": 0.450864,
+      "throughput_out_gibs": 0.272938,
+      "compression_fold": 2.20898,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.12824,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 7.79753,
+      "init_s": 11.8633,
+      "flush_s": 3.58e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.12062,
+          "best_ms": 1.13414,
+          "best_in_gibs": 13.777,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.15417,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 60.7213,
+          "best_ms": 58.5009,
+          "best_in_gibs": 2.40381,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.31591,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 58.2007,
+          "best_ms": 56.2289,
+          "best_in_gibs": 3.33486,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.22187,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 29.6493,
+          "best_ms": 21.5833,
+          "best_in_gibs": 2.17253,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.5815,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 69.0898,
+          "best_ms": 55.9484,
+          "best_in_gibs": 3.36112,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.72181,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 93.3849,
+          "best_ms": 37.6089,
+          "best_in_gibs": 5.00013,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.23563,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 23.7887,
+          "best_ms": 5.32214,
+          "best_in_gibs": 105.392,
+          "best_out_gibs": 0.0,
+          "in_gibs": 23.5788,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000349506,
+          "best_ms": 6.2e-05,
+          "best_in_gibs": 264691,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18015.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014378,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 21.56,
+      "status": "pass",
+      "throughput_in_gibs": 0.454388,
+      "throughput_out_gibs": 0.0104155,
+      "compression_fold": 58.3385,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0805855,
+      "total_chunks": 154050,
+      "chunks_per_epoch": 6162,
+      "wall_s": 7.73706,
+      "init_s": 11.8476,
+      "flush_s": 3.66e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.19134,
+          "best_ms": 1.13151,
+          "best_in_gibs": 13.809,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.1838,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 60.1287,
+          "best_ms": 57.4348,
+          "best_in_gibs": 2.44843,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.33873,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 58.3195,
+          "best_ms": 55.1694,
+          "best_in_gibs": 3.3989,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.21531,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 29.5103,
+          "best_ms": 21.3719,
+          "best_in_gibs": 2.19402,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.58895,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 69.8535,
+          "best_ms": 56.4052,
+          "best_in_gibs": 3.3339,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.69205,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 118.78,
+          "best_ms": 48.7771,
+          "best_in_gibs": 3.85527,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.11623,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.7739,
+          "best_ms": 3.56817,
+          "best_in_gibs": 157.198,
+          "best_out_gibs": 0.0,
+          "in_gibs": 47.64,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000308833,
+          "best_ms": 6.3e-05,
+          "best_in_gibs": 8961.51,
+          "best_out_gibs": 0.0,
+          "in_gibs": 776.593,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.013312,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 4.69,
+      "status": "pass",
+      "throughput_in_gibs": 2.08485,
+      "throughput_out_gibs": 2.40507,
+      "compression_fold": 1.17086,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.05561,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.68627,
+      "init_s": 0.518805,
+      "flush_s": 5.8e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.2841,
+          "best_ms": 0.517155,
+          "best_in_gibs": 30.2134,
+          "best_out_gibs": 30.2134,
+          "in_gibs": 20.5223,
+          "out_gibs": 20.5223
+        },
+        "h2d": {
+          "avg_ms": 1.97778,
+          "best_ms": 0.626272,
+          "best_in_gibs": 24.9492,
+          "best_out_gibs": 24.9492,
+          "in_gibs": 23.809,
+          "out_gibs": 23.809
+        },
+        "scatter": {
+          "avg_ms": 0.152231,
+          "best_ms": 0.036,
+          "best_in_gibs": 434.028,
+          "best_out_gibs": 434.028,
+          "in_gibs": 309.327,
+          "out_gibs": 309.327
+        },
+        "lod_gather": {
+          "avg_ms": 0.562755,
+          "best_ms": 0.540832,
+          "best_in_gibs": 260.016,
+          "best_out_gibs": 260.016,
+          "in_gibs": 249.887,
+          "out_gibs": 249.887
+        },
+        "lod_reduce": {
+          "avg_ms": 1.78907,
+          "best_ms": 1.78234,
+          "best_in_gibs": 78.8993,
+          "best_out_gibs": 105.37,
+          "in_gibs": 78.6025,
+          "out_gibs": 104.974
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.198013,
+          "best_ms": 0.13728,
+          "best_in_gibs": 343.678,
+          "best_out_gibs": 343.678,
+          "in_gibs": 238.268,
+          "out_gibs": 238.268
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 17.3439,
+          "best_ms": 0.442624,
+          "best_in_gibs": 424.3,
+          "best_out_gibs": 429.126,
+          "in_gibs": 10.8283,
+          "out_gibs": 10.9515
+        },
+        "aggregate": {
+          "avg_ms": 34.8847,
+          "best_ms": 0.402432,
+          "best_in_gibs": 122.546,
+          "best_out_gibs": 122.546,
+          "in_gibs": 11.6245,
+          "out_gibs": 11.6245
+        },
+        "d2h": {
+          "avg_ms": 24.2762,
+          "best_ms": 23.118,
+          "best_in_gibs": 6.08293,
+          "best_out_gibs": 6.08293,
+          "in_gibs": 16.7043,
+          "out_gibs": 16.7043
+        },
+        "sink": {
+          "avg_ms": 0.000640828,
+          "best_ms": 4.6e-05,
+          "best_in_gibs": 82.9282,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20547.7,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 196.999,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 262.895,
+        "kick_sync_count": 10,
+        "io_fence_ms": 825.718,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 134.364,
+        "peak_pending_mib": 935.086
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 21.06,
+      "status": "pass",
+      "throughput_in_gibs": 0.487541,
+      "throughput_out_gibs": 0.562425,
+      "compression_fold": 1.17086,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.05561,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 7.21094,
+      "init_s": 11.7765,
+      "flush_s": 3.67e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.42431,
+          "best_ms": 1.13399,
+          "best_in_gibs": 13.7788,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.64165,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 61.3507,
+          "best_ms": 58.5384,
+          "best_in_gibs": 2.40227,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.29215,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 57.3616,
+          "best_ms": 52.9123,
+          "best_in_gibs": 3.54937,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.27406,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 27.806,
+          "best_ms": 18.6109,
+          "best_in_gibs": 2.53509,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.69676,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 69.5742,
+          "best_ms": 55.8985,
+          "best_in_gibs": 3.39797,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.73005,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 22.4576,
+          "best_ms": 8.90818,
+          "best_in_gibs": 21.3221,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.9902,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 33.2983,
+          "best_ms": 8.8343,
+          "best_in_gibs": 63.5168,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.8515,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000356964,
+          "best_ms": 4.3e-05,
+          "best_in_gibs": 88.7139,
+          "best_out_gibs": 0.0,
+          "in_gibs": 36887.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014849,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 4.34,
+      "status": "pass",
+      "throughput_in_gibs": 2.47331,
+      "throughput_out_gibs": 0.351266,
+      "compression_fold": 9.51042,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.499298,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.42142,
+      "init_s": 0.547141,
+      "flush_s": 5.22e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.36697,
+          "best_ms": 0.320615,
+          "best_in_gibs": 48.7345,
+          "best_out_gibs": 48.7345,
+          "in_gibs": 34.2912,
+          "out_gibs": 34.2912
+        },
+        "h2d": {
+          "avg_ms": 1.94641,
+          "best_ms": 0.62576,
+          "best_in_gibs": 24.9696,
+          "best_out_gibs": 24.9696,
+          "in_gibs": 24.1927,
+          "out_gibs": 24.1927
+        },
+        "scatter": {
+          "avg_ms": 0.252687,
+          "best_ms": 0.038816,
+          "best_in_gibs": 402.54,
+          "best_out_gibs": 402.54,
+          "in_gibs": 191.69,
+          "out_gibs": 191.69
+        },
+        "lod_gather": {
+          "avg_ms": 6.05359,
+          "best_ms": 0.575712,
+          "best_in_gibs": 244.263,
+          "best_out_gibs": 244.263,
+          "in_gibs": 23.23,
+          "out_gibs": 23.23
+        },
+        "lod_reduce": {
+          "avg_ms": 5.7921,
+          "best_ms": 1.7815,
+          "best_in_gibs": 78.9361,
+          "best_out_gibs": 105.419,
+          "in_gibs": 24.2787,
+          "out_gibs": 32.4244
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.29683,
+          "best_ms": 0.151712,
+          "best_in_gibs": 310.985,
+          "best_out_gibs": 310.985,
+          "in_gibs": 36.3813,
+          "out_gibs": 36.3813
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 49.7353,
+          "best_ms": 0.44512,
+          "best_in_gibs": 421.92,
+          "best_out_gibs": 426.72,
+          "in_gibs": 3.7761,
+          "out_gibs": 3.81905
+        },
+        "compress": {
+          "avg_ms": 122.307,
+          "best_ms": 29.7368,
+          "best_in_gibs": 6.38743,
+          "best_out_gibs": 0.603525,
+          "in_gibs": 4.03777,
+          "out_gibs": 0.407791
+        },
+        "aggregate": {
+          "avg_ms": 0.236749,
+          "best_ms": 0.04784,
+          "best_in_gibs": 108.723,
+          "best_out_gibs": 108.723,
+          "in_gibs": 210.669,
+          "out_gibs": 210.669
+        },
+        "d2h": {
+          "avg_ms": 20.7662,
+          "best_ms": 2.53642,
+          "best_in_gibs": 2.05066,
+          "best_out_gibs": 2.05066,
+          "in_gibs": 2.40177,
+          "out_gibs": 2.40177
+        },
+        "sink": {
+          "avg_ms": 0.000420205,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 169.542,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3857.88,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 305.104,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 1279.48,
+        "kick_sync_count": 10,
+        "io_fence_ms": 96.8867,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 116.068,
+        "peak_pending_mib": 43.3281
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 22.48,
+      "status": "pass",
+      "throughput_in_gibs": 0.406365,
+      "throughput_out_gibs": 0.0435449,
+      "compression_fold": 12.6048,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.376724,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 8.65139,
+      "init_s": 11.8299,
+      "flush_s": 3.66e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.49796,
+          "best_ms": 1.13476,
+          "best_in_gibs": 13.7695,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.4214,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 60.1253,
+          "best_ms": 58.1328,
+          "best_in_gibs": 2.41903,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.33886,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 55.2695,
+          "best_ms": 52.2123,
+          "best_in_gibs": 3.59696,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.39799,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 26.4493,
+          "best_ms": 18.1751,
+          "best_in_gibs": 2.59587,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.7838,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 69.8807,
+          "best_ms": 56.2762,
+          "best_in_gibs": 3.37516,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.71808,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 221.006,
+          "best_ms": 87.8559,
+          "best_in_gibs": 2.16196,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.23454,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.1032,
+          "best_ms": 3.64448,
+          "best_in_gibs": 154.568,
+          "best_out_gibs": 0.0,
+          "in_gibs": 42.9909,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00034374,
+          "best_ms": 4.7e-05,
+          "best_in_gibs": 162.328,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3558.3,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014838,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 21.56,
+      "status": "pass",
+      "throughput_in_gibs": 0.455809,
+      "throughput_out_gibs": 0.28016,
+      "compression_fold": 2.19753,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.16085,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 7.71294,
+      "init_s": 11.8257,
+      "flush_s": 3.46e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.04665,
+          "best_ms": 1.13381,
+          "best_in_gibs": 13.7809,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.28835,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 61.8426,
+          "best_ms": 57.9106,
+          "best_in_gibs": 2.42831,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.27392,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 55.8037,
+          "best_ms": 53.2191,
+          "best_in_gibs": 3.52891,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.36546,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 26.5815,
+          "best_ms": 18.3722,
+          "best_in_gibs": 2.56802,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.77493,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 70.0971,
+          "best_ms": 56.7927,
+          "best_in_gibs": 3.34447,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.70969,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 97.0453,
+          "best_ms": 39.0394,
+          "best_in_gibs": 4.86537,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.08884,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 22.7755,
+          "best_ms": 8.5309,
+          "best_in_gibs": 65.7865,
+          "best_out_gibs": 0.0,
+          "in_gibs": 24.6414,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000328773,
+          "best_ms": 4.8e-05,
+          "best_in_gibs": 158.946,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21339.2,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014157,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 20.85,
+      "status": "pass",
+      "throughput_in_gibs": 0.497443,
+      "throughput_out_gibs": 0.00833875,
+      "compression_fold": 80.5748,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0589333,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 7.06739,
+      "init_s": 11.7711,
+      "flush_s": 4.65e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.36123,
+          "best_ms": 1.13604,
+          "best_in_gibs": 13.754,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.7481,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 60.0485,
+          "best_ms": 57.6806,
+          "best_in_gibs": 2.43799,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.34186,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 54.9746,
+          "best_ms": 53.0257,
+          "best_in_gibs": 3.54178,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.41622,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 26.163,
+          "best_ms": 18.1338,
+          "best_in_gibs": 2.60178,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.80331,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 69.1719,
+          "best_ms": 55.1785,
+          "best_in_gibs": 3.44231,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.74593,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 71.7567,
+          "best_ms": 29.2994,
+          "best_in_gibs": 6.48277,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.88225,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.3295,
+          "best_ms": 3.43901,
+          "best_in_gibs": 163.192,
+          "best_out_gibs": 0.0,
+          "in_gibs": 49.5361,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000314508,
+          "best_ms": 4.3e-05,
+          "best_in_gibs": 177.428,
+          "best_out_gibs": 0.0,
+          "in_gibs": 610.366,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.015171,
+        "io_fence_count": 10,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 4.93,
+      "status": "pass",
+      "throughput_in_gibs": 1.97226,
+      "throughput_out_gibs": 2.42171,
+      "compression_fold": 1.18814,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31677,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 1.78253,
+      "init_s": 0.681589,
+      "flush_s": 6.55e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.67134,
+          "best_ms": 0.642266,
+          "best_in_gibs": 48.6559,
+          "best_out_gibs": 48.6559,
+          "in_gibs": 20.8897,
+          "out_gibs": 20.8897
+        },
+        "h2d": {
+          "avg_ms": 2.35581,
+          "best_ms": 1.24586,
+          "best_in_gibs": 25.0832,
+          "best_out_gibs": 25.0832,
+          "in_gibs": 23.9206,
+          "out_gibs": 23.9206
+        },
+        "scatter": {
+          "avg_ms": 0.158579,
+          "best_ms": 0.079552,
+          "best_in_gibs": 392.825,
+          "best_out_gibs": 392.825,
+          "in_gibs": 355.359,
+          "out_gibs": 355.359
+        },
+        "lod_gather": {
+          "avg_ms": 1.08346,
+          "best_ms": 1.06061,
+          "best_in_gibs": 265.178,
+          "best_out_gibs": 265.178,
+          "in_gibs": 259.586,
+          "out_gibs": 259.586
+        },
+        "lod_reduce": {
+          "avg_ms": 3.51582,
+          "best_ms": 3.51062,
+          "best_in_gibs": 80.114,
+          "best_out_gibs": 107.514,
+          "in_gibs": 79.9956,
+          "out_gibs": 107.355
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.591608,
+          "best_ms": 0.336832,
+          "best_in_gibs": 285.577,
+          "best_out_gibs": 285.577,
+          "in_gibs": 162.593,
+          "out_gibs": 162.593
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.2187,
+          "best_ms": 0.878944,
+          "best_in_gibs": 429.426,
+          "best_out_gibs": 448.87,
+          "in_gibs": 72.3247,
+          "out_gibs": 75.5995
+        },
+        "aggregate": {
+          "avg_ms": 62.8921,
+          "best_ms": 2.53219,
+          "best_in_gibs": 44.7364,
+          "best_out_gibs": 44.7364,
+          "in_gibs": 8.57899,
+          "out_gibs": 8.57899
+        },
+        "d2h": {
+          "avg_ms": 29.7761,
+          "best_ms": 28.4717,
+          "best_in_gibs": 9.87823,
+          "best_out_gibs": 9.87823,
+          "in_gibs": 18.1203,
+          "out_gibs": 18.1203
+        },
+        "sink": {
+          "avg_ms": 0.000466386,
+          "best_ms": 4.6e-05,
+          "best_in_gibs": 509511,
+          "best_out_gibs": 0.0,
+          "in_gibs": 38889.8,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 278.116,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 284.275,
+        "kick_sync_count": 8,
+        "io_fence_ms": 823.952,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 153.621,
+        "peak_pending_mib": 1144.07
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 32.01,
+      "status": "pass",
+      "throughput_in_gibs": 0.510205,
+      "throughput_out_gibs": 0.626471,
+      "compression_fold": 1.18814,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31677,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 6.89061,
+      "init_s": 22.9461,
+      "flush_s": 3.69e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 7.3307,
+          "best_ms": 2.19734,
+          "best_in_gibs": 14.2218,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.61231,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 121.113,
+          "best_ms": 113.773,
+          "best_in_gibs": 2.47203,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.32221,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 94.7335,
+          "best_ms": 86.928,
+          "best_in_gibs": 4.342,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.98424,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 33.2661,
+          "best_ms": 17.9626,
+          "best_in_gibs": 5.35509,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.89158,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 132.083,
+          "best_ms": 108.742,
+          "best_in_gibs": 3.62816,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.987,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.2967,
+          "best_ms": 8.86154,
+          "best_in_gibs": 44.5217,
+          "best_out_gibs": 0.0,
+          "in_gibs": 29.6364,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 36.3389,
+          "best_ms": 11.6208,
+          "best_in_gibs": 59.5034,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.0286,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000347517,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 520833,
+          "best_out_gibs": 0.0,
+          "in_gibs": 52192.3,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.013631,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 4.6,
+      "status": "pass",
+      "throughput_in_gibs": 2.64464,
+      "throughput_out_gibs": 0.413887,
+      "compression_fold": 9.32193,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.550198,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 1.32934,
+      "init_s": 0.66965,
+      "flush_s": 5.54e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.61133,
+          "best_ms": 0.551883,
+          "best_in_gibs": 28.3122,
+          "best_out_gibs": 28.3122,
+          "in_gibs": 34.6321,
+          "out_gibs": 34.6321
+        },
+        "h2d": {
+          "avg_ms": 2.3315,
+          "best_ms": 1.24925,
+          "best_in_gibs": 25.015,
+          "best_out_gibs": 25.015,
+          "in_gibs": 24.1701,
+          "out_gibs": 24.1701
+        },
+        "scatter": {
+          "avg_ms": 0.26552,
+          "best_ms": 0.079968,
+          "best_in_gibs": 390.781,
+          "best_out_gibs": 390.781,
+          "in_gibs": 209.94,
+          "out_gibs": 209.94
+        },
+        "lod_gather": {
+          "avg_ms": 4.59472,
+          "best_ms": 1.0769,
+          "best_in_gibs": 261.167,
+          "best_out_gibs": 261.167,
+          "in_gibs": 61.2115,
+          "out_gibs": 61.2115
+        },
+        "lod_reduce": {
+          "avg_ms": 5.94172,
+          "best_ms": 3.51178,
+          "best_in_gibs": 80.0877,
+          "best_out_gibs": 107.479,
+          "in_gibs": 47.3348,
+          "out_gibs": 63.524
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.30452,
+          "best_ms": 0.338688,
+          "best_in_gibs": 284.012,
+          "best_out_gibs": 284.012,
+          "in_gibs": 73.7372,
+          "out_gibs": 73.7372
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.6141,
+          "best_ms": 0.877024,
+          "best_in_gibs": 430.366,
+          "best_out_gibs": 449.852,
+          "in_gibs": 27.7243,
+          "out_gibs": 28.9796
+        },
+        "compress": {
+          "avg_ms": 134.214,
+          "best_ms": 61.2827,
+          "best_in_gibs": 6.43789,
+          "best_out_gibs": 0.607789,
+          "in_gibs": 5.14425,
+          "out_gibs": 0.512223
+        },
+        "aggregate": {
+          "avg_ms": 0.58554,
+          "best_ms": 0.191616,
+          "best_in_gibs": 51.7887,
+          "best_out_gibs": 51.7887,
+          "in_gibs": 117.409,
+          "out_gibs": 117.409
+        },
+        "d2h": {
+          "avg_ms": 25.2434,
+          "best_ms": 3.08106,
+          "best_in_gibs": 3.22082,
+          "best_out_gibs": 3.22082,
+          "in_gibs": 2.72338,
+          "out_gibs": 2.72338
+        },
+        "sink": {
+          "avg_ms": 0.207513,
+          "best_ms": 4.7e-05,
+          "best_in_gibs": 65174.5,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.1403,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 417.776,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 1098.44,
+        "kick_sync_count": 8,
+        "io_fence_ms": 98.2217,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 124.686,
+        "peak_pending_mib": 46.8086
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 33.24,
+      "status": "pass",
+      "throughput_in_gibs": 0.422696,
+      "throughput_out_gibs": 0.0473276,
+      "compression_fold": 13.0297,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.393631,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 8.31715,
+      "init_s": 22.8416,
+      "flush_s": 3.55e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.69882,
+          "best_ms": 1.13877,
+          "best_in_gibs": 13.7209,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.33036,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 115.748,
+          "best_ms": 112.509,
+          "best_in_gibs": 2.49979,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.42984,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 92.2565,
+          "best_ms": 86.3,
+          "best_in_gibs": 4.3736,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.09122,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 32.0674,
+          "best_ms": 17.669,
+          "best_in_gibs": 5.44408,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.99966,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 131.427,
+          "best_ms": 108.332,
+          "best_in_gibs": 3.64186,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.00191,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 276.293,
+          "best_ms": 139.301,
+          "best_in_gibs": 2.83222,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.4989,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.8472,
+          "best_ms": 4.29852,
+          "best_in_gibs": 161.493,
+          "best_out_gibs": 0.0,
+          "in_gibs": 58.5943,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.14479,
+          "best_ms": 5e-05,
+          "best_in_gibs": 76.2939,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.4228,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.013846,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 32.65,
+      "status": "pass",
+      "throughput_in_gibs": 0.460346,
+      "throughput_out_gibs": 0.293053,
+      "compression_fold": 2.29171,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.23802,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 7.63692,
+      "init_s": 22.8441,
+      "flush_s": 3.78e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 7.61007,
+          "best_ms": 1.89405,
+          "best_in_gibs": 8.24952,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.33286,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 118.622,
+          "best_ms": 114.313,
+          "best_in_gibs": 2.46035,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.37098,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 92.6044,
+          "best_ms": 86.9917,
+          "best_in_gibs": 4.33882,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.07585,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 33.3091,
+          "best_ms": 17.9154,
+          "best_in_gibs": 5.3692,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.88784,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 131.499,
+          "best_ms": 111.05,
+          "best_in_gibs": 3.55275,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.00026,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 128.451,
+          "best_ms": 63.6701,
+          "best_in_gibs": 6.19649,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.37506,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 24.0598,
+          "best_ms": 7.40075,
+          "best_in_gibs": 93.4433,
+          "best_out_gibs": 0.0,
+          "in_gibs": 28.743,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.800506,
+          "best_ms": 4.7e-05,
+          "best_in_gibs": 81.1638,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.7469,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.012961,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 31.56,
+      "status": "pass",
+      "throughput_in_gibs": 0.534852,
+      "throughput_out_gibs": 0.0096733,
+      "compression_fold": 80.6643,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0635834,
+      "total_chunks": 2626,
+      "chunks_per_epoch": 202,
+      "wall_s": 6.57308,
+      "init_s": 22.8833,
+      "flush_s": 5.55e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.69605,
+          "best_ms": 1.15915,
+          "best_in_gibs": 13.4797,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.3338,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 116.913,
+          "best_ms": 111.724,
+          "best_in_gibs": 2.51736,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.40564,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 92.5433,
+          "best_ms": 86.7418,
+          "best_in_gibs": 4.35132,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.07854,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 32.1136,
+          "best_ms": 17.8015,
+          "best_in_gibs": 5.40356,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.99535,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 129.89,
+          "best_ms": 109.254,
+          "best_in_gibs": 3.61114,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.03742,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 75.8813,
+          "best_ms": 40.0367,
+          "best_in_gibs": 9.85424,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.09881,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.64707,
+          "best_ms": 3.83042,
+          "best_in_gibs": 180.542,
+          "best_out_gibs": 0.0,
+          "in_gibs": 71.6851,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00933358,
+          "best_ms": 4.7e-05,
+          "best_in_gibs": 81.1638,
+          "best_out_gibs": 0.0,
+          "in_gibs": 28.6232,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.013383,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 15.4,
+      "status": "pass",
+      "throughput_in_gibs": 1.67106,
+      "throughput_out_gibs": 1.7835,
+      "compression_fold": 1.07146,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00234,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 2.24409,
+      "init_s": 0.511205,
+      "flush_s": 9.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 3.00561,
+          "best_ms": 1.04294,
+          "best_in_gibs": 29.9634,
+          "best_out_gibs": 29.9634,
+          "in_gibs": 15.5958,
+          "out_gibs": 15.5958
+        },
+        "h2d": {
+          "avg_ms": 1.94749,
+          "best_ms": 1.24771,
+          "best_in_gibs": 25.0458,
+          "best_out_gibs": 25.0458,
+          "in_gibs": 24.0695,
+          "out_gibs": 24.0695
+        },
+        "scatter": {
+          "avg_ms": 0.118582,
+          "best_ms": 0.063904,
+          "best_in_gibs": 489.015,
+          "best_out_gibs": 489.015,
+          "in_gibs": 395.297,
+          "out_gibs": 395.297
+        },
+        "lod_gather": {
+          "avg_ms": 1.20015,
+          "best_ms": 1.1929,
+          "best_in_gibs": 78.5903,
+          "best_out_gibs": 78.5903,
+          "in_gibs": 78.1151,
+          "out_gibs": 78.1151
+        },
+        "lod_reduce": {
+          "avg_ms": 0.974368,
+          "best_ms": 0.969536,
+          "best_in_gibs": 96.6957,
+          "best_out_gibs": 110.577,
+          "in_gibs": 96.2162,
+          "out_gibs": 110.029
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.0396978,
+          "best_ms": 0.026944,
+          "best_in_gibs": 499.49,
+          "best_out_gibs": 499.49,
+          "in_gibs": 339.018,
+          "out_gibs": 339.018
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 91.0499,
+          "best_ms": 0.527744,
+          "best_in_gibs": 203.144,
+          "best_out_gibs": 203.144,
+          "in_gibs": 1.17747,
+          "out_gibs": 1.17747
+        },
+        "aggregate": {
+          "avg_ms": 23.4725,
+          "best_ms": 0.071968,
+          "best_in_gibs": 1.27213,
+          "best_out_gibs": 1.27213,
+          "in_gibs": 18.9357,
+          "out_gibs": 18.9357
+        },
+        "d2h": {
+          "avg_ms": 21.5783,
+          "best_ms": 20.9353,
+          "best_in_gibs": 24.2184,
+          "best_out_gibs": 24.2184,
+          "in_gibs": 20.5979,
+          "out_gibs": 20.5979
+        },
+        "sink": {
+          "avg_ms": 0.00100519,
+          "best_ms": 5.2e-05,
+          "best_in_gibs": 563401,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16185.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 329.715,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 222.228,
+        "kick_sync_count": 9,
+        "io_fence_ms": 693.423,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 230.807,
+        "peak_pending_mib": 993.793
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 27.95,
+      "status": "pass",
+      "throughput_in_gibs": 0.48532,
+      "throughput_out_gibs": 0.517977,
+      "compression_fold": 1.07146,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00234,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 7.72686,
+      "init_s": 7.77503,
+      "flush_s": 5.06e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.58115,
+          "best_ms": 2.17596,
+          "best_in_gibs": 14.3615,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.2322,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 47.2508,
+          "best_ms": 43.6119,
+          "best_in_gibs": 2.14964,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.98409,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 29.6574,
+          "best_ms": 27.2794,
+          "best_in_gibs": 3.93001,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.61489,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 19.4544,
+          "best_ms": 9.75611,
+          "best_in_gibs": 1.37947,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.691783,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 46.0439,
+          "best_ms": 38.3239,
+          "best_in_gibs": 2.79743,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.32839,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.3488,
+          "best_ms": 7.23927,
+          "best_in_gibs": 14.8093,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.9173,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 33.2835,
+          "best_ms": 3.95081,
+          "best_in_gibs": 128.376,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.2385,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000540439,
+          "best_ms": 4.8e-05,
+          "best_in_gibs": 610352,
+          "best_out_gibs": 0.0,
+          "in_gibs": 30104.5,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.015938,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 13.73,
+      "status": "pass",
+      "throughput_in_gibs": 4.18166,
+      "throughput_out_gibs": 0.539859,
+      "compression_fold": 8.85779,
+      "input_gib": 3.75,
+      "compressed_gib": 0.484131,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.896773,
+      "init_s": 0.435604,
+      "flush_s": 3.27e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.32965,
+          "best_ms": 0.628966,
+          "best_in_gibs": 49.6847,
+          "best_out_gibs": 49.6847,
+          "in_gibs": 35.2535,
+          "out_gibs": 35.2535
+        },
+        "h2d": {
+          "avg_ms": 1.95963,
+          "best_ms": 1.24598,
+          "best_in_gibs": 25.0806,
+          "best_out_gibs": 25.0806,
+          "in_gibs": 23.9203,
+          "out_gibs": 23.9203
+        },
+        "scatter": {
+          "avg_ms": 0.226464,
+          "best_ms": 0.065024,
+          "best_in_gibs": 480.592,
+          "best_out_gibs": 480.592,
+          "in_gibs": 206.987,
+          "out_gibs": 206.987
+        },
+        "lod_gather": {
+          "avg_ms": 1.97706,
+          "best_ms": 1.17952,
+          "best_in_gibs": 79.4815,
+          "best_out_gibs": 79.4815,
+          "in_gibs": 47.4188,
+          "out_gibs": 47.4188
+        },
+        "lod_reduce": {
+          "avg_ms": 1.23115,
+          "best_ms": 0.97104,
+          "best_in_gibs": 96.546,
+          "best_out_gibs": 110.406,
+          "in_gibs": 76.1485,
+          "out_gibs": 87.08
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.119989,
+          "best_ms": 0.027584,
+          "best_in_gibs": 487.901,
+          "best_out_gibs": 487.901,
+          "in_gibs": 112.162,
+          "out_gibs": 112.162
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 24.4388,
+          "best_ms": 0.527168,
+          "best_in_gibs": 203.366,
+          "best_out_gibs": 203.366,
+          "in_gibs": 4.3868,
+          "out_gibs": 4.3868
+        },
+        "compress": {
+          "avg_ms": 50.3561,
+          "best_ms": 3.68598,
+          "best_in_gibs": 29.0854,
+          "best_out_gibs": 0.00151903,
+          "in_gibs": 9.69879,
+          "out_gibs": 1.06344
+        },
+        "aggregate": {
+          "avg_ms": 0.228683,
+          "best_ms": 0.01824,
+          "best_in_gibs": 0.306969,
+          "best_out_gibs": 0.306969,
+          "in_gibs": 234.171,
+          "out_gibs": 234.171
+        },
+        "d2h": {
+          "avg_ms": 18.3247,
+          "best_ms": 0.06944,
+          "best_in_gibs": 0.0806324,
+          "best_out_gibs": 0.0806324,
+          "in_gibs": 2.92233,
+          "out_gibs": 2.92233
+        },
+        "sink": {
+          "avg_ms": 0.00109661,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 78328.4,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1794.63,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 81.7939,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 514.843,
+        "kick_sync_count": 9,
+        "io_fence_ms": 39.4116,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 19.5503,
+        "peak_pending_mib": 53.6875
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 28.92,
+      "status": "pass",
+      "throughput_in_gibs": 0.409578,
+      "throughput_out_gibs": 0.0402508,
+      "compression_fold": 11.6364,
+      "input_gib": 3.75,
+      "compressed_gib": 0.368526,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 9.15576,
+      "init_s": 7.71674,
+      "flush_s": 5.73e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.89708,
+          "best_ms": 2.17564,
+          "best_in_gibs": 14.3636,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.0282,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 46.5723,
+          "best_ms": 44.8882,
+          "best_in_gibs": 2.08852,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.013,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 28.4127,
+          "best_ms": 27.364,
+          "best_in_gibs": 3.91785,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.77325,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 17.5277,
+          "best_ms": 7.06201,
+          "best_in_gibs": 1.90573,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.767827,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.3796,
+          "best_ms": 37.8165,
+          "best_in_gibs": 2.83496,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.36248,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 266.216,
+          "best_ms": 62.6869,
+          "best_in_gibs": 1.71022,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.83457,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.3753,
+          "best_ms": 3.40563,
+          "best_in_gibs": 149.744,
+          "best_out_gibs": 0.0,
+          "in_gibs": 35.4755,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000559481,
+          "best_ms": 6.2e-05,
+          "best_in_gibs": 43376.8,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2710.67,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.017064,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 28.23,
+      "status": "pass",
+      "throughput_in_gibs": 0.454725,
+      "throughput_out_gibs": 0.301996,
+      "compression_fold": 1.72189,
+      "input_gib": 3.75,
+      "compressed_gib": 2.49048,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 8.24674,
+      "init_s": 7.76709,
+      "flush_s": 5.68e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.33292,
+          "best_ms": 2.17544,
+          "best_in_gibs": 14.3649,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.8183,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 46.8642,
+          "best_ms": 44.5743,
+          "best_in_gibs": 2.10323,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.00046,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 28.9039,
+          "best_ms": 27.3402,
+          "best_in_gibs": 3.92127,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.70912,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 18.3108,
+          "best_ms": 7.07433,
+          "best_in_gibs": 1.90241,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.734989,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.3336,
+          "best_ms": 37.8334,
+          "best_in_gibs": 2.83369,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.36487,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 121.235,
+          "best_ms": 28.4021,
+          "best_in_gibs": 3.77466,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.02847,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 25.8925,
+          "best_ms": 3.33539,
+          "best_in_gibs": 152.147,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.5991,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00349425,
+          "best_ms": 6.2e-05,
+          "best_in_gibs": 293424,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2897.3,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014117,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__32K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "fs",
+      "elapsed_s": 28.17,
+      "status": "pass",
+      "throughput_in_gibs": 0.451678,
+      "throughput_out_gibs": 0.0126157,
+      "compression_fold": 40.9426,
+      "input_gib": 3.75,
+      "compressed_gib": 0.10474,
+      "total_chunks": 140520,
+      "chunks_per_epoch": 3513,
+      "wall_s": 8.30237,
+      "init_s": 7.82069,
+      "flush_s": 4.88e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.82493,
+          "best_ms": 2.18567,
+          "best_in_gibs": 14.2977,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.2551,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 46.2976,
+          "best_ms": 44.2231,
+          "best_in_gibs": 2.11993,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.02494,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 28.5899,
+          "best_ms": 27.3864,
+          "best_in_gibs": 3.91465,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.74987,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 17.5482,
+          "best_ms": 6.8827,
+          "best_in_gibs": 1.95537,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.766931,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.5714,
+          "best_ms": 38.0563,
+          "best_in_gibs": 2.8171,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.35253,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 170.167,
+          "best_ms": 40.3772,
+          "best_in_gibs": 2.65517,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.87008,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.167,
+          "best_ms": 3.37431,
+          "best_in_gibs": 150.392,
+          "best_out_gibs": 0.0,
+          "in_gibs": 38.541,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00043463,
+          "best_ms": 6.3e-05,
+          "best_in_gibs": 11867.9,
+          "best_out_gibs": 0.0,
+          "in_gibs": 991.716,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014911,
+        "io_fence_count": 9,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 14.8,
+      "status": "pass",
+      "throughput_in_gibs": 2.16689,
+      "throughput_out_gibs": 2.31308,
+      "compression_fold": 1.07585,
+      "input_gib": 3.75,
+      "compressed_gib": 4.003,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.73059,
+      "init_s": 0.458668,
+      "flush_s": 1.085e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.16458,
+          "best_ms": 0.627284,
+          "best_in_gibs": 49.8179,
+          "best_out_gibs": 49.8179,
+          "in_gibs": 21.6554,
+          "out_gibs": 21.6554
+        },
+        "h2d": {
+          "avg_ms": 1.93214,
+          "best_ms": 1.24525,
+          "best_in_gibs": 25.0954,
+          "best_out_gibs": 25.0954,
+          "in_gibs": 24.2607,
+          "out_gibs": 24.2607
+        },
+        "scatter": {
+          "avg_ms": 0.135673,
+          "best_ms": 0.065408,
+          "best_in_gibs": 477.77,
+          "best_out_gibs": 477.77,
+          "in_gibs": 345.5,
+          "out_gibs": 345.5
+        },
+        "lod_gather": {
+          "avg_ms": 1.20211,
+          "best_ms": 1.19149,
+          "best_in_gibs": 78.6831,
+          "best_out_gibs": 78.6831,
+          "in_gibs": 77.9877,
+          "out_gibs": 77.9877
+        },
+        "lod_reduce": {
+          "avg_ms": 0.972132,
+          "best_ms": 0.969728,
+          "best_in_gibs": 96.6766,
+          "best_out_gibs": 111.027,
+          "in_gibs": 96.4375,
+          "out_gibs": 110.752
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.041192,
+          "best_ms": 0.027392,
+          "best_in_gibs": 508.032,
+          "best_out_gibs": 508.032,
+          "in_gibs": 337.833,
+          "out_gibs": 337.833
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.6057,
+          "best_ms": 0.559072,
+          "best_in_gibs": 192.58,
+          "best_out_gibs": 192.58,
+          "in_gibs": 177.755,
+          "out_gibs": 177.755
+        },
+        "aggregate": {
+          "avg_ms": 15.9365,
+          "best_ms": 2.03293,
+          "best_in_gibs": 243.189,
+          "best_out_gibs": 243.189,
+          "in_gibs": 31.3955,
+          "out_gibs": 31.3955
+        },
+        "d2h": {
+          "avg_ms": 21.6928,
+          "best_ms": 21.1978,
+          "best_in_gibs": 23.8753,
+          "best_out_gibs": 23.8753,
+          "in_gibs": 23.0646,
+          "out_gibs": 23.0646
+        },
+        "sink": {
+          "avg_ms": 0.000659316,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 84.771,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25297.7,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 188.735,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 203.456,
+        "kick_sync_count": 8,
+        "io_fence_ms": 459.524,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 115.002,
+        "peak_pending_mib": 963.82
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 27.25,
+      "status": "pass",
+      "throughput_in_gibs": 0.50493,
+      "throughput_out_gibs": 0.538995,
+      "compression_fold": 1.07585,
+      "input_gib": 3.75,
+      "compressed_gib": 4.003,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 7.42678,
+      "init_s": 7.71489,
+      "flush_s": 7.35e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.66456,
+          "best_ms": 2.17146,
+          "best_in_gibs": 14.3912,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.0492,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 47.348,
+          "best_ms": 44.956,
+          "best_in_gibs": 2.08537,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.98002,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 26.2776,
+          "best_ms": 24.8657,
+          "best_in_gibs": 4.32991,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.09725,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 15.1051,
+          "best_ms": 0.000178,
+          "best_in_gibs": 78179.9,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.921282,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.7835,
+          "best_ms": 37.5242,
+          "best_in_gibs": 2.86924,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.35163,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.3448,
+          "best_ms": 19.1025,
+          "best_in_gibs": 28.1812,
+          "best_out_gibs": 0.0,
+          "in_gibs": 22.1127,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 36.6576,
+          "best_ms": 25.7661,
+          "best_in_gibs": 19.702,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.8483,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000383325,
+          "best_ms": 4.4e-05,
+          "best_in_gibs": 86.6977,
+          "best_out_gibs": 0.0,
+          "in_gibs": 43511.8,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014422,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 14.18,
+      "status": "pass",
+      "throughput_in_gibs": 3.60462,
+      "throughput_out_gibs": 0.455263,
+      "compression_fold": 9.09293,
+      "input_gib": 3.75,
+      "compressed_gib": 0.473625,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 1.04033,
+      "init_s": 0.445307,
+      "flush_s": 4.86e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.30183,
+          "best_ms": 0.633144,
+          "best_in_gibs": 49.3569,
+          "best_out_gibs": 49.3569,
+          "in_gibs": 36.0069,
+          "out_gibs": 36.0069
+        },
+        "h2d": {
+          "avg_ms": 1.96351,
+          "best_ms": 1.24544,
+          "best_in_gibs": 25.0915,
+          "best_out_gibs": 25.0915,
+          "in_gibs": 23.873,
+          "out_gibs": 23.873
+        },
+        "scatter": {
+          "avg_ms": 0.20272,
+          "best_ms": 0.06448,
+          "best_in_gibs": 484.646,
+          "best_out_gibs": 484.646,
+          "in_gibs": 227.376,
+          "out_gibs": 227.376
+        },
+        "lod_gather": {
+          "avg_ms": 3.33924,
+          "best_ms": 1.20246,
+          "best_in_gibs": 77.9649,
+          "best_out_gibs": 77.9649,
+          "in_gibs": 28.0752,
+          "out_gibs": 28.0752
+        },
+        "lod_reduce": {
+          "avg_ms": 2.17049,
+          "best_ms": 0.970592,
+          "best_in_gibs": 96.5905,
+          "best_out_gibs": 110.928,
+          "in_gibs": 43.1931,
+          "out_gibs": 49.6046
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.286219,
+          "best_ms": 0.028192,
+          "best_in_gibs": 493.616,
+          "best_out_gibs": 493.616,
+          "in_gibs": 48.6202,
+          "out_gibs": 48.6202
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.23305,
+          "best_ms": 0.560128,
+          "best_in_gibs": 192.217,
+          "best_out_gibs": 192.217,
+          "in_gibs": 48.2149,
+          "out_gibs": 48.2149
+        },
+        "compress": {
+          "avg_ms": 99.1447,
+          "best_ms": 76.9536,
+          "best_in_gibs": 6.99552,
+          "best_out_gibs": 0.758749,
+          "in_gibs": 5.42974,
+          "out_gibs": 0.596578
+        },
+        "aggregate": {
+          "avg_ms": 0.477604,
+          "best_ms": 0.230208,
+          "best_in_gibs": 253.621,
+          "best_out_gibs": 253.621,
+          "in_gibs": 123.842,
+          "out_gibs": 123.842
+        },
+        "d2h": {
+          "avg_ms": 21.7337,
+          "best_ms": 18.9582,
+          "best_in_gibs": 3.16423,
+          "best_out_gibs": 3.16423,
+          "in_gibs": 2.72146,
+          "out_gibs": 2.72146
+        },
+        "sink": {
+          "avg_ms": 0.00102485,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 84.771,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1925.58,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 153.407,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 834.675,
+        "kick_sync_count": 8,
+        "io_fence_ms": 50.4907,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 47.788,
+        "peak_pending_mib": 54.4609
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 28.25,
+      "status": "pass",
+      "throughput_in_gibs": 0.442168,
+      "throughput_out_gibs": 0.0413925,
+      "compression_fold": 12.268,
+      "input_gib": 3.75,
+      "compressed_gib": 0.351048,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 8.48094,
+      "init_s": 7.71426,
+      "flush_s": 4.25e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.91822,
+          "best_ms": 2.17237,
+          "best_in_gibs": 14.3852,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.9633,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 46.3042,
+          "best_ms": 44.8397,
+          "best_in_gibs": 2.09078,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.02466,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 25.2325,
+          "best_ms": 24.4711,
+          "best_in_gibs": 4.39973,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.26696,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 14.1799,
+          "best_ms": 7e-05,
+          "best_in_gibs": 198800,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.981391,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.0434,
+          "best_ms": 37.6552,
+          "best_in_gibs": 2.85926,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.39027,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 251.228,
+          "best_ms": 247.866,
+          "best_in_gibs": 2.17186,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.14279,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.6698,
+          "best_ms": 11.3607,
+          "best_in_gibs": 44.859,
+          "best_out_gibs": 0.0,
+          "in_gibs": 34.74,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000385025,
+          "best_ms": 6e-05,
+          "best_in_gibs": 45522.1,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3798.97,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.013845,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 27.85,
+      "status": "pass",
+      "throughput_in_gibs": 0.475712,
+      "throughput_out_gibs": 0.285627,
+      "compression_fold": 1.91273,
+      "input_gib": 3.75,
+      "compressed_gib": 2.25157,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 7.88292,
+      "init_s": 7.77988,
+      "flush_s": 8.55e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.18434,
+          "best_ms": 2.17578,
+          "best_in_gibs": 14.3627,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.2025,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 46.6725,
+          "best_ms": 44.1528,
+          "best_in_gibs": 2.12331,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.00868,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 25.8109,
+          "best_ms": 24.3107,
+          "best_in_gibs": 4.42875,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.17134,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 14.7272,
+          "best_ms": 0.00017,
+          "best_in_gibs": 81858.9,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.944918,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.051,
+          "best_ms": 37.7929,
+          "best_in_gibs": 2.84884,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.38987,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 123.892,
+          "best_ms": 121.32,
+          "best_in_gibs": 4.43728,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.34514,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 25.8845,
+          "best_ms": 19.3869,
+          "best_in_gibs": 26.1889,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.6149,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00214008,
+          "best_ms": 6e-05,
+          "best_in_gibs": 127.157,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4383.74,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.014043,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "fs",
+      "elapsed_s": 27.33,
+      "status": "pass",
+      "throughput_in_gibs": 0.521502,
+      "throughput_out_gibs": 0.00844448,
+      "compression_fold": 70.9235,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0607224,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 7.19077,
+      "init_s": 7.76305,
+      "flush_s": 4.22e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.78603,
+          "best_ms": 2.17849,
+          "best_in_gibs": 14.3448,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.381,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 46.2761,
+          "best_ms": 44.3757,
+          "best_in_gibs": 2.11264,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.02588,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 25.3314,
+          "best_ms": 24.0929,
+          "best_in_gibs": 4.46878,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.25029,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 14.0117,
+          "best_ms": 5.8e-05,
+          "best_in_gibs": 239931,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.993169,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.0949,
+          "best_ms": 37.3657,
+          "best_in_gibs": 2.88141,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.38754,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 98.5116,
+          "best_ms": 95.2007,
+          "best_in_gibs": 5.65469,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.46464,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.6658,
+          "best_ms": 10.419,
+          "best_in_gibs": 48.7303,
+          "best_out_gibs": 0.0,
+          "in_gibs": 40.0861,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000442579,
+          "best_ms": 6.1e-05,
+          "best_in_gibs": 125.072,
+          "best_out_gibs": 0.0,
+          "in_gibs": 571.671,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.012222,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.74,
+      "status": "pass",
+      "throughput_in_gibs": 2.30129,
+      "throughput_out_gibs": 2.48129,
+      "compression_fold": 1.10136,
+      "input_gib": 3.75,
+      "compressed_gib": 4.04331,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 1.62952,
+      "init_s": 0.544046,
+      "flush_s": 1.111e-06,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.51939,
+          "best_ms": 0.631766,
+          "best_in_gibs": 49.4645,
+          "best_out_gibs": 49.4645,
+          "in_gibs": 18.6057,
+          "out_gibs": 18.6057
+        },
+        "h2d": {
+          "avg_ms": 1.9499,
+          "best_ms": 1.24653,
+          "best_in_gibs": 25.0696,
+          "best_out_gibs": 25.0696,
+          "in_gibs": 24.0397,
+          "out_gibs": 24.0397
+        },
+        "scatter": {
+          "avg_ms": 0.119308,
+          "best_ms": 0.065952,
+          "best_in_gibs": 473.829,
+          "best_out_gibs": 473.829,
+          "in_gibs": 392.891,
+          "out_gibs": 392.891
+        },
+        "lod_gather": {
+          "avg_ms": 1.21955,
+          "best_ms": 1.1945,
+          "best_in_gibs": 78.485,
+          "best_out_gibs": 78.485,
+          "in_gibs": 76.8727,
+          "out_gibs": 76.8727
+        },
+        "lod_reduce": {
+          "avg_ms": 0.983728,
+          "best_ms": 0.978528,
+          "best_in_gibs": 95.8072,
+          "best_out_gibs": 113.771,
+          "in_gibs": 95.3007,
+          "out_gibs": 113.17
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.051924,
+          "best_ms": 0.034464,
+          "best_in_gibs": 510.043,
+          "best_out_gibs": 510.043,
+          "in_gibs": 338.536,
+          "out_gibs": 338.536
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.638368,
+          "best_ms": 0.57568,
+          "best_in_gibs": 193.385,
+          "best_out_gibs": 193.385,
+          "in_gibs": 174.395,
+          "out_gibs": 174.395
+        },
+        "aggregate": {
+          "avg_ms": 16.2871,
+          "best_ms": 3.0689,
+          "best_in_gibs": 162.289,
+          "best_out_gibs": 162.289,
+          "in_gibs": 31.0289,
+          "out_gibs": 31.0289
+        },
+        "d2h": {
+          "avg_ms": 29.2598,
+          "best_ms": 28.2228,
+          "best_in_gibs": 18.2698,
+          "best_out_gibs": 18.2698,
+          "in_gibs": 17.2718,
+          "out_gibs": 17.2718
+        },
+        "sink": {
+          "avg_ms": 0.000691836,
+          "best_ms": 4.7e-05,
+          "best_in_gibs": 415558,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21807.2,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 172.281,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 265.074,
+        "kick_sync_count": 8,
+        "io_fence_ms": 404.291,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 115.306,
+        "peak_pending_mib": 956.078
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 26.7,
+      "status": "pass",
+      "throughput_in_gibs": 0.528828,
+      "throughput_out_gibs": 0.570191,
+      "compression_fold": 1.10136,
+      "input_gib": 3.75,
+      "compressed_gib": 4.04331,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 7.09116,
+      "init_s": 7.49019,
+      "flush_s": 5.33e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.76733,
+          "best_ms": 2.18128,
+          "best_in_gibs": 14.3265,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.83254,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 47.1063,
+          "best_ms": 45.4863,
+          "best_in_gibs": 2.06106,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.99018,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.1318,
+          "best_ms": 22.6121,
+          "best_in_gibs": 4.92339,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.61333,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 12.08,
+          "best_ms": 0.00014,
+          "best_in_gibs": 125558,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.45515,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.946,
+          "best_ms": 37.2759,
+          "best_in_gibs": 2.9866,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.42302,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 18.7392,
+          "best_ms": 12.4901,
+          "best_in_gibs": 44.5666,
+          "best_out_gibs": 0.0,
+          "in_gibs": 29.7046,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 28.8921,
+          "best_ms": 18.6447,
+          "best_in_gibs": 36.8783,
+          "best_out_gibs": 0.0,
+          "in_gibs": 23.7983,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000363239,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 84.771,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41534.6,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.016283,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 14.19,
+      "status": "pass",
+      "throughput_in_gibs": 3.57,
+      "throughput_out_gibs": 0.462069,
+      "compression_fold": 9.17476,
+      "input_gib": 3.75,
+      "compressed_gib": 0.485367,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 1.05042,
+      "init_s": 0.561424,
+      "flush_s": 7.04e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.50498,
+          "best_ms": 0.632523,
+          "best_in_gibs": 49.4053,
+          "best_out_gibs": 49.4053,
+          "in_gibs": 31.1465,
+          "out_gibs": 31.1465
+        },
+        "h2d": {
+          "avg_ms": 2.00709,
+          "best_ms": 1.24595,
+          "best_in_gibs": 25.0812,
+          "best_out_gibs": 25.0812,
+          "in_gibs": 23.3547,
+          "out_gibs": 23.3547
+        },
+        "scatter": {
+          "avg_ms": 0.202882,
+          "best_ms": 0.065568,
+          "best_in_gibs": 476.604,
+          "best_out_gibs": 476.604,
+          "in_gibs": 229.824,
+          "out_gibs": 229.824
+        },
+        "lod_gather": {
+          "avg_ms": 2.11926,
+          "best_ms": 1.17232,
+          "best_in_gibs": 79.9696,
+          "best_out_gibs": 79.9696,
+          "in_gibs": 44.2372,
+          "out_gibs": 44.2372
+        },
+        "lod_reduce": {
+          "avg_ms": 1.47889,
+          "best_ms": 0.980288,
+          "best_in_gibs": 95.6352,
+          "best_out_gibs": 113.567,
+          "in_gibs": 63.3921,
+          "out_gibs": 75.2781
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.225882,
+          "best_ms": 0.034848,
+          "best_in_gibs": 504.423,
+          "best_out_gibs": 504.423,
+          "in_gibs": 77.8201,
+          "out_gibs": 77.8201
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.24379,
+          "best_ms": 0.576192,
+          "best_in_gibs": 193.214,
+          "best_out_gibs": 193.214,
+          "in_gibs": 89.5073,
+          "out_gibs": 89.5073
+        },
+        "compress": {
+          "avg_ms": 98.2833,
+          "best_ms": 80.2021,
+          "best_in_gibs": 6.94047,
+          "best_out_gibs": 0.74599,
+          "in_gibs": 5.66363,
+          "out_gibs": 0.617028
+        },
+        "aggregate": {
+          "avg_ms": 0.505328,
+          "best_ms": 0.37376,
+          "best_in_gibs": 160.122,
+          "best_out_gibs": 160.122,
+          "in_gibs": 120.008,
+          "out_gibs": 120.008
+        },
+        "d2h": {
+          "avg_ms": 29.0264,
+          "best_ms": 25.8344,
+          "best_in_gibs": 2.38152,
+          "best_out_gibs": 2.38152,
+          "in_gibs": 2.08926,
+          "out_gibs": 2.08926
+        },
+        "sink": {
+          "avg_ms": 0.00107179,
+          "best_ms": 4.5e-05,
+          "best_in_gibs": 52558.1,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1689.77,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 153.059,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 852.078,
+        "kick_sync_count": 8,
+        "io_fence_ms": 114.695,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 50.0049,
+        "peak_pending_mib": 53.1484
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 27.33,
+      "status": "pass",
+      "throughput_in_gibs": 0.477846,
+      "throughput_out_gibs": 0.0346903,
+      "compression_fold": 16.3574,
+      "input_gib": 3.75,
+      "compressed_gib": 0.27224,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 7.84772,
+      "init_s": 7.45059,
+      "flush_s": 4.25e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.95117,
+          "best_ms": 2.19168,
+          "best_in_gibs": 14.2584,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.8636,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 46.2742,
+          "best_ms": 43.1662,
+          "best_in_gibs": 2.17184,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.02597,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 23.5701,
+          "best_ms": 22.7203,
+          "best_in_gibs": 4.89995,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.72328,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 11.0057,
+          "best_ms": 0.000142,
+          "best_in_gibs": 123790,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.59718,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.2824,
+          "best_ms": 36.8466,
+          "best_in_gibs": 3.02139,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.45853,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 196.153,
+          "best_ms": 191.924,
+          "best_in_gibs": 2.90031,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.83778,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.9623,
+          "best_ms": 10.7856,
+          "best_in_gibs": 63.9994,
+          "best_out_gibs": 0.0,
+          "in_gibs": 57.7036,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000337235,
+          "best_ms": 5.9e-05,
+          "best_in_gibs": 64.6559,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3012.2,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.012947,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 27.26,
+      "status": "pass",
+      "throughput_in_gibs": 0.487852,
+      "throughput_out_gibs": 0.309871,
+      "compression_fold": 1.86956,
+      "input_gib": 3.75,
+      "compressed_gib": 2.3819,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 7.68676,
+      "init_s": 7.48125,
+      "flush_s": 5.33e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.27985,
+          "best_ms": 2.17539,
+          "best_in_gibs": 14.3652,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9525,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 46.6583,
+          "best_ms": 43.9971,
+          "best_in_gibs": 2.13082,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.00929,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 23.9763,
+          "best_ms": 22.3549,
+          "best_in_gibs": 4.98004,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.64326,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 11.3401,
+          "best_ms": 5.7e-05,
+          "best_in_gibs": 308388,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.55008,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.8088,
+          "best_ms": 37.557,
+          "best_in_gibs": 2.96425,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.43028,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 131.149,
+          "best_ms": 127.19,
+          "best_in_gibs": 4.37646,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.24434,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 24.5825,
+          "best_ms": 18.6658,
+          "best_in_gibs": 36.841,
+          "best_out_gibs": 0.0,
+          "in_gibs": 27.9739,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.00173071,
+          "best_ms": 6.3e-05,
+          "best_in_gibs": 121.102,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5135.3,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.017318,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__2M__fs",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "fs",
+      "elapsed_s": 26.76,
+      "status": "pass",
+      "throughput_in_gibs": 0.538504,
+      "throughput_out_gibs": 0.00851985,
+      "compression_fold": 75.0569,
+      "input_gib": 3.75,
+      "compressed_gib": 0.05933,
+      "total_chunks": 2280,
+      "chunks_per_epoch": 57,
+      "wall_s": 6.96374,
+      "init_s": 7.50787,
+      "flush_s": 5.32e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.87943,
+          "best_ms": 2.17819,
+          "best_in_gibs": 14.3467,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.083,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 46.9378,
+          "best_ms": 45.2169,
+          "best_in_gibs": 2.07334,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.99732,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 23.6542,
+          "best_ms": 22.2242,
+          "best_in_gibs": 5.00933,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.70649,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 11.1259,
+          "best_ms": 6.6e-05,
+          "best_in_gibs": 266335,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.57993,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 45.4136,
+          "best_ms": 38.0877,
+          "best_in_gibs": 2.92294,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.45143,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 83.6188,
+          "best_ms": 81.2351,
+          "best_in_gibs": 6.85221,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.65688,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.0544,
+          "best_ms": 10.33,
+          "best_in_gibs": 66.5698,
+          "best_out_gibs": 0.0,
+          "in_gibs": 62.2074,
+          "out_gibs": 0.0
+        },
+        "sink": {
+          "avg_ms": 0.000448907,
+          "best_ms": 6.2e-05,
+          "best_in_gibs": 4614.55,
+          "best_out_gibs": 0.0,
+          "in_gibs": 493.155,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.017951,
+        "io_fence_count": 8,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 3.39,
+      "status": "pass",
+      "throughput_in_gibs": 7.85897,
+      "throughput_out_gibs": 7.86818,
+      "compression_fold": 0.998829,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51975,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.447339,
+      "init_s": 0.443255,
+      "flush_s": 2.64e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.23638,
+          "best_ms": 0.325764,
+          "best_in_gibs": 47.9642,
+          "best_out_gibs": 47.9642,
+          "in_gibs": 37.9131,
+          "out_gibs": 37.9131
+        },
+        "h2d": {
+          "avg_ms": 1.95515,
+          "best_ms": 0.626368,
+          "best_in_gibs": 24.9454,
+          "best_out_gibs": 24.9454,
+          "in_gibs": 24.0847,
+          "out_gibs": 24.0847
+        },
+        "scatter": {
+          "avg_ms": 0.275158,
+          "best_ms": 0.100192,
+          "best_in_gibs": 155.951,
+          "best_out_gibs": 155.951,
+          "in_gibs": 171.134,
+          "out_gibs": 171.134
+        },
+        "aggregate": {
+          "avg_ms": 2.44412,
+          "best_ms": 0.508928,
+          "best_in_gibs": 276.316,
+          "best_out_gibs": 276.316,
+          "in_gibs": 205.486,
+          "out_gibs": 205.486
+        },
+        "d2h": {
+          "avg_ms": 22.2685,
+          "best_ms": 6.01446,
+          "best_in_gibs": 23.3811,
+          "best_out_gibs": 23.3811,
+          "in_gibs": 22.5535,
+          "out_gibs": 22.5535
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 23.2516,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 188.984,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.89876,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 4.17,
+      "status": "pass",
+      "throughput_in_gibs": 1.63071,
+      "throughput_out_gibs": 1.63262,
+      "compression_fold": 0.998829,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51975,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 2.15589,
+      "init_s": 0.00481293,
+      "flush_s": 2.15e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 19.5267,
+          "best_ms": 8.45464,
+          "best_in_gibs": 1.8481,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.40056,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.2304,
+          "best_ms": 7.04759,
+          "best_in_gibs": 19.9536,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.7273,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 30.177,
+          "best_ms": 7.19327,
+          "best_in_gibs": 19.5495,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.6429,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.18,
+      "status": "pass",
+      "throughput_in_gibs": 7.87413,
+      "throughput_out_gibs": 7.87882,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.446478,
+      "init_s": 0.422295,
+      "flush_s": 1.62e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.996302,
+          "best_ms": 0.329151,
+          "best_in_gibs": 47.4706,
+          "best_out_gibs": 47.4706,
+          "in_gibs": 47.049,
+          "out_gibs": 47.049
+        },
+        "h2d": {
+          "avg_ms": 1.97219,
+          "best_ms": 0.625888,
+          "best_in_gibs": 24.9645,
+          "best_out_gibs": 24.9645,
+          "in_gibs": 23.8766,
+          "out_gibs": 23.8766
+        },
+        "scatter": {
+          "avg_ms": 0.275492,
+          "best_ms": 0.10016,
+          "best_in_gibs": 156,
+          "best_out_gibs": 156,
+          "in_gibs": 170.927,
+          "out_gibs": 170.927
+        },
+        "aggregate": {
+          "avg_ms": 2.54748,
+          "best_ms": 0.537152,
+          "best_in_gibs": 261.797,
+          "best_out_gibs": 261.797,
+          "in_gibs": 197.148,
+          "out_gibs": 197.148
+        },
+        "d2h": {
+          "avg_ms": 22.1683,
+          "best_ms": 5.94093,
+          "best_in_gibs": 23.6705,
+          "best_out_gibs": 23.6705,
+          "in_gibs": 22.6554,
+          "out_gibs": 22.6554
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 23.9538,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 189.774,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90238,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.89,
+      "status": "pass",
+      "throughput_in_gibs": 1.87695,
+      "throughput_out_gibs": 1.87807,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 1.87305,
+      "init_s": 0.0043755,
+      "flush_s": 1.83e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.8656,
+          "best_ms": 6.78648,
+          "best_in_gibs": 2.30237,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.9545,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.6384,
+          "best_ms": 6.79637,
+          "best_in_gibs": 20.6912,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.3841,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 30.4672,
+          "best_ms": 7.41919,
+          "best_in_gibs": 18.9542,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.4843,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.15,
+      "status": "pass",
+      "throughput_in_gibs": 7.84768,
+      "throughput_out_gibs": 7.84998,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51666,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.447983,
+      "init_s": 0.432957,
+      "flush_s": 2.67e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.991485,
+          "best_ms": 0.32484,
+          "best_in_gibs": 48.1006,
+          "best_out_gibs": 48.1006,
+          "in_gibs": 47.2776,
+          "out_gibs": 47.2776
+        },
+        "h2d": {
+          "avg_ms": 1.98683,
+          "best_ms": 0.628192,
+          "best_in_gibs": 24.873,
+          "best_out_gibs": 24.873,
+          "in_gibs": 23.7006,
+          "out_gibs": 23.7006
+        },
+        "scatter": {
+          "avg_ms": 0.275589,
+          "best_ms": 0.099808,
+          "best_in_gibs": 156.551,
+          "best_out_gibs": 156.551,
+          "in_gibs": 170.867,
+          "out_gibs": 170.867
+        },
+        "aggregate": {
+          "avg_ms": 2.66515,
+          "best_ms": 0.554688,
+          "best_in_gibs": 253.521,
+          "best_out_gibs": 253.521,
+          "in_gibs": 188.444,
+          "out_gibs": 188.444
+        },
+        "d2h": {
+          "avg_ms": 21.9347,
+          "best_ms": 5.86758,
+          "best_in_gibs": 23.9664,
+          "best_out_gibs": 23.9664,
+          "in_gibs": 22.8967,
+          "out_gibs": 22.8967
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 22.9776,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 189.076,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.89896,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.89,
+      "status": "pass",
+      "throughput_in_gibs": 1.91073,
+      "throughput_out_gibs": 1.91129,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51666,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 1.83994,
+      "init_s": 0.00436256,
+      "flush_s": 2.15e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.4897,
+          "best_ms": 6.80613,
+          "best_in_gibs": 2.29573,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.0262,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 23.6776,
+          "best_ms": 7.37705,
+          "best_in_gibs": 19.0625,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.2113,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 30.0256,
+          "best_ms": 7.07808,
+          "best_in_gibs": 19.8677,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.7268,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 3.32,
+      "status": "pass",
+      "throughput_in_gibs": 8.11095,
+      "throughput_out_gibs": 8.11225,
+      "compression_fold": 0.99984,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51619,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.433442,
+      "init_s": 0.413854,
+      "flush_s": 3.96e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.04063,
+          "best_ms": 0.325473,
+          "best_in_gibs": 48.0071,
+          "best_out_gibs": 48.0071,
+          "in_gibs": 45.0447,
+          "out_gibs": 45.0447
+        },
+        "h2d": {
+          "avg_ms": 2.00582,
+          "best_ms": 0.625664,
+          "best_in_gibs": 24.9735,
+          "best_out_gibs": 24.9735,
+          "in_gibs": 23.4762,
+          "out_gibs": 23.4762
+        },
+        "scatter": {
+          "avg_ms": 0.274908,
+          "best_ms": 0.099904,
+          "best_in_gibs": 156.4,
+          "best_out_gibs": 156.4,
+          "in_gibs": 171.29,
+          "out_gibs": 171.29
+        },
+        "aggregate": {
+          "avg_ms": 2.74818,
+          "best_ms": 0.607776,
+          "best_in_gibs": 231.376,
+          "best_out_gibs": 231.376,
+          "in_gibs": 182.751,
+          "out_gibs": 182.751
+        },
+        "d2h": {
+          "avg_ms": 21.8543,
+          "best_ms": 5.79808,
+          "best_in_gibs": 24.2537,
+          "best_out_gibs": 24.2537,
+          "in_gibs": 22.9809,
+          "out_gibs": 22.9809
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 21.3645,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 189.242,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.91257,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 3.66,
+      "status": "pass",
+      "throughput_in_gibs": 2.16366,
+      "throughput_out_gibs": 2.16401,
+      "compression_fold": 0.99984,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51619,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 1.62485,
+      "init_s": 0.00454405,
+      "flush_s": 2.06e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.7522,
+          "best_ms": 6.08412,
+          "best_in_gibs": 2.56816,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.67583,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.2516,
+          "best_ms": 7.03777,
+          "best_in_gibs": 19.9815,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.7093,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 30.1348,
+          "best_ms": 7.12102,
+          "best_in_gibs": 19.7479,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.6662,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.27,
+      "status": "pass",
+      "throughput_in_gibs": 8.00051,
+      "throughput_out_gibs": 8.00116,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.439425,
+      "init_s": 0.41983,
+      "flush_s": 3.92e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.99407,
+          "best_ms": 0.326072,
+          "best_in_gibs": 47.9189,
+          "best_out_gibs": 47.9189,
+          "in_gibs": 47.1546,
+          "out_gibs": 47.1546
+        },
+        "h2d": {
+          "avg_ms": 2.00462,
+          "best_ms": 0.625888,
+          "best_in_gibs": 24.9645,
+          "best_out_gibs": 24.9645,
+          "in_gibs": 23.4903,
+          "out_gibs": 23.4903
+        },
+        "scatter": {
+          "avg_ms": 0.274444,
+          "best_ms": 0.099552,
+          "best_in_gibs": 156.953,
+          "best_out_gibs": 156.953,
+          "in_gibs": 171.58,
+          "out_gibs": 171.58
+        },
+        "aggregate": {
+          "avg_ms": 2.83548,
+          "best_ms": 0.627392,
+          "best_in_gibs": 224.142,
+          "best_out_gibs": 224.142,
+          "in_gibs": 177.124,
+          "out_gibs": 177.124
+        },
+        "d2h": {
+          "avg_ms": 21.7663,
+          "best_ms": 5.7472,
+          "best_in_gibs": 24.4684,
+          "best_out_gibs": 24.4684,
+          "in_gibs": 23.0739,
+          "out_gibs": 23.0739
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 22.5326,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 189.144,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.89699,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.65,
+      "status": "pass",
+      "throughput_in_gibs": 2.16077,
+      "throughput_out_gibs": 2.16095,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.62702,
+      "init_s": 0.00422827,
+      "flush_s": 3.05e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.6381,
+          "best_ms": 5.81056,
+          "best_in_gibs": 2.68907,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.70902,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.2938,
+          "best_ms": 7.4044,
+          "best_in_gibs": 18.9921,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.6732,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 30.6234,
+          "best_ms": 6.93075,
+          "best_in_gibs": 20.29,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.4003,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.23,
+      "status": "pass",
+      "throughput_in_gibs": 7.36106,
+      "throughput_out_gibs": 7.6558,
+      "compression_fold": 0.999961,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65639,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.477598,
+      "init_s": 0.434171,
+      "flush_s": 2.03e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.55326,
+          "best_ms": 0.578603,
+          "best_in_gibs": 27.0047,
+          "best_out_gibs": 27.0047,
+          "in_gibs": 35.9268,
+          "out_gibs": 35.9268
+        },
+        "h2d": {
+          "avg_ms": 2.39266,
+          "best_ms": 1.24474,
+          "best_in_gibs": 25.1057,
+          "best_out_gibs": 25.1057,
+          "in_gibs": 23.5523,
+          "out_gibs": 23.5523
+        },
+        "scatter": {
+          "avg_ms": 0.324965,
+          "best_ms": 0.18528,
+          "best_in_gibs": 168.664,
+          "best_out_gibs": 168.664,
+          "in_gibs": 173.411,
+          "out_gibs": 173.411
+        },
+        "aggregate": {
+          "avg_ms": 3.09761,
+          "best_ms": 1.26032,
+          "best_in_gibs": 223.158,
+          "best_out_gibs": 223.158,
+          "in_gibs": 168.621,
+          "out_gibs": 168.621
+        },
+        "d2h": {
+          "avg_ms": 22.5943,
+          "best_ms": 11.5276,
+          "best_in_gibs": 24.398,
+          "best_out_gibs": 24.398,
+          "in_gibs": 23.1174,
+          "out_gibs": 23.1174
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 27.5448,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 196.692,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.89825,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.63,
+      "status": "pass",
+      "throughput_in_gibs": 2.18945,
+      "throughput_out_gibs": 2.27712,
+      "compression_fold": 0.999961,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65639,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.60571,
+      "init_s": 0.00423142,
+      "flush_s": 3.13e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.4532,
+          "best_ms": 6.54841,
+          "best_in_gibs": 2.38608,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.86098,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.9516,
+          "best_ms": 11.0523,
+          "best_in_gibs": 25.4473,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.9334,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 31.6315,
+          "best_ms": 11.4336,
+          "best_in_gibs": 24.5985,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.5127,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.32,
+      "status": "pass",
+      "throughput_in_gibs": 7.76987,
+      "throughput_out_gibs": 8.08081,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65631,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.452469,
+      "init_s": 0.430411,
+      "flush_s": 2.46e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.17854,
+          "best_ms": 0.364005,
+          "best_in_gibs": 42.9252,
+          "best_out_gibs": 42.9252,
+          "in_gibs": 47.3498,
+          "out_gibs": 47.3498
+        },
+        "h2d": {
+          "avg_ms": 2.39097,
+          "best_ms": 1.2464,
+          "best_in_gibs": 25.0722,
+          "best_out_gibs": 25.0722,
+          "in_gibs": 23.5689,
+          "out_gibs": 23.5689
+        },
+        "scatter": {
+          "avg_ms": 0.325187,
+          "best_ms": 0.185408,
+          "best_in_gibs": 168.547,
+          "best_out_gibs": 168.547,
+          "in_gibs": 173.292,
+          "out_gibs": 173.292
+        },
+        "aggregate": {
+          "avg_ms": 3.2451,
+          "best_ms": 1.59434,
+          "best_in_gibs": 176.406,
+          "best_out_gibs": 176.406,
+          "in_gibs": 160.957,
+          "out_gibs": 160.957
+        },
+        "d2h": {
+          "avg_ms": 22.757,
+          "best_ms": 11.5827,
+          "best_in_gibs": 24.282,
+          "best_out_gibs": 24.282,
+          "in_gibs": 22.9521,
+          "out_gibs": 22.9521
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 29.965,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 199.09,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90727,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.57,
+      "status": "pass",
+      "throughput_in_gibs": 2.28165,
+      "throughput_out_gibs": 2.37296,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65631,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 1.54083,
+      "init_s": 0.00421049,
+      "flush_s": 2.09e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.5087,
+          "best_ms": 6.1472,
+          "best_in_gibs": 2.54181,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.13094,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.0174,
+          "best_ms": 11.1405,
+          "best_in_gibs": 25.2458,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.8783,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 31.2507,
+          "best_ms": 10.8803,
+          "best_in_gibs": 25.8494,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.7139,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.24,
+      "status": "pass",
+      "throughput_in_gibs": 8.04029,
+      "throughput_out_gibs": 8.36197,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.437251,
+      "init_s": 0.418025,
+      "flush_s": 1.62e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.17791,
+          "best_ms": 0.371993,
+          "best_in_gibs": 42.0035,
+          "best_out_gibs": 42.0035,
+          "in_gibs": 47.3752,
+          "out_gibs": 47.3752
+        },
+        "h2d": {
+          "avg_ms": 2.37531,
+          "best_ms": 1.24486,
+          "best_in_gibs": 25.1031,
+          "best_out_gibs": 25.1031,
+          "in_gibs": 23.7243,
+          "out_gibs": 23.7243
+        },
+        "scatter": {
+          "avg_ms": 0.325642,
+          "best_ms": 0.185344,
+          "best_in_gibs": 168.605,
+          "best_out_gibs": 168.605,
+          "in_gibs": 173.05,
+          "out_gibs": 173.05
+        },
+        "aggregate": {
+          "avg_ms": 3.90053,
+          "best_ms": 2.74099,
+          "best_in_gibs": 102.609,
+          "best_out_gibs": 102.609,
+          "in_gibs": 133.911,
+          "out_gibs": 133.911
+        },
+        "d2h": {
+          "avg_ms": 22.8268,
+          "best_ms": 11.6047,
+          "best_in_gibs": 24.2358,
+          "best_out_gibs": 24.2358,
+          "in_gibs": 22.882,
+          "out_gibs": 22.882
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 31.9382,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 204.229,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90739,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.51,
+      "status": "pass",
+      "throughput_in_gibs": 2.37992,
+      "throughput_out_gibs": 2.47514,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.4772,
+      "init_s": 0.00409301,
+      "flush_s": 1.52e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.667,
+          "best_ms": 6.34541,
+          "best_in_gibs": 2.46241,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.08309,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 19.6854,
+          "best_ms": 7.99612,
+          "best_in_gibs": 35.1733,
+          "best_out_gibs": 0.0,
+          "in_gibs": 26.5334,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 27.1557,
+          "best_ms": 8.11667,
+          "best_in_gibs": 34.6509,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.2343,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 3.26,
+      "status": "pass",
+      "throughput_in_gibs": 6.70916,
+      "throughput_out_gibs": 3.39596,
+      "compression_fold": 1.97563,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.7795,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.524004,
+      "init_s": 0.421286,
+      "flush_s": 2.79e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.979268,
+          "best_ms": 0.32531,
+          "best_in_gibs": 48.0311,
+          "best_out_gibs": 48.0311,
+          "in_gibs": 47.8674,
+          "out_gibs": 47.8674
+        },
+        "h2d": {
+          "avg_ms": 1.94272,
+          "best_ms": 0.624576,
+          "best_in_gibs": 25.017,
+          "best_out_gibs": 25.017,
+          "in_gibs": 24.2387,
+          "out_gibs": 24.2387
+        },
+        "scatter": {
+          "avg_ms": 0.280878,
+          "best_ms": 0.100064,
+          "best_in_gibs": 156.15,
+          "best_out_gibs": 156.15,
+          "in_gibs": 164.969,
+          "out_gibs": 164.969
+        },
+        "compress": {
+          "avg_ms": 26.2769,
+          "best_ms": 8.24739,
+          "best_in_gibs": 17.0508,
+          "best_out_gibs": 8.61355,
+          "in_gibs": 19.113,
+          "out_gibs": 9.652
+        },
+        "aggregate": {
+          "avg_ms": 1.15019,
+          "best_ms": 0.29216,
+          "best_in_gibs": 243.152,
+          "best_out_gibs": 243.152,
+          "in_gibs": 220.506,
+          "out_gibs": 220.506
+        },
+        "d2h": {
+          "avg_ms": 11.1584,
+          "best_ms": 2.97434,
+          "best_in_gibs": 23.8841,
+          "best_out_gibs": 23.8841,
+          "in_gibs": 22.7294,
+          "out_gibs": 22.7294
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 45.5003,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 282.275,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 17.1582,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 5.23,
+      "status": "pass",
+      "throughput_in_gibs": 1.08032,
+      "throughput_out_gibs": 0.402591,
+      "compression_fold": 2.68343,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.31013,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 3.25423,
+      "init_s": 0.00459065,
+      "flush_s": 2.32e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 19.7066,
+          "best_ms": 8.17458,
+          "best_in_gibs": 1.91141,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.37864,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 192.313,
+          "best_ms": 54.9244,
+          "best_in_gibs": 2.56034,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.61153,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 15.7128,
+          "best_ms": 4.92513,
+          "best_in_gibs": 28.692,
+          "best_out_gibs": 0.0,
+          "in_gibs": 32.1194,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.28,
+      "status": "pass",
+      "throughput_in_gibs": 6.62553,
+      "throughput_out_gibs": 3.31589,
+      "compression_fold": 1.99811,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.75947,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.530618,
+      "init_s": 0.428395,
+      "flush_s": 2.12e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.985474,
+          "best_ms": 0.325614,
+          "best_in_gibs": 47.9863,
+          "best_out_gibs": 47.9863,
+          "in_gibs": 47.566,
+          "out_gibs": 47.566
+        },
+        "h2d": {
+          "avg_ms": 1.93291,
+          "best_ms": 0.624576,
+          "best_in_gibs": 25.017,
+          "best_out_gibs": 25.017,
+          "in_gibs": 24.3618,
+          "out_gibs": 24.3618
+        },
+        "scatter": {
+          "avg_ms": 0.303065,
+          "best_ms": 0.099776,
+          "best_in_gibs": 156.601,
+          "best_out_gibs": 156.601,
+          "in_gibs": 152.892,
+          "out_gibs": 152.892
+        },
+        "compress": {
+          "avg_ms": 28.3402,
+          "best_ms": 10.4744,
+          "best_in_gibs": 13.4256,
+          "best_out_gibs": 6.71033,
+          "in_gibs": 17.7215,
+          "out_gibs": 8.85859
+        },
+        "aggregate": {
+          "avg_ms": 1.0348,
+          "best_ms": 0.290784,
+          "best_in_gibs": 241.714,
+          "best_out_gibs": 241.714,
+          "in_gibs": 242.611,
+          "out_gibs": 242.611
+        },
+        "d2h": {
+          "avg_ms": 11.0163,
+          "best_ms": 2.91107,
+          "best_in_gibs": 24.1446,
+          "best_out_gibs": 24.1446,
+          "in_gibs": 22.7893,
+          "out_gibs": 22.7893
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 47.7249,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 294.866,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 19.0258,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 4.98,
+      "status": "pass",
+      "throughput_in_gibs": 1.17997,
+      "throughput_out_gibs": 0.4308,
+      "compression_fold": 2.73903,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.28353,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 2.97941,
+      "init_s": 0.00437854,
+      "flush_s": 3.6e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.1204,
+          "best_ms": 6.96271,
+          "best_in_gibs": 2.2441,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.9078,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 194.549,
+          "best_ms": 56.3425,
+          "best_in_gibs": 2.4959,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.58152,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.6459,
+          "best_ms": 4.89517,
+          "best_in_gibs": 28.8535,
+          "best_out_gibs": 0.0,
+          "in_gibs": 34.4424,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.25,
+      "status": "pass",
+      "throughput_in_gibs": 6.83991,
+      "throughput_out_gibs": 3.43549,
+      "compression_fold": 1.99096,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.7658,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.513987,
+      "init_s": 0.441926,
+      "flush_s": 2.03e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.981672,
+          "best_ms": 0.32443,
+          "best_in_gibs": 48.1614,
+          "best_out_gibs": 48.1614,
+          "in_gibs": 47.7501,
+          "out_gibs": 47.7501
+        },
+        "h2d": {
+          "avg_ms": 1.93495,
+          "best_ms": 0.624576,
+          "best_in_gibs": 25.017,
+          "best_out_gibs": 25.017,
+          "in_gibs": 24.3361,
+          "out_gibs": 24.3361
+        },
+        "scatter": {
+          "avg_ms": 0.37372,
+          "best_ms": 0.099744,
+          "best_in_gibs": 156.651,
+          "best_out_gibs": 156.651,
+          "in_gibs": 123.986,
+          "out_gibs": 123.986
+        },
+        "compress": {
+          "avg_ms": 29.2965,
+          "best_ms": 10.5296,
+          "best_in_gibs": 13.3552,
+          "best_out_gibs": 6.70071,
+          "in_gibs": 17.1431,
+          "out_gibs": 8.60544
+        },
+        "aggregate": {
+          "avg_ms": 1.15095,
+          "best_ms": 0.296128,
+          "best_in_gibs": 238.261,
+          "best_out_gibs": 238.261,
+          "in_gibs": 219.044,
+          "out_gibs": 219.044
+        },
+        "d2h": {
+          "avg_ms": 11.0456,
+          "best_ms": 2.93923,
+          "best_in_gibs": 24.0048,
+          "best_out_gibs": 24.0048,
+          "in_gibs": 22.8245,
+          "out_gibs": 22.8245
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 49.3257,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 302.827,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 20.1686,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 4.85,
+      "status": "pass",
+      "throughput_in_gibs": 1.22232,
+      "throughput_out_gibs": 0.437875,
+      "compression_fold": 2.79147,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.25942,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 2.8762,
+      "init_s": 0.0043239,
+      "flush_s": 2.28e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.027,
+          "best_ms": 6.78246,
+          "best_in_gibs": 2.30374,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.92475,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 180.426,
+          "best_ms": 52.162,
+          "best_in_gibs": 2.69593,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.78359,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.6858,
+          "best_ms": 4.78068,
+          "best_in_gibs": 29.5381,
+          "best_out_gibs": 0.0,
+          "in_gibs": 34.3412,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 3.36,
+      "status": "pass",
+      "throughput_in_gibs": 6.98812,
+      "throughput_out_gibs": 3.13579,
+      "compression_fold": 2.2285,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.57757,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.503086,
+      "init_s": 0.442678,
+      "flush_s": 2.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.985416,
+          "best_ms": 0.32603,
+          "best_in_gibs": 47.925,
+          "best_out_gibs": 47.925,
+          "in_gibs": 47.5687,
+          "out_gibs": 47.5687
+        },
+        "h2d": {
+          "avg_ms": 1.9243,
+          "best_ms": 0.62512,
+          "best_in_gibs": 24.9952,
+          "best_out_gibs": 24.9952,
+          "in_gibs": 24.4707,
+          "out_gibs": 24.4707
+        },
+        "scatter": {
+          "avg_ms": 0.301857,
+          "best_ms": 0.099232,
+          "best_in_gibs": 157.459,
+          "best_out_gibs": 157.459,
+          "in_gibs": 153.504,
+          "out_gibs": 153.504
+        },
+        "compress": {
+          "avg_ms": 35.9012,
+          "best_ms": 18.3821,
+          "best_in_gibs": 7.6501,
+          "best_out_gibs": 3.42397,
+          "in_gibs": 13.9893,
+          "out_gibs": 6.27519
+        },
+        "aggregate": {
+          "avg_ms": 1.04179,
+          "best_ms": 0.2832,
+          "best_in_gibs": 222.245,
+          "best_out_gibs": 222.245,
+          "in_gibs": 216.25,
+          "out_gibs": 216.25
+        },
+        "d2h": {
+          "avg_ms": 10.0468,
+          "best_ms": 2.69075,
+          "best_in_gibs": 23.3912,
+          "best_out_gibs": 23.3912,
+          "in_gibs": 22.4237,
+          "out_gibs": 22.4237
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 61.5331,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 341.097,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 26.699,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 4.52,
+      "status": "pass",
+      "throughput_in_gibs": 1.36409,
+      "throughput_out_gibs": 0.465545,
+      "compression_fold": 2.93009,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.19984,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 2.57727,
+      "init_s": 0.00447181,
+      "flush_s": 1.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.8097,
+          "best_ms": 6.3335,
+          "best_in_gibs": 2.46704,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.65934,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 174.469,
+          "best_ms": 50.4845,
+          "best_in_gibs": 2.78551,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.87863,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.5954,
+          "best_ms": 4.58875,
+          "best_in_gibs": 30.7703,
+          "best_out_gibs": 0.0,
+          "in_gibs": 37.0908,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.39,
+      "status": "pass",
+      "throughput_in_gibs": 6.59586,
+      "throughput_out_gibs": 3.22806,
+      "compression_fold": 2.04329,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.72057,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.533004,
+      "init_s": 0.427332,
+      "flush_s": 1.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.993909,
+          "best_ms": 0.327542,
+          "best_in_gibs": 47.7038,
+          "best_out_gibs": 47.7038,
+          "in_gibs": 47.1623,
+          "out_gibs": 47.1623
+        },
+        "h2d": {
+          "avg_ms": 1.92846,
+          "best_ms": 0.624576,
+          "best_in_gibs": 25.017,
+          "best_out_gibs": 25.017,
+          "in_gibs": 24.4179,
+          "out_gibs": 24.4179
+        },
+        "scatter": {
+          "avg_ms": 0.372785,
+          "best_ms": 0.099904,
+          "best_in_gibs": 156.4,
+          "best_out_gibs": 156.4,
+          "in_gibs": 125.152,
+          "out_gibs": 125.152
+        },
+        "compress": {
+          "avg_ms": 40.8424,
+          "best_ms": 33.9382,
+          "best_in_gibs": 4.14356,
+          "best_out_gibs": 2.03655,
+          "in_gibs": 12.2968,
+          "out_gibs": 6.01715
+        },
+        "aggregate": {
+          "avg_ms": 1.16071,
+          "best_ms": 0.303936,
+          "best_in_gibs": 227.406,
+          "best_out_gibs": 227.406,
+          "in_gibs": 211.727,
+          "out_gibs": 211.727
+        },
+        "d2h": {
+          "avg_ms": 11.0051,
+          "best_ms": 2.86317,
+          "best_in_gibs": 24.14,
+          "best_out_gibs": 24.14,
+          "in_gibs": 22.331,
+          "out_gibs": 22.331
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 81.0603,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 362.452,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 30.2461,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 4.6,
+      "status": "pass",
+      "throughput_in_gibs": 1.37803,
+      "throughput_out_gibs": 0.466064,
+      "compression_fold": 2.95673,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.18902,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 2.5512,
+      "init_s": 0.00426575,
+      "flush_s": 1.62e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.7307,
+          "best_ms": 6.22102,
+          "best_in_gibs": 2.51164,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.68206,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 171.181,
+          "best_ms": 49.8159,
+          "best_in_gibs": 2.8229,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.93393,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.4748,
+          "best_ms": 5.10213,
+          "best_in_gibs": 27.6719,
+          "best_out_gibs": 0.0,
+          "in_gibs": 37.4206,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.69,
+      "status": "pass",
+      "throughput_in_gibs": 4.90849,
+      "throughput_out_gibs": 2.34221,
+      "compression_fold": 2.1795,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.67757,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.716234,
+      "init_s": 0.433251,
+      "flush_s": 3.22e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.42567,
+          "best_ms": 0.553287,
+          "best_in_gibs": 28.2403,
+          "best_out_gibs": 28.2403,
+          "in_gibs": 39.142,
+          "out_gibs": 39.142
+        },
+        "h2d": {
+          "avg_ms": 2.32837,
+          "best_ms": 1.24602,
+          "best_in_gibs": 25.0799,
+          "best_out_gibs": 25.0799,
+          "in_gibs": 24.2025,
+          "out_gibs": 24.2025
+        },
+        "scatter": {
+          "avg_ms": 0.377105,
+          "best_ms": 0.185792,
+          "best_in_gibs": 168.199,
+          "best_out_gibs": 168.199,
+          "in_gibs": 144.578,
+          "out_gibs": 144.578
+        },
+        "compress": {
+          "avg_ms": 75.7828,
+          "best_ms": 36.3417,
+          "best_in_gibs": 7.73904,
+          "best_out_gibs": 1.91704,
+          "in_gibs": 6.89235,
+          "out_gibs": 3.16209
+        },
+        "aggregate": {
+          "avg_ms": 1.19696,
+          "best_ms": 0.239296,
+          "best_in_gibs": 291.139,
+          "best_out_gibs": 291.139,
+          "in_gibs": 200.2,
+          "out_gibs": 200.2
+        },
+        "d2h": {
+          "avg_ms": 10.7176,
+          "best_ms": 2.9529,
+          "best_in_gibs": 23.5932,
+          "best_out_gibs": 23.5932,
+          "in_gibs": 22.3587,
+          "out_gibs": 22.3587
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 173.918,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 565.624,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 60.9026,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 4.49,
+      "status": "pass",
+      "throughput_in_gibs": 1.38494,
+      "throughput_out_gibs": 0.479645,
+      "compression_fold": 3.00293,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.21756,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 2.53846,
+      "init_s": 0.00423122,
+      "flush_s": 1.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.513,
+          "best_ms": 6.63446,
+          "best_in_gibs": 2.35513,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.84506,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 175.783,
+          "best_ms": 94.7115,
+          "best_in_gibs": 2.96954,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.9714,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.3819,
+          "best_ms": 5.8083,
+          "best_in_gibs": 48.6139,
+          "best_out_gibs": 0.0,
+          "in_gibs": 39.1863,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.75,
+      "status": "pass",
+      "throughput_in_gibs": 3.97103,
+      "throughput_out_gibs": 1.13169,
+      "compression_fold": 3.64929,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.00191,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.885318,
+      "init_s": 0.421875,
+      "flush_s": 2.2e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.82525,
+          "best_ms": 0.548978,
+          "best_in_gibs": 28.462,
+          "best_out_gibs": 28.462,
+          "in_gibs": 30.5731,
+          "out_gibs": 30.5731
+        },
+        "h2d": {
+          "avg_ms": 2.29091,
+          "best_ms": 1.24605,
+          "best_in_gibs": 25.0793,
+          "best_out_gibs": 25.0793,
+          "in_gibs": 24.5983,
+          "out_gibs": 24.5983
+        },
+        "scatter": {
+          "avg_ms": 0.343608,
+          "best_ms": 0.18608,
+          "best_in_gibs": 167.939,
+          "best_out_gibs": 167.939,
+          "in_gibs": 158.673,
+          "out_gibs": 158.673
+        },
+        "compress": {
+          "avg_ms": 99.1864,
+          "best_ms": 55.8083,
+          "best_in_gibs": 5.03957,
+          "best_out_gibs": 0.83697,
+          "in_gibs": 5.26606,
+          "out_gibs": 1.44294
+        },
+        "aggregate": {
+          "avg_ms": 0.791205,
+          "best_ms": 0.271424,
+          "best_in_gibs": 172.092,
+          "best_out_gibs": 172.092,
+          "in_gibs": 180.889,
+          "out_gibs": 180.889
+        },
+        "d2h": {
+          "avg_ms": 6.654,
+          "best_ms": 2.06278,
+          "best_in_gibs": 22.6441,
+          "best_out_gibs": 22.6441,
+          "in_gibs": 21.5089,
+          "out_gibs": 21.5089
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 240.919,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 716.775,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 80.1914,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 4.37,
+      "status": "pass",
+      "throughput_in_gibs": 1.48072,
+      "throughput_out_gibs": 0.460314,
+      "compression_fold": 3.34543,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.09291,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 2.37426,
+      "init_s": 0.00424054,
+      "flush_s": 2.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.5755,
+          "best_ms": 5.95528,
+          "best_in_gibs": 2.62372,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.11062,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 160.763,
+          "best_ms": 86.3931,
+          "best_in_gibs": 3.25547,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.24902,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.5339,
+          "best_ms": 5.60527,
+          "best_in_gibs": 50.374,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41.8371,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 4.35,
+      "status": "pass",
+      "throughput_in_gibs": 2.47235,
+      "throughput_out_gibs": 0.661477,
+      "compression_fold": 3.88713,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.940604,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.42198,
+      "init_s": 0.439373,
+      "flush_s": 2.27e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.25413,
+          "best_ms": 0.560427,
+          "best_in_gibs": 27.8805,
+          "best_out_gibs": 27.8805,
+          "in_gibs": 44.4959,
+          "out_gibs": 44.4959
+        },
+        "h2d": {
+          "avg_ms": 2.27222,
+          "best_ms": 1.24685,
+          "best_in_gibs": 25.0632,
+          "best_out_gibs": 25.0632,
+          "in_gibs": 24.8006,
+          "out_gibs": 24.8006
+        },
+        "scatter": {
+          "avg_ms": 0.331685,
+          "best_ms": 0.185856,
+          "best_in_gibs": 168.141,
+          "best_out_gibs": 168.141,
+          "in_gibs": 164.377,
+          "out_gibs": 164.377
+        },
+        "compress": {
+          "avg_ms": 176.873,
+          "best_ms": 92.0601,
+          "best_in_gibs": 3.05507,
+          "best_out_gibs": 0.486722,
+          "in_gibs": 2.95309,
+          "out_gibs": 0.759683
+        },
+        "aggregate": {
+          "avg_ms": 0.955607,
+          "best_ms": 0.431264,
+          "best_in_gibs": 103.899,
+          "best_out_gibs": 103.899,
+          "in_gibs": 140.609,
+          "out_gibs": 140.609
+        },
+        "d2h": {
+          "avg_ms": 6.3392,
+          "best_ms": 1.94406,
+          "best_in_gibs": 23.0485,
+          "best_out_gibs": 23.0485,
+          "in_gibs": 21.1963,
+          "out_gibs": 21.1963
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 465.728,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 1261.07,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 153.414,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 4.34,
+      "status": "pass",
+      "throughput_in_gibs": 1.48385,
+      "throughput_out_gibs": 0.456913,
+      "compression_fold": 3.37746,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.08254,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 2.36926,
+      "init_s": 0.00414735,
+      "flush_s": 2.03e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.7588,
+          "best_ms": 6.26273,
+          "best_in_gibs": 2.49492,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.05584,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 159.235,
+          "best_ms": 84.9962,
+          "best_in_gibs": 3.30897,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.28018,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.3136,
+          "best_ms": 5.38397,
+          "best_in_gibs": 52.4439,
+          "best_out_gibs": 0.0,
+          "in_gibs": 42.585,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 3.41,
+      "status": "pass",
+      "throughput_in_gibs": 6.2044,
+      "throughput_out_gibs": 0.799469,
+      "compression_fold": 7.76066,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.453006,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.566634,
+      "init_s": 0.436994,
+      "flush_s": 3.35e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.53957,
+          "best_ms": 0.323053,
+          "best_in_gibs": 48.3667,
+          "best_out_gibs": 48.3667,
+          "in_gibs": 30.4468,
+          "out_gibs": 30.4468
+        },
+        "h2d": {
+          "avg_ms": 1.89105,
+          "best_ms": 0.624672,
+          "best_in_gibs": 25.0131,
+          "best_out_gibs": 25.0131,
+          "in_gibs": 24.901,
+          "out_gibs": 24.901
+        },
+        "scatter": {
+          "avg_ms": 1.14693,
+          "best_ms": 0.099776,
+          "best_in_gibs": 156.601,
+          "best_out_gibs": 156.601,
+          "in_gibs": 40.4809,
+          "out_gibs": 40.4809
+        },
+        "compress": {
+          "avg_ms": 53.5455,
+          "best_ms": 16.782,
+          "best_in_gibs": 8.37949,
+          "best_out_gibs": 1.0697,
+          "in_gibs": 9.37954,
+          "out_gibs": 1.19761
+        },
+        "aggregate": {
+          "avg_ms": 0.405851,
+          "best_ms": 0.050944,
+          "best_in_gibs": 352.382,
+          "best_out_gibs": 352.382,
+          "in_gibs": 158.005,
+          "out_gibs": 158.005
+        },
+        "d2h": {
+          "avg_ms": 3.17167,
+          "best_ms": 0.845568,
+          "best_in_gibs": 21.2304,
+          "best_out_gibs": 21.2304,
+          "in_gibs": 20.2186,
+          "out_gibs": 20.2186
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 76.3556,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 382.214,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 42.9187,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 5.83,
+      "status": "pass",
+      "throughput_in_gibs": 0.902138,
+      "throughput_out_gibs": 0.0863439,
+      "compression_fold": 10.4482,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.336482,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 3.89699,
+      "init_s": 0.00453009,
+      "flush_s": 2.27e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 19.649,
+          "best_ms": 8.16603,
+          "best_in_gibs": 1.91341,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.38562,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 293.758,
+          "best_ms": 83.6464,
+          "best_in_gibs": 1.68118,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.70968,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.10037,
+          "best_ms": 5.48142,
+          "best_in_gibs": 25.8428,
+          "best_out_gibs": 0.0,
+          "in_gibs": 71.2513,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.67,
+      "status": "pass",
+      "throughput_in_gibs": 4.08162,
+      "throughput_out_gibs": 0.528533,
+      "compression_fold": 7.72253,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.455243,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.861332,
+      "init_s": 0.434254,
+      "flush_s": 3.29e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.972144,
+          "best_ms": 0.323703,
+          "best_in_gibs": 48.2696,
+          "best_out_gibs": 48.2696,
+          "in_gibs": 48.2182,
+          "out_gibs": 48.2182
+        },
+        "h2d": {
+          "avg_ms": 1.89536,
+          "best_ms": 0.62576,
+          "best_in_gibs": 24.9696,
+          "best_out_gibs": 24.9696,
+          "in_gibs": 24.8444,
+          "out_gibs": 24.8444
+        },
+        "scatter": {
+          "avg_ms": 1.17757,
+          "best_ms": 0.099776,
+          "best_in_gibs": 156.601,
+          "best_out_gibs": 156.601,
+          "in_gibs": 38.1179,
+          "out_gibs": 38.1179
+        },
+        "compress": {
+          "avg_ms": 95.3949,
+          "best_ms": 27.1053,
+          "best_in_gibs": 5.1881,
+          "best_out_gibs": 0.670567,
+          "in_gibs": 5.26477,
+          "out_gibs": 0.678608
+        },
+        "aggregate": {
+          "avg_ms": 0.386706,
+          "best_ms": 0.054912,
+          "best_in_gibs": 331.001,
+          "best_out_gibs": 331.001,
+          "in_gibs": 167.403,
+          "out_gibs": 167.403
+        },
+        "d2h": {
+          "avg_ms": 3.28059,
+          "best_ms": 0.787552,
+          "best_in_gibs": 23.079,
+          "best_out_gibs": 23.079,
+          "in_gibs": 19.7329,
+          "out_gibs": 19.7329
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 197.588,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 677.329,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 94.2238,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 5.57,
+      "status": "pass",
+      "throughput_in_gibs": 0.968343,
+      "throughput_out_gibs": 0.0998084,
+      "compression_fold": 9.70202,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.36236,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 3.63056,
+      "init_s": 0.00483457,
+      "flush_s": 2.53e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.2109,
+          "best_ms": 6.94605,
+          "best_in_gibs": 2.24948,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.89157,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 294.758,
+          "best_ms": 83.5532,
+          "best_in_gibs": 1.68306,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.70388,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.26729,
+          "best_ms": 3.94975,
+          "best_in_gibs": 35.7947,
+          "best_out_gibs": 0.0,
+          "in_gibs": 69.4798,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.71,
+      "status": "pass",
+      "throughput_in_gibs": 4.23426,
+      "throughput_out_gibs": 0.526908,
+      "compression_fold": 8.03606,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.437481,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.83028,
+      "init_s": 0.441199,
+      "flush_s": 1.96e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.970291,
+          "best_ms": 0.324091,
+          "best_in_gibs": 48.2118,
+          "best_out_gibs": 48.2118,
+          "in_gibs": 48.3103,
+          "out_gibs": 48.3103
+        },
+        "h2d": {
+          "avg_ms": 1.89686,
+          "best_ms": 0.624448,
+          "best_in_gibs": 25.0221,
+          "best_out_gibs": 25.0221,
+          "in_gibs": 24.8247,
+          "out_gibs": 24.8247
+        },
+        "scatter": {
+          "avg_ms": 1.17707,
+          "best_ms": 0.099552,
+          "best_in_gibs": 156.953,
+          "best_out_gibs": 156.953,
+          "in_gibs": 38.401,
+          "out_gibs": 38.401
+        },
+        "compress": {
+          "avg_ms": 93.3425,
+          "best_ms": 29.4602,
+          "best_in_gibs": 4.7734,
+          "best_out_gibs": 0.594206,
+          "in_gibs": 5.38053,
+          "out_gibs": 0.667972
+        },
+        "aggregate": {
+          "avg_ms": 0.362286,
+          "best_ms": 0.046048,
+          "best_in_gibs": 380.156,
+          "best_out_gibs": 380.156,
+          "in_gibs": 172.102,
+          "out_gibs": 172.102
+        },
+        "d2h": {
+          "avg_ms": 3.19812,
+          "best_ms": 0.752576,
+          "best_in_gibs": 23.2607,
+          "best_out_gibs": 23.2607,
+          "in_gibs": 19.4959,
+          "out_gibs": 19.4959
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 191.613,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 663.703,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 92.4042,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 5.38,
+      "status": "pass",
+      "throughput_in_gibs": 1.01683,
+      "throughput_out_gibs": 0.0986559,
+      "compression_fold": 10.3069,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.341096,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 3.45743,
+      "init_s": 0.00452054,
+      "flush_s": 2.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.9314,
+          "best_ms": 6.98421,
+          "best_in_gibs": 2.23719,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.9423,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 272.985,
+          "best_ms": 79.2297,
+          "best_in_gibs": 1.7749,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.83978,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.54209,
+          "best_ms": 3.86201,
+          "best_in_gibs": 36.5724,
+          "best_out_gibs": 0.0,
+          "in_gibs": 77.1067,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 4.03,
+      "status": "pass",
+      "throughput_in_gibs": 2.72106,
+      "throughput_out_gibs": 0.352734,
+      "compression_fold": 7.71419,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.455735,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 1.29201,
+      "init_s": 0.430734,
+      "flush_s": 1.93e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.39021,
+          "best_ms": 0.325717,
+          "best_in_gibs": 47.9711,
+          "best_out_gibs": 47.9711,
+          "in_gibs": 33.718,
+          "out_gibs": 33.718
+        },
+        "h2d": {
+          "avg_ms": 1.89686,
+          "best_ms": 0.624544,
+          "best_in_gibs": 25.0183,
+          "best_out_gibs": 25.0183,
+          "in_gibs": 24.8248,
+          "out_gibs": 24.8248
+        },
+        "scatter": {
+          "avg_ms": 1.4478,
+          "best_ms": 0.099072,
+          "best_in_gibs": 157.714,
+          "best_out_gibs": 157.714,
+          "in_gibs": 30.9513,
+          "out_gibs": 30.9513
+        },
+        "compress": {
+          "avg_ms": 159.059,
+          "best_ms": 24.3463,
+          "best_in_gibs": 5.77604,
+          "best_out_gibs": 0.752134,
+          "in_gibs": 3.15751,
+          "out_gibs": 0.408806
+        },
+        "aggregate": {
+          "avg_ms": 0.286414,
+          "best_ms": 0.04736,
+          "best_in_gibs": 386.648,
+          "best_out_gibs": 386.648,
+          "in_gibs": 227.03,
+          "out_gibs": 227.03
+        },
+        "d2h": {
+          "avg_ms": 3.35477,
+          "best_ms": 0.86544,
+          "best_in_gibs": 21.1588,
+          "best_out_gibs": 21.1588,
+          "in_gibs": 19.3827,
+          "out_gibs": 19.3827
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 322.355,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 1124.85,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 177.686,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 5.09,
+      "status": "pass",
+      "throughput_in_gibs": 1.13019,
+      "throughput_out_gibs": 0.117624,
+      "compression_fold": 9.6085,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.365887,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 3.11066,
+      "init_s": 0.00430171,
+      "flush_s": 1.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.7844,
+          "best_ms": 6.18019,
+          "best_in_gibs": 2.52824,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.66659,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 257.714,
+          "best_ms": 74.1266,
+          "best_in_gibs": 1.89709,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.9488,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.46541,
+          "best_ms": 3.68514,
+          "best_in_gibs": 38.3091,
+          "best_out_gibs": 0.0,
+          "in_gibs": 77.9833,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 4.29,
+      "status": "pass",
+      "throughput_in_gibs": 2.64686,
+      "throughput_out_gibs": 0.336557,
+      "compression_fold": 7.86454,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.447023,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.32822,
+      "init_s": 0.427182,
+      "flush_s": 2.36e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.29454,
+          "best_ms": 0.330748,
+          "best_in_gibs": 47.2414,
+          "best_out_gibs": 47.2414,
+          "in_gibs": 36.2098,
+          "out_gibs": 36.2098
+        },
+        "h2d": {
+          "avg_ms": 1.89402,
+          "best_ms": 0.625824,
+          "best_in_gibs": 24.9671,
+          "best_out_gibs": 24.9671,
+          "in_gibs": 24.8619,
+          "out_gibs": 24.8619
+        },
+        "scatter": {
+          "avg_ms": 1.39201,
+          "best_ms": 0.099744,
+          "best_in_gibs": 156.651,
+          "best_out_gibs": 156.651,
+          "in_gibs": 31.8417,
+          "out_gibs": 31.8417
+        },
+        "compress": {
+          "avg_ms": 163.8,
+          "best_ms": 29.4737,
+          "best_in_gibs": 4.77121,
+          "best_out_gibs": 0.608913,
+          "in_gibs": 3.06612,
+          "out_gibs": 0.389617
+        },
+        "aggregate": {
+          "avg_ms": 0.325641,
+          "best_ms": 0.044672,
+          "best_in_gibs": 401.748,
+          "best_out_gibs": 401.748,
+          "in_gibs": 195.981,
+          "out_gibs": 195.981
+        },
+        "d2h": {
+          "avg_ms": 3.29801,
+          "best_ms": 0.810528,
+          "best_in_gibs": 22.1422,
+          "best_out_gibs": 22.1422,
+          "in_gibs": 19.3509,
+          "out_gibs": 19.3509
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 356.073,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 1158.5,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 188.069,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 5.1,
+      "status": "pass",
+      "throughput_in_gibs": 1.11134,
+      "throughput_out_gibs": 0.111959,
+      "compression_fold": 9.9263,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.354173,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 3.1634,
+      "init_s": 0.00425343,
+      "flush_s": 2.85e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.7498,
+          "best_ms": 6.30928,
+          "best_in_gibs": 2.47651,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.67653,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 266.234,
+          "best_ms": 78.9605,
+          "best_in_gibs": 1.78095,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.88643,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.4082,
+          "best_ms": 3.7678,
+          "best_in_gibs": 37.4686,
+          "best_out_gibs": 0.0,
+          "in_gibs": 78.6795,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.67,
+      "status": "pass",
+      "throughput_in_gibs": 4.27286,
+      "throughput_out_gibs": 0.536024,
+      "compression_fold": 8.29026,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.44103,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.82278,
+      "init_s": 0.437397,
+      "flush_s": 1.73e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.1587,
+          "best_ms": 0.345261,
+          "best_in_gibs": 45.2556,
+          "best_out_gibs": 45.2556,
+          "in_gibs": 48.1604,
+          "out_gibs": 48.1604
+        },
+        "h2d": {
+          "avg_ms": 2.2721,
+          "best_ms": 1.24544,
+          "best_in_gibs": 25.0915,
+          "best_out_gibs": 25.0915,
+          "in_gibs": 24.8019,
+          "out_gibs": 24.8019
+        },
+        "scatter": {
+          "avg_ms": 0.488052,
+          "best_ms": 0.186048,
+          "best_in_gibs": 167.967,
+          "best_out_gibs": 167.967,
+          "in_gibs": 111.712,
+          "out_gibs": 111.712
+        },
+        "compress": {
+          "avg_ms": 92.2403,
+          "best_ms": 33.0953,
+          "best_in_gibs": 8.49819,
+          "best_out_gibs": 0.543057,
+          "in_gibs": 5.66261,
+          "out_gibs": 0.682822
+        },
+        "aggregate": {
+          "avg_ms": 0.405198,
+          "best_ms": 0.042848,
+          "best_in_gibs": 419.451,
+          "best_out_gibs": 419.451,
+          "in_gibs": 155.44,
+          "out_gibs": 155.44
+        },
+        "d2h": {
+          "avg_ms": 3.22875,
+          "best_ms": 0.8272,
+          "best_in_gibs": 21.7271,
+          "best_out_gibs": 21.7271,
+          "in_gibs": 19.5072,
+          "out_gibs": 19.5072
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 198.921,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 658.212,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 84.2283,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 5.1,
+      "status": "pass",
+      "throughput_in_gibs": 1.10923,
+      "throughput_out_gibs": 0.112233,
+      "compression_fold": 10.2786,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.355715,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 3.16943,
+      "init_s": 0.00447477,
+      "flush_s": 1.9e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.5145,
+          "best_ms": 6.3798,
+          "best_in_gibs": 2.44913,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.84468,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 272.527,
+          "best_ms": 151.249,
+          "best_in_gibs": 1.85952,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.91658,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.32477,
+          "best_ms": 4.10419,
+          "best_in_gibs": 68.7952,
+          "best_out_gibs": 0.0,
+          "in_gibs": 82.9061,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.77,
+      "status": "pass",
+      "throughput_in_gibs": 3.95077,
+      "throughput_out_gibs": 0.522145,
+      "compression_fold": 7.86908,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.464635,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.889859,
+      "init_s": 0.434778,
+      "flush_s": 1.59e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.15007,
+          "best_ms": 0.347828,
+          "best_in_gibs": 44.9216,
+          "best_out_gibs": 44.9216,
+          "in_gibs": 48.5217,
+          "out_gibs": 48.5217
+        },
+        "h2d": {
+          "avg_ms": 2.26843,
+          "best_ms": 1.24624,
+          "best_in_gibs": 25.0754,
+          "best_out_gibs": 25.0754,
+          "in_gibs": 24.842,
+          "out_gibs": 24.842
+        },
+        "scatter": {
+          "avg_ms": 0.523617,
+          "best_ms": 0.185664,
+          "best_in_gibs": 168.315,
+          "best_out_gibs": 168.315,
+          "in_gibs": 104.124,
+          "out_gibs": 104.124
+        },
+        "compress": {
+          "avg_ms": 100.333,
+          "best_ms": 53.1683,
+          "best_in_gibs": 5.2898,
+          "best_out_gibs": 0.355556,
+          "in_gibs": 5.20589,
+          "out_gibs": 0.661471
+        },
+        "aggregate": {
+          "avg_ms": 0.429157,
+          "best_ms": 0.059264,
+          "best_in_gibs": 318.985,
+          "best_out_gibs": 318.985,
+          "in_gibs": 154.646,
+          "out_gibs": 154.646
+        },
+        "d2h": {
+          "avg_ms": 3.44035,
+          "best_ms": 0.873184,
+          "best_in_gibs": 21.6499,
+          "best_out_gibs": 21.6499,
+          "in_gibs": 19.2908,
+          "out_gibs": 19.2908
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 228.995,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 715.561,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 92.082,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 5.01,
+      "status": "pass",
+      "throughput_in_gibs": 1.14316,
+      "throughput_out_gibs": 0.119571,
+      "compression_fold": 9.94288,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.367726,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 3.07537,
+      "init_s": 0.00415772,
+      "flush_s": 2.05e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.7579,
+          "best_ms": 6.41128,
+          "best_in_gibs": 2.43711,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.05612,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 265.846,
+          "best_ms": 140.529,
+          "best_in_gibs": 2.00136,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.96475,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.36185,
+          "best_ms": 4.2977,
+          "best_in_gibs": 65.6977,
+          "best_out_gibs": 0.0,
+          "in_gibs": 82.4228,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.88,
+      "status": "pass",
+      "throughput_in_gibs": 3.98063,
+      "throughput_out_gibs": 0.527422,
+      "compression_fold": 7.84922,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.465811,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.883184,
+      "init_s": 0.520305,
+      "flush_s": 3.1e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.15872,
+          "best_ms": 0.346661,
+          "best_in_gibs": 45.0729,
+          "best_out_gibs": 45.0729,
+          "in_gibs": 48.1595,
+          "out_gibs": 48.1595
+        },
+        "h2d": {
+          "avg_ms": 2.26999,
+          "best_ms": 1.24608,
+          "best_in_gibs": 25.0786,
+          "best_out_gibs": 25.0786,
+          "in_gibs": 24.825,
+          "out_gibs": 24.825
+        },
+        "scatter": {
+          "avg_ms": 0.527168,
+          "best_ms": 0.185408,
+          "best_in_gibs": 168.547,
+          "best_out_gibs": 168.547,
+          "in_gibs": 103.423,
+          "out_gibs": 103.423
+        },
+        "compress": {
+          "avg_ms": 101.602,
+          "best_ms": 55.3468,
+          "best_in_gibs": 5.0816,
+          "best_out_gibs": 0.339946,
+          "in_gibs": 5.14087,
+          "out_gibs": 0.654907
+        },
+        "aggregate": {
+          "avg_ms": 0.538519,
+          "best_ms": 0.10128,
+          "best_in_gibs": 185.771,
+          "best_out_gibs": 185.771,
+          "in_gibs": 123.561,
+          "out_gibs": 123.561
+        },
+        "d2h": {
+          "avg_ms": 3.46132,
+          "best_ms": 0.869344,
+          "best_in_gibs": 21.6426,
+          "best_out_gibs": 21.6426,
+          "in_gibs": 19.2238,
+          "out_gibs": 19.2238
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 232.235,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 725.184,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 92.8067,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 4.92,
+      "status": "pass",
+      "throughput_in_gibs": 1.17776,
+      "throughput_out_gibs": 0.116224,
+      "compression_fold": 10.5389,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.346929,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 2.98501,
+      "init_s": 0.00412151,
+      "flush_s": 2.98e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.7396,
+          "best_ms": 6.73169,
+          "best_in_gibs": 2.32111,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.06151,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 253.638,
+          "best_ms": 136.473,
+          "best_in_gibs": 2.06085,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.05932,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.10524,
+          "best_ms": 4.02774,
+          "best_in_gibs": 70.1009,
+          "best_out_gibs": 0.0,
+          "in_gibs": 85.8872,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 4.81,
+      "status": "pass",
+      "throughput_in_gibs": 1.25045,
+      "throughput_out_gibs": 0.789637,
+      "compression_fold": 1.58358,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.22005,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 2.81148,
+      "init_s": 0.0046602,
+      "flush_s": 2.42e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 19.5099,
+          "best_ms": 8.23867,
+          "best_in_gibs": 1.89654,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.40262,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 125.556,
+          "best_ms": 35.9677,
+          "best_in_gibs": 3.90976,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.00006,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 22.2365,
+          "best_ms": 6.05428,
+          "best_in_gibs": 23.25,
+          "best_out_gibs": 0.0,
+          "in_gibs": 22.608,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 4.41,
+      "status": "pass",
+      "throughput_in_gibs": 1.44956,
+      "throughput_out_gibs": 0.833426,
+      "compression_fold": 1.73928,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.02131,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 2.4253,
+      "init_s": 0.00427775,
+      "flush_s": 1.53e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.8886,
+          "best_ms": 7.23907,
+          "best_in_gibs": 2.15843,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.95023,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 113.687,
+          "best_ms": 32.9853,
+          "best_in_gibs": 4.26326,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.41769,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 19.5708,
+          "best_ms": 5.45348,
+          "best_in_gibs": 25.7989,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25.6748,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 4.45,
+      "status": "pass",
+      "throughput_in_gibs": 1.43099,
+      "throughput_out_gibs": 0.818287,
+      "compression_fold": 1.74876,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.01035,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 2.45678,
+      "init_s": 0.0043633,
+      "flush_s": 2.29e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.9834,
+          "best_ms": 6.87193,
+          "best_in_gibs": 2.27374,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.93272,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 117.75,
+          "best_ms": 34.2688,
+          "best_in_gibs": 4.10359,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.26522,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 19.6255,
+          "best_ms": 5.64391,
+          "best_in_gibs": 24.9223,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25.5971,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 4.21,
+      "status": "pass",
+      "throughput_in_gibs": 1.57739,
+      "throughput_out_gibs": 0.927832,
+      "compression_fold": 1.70008,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.06792,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 2.22876,
+      "init_s": 0.00434007,
+      "flush_s": 2.25e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.7127,
+          "best_ms": 6.20982,
+          "best_in_gibs": 2.51618,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.68726,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 121.093,
+          "best_ms": 35.1047,
+          "best_in_gibs": 4.00587,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.14748,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 19.6075,
+          "best_ms": 6.29046,
+          "best_in_gibs": 22.3583,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25.6174,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 4.22,
+      "status": "pass",
+      "throughput_in_gibs": 1.57036,
+      "throughput_out_gibs": 0.929781,
+      "compression_fold": 1.68896,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.08153,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 2.23874,
+      "init_s": 0.00419891,
+      "flush_s": 3.35e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.6954,
+          "best_ms": 6.18008,
+          "best_in_gibs": 2.52828,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.69228,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 121.588,
+          "best_ms": 35.2126,
+          "best_in_gibs": 3.9936,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.1306,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 20.3285,
+          "best_ms": 5.84397,
+          "best_in_gibs": 24.0652,
+          "best_out_gibs": 0.0,
+          "in_gibs": 24.7074,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 4.23,
+      "status": "pass",
+      "throughput_in_gibs": 1.57907,
+      "throughput_out_gibs": 0.972246,
+      "compression_fold": 1.68911,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.1646,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 2.22639,
+      "init_s": 0.00409757,
+      "flush_s": 2.46e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.4388,
+          "best_ms": 6.45304,
+          "best_in_gibs": 2.42134,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.86483,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 127.097,
+          "best_ms": 67.7003,
+          "best_in_gibs": 4.15434,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.10964,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 19.6468,
+          "best_ms": 7.94581,
+          "best_in_gibs": 35.3974,
+          "best_out_gibs": 0.0,
+          "in_gibs": 26.5865,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 4.12,
+      "status": "pass",
+      "throughput_in_gibs": 1.67918,
+      "throughput_out_gibs": 0.928945,
+      "compression_fold": 1.87993,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.94489,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 2.09366,
+      "init_s": 0.00405968,
+      "flush_s": 3.19e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.6964,
+          "best_ms": 6.49519,
+          "best_in_gibs": 2.40563,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.07434,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 116.058,
+          "best_ms": 61.5508,
+          "best_in_gibs": 4.5694,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.50051,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 18.2096,
+          "best_ms": 8.51437,
+          "best_in_gibs": 33.0333,
+          "best_out_gibs": 0.0,
+          "in_gibs": 28.6845,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 4.07,
+      "status": "pass",
+      "throughput_in_gibs": 1.67018,
+      "throughput_out_gibs": 0.923937,
+      "compression_fold": 1.87998,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.94483,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 2.10494,
+      "init_s": 0.00421938,
+      "flush_s": 2.57e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.5678,
+          "best_ms": 6.28456,
+          "best_in_gibs": 2.48625,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.11293,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 117.583,
+          "best_ms": 62.8173,
+          "best_in_gibs": 4.47727,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.44213,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 18.5764,
+          "best_ms": 7.34405,
+          "best_in_gibs": 38.2968,
+          "best_out_gibs": 0.0,
+          "in_gibs": 28.1178,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 5.26,
+      "status": "pass",
+      "throughput_in_gibs": 1.05587,
+      "throughput_out_gibs": 0.0351347,
+      "compression_fold": 30.052,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.116985,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 3.3296,
+      "init_s": 0.00463767,
+      "flush_s": 2.43e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 19.4518,
+          "best_ms": 8.17017,
+          "best_in_gibs": 1.91245,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.40981,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 217.208,
+          "best_ms": 63.0166,
+          "best_in_gibs": 2.23155,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.31222,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.84866,
+          "best_ms": 3.77095,
+          "best_in_gibs": 37.3281,
+          "best_out_gibs": 0.0,
+          "in_gibs": 103.683,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 4.4,
+      "status": "pass",
+      "throughput_in_gibs": 1.42661,
+      "throughput_out_gibs": 0.0290733,
+      "compression_fold": 49.0695,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0716459,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 2.46432,
+      "init_s": 0.00437362,
+      "flush_s": 1.52e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.1287,
+          "best_ms": 6.75132,
+          "best_in_gibs": 2.31436,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.9063,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 131.916,
+          "best_ms": 39.207,
+          "best_in_gibs": 3.58673,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.8072,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.33793,
+          "best_ms": 3.44248,
+          "best_in_gibs": 40.8699,
+          "best_out_gibs": 0.0,
+          "in_gibs": 115.834,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 4.25,
+      "status": "pass",
+      "throughput_in_gibs": 1.52272,
+      "throughput_out_gibs": 0.0264056,
+      "compression_fold": 57.6665,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0609648,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 2.30878,
+      "init_s": 0.00441451,
+      "flush_s": 2.7e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.921,
+          "best_ms": 7.12224,
+          "best_in_gibs": 2.19383,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.94422,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 113.67,
+          "best_ms": 33.6043,
+          "best_in_gibs": 4.18473,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.41832,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.08417,
+          "best_ms": 3.43245,
+          "best_in_gibs": 40.9792,
+          "best_out_gibs": 0.0,
+          "in_gibs": 123,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 4.4,
+      "status": "pass",
+      "throughput_in_gibs": 1.43403,
+      "throughput_out_gibs": 0.0342338,
+      "compression_fold": 41.8892,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0839267,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 2.45157,
+      "init_s": 0.00410585,
+      "flush_s": 1.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.7503,
+          "best_ms": 6.1742,
+          "best_in_gibs": 2.53069,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.67639,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 168.032,
+          "best_ms": 47.8756,
+          "best_in_gibs": 2.9373,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.9889,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.31299,
+          "best_ms": 3.4221,
+          "best_in_gibs": 41.0988,
+          "best_out_gibs": 0.0,
+          "in_gibs": 116.461,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.77,
+      "status": "pass",
+      "throughput_in_gibs": 1.92655,
+      "throughput_out_gibs": 0.0286061,
+      "compression_fold": 67.3474,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0522013,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.82483,
+      "init_s": 0.00427957,
+      "flush_s": 1.61e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 12.7282,
+          "best_ms": 6.21881,
+          "best_in_gibs": 2.51254,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.68278,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 78.5067,
+          "best_ms": 23.6553,
+          "best_in_gibs": 5.94475,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.39732,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.87087,
+          "best_ms": 3.47449,
+          "best_in_gibs": 40.4768,
+          "best_out_gibs": 0.0,
+          "in_gibs": 129.755,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.75,
+      "status": "pass",
+      "throughput_in_gibs": 1.95145,
+      "throughput_out_gibs": 0.0299872,
+      "compression_fold": 67.6793,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0540232,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.80154,
+      "init_s": 0.0039898,
+      "flush_s": 1.97e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.544,
+          "best_ms": 6.37604,
+          "best_in_gibs": 2.45058,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.83688,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 81.7539,
+          "best_ms": 45.0056,
+          "best_in_gibs": 6.24922,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.38895,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.92269,
+          "best_ms": 3.57146,
+          "best_in_gibs": 157.504,
+          "best_out_gibs": 0.0,
+          "in_gibs": 133.159,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.56,
+      "status": "pass",
+      "throughput_in_gibs": 2.16368,
+      "throughput_out_gibs": 0.0302702,
+      "compression_fold": 74.338,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0491842,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 1.62484,
+      "init_s": 0.00403461,
+      "flush_s": 2.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.63,
+          "best_ms": 8.65356,
+          "best_in_gibs": 3.61123,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.09419,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 64.0371,
+          "best_ms": 34.9901,
+          "best_in_gibs": 8.038,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.15654,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.81323,
+          "best_ms": 3.50363,
+          "best_in_gibs": 80.2761,
+          "best_out_gibs": 0.0,
+          "in_gibs": 136.979,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.57,
+      "status": "pass",
+      "throughput_in_gibs": 2.13902,
+      "throughput_out_gibs": 0.0325172,
+      "compression_fold": 68.4123,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.0534443,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.64357,
+      "init_s": 0.00402313,
+      "flush_s": 3.12e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 13.6661,
+          "best_ms": 6.43314,
+          "best_in_gibs": 2.42883,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.08336,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 66.6221,
+          "best_ms": 35.1202,
+          "best_in_gibs": 8.00821,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.84006,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.78096,
+          "best_ms": 3.53775,
+          "best_in_gibs": 159.001,
+          "best_out_gibs": 0.0,
+          "in_gibs": 138.147,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 13.61,
+      "status": "pass",
+      "throughput_in_gibs": 5.83488,
+      "throughput_out_gibs": 5.84058,
+      "compression_fold": 0.999024,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75366,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.642686,
+      "init_s": 0.429644,
+      "flush_s": 2.01e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.31707,
+          "best_ms": 1.26728,
+          "best_in_gibs": 49.3183,
+          "best_out_gibs": 49.3183,
+          "in_gibs": 47.4539,
+          "out_gibs": 47.4539
+        },
+        "h2d": {
+          "avg_ms": 2.58761,
+          "best_ms": 2.48902,
+          "best_in_gibs": 25.1102,
+          "best_out_gibs": 25.1102,
+          "in_gibs": 24.1535,
+          "out_gibs": 24.1535
+        },
+        "scatter": {
+          "avg_ms": 0.443421,
+          "best_ms": 0.440448,
+          "best_in_gibs": 141.901,
+          "best_out_gibs": 141.901,
+          "in_gibs": 140.949,
+          "out_gibs": 140.949
+        },
+        "aggregate": {
+          "avg_ms": 2.55807,
+          "best_ms": 1.33379,
+          "best_in_gibs": 281.153,
+          "best_out_gibs": 281.153,
+          "in_gibs": 209.422,
+          "out_gibs": 209.422
+        },
+        "d2h": {
+          "avg_ms": 23.5478,
+          "best_ms": 15.9069,
+          "best_in_gibs": 23.5746,
+          "best_out_gibs": 23.5746,
+          "in_gibs": 22.75,
+          "out_gibs": 22.75
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 21.7823,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 201.421,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.89656,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 13.97,
+      "status": "pass",
+      "throughput_in_gibs": 1.98328,
+      "throughput_out_gibs": 1.98521,
+      "compression_fold": 0.999024,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75366,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 1.89081,
+      "init_s": 0.00447834,
+      "flush_s": 2.18e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 19.7372,
+          "best_ms": 18.0991,
+          "best_in_gibs": 3.4532,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.16661,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.0177,
+          "best_ms": 14.2984,
+          "best_in_gibs": 26.2267,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.4134,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 30.206,
+          "best_ms": 15.3363,
+          "best_in_gibs": 24.4518,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.7354,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 13.58,
+      "status": "pass",
+      "throughput_in_gibs": 5.76584,
+      "throughput_out_gibs": 5.76866,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.650382,
+      "init_s": 0.424977,
+      "flush_s": 2.35e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.31381,
+          "best_ms": 1.27024,
+          "best_in_gibs": 49.2033,
+          "best_out_gibs": 49.2033,
+          "in_gibs": 47.5716,
+          "out_gibs": 47.5716
+        },
+        "h2d": {
+          "avg_ms": 2.58879,
+          "best_ms": 2.49018,
+          "best_in_gibs": 25.0986,
+          "best_out_gibs": 25.0986,
+          "in_gibs": 24.1426,
+          "out_gibs": 24.1426
+        },
+        "scatter": {
+          "avg_ms": 0.442143,
+          "best_ms": 0.43936,
+          "best_in_gibs": 142.252,
+          "best_out_gibs": 142.252,
+          "in_gibs": 141.357,
+          "out_gibs": 141.357
+        },
+        "aggregate": {
+          "avg_ms": 2.663,
+          "best_ms": 1.38445,
+          "best_in_gibs": 270.866,
+          "best_out_gibs": 270.866,
+          "in_gibs": 201.17,
+          "out_gibs": 201.17
+        },
+        "d2h": {
+          "avg_ms": 23.3856,
+          "best_ms": 15.8126,
+          "best_in_gibs": 23.7153,
+          "best_out_gibs": 23.7153,
+          "in_gibs": 22.9079,
+          "out_gibs": 22.9079
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 20.9706,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 201.914,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90892,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 13.8,
+      "status": "pass",
+      "throughput_in_gibs": 2.18379,
+      "throughput_out_gibs": 2.18486,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 1.7172,
+      "init_s": 0.00434782,
+      "flush_s": 2.25e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.9218,
+          "best_ms": 15.5881,
+          "best_in_gibs": 4.00947,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.69346,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.9543,
+          "best_ms": 14.6312,
+          "best_in_gibs": 25.6302,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.4678,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 30.4367,
+          "best_ms": 15.1859,
+          "best_in_gibs": 24.6939,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.6009,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.74,
+      "status": "pass",
+      "throughput_in_gibs": 5.82276,
+      "throughput_out_gibs": 5.82418,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75092,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.644025,
+      "init_s": 0.430846,
+      "flush_s": 1.95e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.31658,
+          "best_ms": 1.27065,
+          "best_in_gibs": 49.1874,
+          "best_out_gibs": 49.1874,
+          "in_gibs": 47.4716,
+          "out_gibs": 47.4716
+        },
+        "h2d": {
+          "avg_ms": 2.60471,
+          "best_ms": 2.49027,
+          "best_in_gibs": 25.0977,
+          "best_out_gibs": 25.0977,
+          "in_gibs": 23.995,
+          "out_gibs": 23.995
+        },
+        "scatter": {
+          "avg_ms": 0.441975,
+          "best_ms": 0.439136,
+          "best_in_gibs": 142.325,
+          "best_out_gibs": 142.325,
+          "in_gibs": 141.411,
+          "out_gibs": 141.411
+        },
+        "aggregate": {
+          "avg_ms": 2.74346,
+          "best_ms": 1.4343,
+          "best_in_gibs": 261.451,
+          "best_out_gibs": 261.451,
+          "in_gibs": 195.27,
+          "out_gibs": 195.27
+        },
+        "d2h": {
+          "avg_ms": 23.3362,
+          "best_ms": 15.797,
+          "best_in_gibs": 23.7386,
+          "best_out_gibs": 23.7386,
+          "in_gibs": 22.9564,
+          "out_gibs": 22.9564
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 20.6438,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 202.55,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.89371,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.77,
+      "status": "pass",
+      "throughput_in_gibs": 2.20523,
+      "throughput_out_gibs": 2.20577,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75092,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 1.7005,
+      "init_s": 0.00448317,
+      "flush_s": 1.79e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.8362,
+          "best_ms": 15.5409,
+          "best_in_gibs": 4.02165,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.71224,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.8117,
+          "best_ms": 14.9115,
+          "best_in_gibs": 25.1483,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.5912,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 30.3607,
+          "best_ms": 14.3669,
+          "best_in_gibs": 26.1018,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.645,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 13.61,
+      "status": "pass",
+      "throughput_in_gibs": 5.8545,
+      "throughput_out_gibs": 5.85521,
+      "compression_fold": 0.999878,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75046,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.640533,
+      "init_s": 0.425306,
+      "flush_s": 3.08e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.31231,
+          "best_ms": 1.27055,
+          "best_in_gibs": 49.1915,
+          "best_out_gibs": 49.1915,
+          "in_gibs": 47.6258,
+          "out_gibs": 47.6258
+        },
+        "h2d": {
+          "avg_ms": 2.59892,
+          "best_ms": 2.49043,
+          "best_in_gibs": 25.096,
+          "best_out_gibs": 25.096,
+          "in_gibs": 24.0484,
+          "out_gibs": 24.0484
+        },
+        "scatter": {
+          "avg_ms": 0.442518,
+          "best_ms": 0.43952,
+          "best_in_gibs": 142.201,
+          "best_out_gibs": 142.201,
+          "in_gibs": 141.237,
+          "out_gibs": 141.237
+        },
+        "aggregate": {
+          "avg_ms": 2.87341,
+          "best_ms": 1.47446,
+          "best_in_gibs": 254.33,
+          "best_out_gibs": 254.33,
+          "in_gibs": 186.439,
+          "out_gibs": 186.439
+        },
+        "d2h": {
+          "avg_ms": 23.4131,
+          "best_ms": 15.8749,
+          "best_in_gibs": 23.6222,
+          "best_out_gibs": 23.6222,
+          "in_gibs": 22.881,
+          "out_gibs": 22.881
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 20.5139,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 204.15,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.89561,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 13.77,
+      "status": "pass",
+      "throughput_in_gibs": 2.20975,
+      "throughput_out_gibs": 2.21002,
+      "compression_fold": 0.999878,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75046,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 1.69703,
+      "init_s": 0.00423597,
+      "flush_s": 2.03e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.713,
+          "best_ms": 15.5619,
+          "best_in_gibs": 4.01623,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.7396,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.8699,
+          "best_ms": 14.5706,
+          "best_in_gibs": 25.7368,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.5406,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 30.7271,
+          "best_ms": 14.1049,
+          "best_in_gibs": 26.5865,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.4346,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.72,
+      "status": "pass",
+      "throughput_in_gibs": 5.4935,
+      "throughput_out_gibs": 5.49383,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.682625,
+      "init_s": 0.540465,
+      "flush_s": 2.13e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.77578,
+          "best_ms": 1.27357,
+          "best_in_gibs": 49.0748,
+          "best_out_gibs": 49.0748,
+          "in_gibs": 35.1957,
+          "out_gibs": 35.1957
+        },
+        "h2d": {
+          "avg_ms": 2.59226,
+          "best_ms": 2.48976,
+          "best_in_gibs": 25.1028,
+          "best_out_gibs": 25.1028,
+          "in_gibs": 24.1102,
+          "out_gibs": 24.1102
+        },
+        "scatter": {
+          "avg_ms": 0.442082,
+          "best_ms": 0.43904,
+          "best_in_gibs": 142.356,
+          "best_out_gibs": 142.356,
+          "in_gibs": 141.376,
+          "out_gibs": 141.376
+        },
+        "aggregate": {
+          "avg_ms": 4.25502,
+          "best_ms": 4.17856,
+          "best_in_gibs": 179.488,
+          "best_out_gibs": 179.488,
+          "in_gibs": 176.262,
+          "out_gibs": 176.262
+        },
+        "d2h": {
+          "avg_ms": 32.1838,
+          "best_ms": 31.1944,
+          "best_in_gibs": 24.0428,
+          "best_out_gibs": 24.0428,
+          "in_gibs": 23.3036,
+          "out_gibs": 23.3036
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 38.5578,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 196.674,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90885,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.89,
+      "status": "pass",
+      "throughput_in_gibs": 2.15632,
+      "throughput_out_gibs": 2.15645,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 1.73908,
+      "init_s": 0.0042328,
+      "flush_s": 2.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.0754,
+          "best_ms": 15.5931,
+          "best_in_gibs": 4.00818,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.66025,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.0899,
+          "best_ms": 26.1216,
+          "best_in_gibs": 28.7119,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.7814,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 46.4879,
+          "best_ms": 26.248,
+          "best_in_gibs": 28.5736,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.1332,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 13.77,
+      "status": "pass",
+      "throughput_in_gibs": 5.75544,
+      "throughput_out_gibs": 5.75561,
+      "compression_fold": 0.999969,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75011,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.651558,
+      "init_s": 0.52635,
+      "flush_s": 1.65e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.30851,
+          "best_ms": 1.27314,
+          "best_in_gibs": 49.0912,
+          "best_out_gibs": 49.0912,
+          "in_gibs": 47.7643,
+          "out_gibs": 47.7643
+        },
+        "h2d": {
+          "avg_ms": 2.59973,
+          "best_ms": 2.49126,
+          "best_in_gibs": 25.0877,
+          "best_out_gibs": 25.0877,
+          "in_gibs": 24.041,
+          "out_gibs": 24.041
+        },
+        "scatter": {
+          "avg_ms": 0.441382,
+          "best_ms": 0.438656,
+          "best_in_gibs": 142.481,
+          "best_out_gibs": 142.481,
+          "in_gibs": 141.601,
+          "out_gibs": 141.601
+        },
+        "aggregate": {
+          "avg_ms": 4.40335,
+          "best_ms": 4.33398,
+          "best_in_gibs": 173.051,
+          "best_out_gibs": 173.051,
+          "in_gibs": 170.325,
+          "out_gibs": 170.325
+        },
+        "d2h": {
+          "avg_ms": 32.5671,
+          "best_ms": 31.5143,
+          "best_in_gibs": 23.7987,
+          "best_out_gibs": 23.7987,
+          "in_gibs": 23.0294,
+          "out_gibs": 23.0294
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 38.9364,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 199.496,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.89854,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 13.81,
+      "status": "pass",
+      "throughput_in_gibs": 2.18278,
+      "throughput_out_gibs": 2.18285,
+      "compression_fold": 0.999969,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75011,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 1.71799,
+      "init_s": 0.00462941,
+      "flush_s": 2.66e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.615,
+          "best_ms": 14.909,
+          "best_in_gibs": 4.19209,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.76167,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.6657,
+          "best_ms": 26.3607,
+          "best_in_gibs": 28.4515,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.4551,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 47.0043,
+          "best_ms": 26.3331,
+          "best_in_gibs": 28.4813,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.956,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.63,
+      "status": "pass",
+      "throughput_in_gibs": 5.57754,
+      "throughput_out_gibs": 5.57763,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75006,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.672339,
+      "init_s": 0.533707,
+      "flush_s": 2.12e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.31195,
+          "best_ms": 1.27363,
+          "best_in_gibs": 49.0725,
+          "best_out_gibs": 49.0725,
+          "in_gibs": 47.6391,
+          "out_gibs": 47.6391
+        },
+        "h2d": {
+          "avg_ms": 2.60363,
+          "best_ms": 2.4903,
+          "best_in_gibs": 25.0973,
+          "best_out_gibs": 25.0973,
+          "in_gibs": 24.005,
+          "out_gibs": 24.005
+        },
+        "scatter": {
+          "avg_ms": 0.442205,
+          "best_ms": 0.439392,
+          "best_in_gibs": 142.242,
+          "best_out_gibs": 142.242,
+          "in_gibs": 141.337,
+          "out_gibs": 141.337
+        },
+        "aggregate": {
+          "avg_ms": 4.48222,
+          "best_ms": 4.42192,
+          "best_in_gibs": 169.61,
+          "best_out_gibs": 169.61,
+          "in_gibs": 167.328,
+          "out_gibs": 167.328
+        },
+        "d2h": {
+          "avg_ms": 32.3188,
+          "best_ms": 31.179,
+          "best_in_gibs": 24.0547,
+          "best_out_gibs": 24.0547,
+          "in_gibs": 23.2063,
+          "out_gibs": 23.2063
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 38.7008,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 198.556,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90553,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.83,
+      "status": "pass",
+      "throughput_in_gibs": 2.17677,
+      "throughput_out_gibs": 2.1768,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75006,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 1.72274,
+      "init_s": 0.0040174,
+      "flush_s": 3.49e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.6348,
+          "best_ms": 15.1631,
+          "best_in_gibs": 4.12186,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.75718,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 37.3091,
+          "best_ms": 26.344,
+          "best_in_gibs": 28.4695,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.1024,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 47.1451,
+          "best_ms": 26.5246,
+          "best_in_gibs": 28.2756,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.9083,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 13.71,
+      "status": "pass",
+      "throughput_in_gibs": 5.72429,
+      "throughput_out_gibs": 5.72435,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.655103,
+      "init_s": 0.544172,
+      "flush_s": 1.9e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.30641,
+          "best_ms": 1.27319,
+          "best_in_gibs": 49.0892,
+          "best_out_gibs": 49.0892,
+          "in_gibs": 47.8409,
+          "out_gibs": 47.8409
+        },
+        "h2d": {
+          "avg_ms": 2.60672,
+          "best_ms": 2.49126,
+          "best_in_gibs": 25.0877,
+          "best_out_gibs": 25.0877,
+          "in_gibs": 23.9765,
+          "out_gibs": 23.9765
+        },
+        "scatter": {
+          "avg_ms": 0.441681,
+          "best_ms": 0.43872,
+          "best_in_gibs": 142.46,
+          "best_out_gibs": 142.46,
+          "in_gibs": 141.505,
+          "out_gibs": 141.505
+        },
+        "aggregate": {
+          "avg_ms": 4.96128,
+          "best_ms": 4.90886,
+          "best_in_gibs": 152.785,
+          "best_out_gibs": 152.785,
+          "in_gibs": 151.171,
+          "out_gibs": 151.171
+        },
+        "d2h": {
+          "avg_ms": 32.336,
+          "best_ms": 31.1416,
+          "best_in_gibs": 24.0835,
+          "best_out_gibs": 24.0835,
+          "in_gibs": 23.1939,
+          "out_gibs": 23.1939
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 39.0968,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 201.122,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90951,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 13.77,
+      "status": "pass",
+      "throughput_in_gibs": 2.24811,
+      "throughput_out_gibs": 2.24814,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 1.66807,
+      "init_s": 0.00434441,
+      "flush_s": 1.93e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.7322,
+          "best_ms": 15.1157,
+          "best_in_gibs": 4.13477,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.73532,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.7736,
+          "best_ms": 17.1113,
+          "best_in_gibs": 43.8307,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25.1901,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 41.6072,
+          "best_ms": 16.9037,
+          "best_in_gibs": 44.369,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.0257,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 13.7,
+      "status": "pass",
+      "throughput_in_gibs": 5.6369,
+      "throughput_out_gibs": 2.6168,
+      "compression_fold": 2.15412,
+      "input_gib": 3.75,
+      "compressed_gib": 1.74085,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.665259,
+      "init_s": 0.424579,
+      "flush_s": 1.57e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.31694,
+          "best_ms": 1.27409,
+          "best_in_gibs": 49.0546,
+          "best_out_gibs": 49.0546,
+          "in_gibs": 47.4586,
+          "out_gibs": 47.4586
+        },
+        "h2d": {
+          "avg_ms": 2.5639,
+          "best_ms": 2.49078,
+          "best_in_gibs": 25.0925,
+          "best_out_gibs": 25.0925,
+          "in_gibs": 24.3769,
+          "out_gibs": 24.3769
+        },
+        "scatter": {
+          "avg_ms": 0.460102,
+          "best_ms": 0.439872,
+          "best_in_gibs": 142.087,
+          "best_out_gibs": 142.087,
+          "in_gibs": 135.84,
+          "out_gibs": 135.84
+        },
+        "compress": {
+          "avg_ms": 25.535,
+          "best_ms": 18.8667,
+          "best_in_gibs": 19.8763,
+          "best_out_gibs": 9.22391,
+          "in_gibs": 20.9796,
+          "out_gibs": 9.7188
+        },
+        "aggregate": {
+          "avg_ms": 1.13583,
+          "best_ms": 0.69248,
+          "best_in_gibs": 251.306,
+          "best_out_gibs": 251.306,
+          "in_gibs": 218.493,
+          "out_gibs": 218.493
+        },
+        "d2h": {
+          "avg_ms": 11.2021,
+          "best_ms": 7.37258,
+          "best_in_gibs": 23.6043,
+          "best_out_gibs": 23.6043,
+          "in_gibs": 22.1539,
+          "out_gibs": 22.1539
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 33.2102,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 278.008,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.0538,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 14.84,
+      "status": "pass",
+      "throughput_in_gibs": 1.33626,
+      "throughput_out_gibs": 0.487268,
+      "compression_fold": 2.74235,
+      "input_gib": 3.75,
+      "compressed_gib": 1.36744,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 2.80635,
+      "init_s": 0.00449118,
+      "flush_s": 1.57e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 20.0115,
+          "best_ms": 18.176,
+          "best_in_gibs": 3.4386,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.1232,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 169.679,
+          "best_ms": 118.544,
+          "best_in_gibs": 3.16338,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.15722,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.0391,
+          "best_ms": 8.3701,
+          "best_in_gibs": 45.0211,
+          "best_out_gibs": 0.0,
+          "in_gibs": 38.345,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 13.5,
+      "status": "pass",
+      "throughput_in_gibs": 5.35608,
+      "throughput_out_gibs": 2.39065,
+      "compression_fold": 2.24043,
+      "input_gib": 3.75,
+      "compressed_gib": 1.67379,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.700139,
+      "init_s": 0.420428,
+      "flush_s": 2.85e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.10932,
+          "best_ms": 1.30288,
+          "best_in_gibs": 47.9708,
+          "best_out_gibs": 47.9708,
+          "in_gibs": 29.6304,
+          "out_gibs": 29.6304
+        },
+        "h2d": {
+          "avg_ms": 2.53309,
+          "best_ms": 2.48682,
+          "best_in_gibs": 25.1325,
+          "best_out_gibs": 25.1325,
+          "in_gibs": 24.6734,
+          "out_gibs": 24.6734
+        },
+        "scatter": {
+          "avg_ms": 0.795533,
+          "best_ms": 0.438752,
+          "best_in_gibs": 142.449,
+          "best_out_gibs": 142.449,
+          "in_gibs": 78.5637,
+          "out_gibs": 78.5637
+        },
+        "compress": {
+          "avg_ms": 26.085,
+          "best_ms": 18.199,
+          "best_in_gibs": 20.6055,
+          "best_out_gibs": 9.18256,
+          "in_gibs": 20.5373,
+          "out_gibs": 9.15664
+        },
+        "aggregate": {
+          "avg_ms": 1.09839,
+          "best_ms": 0.659488,
+          "best_in_gibs": 253.399,
+          "best_out_gibs": 253.399,
+          "in_gibs": 217.455,
+          "out_gibs": 217.455
+        },
+        "d2h": {
+          "avg_ms": 10.4906,
+          "best_ms": 7.09626,
+          "best_in_gibs": 23.5495,
+          "best_out_gibs": 23.5495,
+          "in_gibs": 22.7681,
+          "out_gibs": 22.7681
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 29.859,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 277.763,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.87428,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 14.62,
+      "status": "pass",
+      "throughput_in_gibs": 1.4643,
+      "throughput_out_gibs": 0.489308,
+      "compression_fold": 2.99259,
+      "input_gib": 3.75,
+      "compressed_gib": 1.2531,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 2.56095,
+      "init_s": 0.00469975,
+      "flush_s": 3.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.1042,
+          "best_ms": 15.4995,
+          "best_in_gibs": 4.03238,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.65407,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 161.854,
+          "best_ms": 112.073,
+          "best_in_gibs": 3.34604,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.30986,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.1102,
+          "best_ms": 6.87413,
+          "best_in_gibs": 54.7921,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41.0421,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.81,
+      "status": "pass",
+      "throughput_in_gibs": 5.64828,
+      "throughput_out_gibs": 2.66095,
+      "compression_fold": 2.12266,
+      "input_gib": 3.75,
+      "compressed_gib": 1.76666,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.663919,
+      "init_s": 0.427039,
+      "flush_s": 2.74e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.30644,
+          "best_ms": 1.27456,
+          "best_in_gibs": 49.0367,
+          "best_out_gibs": 49.0367,
+          "in_gibs": 47.84,
+          "out_gibs": 47.84
+        },
+        "h2d": {
+          "avg_ms": 2.52832,
+          "best_ms": 2.48704,
+          "best_in_gibs": 25.1303,
+          "best_out_gibs": 25.1303,
+          "in_gibs": 24.72,
+          "out_gibs": 24.72
+        },
+        "scatter": {
+          "avg_ms": 0.607587,
+          "best_ms": 0.439648,
+          "best_in_gibs": 142.159,
+          "best_out_gibs": 142.159,
+          "in_gibs": 102.866,
+          "out_gibs": 102.866
+        },
+        "compress": {
+          "avg_ms": 28.482,
+          "best_ms": 19.7369,
+          "best_in_gibs": 19,
+          "best_out_gibs": 8.94469,
+          "in_gibs": 18.8089,
+          "out_gibs": 8.85642
+        },
+        "aggregate": {
+          "avg_ms": 1.0627,
+          "best_ms": 0.714208,
+          "best_in_gibs": 247.183,
+          "best_out_gibs": 247.183,
+          "in_gibs": 237.365,
+          "out_gibs": 237.365
+        },
+        "d2h": {
+          "avg_ms": 11.2472,
+          "best_ms": 7.64867,
+          "best_in_gibs": 23.0812,
+          "best_out_gibs": 23.0812,
+          "in_gibs": 22.4276,
+          "out_gibs": 22.4276
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 36.5101,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 298.153,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.26731,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 14.5,
+      "status": "pass",
+      "throughput_in_gibs": 1.51144,
+      "throughput_out_gibs": 0.507229,
+      "compression_fold": 2.97981,
+      "input_gib": 3.75,
+      "compressed_gib": 1.25847,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 2.48107,
+      "init_s": 0.00435169,
+      "flush_s": 3.62e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.9054,
+          "best_ms": 15.1325,
+          "best_in_gibs": 4.13017,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.69704,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 152.26,
+          "best_ms": 104.271,
+          "best_in_gibs": 3.5964,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.51842,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.0349,
+          "best_ms": 8.31238,
+          "best_in_gibs": 45.3016,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41.2699,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 13.51,
+      "status": "pass",
+      "throughput_in_gibs": 5.46279,
+      "throughput_out_gibs": 2.01878,
+      "compression_fold": 2.70598,
+      "input_gib": 3.75,
+      "compressed_gib": 1.38582,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.686463,
+      "init_s": 0.438824,
+      "flush_s": 1.95e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.29593,
+          "best_ms": 1.27226,
+          "best_in_gibs": 49.1251,
+          "best_out_gibs": 49.1251,
+          "in_gibs": 48.2279,
+          "out_gibs": 48.2279
+        },
+        "h2d": {
+          "avg_ms": 2.52947,
+          "best_ms": 2.49171,
+          "best_in_gibs": 25.0832,
+          "best_out_gibs": 25.0832,
+          "in_gibs": 24.7087,
+          "out_gibs": 24.7087
+        },
+        "scatter": {
+          "avg_ms": 0.486382,
+          "best_ms": 0.439264,
+          "best_in_gibs": 142.283,
+          "best_out_gibs": 142.283,
+          "in_gibs": 128.5,
+          "out_gibs": 128.5
+        },
+        "compress": {
+          "avg_ms": 29.2371,
+          "best_ms": 17.5726,
+          "best_in_gibs": 21.3401,
+          "best_out_gibs": 7.98557,
+          "in_gibs": 18.3231,
+          "out_gibs": 6.76909
+        },
+        "aggregate": {
+          "avg_ms": 0.899054,
+          "best_ms": 0.568128,
+          "best_in_gibs": 246.999,
+          "best_out_gibs": 246.999,
+          "in_gibs": 220.13,
+          "out_gibs": 220.13
+        },
+        "d2h": {
+          "avg_ms": 8.79894,
+          "best_ms": 6.02838,
+          "best_in_gibs": 23.2777,
+          "best_out_gibs": 23.2777,
+          "in_gibs": 22.4923,
+          "out_gibs": 22.4923
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 32.5432,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 285.577,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.06646,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 14.42,
+      "status": "pass",
+      "throughput_in_gibs": 1.57062,
+      "throughput_out_gibs": 0.50689,
+      "compression_fold": 3.09855,
+      "input_gib": 3.75,
+      "compressed_gib": 1.21024,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 2.38759,
+      "init_s": 0.00422283,
+      "flush_s": 1.79e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.8975,
+          "best_ms": 15.5469,
+          "best_in_gibs": 4.0201,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.69878,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 139.885,
+          "best_ms": 96.889,
+          "best_in_gibs": 3.87041,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.82967,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.4425,
+          "best_ms": 6.74946,
+          "best_in_gibs": 55.785,
+          "best_out_gibs": 0.0,
+          "in_gibs": 43.2294,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.72,
+      "status": "pass",
+      "throughput_in_gibs": 5.58291,
+      "throughput_out_gibs": 1.68107,
+      "compression_fold": 3.32105,
+      "input_gib": 3.75,
+      "compressed_gib": 1.12916,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.671693,
+      "init_s": 0.547578,
+      "flush_s": 1.8e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.30182,
+          "best_ms": 1.27184,
+          "best_in_gibs": 49.1415,
+          "best_out_gibs": 49.1415,
+          "in_gibs": 48.0095,
+          "out_gibs": 48.0095
+        },
+        "h2d": {
+          "avg_ms": 2.53544,
+          "best_ms": 2.49091,
+          "best_in_gibs": 25.0912,
+          "best_out_gibs": 25.0912,
+          "in_gibs": 24.6505,
+          "out_gibs": 24.6505
+        },
+        "scatter": {
+          "avg_ms": 0.572347,
+          "best_ms": 0.4392,
+          "best_in_gibs": 142.304,
+          "best_out_gibs": 142.304,
+          "in_gibs": 109.2,
+          "out_gibs": 109.2
+        },
+        "compress": {
+          "avg_ms": 31.417,
+          "best_ms": 29.6542,
+          "best_in_gibs": 25.2915,
+          "best_out_gibs": 7.64005,
+          "in_gibs": 23.8724,
+          "out_gibs": 7.18675
+        },
+        "aggregate": {
+          "avg_ms": 1.14767,
+          "best_ms": 0.908512,
+          "best_in_gibs": 247.247,
+          "best_out_gibs": 247.247,
+          "in_gibs": 196.734,
+          "out_gibs": 196.734
+        },
+        "d2h": {
+          "avg_ms": 9.94641,
+          "best_ms": 9.50106,
+          "best_in_gibs": 23.8457,
+          "best_out_gibs": 23.8457,
+          "in_gibs": 22.7003,
+          "out_gibs": 22.7003
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 43.1841,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 222.471,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.07213,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 14.38,
+      "status": "pass",
+      "throughput_in_gibs": 1.60073,
+      "throughput_out_gibs": 0.498254,
+      "compression_fold": 3.21267,
+      "input_gib": 3.75,
+      "compressed_gib": 1.16725,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 2.34269,
+      "init_s": 0.00426626,
+      "flush_s": 3.88e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.2174,
+          "best_ms": 15.544,
+          "best_in_gibs": 4.02086,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.63006,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 183.765,
+          "best_ms": 179.424,
+          "best_in_gibs": 4.18005,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.0813,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 16.8308,
+          "best_ms": 9.66699,
+          "best_in_gibs": 77.8926,
+          "best_out_gibs": 0.0,
+          "in_gibs": 44.7387,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 13.94,
+      "status": "pass",
+      "throughput_in_gibs": 5.38886,
+      "throughput_out_gibs": 1.6132,
+      "compression_fold": 3.34049,
+      "input_gib": 3.75,
+      "compressed_gib": 1.12259,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.69588,
+      "init_s": 0.535754,
+      "flush_s": 2.43e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.29769,
+          "best_ms": 1.27229,
+          "best_in_gibs": 49.1241,
+          "best_out_gibs": 49.1241,
+          "in_gibs": 48.1624,
+          "out_gibs": 48.1624
+        },
+        "h2d": {
+          "avg_ms": 2.52215,
+          "best_ms": 2.49027,
+          "best_in_gibs": 25.0977,
+          "best_out_gibs": 25.0977,
+          "in_gibs": 24.7804,
+          "out_gibs": 24.7804
+        },
+        "scatter": {
+          "avg_ms": 0.517902,
+          "best_ms": 0.438752,
+          "best_in_gibs": 142.449,
+          "best_out_gibs": 142.449,
+          "in_gibs": 120.679,
+          "out_gibs": 120.679
+        },
+        "compress": {
+          "avg_ms": 52.705,
+          "best_ms": 51.9874,
+          "best_in_gibs": 14.4266,
+          "best_out_gibs": 4.32828,
+          "in_gibs": 14.2302,
+          "out_gibs": 4.25947
+        },
+        "aggregate": {
+          "avg_ms": 1.20842,
+          "best_ms": 0.92816,
+          "best_in_gibs": 242.432,
+          "best_out_gibs": 242.432,
+          "in_gibs": 185.776,
+          "out_gibs": 185.776
+        },
+        "d2h": {
+          "avg_ms": 10.0056,
+          "best_ms": 9.58547,
+          "best_in_gibs": 23.4747,
+          "best_out_gibs": 23.4747,
+          "in_gibs": 22.437,
+          "out_gibs": 22.437
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 65.5402,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 329.512,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.0726,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 14.65,
+      "status": "pass",
+      "throughput_in_gibs": 1.43927,
+      "throughput_out_gibs": 0.490303,
+      "compression_fold": 2.93548,
+      "input_gib": 3.75,
+      "compressed_gib": 1.27747,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 2.60548,
+      "init_s": 0.00419053,
+      "flush_s": 1.66e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.6294,
+          "best_ms": 15.2007,
+          "best_in_gibs": 4.11166,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.7584,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 242.065,
+          "best_ms": 237.981,
+          "best_in_gibs": 3.15151,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.09835,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 18.4766,
+          "best_ms": 11.0598,
+          "best_in_gibs": 68.0814,
+          "best_out_gibs": 0.0,
+          "in_gibs": 40.7523,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.84,
+      "status": "pass",
+      "throughput_in_gibs": 4.42177,
+      "throughput_out_gibs": 1.03041,
+      "compression_fold": 4.29129,
+      "input_gib": 3.75,
+      "compressed_gib": 0.873863,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.848077,
+      "init_s": 0.560144,
+      "flush_s": 2.13e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.28674,
+          "best_ms": 1.27279,
+          "best_in_gibs": 49.1046,
+          "best_out_gibs": 49.1046,
+          "in_gibs": 48.5723,
+          "out_gibs": 48.5723
+        },
+        "h2d": {
+          "avg_ms": 2.51542,
+          "best_ms": 2.48992,
+          "best_in_gibs": 25.1012,
+          "best_out_gibs": 25.1012,
+          "in_gibs": 24.8467,
+          "out_gibs": 24.8467
+        },
+        "scatter": {
+          "avg_ms": 0.501124,
+          "best_ms": 0.438848,
+          "best_in_gibs": 142.418,
+          "best_out_gibs": 142.418,
+          "in_gibs": 124.72,
+          "out_gibs": 124.72
+        },
+        "compress": {
+          "avg_ms": 91.8522,
+          "best_ms": 83.0376,
+          "best_in_gibs": 9.03205,
+          "best_out_gibs": 2.10069,
+          "in_gibs": 8.16529,
+          "out_gibs": 1.90263
+        },
+        "aggregate": {
+          "avg_ms": 1.00277,
+          "best_ms": 0.728416,
+          "best_in_gibs": 240.217,
+          "best_out_gibs": 240.217,
+          "in_gibs": 174.278,
+          "out_gibs": 174.278
+        },
+        "d2h": {
+          "avg_ms": 8.02316,
+          "best_ms": 7.52016,
+          "best_in_gibs": 23.1958,
+          "best_out_gibs": 23.1958,
+          "in_gibs": 21.7821,
+          "out_gibs": 21.7821
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 155.48,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 481.288,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 31.0882,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 14.69,
+      "status": "pass",
+      "throughput_in_gibs": 1.42048,
+      "throughput_out_gibs": 0.492767,
+      "compression_fold": 2.88266,
+      "input_gib": 3.75,
+      "compressed_gib": 1.30088,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 2.63995,
+      "init_s": 0.00467527,
+      "flush_s": 2.37e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.66,
+          "best_ms": 15.1055,
+          "best_in_gibs": 4.13756,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.7515,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 247.99,
+          "best_ms": 241.854,
+          "best_in_gibs": 3.10104,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.02432,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 18.5528,
+          "best_ms": 11.305,
+          "best_in_gibs": 66.6038,
+          "best_out_gibs": 0.0,
+          "in_gibs": 40.5843,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 14.12,
+      "status": "pass",
+      "throughput_in_gibs": 3.72454,
+      "throughput_out_gibs": 0.690916,
+      "compression_fold": 5.39072,
+      "input_gib": 3.75,
+      "compressed_gib": 0.695639,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 1.00684,
+      "init_s": 0.539947,
+      "flush_s": 1.69e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.34819,
+          "best_ms": 1.27358,
+          "best_in_gibs": 49.0743,
+          "best_out_gibs": 49.0743,
+          "in_gibs": 46.3584,
+          "out_gibs": 46.3584
+        },
+        "h2d": {
+          "avg_ms": 2.51482,
+          "best_ms": 2.48925,
+          "best_in_gibs": 25.108,
+          "best_out_gibs": 25.108,
+          "in_gibs": 24.8527,
+          "out_gibs": 24.8527
+        },
+        "scatter": {
+          "avg_ms": 0.469259,
+          "best_ms": 0.4392,
+          "best_in_gibs": 142.304,
+          "best_out_gibs": 142.304,
+          "in_gibs": 133.189,
+          "out_gibs": 133.189
+        },
+        "compress": {
+          "avg_ms": 140.367,
+          "best_ms": 120.372,
+          "best_in_gibs": 6.23066,
+          "best_out_gibs": 1.15624,
+          "in_gibs": 5.34312,
+          "out_gibs": 0.991114
+        },
+        "aggregate": {
+          "avg_ms": 0.969114,
+          "best_ms": 0.69536,
+          "best_in_gibs": 199.941,
+          "best_out_gibs": 199.941,
+          "in_gibs": 143.554,
+          "out_gibs": 143.554
+        },
+        "d2h": {
+          "avg_ms": 6.5174,
+          "best_ms": 6.00842,
+          "best_in_gibs": 23.1641,
+          "best_out_gibs": 23.1641,
+          "in_gibs": 21.346,
+          "out_gibs": 21.346
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 258.648,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 720.543,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 86.5014,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 14.67,
+      "status": "pass",
+      "throughput_in_gibs": 1.42912,
+      "throughput_out_gibs": 0.493566,
+      "compression_fold": 2.89549,
+      "input_gib": 3.75,
+      "compressed_gib": 1.29512,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 2.624,
+      "init_s": 0.00421145,
+      "flush_s": 3.05e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.6127,
+          "best_ms": 14.972,
+          "best_in_gibs": 4.17447,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.76217,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 246.978,
+          "best_ms": 242.206,
+          "best_in_gibs": 3.09654,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.03671,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 17.928,
+          "best_ms": 10.5407,
+          "best_in_gibs": 71.4325,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41.9985,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 13.67,
+      "status": "pass",
+      "throughput_in_gibs": 5.78266,
+      "throughput_out_gibs": 0.715329,
+      "compression_fold": 8.08391,
+      "input_gib": 3.75,
+      "compressed_gib": 0.463885,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.648491,
+      "init_s": 0.430619,
+      "flush_s": 3.22e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.29671,
+          "best_ms": 1.2742,
+          "best_in_gibs": 49.0505,
+          "best_out_gibs": 49.0505,
+          "in_gibs": 48.199,
+          "out_gibs": 48.199
+        },
+        "h2d": {
+          "avg_ms": 2.51593,
+          "best_ms": 2.49155,
+          "best_in_gibs": 25.0848,
+          "best_out_gibs": 25.0848,
+          "in_gibs": 24.8418,
+          "out_gibs": 24.8418
+        },
+        "scatter": {
+          "avg_ms": 1.38655,
+          "best_ms": 0.441056,
+          "best_in_gibs": 141.705,
+          "best_out_gibs": 141.705,
+          "in_gibs": 45.076,
+          "out_gibs": 45.076
+        },
+        "compress": {
+          "avg_ms": 50.7716,
+          "best_ms": 35.0192,
+          "best_in_gibs": 10.7084,
+          "best_out_gibs": 1.31412,
+          "in_gibs": 10.5515,
+          "out_gibs": 1.29494
+        },
+        "aggregate": {
+          "avg_ms": 0.409559,
+          "best_ms": 0.174432,
+          "best_in_gibs": 263.825,
+          "best_out_gibs": 263.825,
+          "in_gibs": 160.529,
+          "out_gibs": 160.529
+        },
+        "d2h": {
+          "avg_ms": 3.17303,
+          "best_ms": 2.02518,
+          "best_in_gibs": 22.7236,
+          "best_out_gibs": 22.7236,
+          "in_gibs": 20.7202,
+          "out_gibs": 20.7202
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 69.8754,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 372.498,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 20.228,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 15.69,
+      "status": "pass",
+      "throughput_in_gibs": 1.0251,
+      "throughput_out_gibs": 0.091237,
+      "compression_fold": 11.2356,
+      "input_gib": 3.75,
+      "compressed_gib": 0.333762,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 3.65818,
+      "init_s": 0.00461577,
+      "flush_s": 1.85e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 19.9099,
+          "best_ms": 18.1482,
+          "best_in_gibs": 3.44386,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.13914,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 299.563,
+          "best_ms": 211.014,
+          "best_in_gibs": 1.77713,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.78832,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.17393,
+          "best_ms": 5.05351,
+          "best_in_gibs": 74.7493,
+          "best_out_gibs": 0.0,
+          "in_gibs": 87.4059,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 13.64,
+      "status": "pass",
+      "throughput_in_gibs": 4.76373,
+      "throughput_out_gibs": 0.577572,
+      "compression_fold": 8.24786,
+      "input_gib": 3.75,
+      "compressed_gib": 0.454663,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.787198,
+      "init_s": 0.440617,
+      "flush_s": 1.77e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.66433,
+          "best_ms": 1.26926,
+          "best_in_gibs": 49.2411,
+          "best_out_gibs": 49.2411,
+          "in_gibs": 37.5526,
+          "out_gibs": 37.5526
+        },
+        "h2d": {
+          "avg_ms": 2.50836,
+          "best_ms": 2.48947,
+          "best_in_gibs": 25.1057,
+          "best_out_gibs": 25.1057,
+          "in_gibs": 24.9167,
+          "out_gibs": 24.9167
+        },
+        "scatter": {
+          "avg_ms": 1.45132,
+          "best_ms": 0.439264,
+          "best_in_gibs": 142.283,
+          "best_out_gibs": 142.283,
+          "in_gibs": 43.0643,
+          "out_gibs": 43.0643
+        },
+        "compress": {
+          "avg_ms": 52.0237,
+          "best_ms": 36.5937,
+          "best_in_gibs": 10.2477,
+          "best_out_gibs": 1.23854,
+          "in_gibs": 10.2975,
+          "out_gibs": 1.24348
+        },
+        "aggregate": {
+          "avg_ms": 0.267721,
+          "best_ms": 0.165312,
+          "best_in_gibs": 274.166,
+          "best_out_gibs": 274.166,
+          "in_gibs": 241.633,
+          "out_gibs": 241.633
+        },
+        "d2h": {
+          "avg_ms": 3.03773,
+          "best_ms": 1.98742,
+          "best_in_gibs": 22.8048,
+          "best_out_gibs": 22.8048,
+          "in_gibs": 21.2956,
+          "out_gibs": 21.2956
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 61.286,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 391.438,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.49489,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 15.44,
+      "status": "pass",
+      "throughput_in_gibs": 1.09497,
+      "throughput_out_gibs": 0.100678,
+      "compression_fold": 10.876,
+      "input_gib": 3.75,
+      "compressed_gib": 0.344796,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 3.42474,
+      "init_s": 0.00468901,
+      "flush_s": 2.53e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.998,
+          "best_ms": 15.1026,
+          "best_in_gibs": 4.13835,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.6769,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 291.816,
+          "best_ms": 206.565,
+          "best_in_gibs": 1.81541,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.83579,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.5193,
+          "best_ms": 4.38246,
+          "best_in_gibs": 86.028,
+          "best_out_gibs": 0.0,
+          "in_gibs": 82.6149,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.69,
+      "status": "pass",
+      "throughput_in_gibs": 4.61748,
+      "throughput_out_gibs": 0.53987,
+      "compression_fold": 8.55294,
+      "input_gib": 3.75,
+      "compressed_gib": 0.438446,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.812131,
+      "init_s": 0.438095,
+      "flush_s": 1.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.12193,
+          "best_ms": 2.09912,
+          "best_in_gibs": 29.7744,
+          "best_out_gibs": 29.7744,
+          "in_gibs": 29.4543,
+          "out_gibs": 29.4543
+        },
+        "h2d": {
+          "avg_ms": 2.50779,
+          "best_ms": 2.49078,
+          "best_in_gibs": 25.0925,
+          "best_out_gibs": 25.0925,
+          "in_gibs": 24.9223,
+          "out_gibs": 24.9223
+        },
+        "scatter": {
+          "avg_ms": 1.2912,
+          "best_ms": 0.43936,
+          "best_in_gibs": 142.252,
+          "best_out_gibs": 142.252,
+          "in_gibs": 48.4044,
+          "out_gibs": 48.4044
+        },
+        "compress": {
+          "avg_ms": 53.2389,
+          "best_ms": 35.3662,
+          "best_in_gibs": 10.6033,
+          "best_out_gibs": 1.23722,
+          "in_gibs": 10.0625,
+          "out_gibs": 1.17403
+        },
+        "aggregate": {
+          "avg_ms": 0.374281,
+          "best_ms": 0.140544,
+          "best_in_gibs": 311.331,
+          "best_out_gibs": 311.331,
+          "in_gibs": 166.998,
+          "out_gibs": 166.998
+        },
+        "d2h": {
+          "avg_ms": 2.91436,
+          "best_ms": 1.95005,
+          "best_in_gibs": 22.4382,
+          "best_out_gibs": 22.4382,
+          "in_gibs": 21.447,
+          "out_gibs": 21.447
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 64.6098,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 401.347,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.38009,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 15.33,
+      "status": "pass",
+      "throughput_in_gibs": 1.1301,
+      "throughput_out_gibs": 0.101289,
+      "compression_fold": 11.1572,
+      "input_gib": 3.75,
+      "compressed_gib": 0.336106,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 3.3183,
+      "init_s": 0.00444718,
+      "flush_s": 1.67e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.9093,
+          "best_ms": 15.611,
+          "best_in_gibs": 4.00359,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.69619,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 278.71,
+          "best_ms": 196.921,
+          "best_in_gibs": 1.90432,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.92212,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.11113,
+          "best_ms": 4.73085,
+          "best_in_gibs": 79.6152,
+          "best_out_gibs": 0.0,
+          "in_gibs": 88.0473,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 13.62,
+      "status": "pass",
+      "throughput_in_gibs": 4.66007,
+      "throughput_out_gibs": 0.540022,
+      "compression_fold": 8.62941,
+      "input_gib": 3.75,
+      "compressed_gib": 0.434561,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.804709,
+      "init_s": 0.422141,
+      "flush_s": 2.67e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.28666,
+          "best_ms": 1.27342,
+          "best_in_gibs": 49.0805,
+          "best_out_gibs": 49.0805,
+          "in_gibs": 48.5754,
+          "out_gibs": 48.5754
+        },
+        "h2d": {
+          "avg_ms": 2.51067,
+          "best_ms": 2.48762,
+          "best_in_gibs": 25.1245,
+          "best_out_gibs": 25.1245,
+          "in_gibs": 24.8937,
+          "out_gibs": 24.8937
+        },
+        "scatter": {
+          "avg_ms": 1.20326,
+          "best_ms": 0.439616,
+          "best_in_gibs": 142.17,
+          "best_out_gibs": 142.17,
+          "in_gibs": 51.9423,
+          "out_gibs": 51.9423
+        },
+        "compress": {
+          "avg_ms": 58.972,
+          "best_ms": 39.5042,
+          "best_in_gibs": 9.49266,
+          "best_out_gibs": 1.0989,
+          "in_gibs": 9.08421,
+          "out_gibs": 1.05159
+        },
+        "aggregate": {
+          "avg_ms": 0.267337,
+          "best_ms": 0.13696,
+          "best_in_gibs": 316.962,
+          "best_out_gibs": 316.962,
+          "in_gibs": 231.972,
+          "out_gibs": 231.972
+        },
+        "d2h": {
+          "avg_ms": 3.03275,
+          "best_ms": 1.95818,
+          "best_in_gibs": 22.1691,
+          "best_out_gibs": 22.1691,
+          "in_gibs": 20.4483,
+          "out_gibs": 20.4483
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 96.8038,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 430.434,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 12.1447,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 15.2,
+      "status": "pass",
+      "throughput_in_gibs": 1.1723,
+      "throughput_out_gibs": 0.103167,
+      "compression_fold": 11.3631,
+      "input_gib": 3.75,
+      "compressed_gib": 0.330016,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 3.19885,
+      "init_s": 0.00457677,
+      "flush_s": 2.43e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.0065,
+          "best_ms": 15.4031,
+          "best_in_gibs": 4.05762,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.67507,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 261.576,
+          "best_ms": 183.334,
+          "best_in_gibs": 2.04545,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.04802,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.71963,
+          "best_ms": 4.29566,
+          "best_in_gibs": 87.6383,
+          "best_out_gibs": 0.0,
+          "in_gibs": 94.0283,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.92,
+      "status": "pass",
+      "throughput_in_gibs": 5.23227,
+      "throughput_out_gibs": 0.60191,
+      "compression_fold": 8.69277,
+      "input_gib": 3.75,
+      "compressed_gib": 0.431393,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.716706,
+      "init_s": 0.552921,
+      "flush_s": 2.33e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.29949,
+          "best_ms": 1.2763,
+          "best_in_gibs": 48.9698,
+          "best_out_gibs": 48.9698,
+          "in_gibs": 48.096,
+          "out_gibs": 48.096
+        },
+        "h2d": {
+          "avg_ms": 2.50666,
+          "best_ms": 2.49082,
+          "best_in_gibs": 25.0922,
+          "best_out_gibs": 25.0922,
+          "in_gibs": 24.9336,
+          "out_gibs": 24.9336
+        },
+        "scatter": {
+          "avg_ms": 1.1543,
+          "best_ms": 0.438976,
+          "best_in_gibs": 142.377,
+          "best_out_gibs": 142.377,
+          "in_gibs": 54.1454,
+          "out_gibs": 54.1454
+        },
+        "compress": {
+          "avg_ms": 82.0692,
+          "best_ms": 73.2493,
+          "best_in_gibs": 10.239,
+          "best_out_gibs": 1.17725,
+          "in_gibs": 9.13863,
+          "out_gibs": 1.05073
+        },
+        "aggregate": {
+          "avg_ms": 0.619648,
+          "best_ms": 0.359104,
+          "best_in_gibs": 240.133,
+          "best_out_gibs": 240.133,
+          "in_gibs": 139.164,
+          "out_gibs": 139.164
+        },
+        "d2h": {
+          "avg_ms": 4.28079,
+          "best_ms": 3.82118,
+          "best_in_gibs": 22.567,
+          "best_out_gibs": 22.567,
+          "in_gibs": 20.1441,
+          "out_gibs": 20.1441
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 126.519,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 423.81,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 34.9623,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 15.24,
+      "status": "pass",
+      "throughput_in_gibs": 1.16521,
+      "throughput_out_gibs": 0.101594,
+      "compression_fold": 11.4692,
+      "input_gib": 3.75,
+      "compressed_gib": 0.326962,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 3.2183,
+      "init_s": 0.00419541,
+      "flush_s": 1.94e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.0261,
+          "best_ms": 15.3091,
+          "best_in_gibs": 4.08255,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.67084,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 370.38,
+          "best_ms": 366.835,
+          "best_in_gibs": 2.04451,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.02495,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.31068,
+          "best_ms": 5.32349,
+          "best_in_gibs": 141.435,
+          "best_out_gibs": 0.0,
+          "in_gibs": 102.99,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 13.69,
+      "status": "pass",
+      "throughput_in_gibs": 5.10653,
+      "throughput_out_gibs": 0.589823,
+      "compression_fold": 8.65775,
+      "input_gib": 3.75,
+      "compressed_gib": 0.433138,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.734353,
+      "init_s": 0.534606,
+      "flush_s": 4.29e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.67732,
+          "best_ms": 1.2731,
+          "best_in_gibs": 49.0929,
+          "best_out_gibs": 49.0929,
+          "in_gibs": 37.2619,
+          "out_gibs": 37.2619
+        },
+        "h2d": {
+          "avg_ms": 2.51303,
+          "best_ms": 2.48995,
+          "best_in_gibs": 25.1009,
+          "best_out_gibs": 25.1009,
+          "in_gibs": 24.8704,
+          "out_gibs": 24.8704
+        },
+        "scatter": {
+          "avg_ms": 0.868073,
+          "best_ms": 0.43904,
+          "best_in_gibs": 142.356,
+          "best_out_gibs": 142.356,
+          "in_gibs": 71.9985,
+          "out_gibs": 71.9985
+        },
+        "compress": {
+          "avg_ms": 83.6129,
+          "best_ms": 77.9114,
+          "best_in_gibs": 9.62632,
+          "best_out_gibs": 1.11159,
+          "in_gibs": 8.96991,
+          "out_gibs": 1.03578
+        },
+        "aggregate": {
+          "avg_ms": 0.502522,
+          "best_ms": 0.362624,
+          "best_in_gibs": 238.829,
+          "best_out_gibs": 238.829,
+          "in_gibs": 172.34,
+          "out_gibs": 172.34
+        },
+        "d2h": {
+          "avg_ms": 4.294,
+          "best_ms": 3.7351,
+          "best_in_gibs": 23.1868,
+          "best_out_gibs": 23.1868,
+          "in_gibs": 20.1687,
+          "out_gibs": 20.1687
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 111.245,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 431.294,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 36.6932,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 15.07,
+      "status": "pass",
+      "throughput_in_gibs": 1.22019,
+      "throughput_out_gibs": 0.104341,
+      "compression_fold": 11.6943,
+      "input_gib": 3.75,
+      "compressed_gib": 0.32067,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 3.0733,
+      "init_s": 0.00413624,
+      "flush_s": 1.63e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.704,
+          "best_ms": 15.0523,
+          "best_in_gibs": 4.1522,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.74162,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 346.815,
+          "best_ms": 341.217,
+          "best_in_gibs": 2.19802,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.16254,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.99723,
+          "best_ms": 4.95843,
+          "best_in_gibs": 151.848,
+          "best_out_gibs": 0.0,
+          "in_gibs": 107.604,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.95643,
+      "throughput_out_gibs": 0.58152,
+      "compression_fold": 8.52324,
+      "input_gib": 3.75,
+      "compressed_gib": 0.439974,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.756593,
+      "init_s": 0.558592,
+      "flush_s": 2.39e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.29008,
+          "best_ms": 1.27285,
+          "best_in_gibs": 49.1025,
+          "best_out_gibs": 49.1025,
+          "in_gibs": 48.4467,
+          "out_gibs": 48.4467
+        },
+        "h2d": {
+          "avg_ms": 2.51154,
+          "best_ms": 2.48918,
+          "best_in_gibs": 25.1086,
+          "best_out_gibs": 25.1086,
+          "in_gibs": 24.8851,
+          "out_gibs": 24.8851
+        },
+        "scatter": {
+          "avg_ms": 0.791053,
+          "best_ms": 0.4392,
+          "best_in_gibs": 142.304,
+          "best_out_gibs": 142.304,
+          "in_gibs": 79.0086,
+          "out_gibs": 79.0086
+        },
+        "compress": {
+          "avg_ms": 88.0699,
+          "best_ms": 82.9221,
+          "best_in_gibs": 9.04464,
+          "best_out_gibs": 1.06103,
+          "in_gibs": 8.51596,
+          "out_gibs": 0.999016
+        },
+        "aggregate": {
+          "avg_ms": 0.618995,
+          "best_ms": 0.35072,
+          "best_in_gibs": 250.864,
+          "best_out_gibs": 250.864,
+          "in_gibs": 142.139,
+          "out_gibs": 142.139
+        },
+        "d2h": {
+          "avg_ms": 4.43152,
+          "best_ms": 3.90246,
+          "best_in_gibs": 22.5455,
+          "best_out_gibs": 22.5455,
+          "in_gibs": 19.854,
+          "out_gibs": 19.854
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 134.472,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 454.412,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 42.4829,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 15.07,
+      "status": "pass",
+      "throughput_in_gibs": 1.22246,
+      "throughput_out_gibs": 0.102004,
+      "compression_fold": 11.9844,
+      "input_gib": 3.75,
+      "compressed_gib": 0.312906,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 3.06759,
+      "init_s": 0.00415172,
+      "flush_s": 1.98e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.7558,
+          "best_ms": 14.8939,
+          "best_in_gibs": 4.19634,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.73006,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 343.817,
+          "best_ms": 340.012,
+          "best_in_gibs": 2.2058,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.18139,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.67836,
+          "best_ms": 4.74288,
+          "best_in_gibs": 158.749,
+          "best_out_gibs": 0.0,
+          "in_gibs": 112.742,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 13.87,
+      "status": "pass",
+      "throughput_in_gibs": 4.2325,
+      "throughput_out_gibs": 0.495118,
+      "compression_fold": 8.54847,
+      "input_gib": 3.75,
+      "compressed_gib": 0.438675,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.886001,
+      "init_s": 0.550429,
+      "flush_s": 2.29e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.06226,
+          "best_ms": 1.28117,
+          "best_in_gibs": 48.7837,
+          "best_out_gibs": 48.7837,
+          "in_gibs": 30.3066,
+          "out_gibs": 30.3066
+        },
+        "h2d": {
+          "avg_ms": 2.50594,
+          "best_ms": 2.49024,
+          "best_in_gibs": 25.098,
+          "best_out_gibs": 25.098,
+          "in_gibs": 24.9407,
+          "out_gibs": 24.9407
+        },
+        "scatter": {
+          "avg_ms": 0.810143,
+          "best_ms": 0.439136,
+          "best_in_gibs": 142.325,
+          "best_out_gibs": 142.325,
+          "in_gibs": 77.1469,
+          "out_gibs": 77.1469
+        },
+        "compress": {
+          "avg_ms": 87.3169,
+          "best_ms": 83.5454,
+          "best_in_gibs": 8.97716,
+          "best_out_gibs": 1.05005,
+          "in_gibs": 8.5894,
+          "out_gibs": 1.0047
+        },
+        "aggregate": {
+          "avg_ms": 0.701696,
+          "best_ms": 0.424704,
+          "best_in_gibs": 206.56,
+          "best_out_gibs": 206.56,
+          "in_gibs": 125.022,
+          "out_gibs": 125.022
+        },
+        "d2h": {
+          "avg_ms": 4.34171,
+          "best_ms": 3.86781,
+          "best_in_gibs": 22.6813,
+          "best_out_gibs": 22.6813,
+          "in_gibs": 20.2057,
+          "out_gibs": 20.2057
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 119.988,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 451.04,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 32.4986,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 15.07,
+      "status": "pass",
+      "throughput_in_gibs": 1.23204,
+      "throughput_out_gibs": 0.101688,
+      "compression_fold": 12.1159,
+      "input_gib": 3.75,
+      "compressed_gib": 0.309511,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 3.04374,
+      "init_s": 0.0041264,
+      "flush_s": 1.54e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.8084,
+          "best_ms": 15.0477,
+          "best_in_gibs": 4.15345,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.71838,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 339.394,
+          "best_ms": 336.489,
+          "best_in_gibs": 2.2289,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.20982,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.71088,
+          "best_ms": 4.86966,
+          "best_in_gibs": 154.617,
+          "best_out_gibs": 0.0,
+          "in_gibs": 112.195,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 14.76,
+      "status": "pass",
+      "throughput_in_gibs": 1.38568,
+      "throughput_out_gibs": 0.926106,
+      "compression_fold": 1.49624,
+      "input_gib": 3.75,
+      "compressed_gib": 2.50627,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 2.70625,
+      "init_s": 0.00475089,
+      "flush_s": 1.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 19.7964,
+          "best_ms": 17.7293,
+          "best_in_gibs": 3.52523,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.15715,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 147.677,
+          "best_ms": 100.384,
+          "best_in_gibs": 3.73564,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.62762,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 23.3582,
+          "best_ms": 12.9386,
+          "best_in_gibs": 29.0113,
+          "best_out_gibs": 0.0,
+          "in_gibs": 22.9572,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 14.45,
+      "status": "pass",
+      "throughput_in_gibs": 1.56247,
+      "throughput_out_gibs": 0.93447,
+      "compression_fold": 1.67204,
+      "input_gib": 3.75,
+      "compressed_gib": 2.24277,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 2.40005,
+      "init_s": 0.00461712,
+      "flush_s": 1.53e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.1661,
+          "best_ms": 15.8682,
+          "best_in_gibs": 3.9387,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.6409,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 130.274,
+          "best_ms": 89.2091,
+          "best_in_gibs": 4.20361,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.11221,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 21.0682,
+          "best_ms": 10.361,
+          "best_in_gibs": 36.2111,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25.44,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 14.55,
+      "status": "pass",
+      "throughput_in_gibs": 1.52027,
+      "throughput_out_gibs": 0.95829,
+      "compression_fold": 1.58644,
+      "input_gib": 3.75,
+      "compressed_gib": 2.36378,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 2.46666,
+      "init_s": 0.00456289,
+      "flush_s": 2.63e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.2275,
+          "best_ms": 15.7008,
+          "best_in_gibs": 3.98069,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.62792,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 138.629,
+          "best_ms": 95.0859,
+          "best_in_gibs": 3.9438,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.86437,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 21.3739,
+          "best_ms": 10.6213,
+          "best_in_gibs": 35.3149,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25.07,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 14.51,
+      "status": "pass",
+      "throughput_in_gibs": 1.50633,
+      "throughput_out_gibs": 0.982867,
+      "compression_fold": 1.53259,
+      "input_gib": 3.75,
+      "compressed_gib": 2.44684,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 2.4895,
+      "init_s": 0.00428583,
+      "flush_s": 1.8e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.8621,
+          "best_ms": 15.5255,
+          "best_in_gibs": 4.02564,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.70653,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 144.691,
+          "best_ms": 99.2246,
+          "best_in_gibs": 3.77931,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.70246,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 22.5395,
+          "best_ms": 12.5896,
+          "best_in_gibs": 29.7901,
+          "best_out_gibs": 0.0,
+          "in_gibs": 23.7707,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 14.59,
+      "status": "pass",
+      "throughput_in_gibs": 1.49906,
+      "throughput_out_gibs": 0.97794,
+      "compression_fold": 1.53287,
+      "input_gib": 3.75,
+      "compressed_gib": 2.44639,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 2.50157,
+      "init_s": 0.00431609,
+      "flush_s": 1.66e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.0107,
+          "best_ms": 15.4359,
+          "best_in_gibs": 4.049,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.67416,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 202.307,
+          "best_ms": 195.587,
+          "best_in_gibs": 3.83461,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.70724,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 32.1603,
+          "best_ms": 18.5168,
+          "best_in_gibs": 40.5061,
+          "best_out_gibs": 0.0,
+          "in_gibs": 23.3221,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 14.38,
+      "status": "pass",
+      "throughput_in_gibs": 1.62406,
+      "throughput_out_gibs": 0.888023,
+      "compression_fold": 1.82885,
+      "input_gib": 3.75,
+      "compressed_gib": 2.05047,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 2.30903,
+      "init_s": 0.00407639,
+      "flush_s": 2.75e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.6778,
+          "best_ms": 15.0446,
+          "best_in_gibs": 4.15431,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.74749,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 170.935,
+          "best_ms": 164.355,
+          "best_in_gibs": 4.5633,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.38764,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 28.1947,
+          "best_ms": 15.992,
+          "best_in_gibs": 46.9,
+          "best_out_gibs": 0.0,
+          "in_gibs": 26.6015,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 14.42,
+      "status": "pass",
+      "throughput_in_gibs": 1.60555,
+      "throughput_out_gibs": 0.905307,
+      "compression_fold": 1.77349,
+      "input_gib": 3.75,
+      "compressed_gib": 2.11448,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 2.33565,
+      "init_s": 0.00407984,
+      "flush_s": 3.13e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.6943,
+          "best_ms": 15.1172,
+          "best_in_gibs": 4.13437,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.7438,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 177.49,
+          "best_ms": 169.48,
+          "best_in_gibs": 4.42529,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.22559,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 27.9452,
+          "best_ms": 16.1701,
+          "best_in_gibs": 46.3827,
+          "best_out_gibs": 0.0,
+          "in_gibs": 26.8387,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 14.46,
+      "status": "pass",
+      "throughput_in_gibs": 1.59609,
+      "throughput_out_gibs": 0.899951,
+      "compression_fold": 1.77353,
+      "input_gib": 3.75,
+      "compressed_gib": 2.11443,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 2.34949,
+      "init_s": 0.00423778,
+      "flush_s": 2.64e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.6643,
+          "best_ms": 15.0689,
+          "best_in_gibs": 4.14763,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.75053,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 182.182,
+          "best_ms": 171.079,
+          "best_in_gibs": 4.38395,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.11675,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 27.2215,
+          "best_ms": 15.8555,
+          "best_in_gibs": 47.3028,
+          "best_out_gibs": 0.0,
+          "in_gibs": 27.552,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 15.11,
+      "status": "pass",
+      "throughput_in_gibs": 1.202,
+      "throughput_out_gibs": 0.0388832,
+      "compression_fold": 30.9131,
+      "input_gib": 3.75,
+      "compressed_gib": 0.121308,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 3.1198,
+      "init_s": 0.00439246,
+      "flush_s": 1.63e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 19.9869,
+          "best_ms": 17.8529,
+          "best_in_gibs": 3.50083,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.12705,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 224.113,
+          "best_ms": 156.009,
+          "best_in_gibs": 2.4037,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.39037,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.71414,
+          "best_ms": 4.19187,
+          "best_in_gibs": 134.319,
+          "best_out_gibs": 0.0,
+          "in_gibs": 113.751,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 14.84,
+      "status": "pass",
+      "throughput_in_gibs": 1.31721,
+      "throughput_out_gibs": 0.0296158,
+      "compression_fold": 44.4765,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0843141,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 2.84693,
+      "init_s": 0.00425398,
+      "flush_s": 1.59e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.1184,
+          "best_ms": 15.4441,
+          "best_in_gibs": 4.04685,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.65103,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 210.287,
+          "best_ms": 146.823,
+          "best_in_gibs": 2.55409,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.54754,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.2708,
+          "best_ms": 3.70092,
+          "best_in_gibs": 101.376,
+          "best_out_gibs": 0.0,
+          "in_gibs": 125.498,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 14.64,
+      "status": "pass",
+      "throughput_in_gibs": 1.4448,
+      "throughput_out_gibs": 0.0336438,
+      "compression_fold": 42.9439,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0873231,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 2.59552,
+      "init_s": 0.00453709,
+      "flush_s": 3.4e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.8918,
+          "best_ms": 15.4356,
+          "best_in_gibs": 4.04908,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.70003,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 176.694,
+          "best_ms": 122.125,
+          "best_in_gibs": 3.07063,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.03187,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.13986,
+          "best_ms": 3.89453,
+          "best_in_gibs": 144.469,
+          "best_out_gibs": 0.0,
+          "in_gibs": 129.436,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 14.52,
+      "status": "pass",
+      "throughput_in_gibs": 1.4972,
+      "throughput_out_gibs": 0.0337051,
+      "compression_fold": 44.4205,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0844204,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 2.50468,
+      "init_s": 0.00445524,
+      "flush_s": 2.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.9518,
+          "best_ms": 15.4545,
+          "best_in_gibs": 4.04413,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.68693,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 164.565,
+          "best_ms": 113.112,
+          "best_in_gibs": 3.3153,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.25534,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.25448,
+          "best_ms": 3.54666,
+          "best_in_gibs": 105.746,
+          "best_out_gibs": 0.0,
+          "in_gibs": 125.933,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 14.52,
+      "status": "pass",
+      "throughput_in_gibs": 1.49613,
+      "throughput_out_gibs": 0.0334985,
+      "compression_fold": 44.6627,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0839627,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 2.50646,
+      "init_s": 0.0041181,
+      "flush_s": 1.54e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 17.1136,
+          "best_ms": 15.2513,
+          "best_in_gibs": 4.09802,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.65206,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 229.423,
+          "best_ms": 222.831,
+          "best_in_gibs": 3.36578,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.26908,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.46576,
+          "best_ms": 3.9404,
+          "best_in_gibs": 190.348,
+          "best_out_gibs": 0.0,
+          "in_gibs": 167.955,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 14.15,
+      "status": "pass",
+      "throughput_in_gibs": 1.75104,
+      "throughput_out_gibs": 0.0245713,
+      "compression_fold": 71.2635,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0526216,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 2.14159,
+      "init_s": 0.0043098,
+      "flush_s": 2.21e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.7055,
+          "best_ms": 15.0782,
+          "best_in_gibs": 4.14505,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.74128,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 162.086,
+          "best_ms": 157.757,
+          "best_in_gibs": 4.75416,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.62716,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.35555,
+          "best_ms": 3.85683,
+          "best_in_gibs": 194.466,
+          "best_out_gibs": 0.0,
+          "in_gibs": 172.199,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 14.03,
+      "status": "pass",
+      "throughput_in_gibs": 1.87214,
+      "throughput_out_gibs": 0.0281467,
+      "compression_fold": 66.5137,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0563794,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 2.00306,
+      "init_s": 0.0040808,
+      "flush_s": 1.55e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.5725,
+          "best_ms": 14.8434,
+          "best_in_gibs": 4.21063,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.7713,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 136.002,
+          "best_ms": 132.596,
+          "best_in_gibs": 5.65629,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.51461,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.14521,
+          "best_ms": 3.55505,
+          "best_in_gibs": 210.971,
+          "best_out_gibs": 0.0,
+          "in_gibs": 180.935,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 14.1,
+      "status": "pass",
+      "throughput_in_gibs": 1.84034,
+      "throughput_out_gibs": 0.0276452,
+      "compression_fold": 66.57,
+      "input_gib": 3.75,
+      "compressed_gib": 0.0563317,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 2.03767,
+      "init_s": 0.00418553,
+      "flush_s": 2.22e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.7354,
+          "best_ms": 15.3557,
+          "best_in_gibs": 4.07015,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.73459,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 140.805,
+          "best_ms": 135.403,
+          "best_in_gibs": 5.53904,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.32652,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.16934,
+          "best_ms": 3.67437,
+          "best_in_gibs": 204.119,
+          "best_out_gibs": 0.0,
+          "in_gibs": 179.886,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 32.09,
+      "status": "pass",
+      "throughput_in_gibs": 3.19615,
+      "throughput_out_gibs": 3.19927,
+      "compression_fold": 0.999024,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93255,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.91663,
+      "init_s": 0.453736,
+      "flush_s": 4.73e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.94586,
+          "best_ms": 0.285355,
+          "best_in_gibs": 27.3782,
+          "best_out_gibs": 27.3782,
+          "in_gibs": 29.5216,
+          "out_gibs": 29.5216
+        },
+        "h2d": {
+          "avg_ms": 2.317,
+          "best_ms": 0.316864,
+          "best_in_gibs": 24.6557,
+          "best_out_gibs": 24.6557,
+          "in_gibs": 24.7726,
+          "out_gibs": 24.7726
+        },
+        "scatter": {
+          "avg_ms": 0.371461,
+          "best_ms": 0.053696,
+          "best_in_gibs": 145.495,
+          "best_out_gibs": 145.495,
+          "in_gibs": 154.519,
+          "out_gibs": 154.519
+        },
+        "aggregate": {
+          "avg_ms": 2.89187,
+          "best_ms": 2.34339,
+          "best_in_gibs": 250.038,
+          "best_out_gibs": 250.038,
+          "in_gibs": 202.616,
+          "out_gibs": 202.616
+        },
+        "d2h": {
+          "avg_ms": 25.0314,
+          "best_ms": 24.7602,
+          "best_in_gibs": 23.6645,
+          "best_out_gibs": 23.6645,
+          "in_gibs": 23.4081,
+          "out_gibs": 23.4081
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 31.8566,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 145.972,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.73705,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 31.93,
+      "status": "pass",
+      "throughput_in_gibs": 1.67065,
+      "throughput_out_gibs": 1.67228,
+      "compression_fold": 0.999024,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93255,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 1.75362,
+      "init_s": 0.00439308,
+      "flush_s": 5.24e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.8825,
+          "best_ms": 5.93864,
+          "best_in_gibs": 1.31554,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.51043,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.7458,
+          "best_ms": 21.9488,
+          "best_in_gibs": 26.6956,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.3834,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 36.4666,
+          "best_ms": 21.5649,
+          "best_in_gibs": 27.1708,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.0678,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 31.95,
+      "status": "pass",
+      "throughput_in_gibs": 3.18566,
+      "throughput_out_gibs": 3.18721,
+      "compression_fold": 0.999512,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93112,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.919649,
+      "init_s": 0.452055,
+      "flush_s": 3.45e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.34497,
+          "best_ms": 0.171543,
+          "best_in_gibs": 45.5425,
+          "best_out_gibs": 45.5425,
+          "in_gibs": 42.711,
+          "out_gibs": 42.711
+        },
+        "h2d": {
+          "avg_ms": 2.3179,
+          "best_ms": 0.315488,
+          "best_in_gibs": 24.7632,
+          "best_out_gibs": 24.7632,
+          "in_gibs": 24.7629,
+          "out_gibs": 24.7629
+        },
+        "scatter": {
+          "avg_ms": 0.373837,
+          "best_ms": 0.053504,
+          "best_in_gibs": 146.017,
+          "best_out_gibs": 146.017,
+          "in_gibs": 153.537,
+          "out_gibs": 153.537
+        },
+        "aggregate": {
+          "avg_ms": 3.01588,
+          "best_ms": 2.60832,
+          "best_in_gibs": 224.642,
+          "best_out_gibs": 224.642,
+          "in_gibs": 194.284,
+          "out_gibs": 194.284
+        },
+        "d2h": {
+          "avg_ms": 24.7811,
+          "best_ms": 24.5844,
+          "best_in_gibs": 23.8338,
+          "best_out_gibs": 23.8338,
+          "in_gibs": 23.6446,
+          "out_gibs": 23.6446
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 30.8763,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 145.844,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.91218,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 31.94,
+      "status": "pass",
+      "throughput_in_gibs": 1.69351,
+      "throughput_out_gibs": 1.69433,
+      "compression_fold": 0.999512,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93112,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 1.72995,
+      "init_s": 0.00422397,
+      "flush_s": 4.73e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.3998,
+          "best_ms": 6.02594,
+          "best_in_gibs": 1.29648,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.56453,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.084,
+          "best_ms": 20.5817,
+          "best_in_gibs": 28.4688,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.1464,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 37.1299,
+          "best_ms": 21.708,
+          "best_in_gibs": 26.9918,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.7808,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 32.03,
+      "status": "pass",
+      "throughput_in_gibs": 3.14397,
+      "throughput_out_gibs": 3.14474,
+      "compression_fold": 0.999756,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.9304,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.931843,
+      "init_s": 0.505069,
+      "flush_s": 3.3e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.19105,
+          "best_ms": 0.184671,
+          "best_in_gibs": 42.305,
+          "best_out_gibs": 42.305,
+          "in_gibs": 48.2304,
+          "out_gibs": 48.2304
+        },
+        "h2d": {
+          "avg_ms": 2.30238,
+          "best_ms": 0.314688,
+          "best_in_gibs": 24.8262,
+          "best_out_gibs": 24.8262,
+          "in_gibs": 24.9299,
+          "out_gibs": 24.9299
+        },
+        "scatter": {
+          "avg_ms": 0.376246,
+          "best_ms": 0.05344,
+          "best_in_gibs": 146.192,
+          "best_out_gibs": 146.192,
+          "in_gibs": 152.554,
+          "out_gibs": 152.554
+        },
+        "aggregate": {
+          "avg_ms": 3.17249,
+          "best_ms": 3.14099,
+          "best_in_gibs": 186.545,
+          "best_out_gibs": 186.545,
+          "in_gibs": 184.693,
+          "out_gibs": 184.693
+        },
+        "d2h": {
+          "avg_ms": 25.211,
+          "best_ms": 25.0017,
+          "best_in_gibs": 23.4359,
+          "best_out_gibs": 23.4359,
+          "in_gibs": 23.2413,
+          "out_gibs": 23.2413
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 31.0453,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 149.053,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.89448,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 31.9,
+      "status": "pass",
+      "throughput_in_gibs": 1.70856,
+      "throughput_out_gibs": 1.70898,
+      "compression_fold": 0.999756,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.9304,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 1.71471,
+      "init_s": 0.00445589,
+      "flush_s": 2.48e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.3673,
+          "best_ms": 5.96659,
+          "best_in_gibs": 1.30937,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.56826,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.7842,
+          "best_ms": 21.1094,
+          "best_in_gibs": 27.7572,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.3562,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 36.8162,
+          "best_ms": 21.2286,
+          "best_in_gibs": 27.6013,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.9152,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 32.04,
+      "status": "pass",
+      "throughput_in_gibs": 3.18226,
+      "throughput_out_gibs": 3.18264,
+      "compression_fold": 0.999878,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93005,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.920632,
+      "init_s": 0.439277,
+      "flush_s": 3.6e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.18691,
+          "best_ms": 0.167949,
+          "best_in_gibs": 46.5171,
+          "best_out_gibs": 46.5171,
+          "in_gibs": 48.3987,
+          "out_gibs": 48.3987
+        },
+        "h2d": {
+          "avg_ms": 2.31474,
+          "best_ms": 0.315072,
+          "best_in_gibs": 24.7959,
+          "best_out_gibs": 24.7959,
+          "in_gibs": 24.7967,
+          "out_gibs": 24.7967
+        },
+        "scatter": {
+          "avg_ms": 0.379238,
+          "best_ms": 0.053536,
+          "best_in_gibs": 145.93,
+          "best_out_gibs": 145.93,
+          "in_gibs": 151.351,
+          "out_gibs": 151.351
+        },
+        "aggregate": {
+          "avg_ms": 3.26335,
+          "best_ms": 3.20182,
+          "best_in_gibs": 183.001,
+          "best_out_gibs": 183.001,
+          "in_gibs": 179.551,
+          "out_gibs": 179.551
+        },
+        "d2h": {
+          "avg_ms": 24.9273,
+          "best_ms": 24.6582,
+          "best_in_gibs": 23.7624,
+          "best_out_gibs": 23.7624,
+          "in_gibs": 23.5058,
+          "out_gibs": 23.5058
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 30.8188,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 148.343,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.9162,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 31.55,
+      "status": "pass",
+      "throughput_in_gibs": 2.1283,
+      "throughput_out_gibs": 2.12856,
+      "compression_fold": 0.999878,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93005,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 1.37654,
+      "init_s": 0.00426652,
+      "flush_s": 3.27e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.8319,
+          "best_ms": 5.24858,
+          "best_in_gibs": 1.4885,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.62843,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.1001,
+          "best_ms": 20.4862,
+          "best_in_gibs": 28.6016,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.8518,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 36.6622,
+          "best_ms": 20.6485,
+          "best_in_gibs": 28.3768,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.9821,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 31.95,
+      "status": "pass",
+      "throughput_in_gibs": 3.2487,
+      "throughput_out_gibs": 3.2489,
+      "compression_fold": 0.999939,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92987,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.901803,
+      "init_s": 0.457758,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.18827,
+          "best_ms": 0.169278,
+          "best_in_gibs": 46.1519,
+          "best_out_gibs": 46.1519,
+          "in_gibs": 48.3433,
+          "out_gibs": 48.3433
+        },
+        "h2d": {
+          "avg_ms": 2.31328,
+          "best_ms": 0.315648,
+          "best_in_gibs": 24.7507,
+          "best_out_gibs": 24.7507,
+          "in_gibs": 24.8124,
+          "out_gibs": 24.8124
+        },
+        "scatter": {
+          "avg_ms": 0.383023,
+          "best_ms": 0.053376,
+          "best_in_gibs": 146.367,
+          "best_out_gibs": 146.367,
+          "in_gibs": 149.855,
+          "out_gibs": 149.855
+        },
+        "aggregate": {
+          "avg_ms": 3.3698,
+          "best_ms": 3.28522,
+          "best_in_gibs": 178.356,
+          "best_out_gibs": 178.356,
+          "in_gibs": 173.879,
+          "out_gibs": 173.879
+        },
+        "d2h": {
+          "avg_ms": 24.8781,
+          "best_ms": 24.6602,
+          "best_in_gibs": 23.7605,
+          "best_out_gibs": 23.7605,
+          "in_gibs": 23.5523,
+          "out_gibs": 23.5523
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 30.6712,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 148.528,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.91041,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 31.55,
+      "status": "pass",
+      "throughput_in_gibs": 2.12417,
+      "throughput_out_gibs": 2.1243,
+      "compression_fold": 0.999939,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92987,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 1.37921,
+      "init_s": 0.00419833,
+      "flush_s": 3.26e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.7135,
+          "best_ms": 5.25353,
+          "best_in_gibs": 1.48709,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.65576,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.7502,
+          "best_ms": 20.7932,
+          "best_in_gibs": 28.1793,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.3803,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 36.7578,
+          "best_ms": 21.7278,
+          "best_in_gibs": 26.9671,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.9405,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 32.03,
+      "status": "pass",
+      "throughput_in_gibs": 3.07,
+      "throughput_out_gibs": 3.0701,
+      "compression_fold": 0.999967,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92978,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.954295,
+      "init_s": 0.443115,
+      "flush_s": 3.4e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.65012,
+          "best_ms": 0.267884,
+          "best_in_gibs": 29.1637,
+          "best_out_gibs": 29.1637,
+          "in_gibs": 34.8126,
+          "out_gibs": 34.8126
+        },
+        "h2d": {
+          "avg_ms": 2.31295,
+          "best_ms": 0.315904,
+          "best_in_gibs": 24.7306,
+          "best_out_gibs": 24.7306,
+          "in_gibs": 24.816,
+          "out_gibs": 24.816
+        },
+        "scatter": {
+          "avg_ms": 0.394438,
+          "best_ms": 0.053472,
+          "best_in_gibs": 146.105,
+          "best_out_gibs": 146.105,
+          "in_gibs": 145.518,
+          "out_gibs": 145.518
+        },
+        "aggregate": {
+          "avg_ms": 3.53992,
+          "best_ms": 3.49734,
+          "best_in_gibs": 167.538,
+          "best_out_gibs": 167.538,
+          "in_gibs": 165.523,
+          "out_gibs": 165.523
+        },
+        "d2h": {
+          "avg_ms": 24.996,
+          "best_ms": 24.7742,
+          "best_in_gibs": 23.6511,
+          "best_out_gibs": 23.6511,
+          "in_gibs": 23.4412,
+          "out_gibs": 23.4412
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 30.9215,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 149.858,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90949,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 31.49,
+      "status": "pass",
+      "throughput_in_gibs": 2.22997,
+      "throughput_out_gibs": 2.23004,
+      "compression_fold": 0.999967,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92978,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 1.31378,
+      "init_s": 0.00424248,
+      "flush_s": 4.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.6457,
+          "best_ms": 5.07179,
+          "best_in_gibs": 1.54038,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.92231,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.603,
+          "best_ms": 20.1629,
+          "best_in_gibs": 29.0602,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.4851,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 35.8326,
+          "best_ms": 20.8733,
+          "best_in_gibs": 28.0712,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.3521,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 31.88,
+      "status": "pass",
+      "throughput_in_gibs": 3.24481,
+      "throughput_out_gibs": 3.24486,
+      "compression_fold": 0.999985,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92973,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.902885,
+      "init_s": 0.447253,
+      "flush_s": 4.97e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.19134,
+          "best_ms": 0.172906,
+          "best_in_gibs": 45.1835,
+          "best_out_gibs": 45.1835,
+          "in_gibs": 48.2185,
+          "out_gibs": 48.2185
+        },
+        "h2d": {
+          "avg_ms": 2.30453,
+          "best_ms": 0.315552,
+          "best_in_gibs": 24.7582,
+          "best_out_gibs": 24.7582,
+          "in_gibs": 24.9066,
+          "out_gibs": 24.9066
+        },
+        "scatter": {
+          "avg_ms": 0.436774,
+          "best_ms": 0.05312,
+          "best_in_gibs": 147.073,
+          "best_out_gibs": 147.073,
+          "in_gibs": 131.413,
+          "out_gibs": 131.413
+        },
+        "aggregate": {
+          "avg_ms": 3.67734,
+          "best_ms": 3.61699,
+          "best_in_gibs": 161.996,
+          "best_out_gibs": 161.996,
+          "in_gibs": 159.337,
+          "out_gibs": 159.337
+        },
+        "d2h": {
+          "avg_ms": 25.1853,
+          "best_ms": 25.0044,
+          "best_in_gibs": 23.4333,
+          "best_out_gibs": 23.4333,
+          "in_gibs": 23.2651,
+          "out_gibs": 23.2651
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 31.1307,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 151.624,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90486,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 31.53,
+      "status": "pass",
+      "throughput_in_gibs": 2.21885,
+      "throughput_out_gibs": 2.21888,
+      "compression_fold": 0.999985,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92973,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.32036,
+      "init_s": 0.00425866,
+      "flush_s": 4.59e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.672,
+          "best_ms": 4.9615,
+          "best_in_gibs": 1.57462,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.91528,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.9812,
+          "best_ms": 20.6381,
+          "best_in_gibs": 28.391,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.2178,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 35.9119,
+          "best_ms": 20.6456,
+          "best_in_gibs": 28.3808,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.316,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 32.56,
+      "status": "pass",
+      "throughput_in_gibs": 3.20905,
+      "throughput_out_gibs": 3.85089,
+      "compression_fold": 0.999992,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.51565,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.912945,
+      "init_s": 0.790007,
+      "flush_s": 3.35e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.23731,
+          "best_ms": 0.337374,
+          "best_in_gibs": 46.3136,
+          "best_out_gibs": 46.3136,
+          "in_gibs": 48.3223,
+          "out_gibs": 48.3223
+        },
+        "h2d": {
+          "avg_ms": 2.43444,
+          "best_ms": 0.674368,
+          "best_in_gibs": 23.1698,
+          "best_out_gibs": 23.1698,
+          "in_gibs": 24.5808,
+          "out_gibs": 24.5808
+        },
+        "scatter": {
+          "avg_ms": 0.44668,
+          "best_ms": 0.189824,
+          "best_in_gibs": 164.626,
+          "best_out_gibs": 164.626,
+          "in_gibs": 133.967,
+          "out_gibs": 133.967
+        },
+        "aggregate": {
+          "avg_ms": 6.74055,
+          "best_ms": 5.36208,
+          "best_in_gibs": 218.549,
+          "best_out_gibs": 218.549,
+          "in_gibs": 173.854,
+          "out_gibs": 173.854
+        },
+        "d2h": {
+          "avg_ms": 49.2639,
+          "best_ms": 48.8909,
+          "best_in_gibs": 23.9692,
+          "best_out_gibs": 23.9692,
+          "in_gibs": 23.7877,
+          "out_gibs": 23.7877
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 56.8044,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 173.912,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.91439,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 31.72,
+      "status": "pass",
+      "throughput_in_gibs": 2.01196,
+      "throughput_out_gibs": 2.41437,
+      "compression_fold": 0.999992,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.51565,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.45614,
+      "init_s": 0.0041641,
+      "flush_s": 2.98e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.0288,
+          "best_ms": 6.47017,
+          "best_in_gibs": 2.41493,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.73013,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 55.8304,
+          "best_ms": 24.818,
+          "best_in_gibs": 47.2187,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.9899,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 86.4801,
+          "best_ms": 24.8096,
+          "best_in_gibs": 47.2348,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.5508,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 32.14,
+      "status": "pass",
+      "throughput_in_gibs": 3.21894,
+      "throughput_out_gibs": 1.6868,
+      "compression_fold": 1.90831,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.53523,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.910141,
+      "init_s": 0.459484,
+      "flush_s": 2.99e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.1874,
+          "best_ms": 0.166467,
+          "best_in_gibs": 46.9312,
+          "best_out_gibs": 46.9312,
+          "in_gibs": 48.3786,
+          "out_gibs": 48.3786
+        },
+        "h2d": {
+          "avg_ms": 2.32043,
+          "best_ms": 0.315776,
+          "best_in_gibs": 24.7406,
+          "best_out_gibs": 24.7406,
+          "in_gibs": 24.7359,
+          "out_gibs": 24.7359
+        },
+        "scatter": {
+          "avg_ms": 2.06045,
+          "best_ms": 0.054304,
+          "best_in_gibs": 143.866,
+          "best_out_gibs": 143.866,
+          "in_gibs": 27.857,
+          "out_gibs": 27.857
+        },
+        "compress": {
+          "avg_ms": 31.9375,
+          "best_ms": 31.774,
+          "best_in_gibs": 18.4408,
+          "best_out_gibs": 9.65361,
+          "in_gibs": 18.3464,
+          "out_gibs": 9.59603
+        },
+        "aggregate": {
+          "avg_ms": 1.20866,
+          "best_ms": 1.17424,
+          "best_in_gibs": 260.837,
+          "best_out_gibs": 260.837,
+          "in_gibs": 253.564,
+          "out_gibs": 253.564
+        },
+        "d2h": {
+          "avg_ms": 13.3922,
+          "best_ms": 13.1271,
+          "best_in_gibs": 23.3396,
+          "best_out_gibs": 23.3396,
+          "in_gibs": 22.8844,
+          "out_gibs": 22.8844
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 50.043,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 237.149,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.26415,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 32.89,
+      "status": "pass",
+      "throughput_in_gibs": 1.05011,
+      "throughput_out_gibs": 0.401288,
+      "compression_fold": 2.61684,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.11955,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 2.7899,
+      "init_s": 0.00435567,
+      "flush_s": 2.52e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.8467,
+          "best_ms": 5.95313,
+          "best_in_gibs": 1.31233,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.51437,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 256.445,
+          "best_ms": 250.92,
+          "best_in_gibs": 2.33515,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.28485,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 17.2227,
+          "best_ms": 10.8562,
+          "best_in_gibs": 54.2363,
+          "best_out_gibs": 0.0,
+          "in_gibs": 34.1874,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 31.96,
+      "status": "pass",
+      "throughput_in_gibs": 3.1679,
+      "throughput_out_gibs": 1.64022,
+      "compression_fold": 1.93138,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.51688,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.924806,
+      "init_s": 0.441655,
+      "flush_s": 2.57e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.18737,
+          "best_ms": 0.168597,
+          "best_in_gibs": 46.3383,
+          "best_out_gibs": 46.3383,
+          "in_gibs": 48.3798,
+          "out_gibs": 48.3798
+        },
+        "h2d": {
+          "avg_ms": 2.32115,
+          "best_ms": 0.315008,
+          "best_in_gibs": 24.801,
+          "best_out_gibs": 24.801,
+          "in_gibs": 24.7282,
+          "out_gibs": 24.7282
+        },
+        "scatter": {
+          "avg_ms": 1.96437,
+          "best_ms": 0.053504,
+          "best_in_gibs": 146.017,
+          "best_out_gibs": 146.017,
+          "in_gibs": 29.2195,
+          "out_gibs": 29.2195
+        },
+        "compress": {
+          "avg_ms": 32.8405,
+          "best_ms": 32.579,
+          "best_in_gibs": 17.9851,
+          "best_out_gibs": 9.28887,
+          "in_gibs": 17.8419,
+          "out_gibs": 9.22919
+        },
+        "aggregate": {
+          "avg_ms": 1.22476,
+          "best_ms": 1.15907,
+          "best_in_gibs": 260.529,
+          "best_out_gibs": 260.529,
+          "in_gibs": 247.469,
+          "out_gibs": 247.469
+        },
+        "d2h": {
+          "avg_ms": 13.1484,
+          "best_ms": 12.7894,
+          "best_in_gibs": 23.6619,
+          "best_out_gibs": 23.6619,
+          "in_gibs": 23.0516,
+          "out_gibs": 23.0516
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 49.8346,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 240.721,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.28481,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 32.79,
+      "status": "pass",
+      "throughput_in_gibs": 1.09906,
+      "throughput_out_gibs": 0.411256,
+      "compression_fold": 2.67244,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.09626,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 2.66563,
+      "init_s": 0.00431294,
+      "flush_s": 2.92e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.4396,
+          "best_ms": 5.92945,
+          "best_in_gibs": 1.31758,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.55997,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 237.766,
+          "best_ms": 232.957,
+          "best_in_gibs": 2.51521,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.46435,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 16.4584,
+          "best_ms": 10.7401,
+          "best_in_gibs": 54.7957,
+          "best_out_gibs": 0.0,
+          "in_gibs": 35.7576,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 32.08,
+      "status": "pass",
+      "throughput_in_gibs": 3.11104,
+      "throughput_out_gibs": 1.57979,
+      "compression_fold": 1.96928,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.4877,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.941707,
+      "init_s": 0.445636,
+      "flush_s": 2.15e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.187,
+          "best_ms": 0.17365,
+          "best_in_gibs": 44.9899,
+          "best_out_gibs": 44.9899,
+          "in_gibs": 48.3951,
+          "out_gibs": 48.3951
+        },
+        "h2d": {
+          "avg_ms": 2.32052,
+          "best_ms": 0.314784,
+          "best_in_gibs": 24.8186,
+          "best_out_gibs": 24.8186,
+          "in_gibs": 24.7349,
+          "out_gibs": 24.7349
+        },
+        "scatter": {
+          "avg_ms": 1.70994,
+          "best_ms": 0.05376,
+          "best_in_gibs": 145.322,
+          "best_out_gibs": 145.322,
+          "in_gibs": 33.5672,
+          "out_gibs": 33.5672
+        },
+        "compress": {
+          "avg_ms": 33.1921,
+          "best_ms": 32.9983,
+          "best_in_gibs": 17.7566,
+          "best_out_gibs": 8.98258,
+          "in_gibs": 17.6529,
+          "out_gibs": 8.95985
+        },
+        "aggregate": {
+          "avg_ms": 1.27162,
+          "best_ms": 1.16643,
+          "best_in_gibs": 254.117,
+          "best_out_gibs": 254.117,
+          "in_gibs": 233.873,
+          "out_gibs": 233.873
+        },
+        "d2h": {
+          "avg_ms": 12.9706,
+          "best_ms": 12.6764,
+          "best_in_gibs": 23.436,
+          "best_out_gibs": 23.436,
+          "in_gibs": 22.9285,
+          "out_gibs": 22.9285
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 49.7857,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 241.696,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.3569,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 32.68,
+      "status": "pass",
+      "throughput_in_gibs": 1.14343,
+      "throughput_out_gibs": 0.413647,
+      "compression_fold": 2.76427,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.05984,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 2.56219,
+      "init_s": 0.00442198,
+      "flush_s": 2.65e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.4549,
+          "best_ms": 5.89382,
+          "best_in_gibs": 1.32554,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.55824,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 218.314,
+          "best_ms": 215.204,
+          "best_in_gibs": 2.7227,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.68392,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 15.5882,
+          "best_ms": 9.2615,
+          "best_in_gibs": 63.5295,
+          "best_out_gibs": 0.0,
+          "in_gibs": 37.7451,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 32.29,
+      "status": "pass",
+      "throughput_in_gibs": 3.19823,
+      "throughput_out_gibs": 1.39428,
+      "compression_fold": 2.29382,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.27721,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.916035,
+      "init_s": 0.452017,
+      "flush_s": 2.08e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.18739,
+          "best_ms": 0.176161,
+          "best_in_gibs": 44.3486,
+          "best_out_gibs": 44.3486,
+          "in_gibs": 48.3792,
+          "out_gibs": 48.3792
+        },
+        "h2d": {
+          "avg_ms": 2.30036,
+          "best_ms": 0.315552,
+          "best_in_gibs": 24.7582,
+          "best_out_gibs": 24.7582,
+          "in_gibs": 24.9517,
+          "out_gibs": 24.9517
+        },
+        "scatter": {
+          "avg_ms": 1.52525,
+          "best_ms": 0.053856,
+          "best_in_gibs": 145.063,
+          "best_out_gibs": 145.063,
+          "in_gibs": 37.8822,
+          "out_gibs": 37.8822
+        },
+        "compress": {
+          "avg_ms": 37.6863,
+          "best_ms": 37.0982,
+          "best_in_gibs": 15.7942,
+          "best_out_gibs": 6.84796,
+          "in_gibs": 15.5478,
+          "out_gibs": 6.7762
+        },
+        "aggregate": {
+          "avg_ms": 1.20863,
+          "best_ms": 1.02285,
+          "best_in_gibs": 250.134,
+          "best_out_gibs": 250.134,
+          "in_gibs": 211.288,
+          "out_gibs": 211.288
+        },
+        "d2h": {
+          "avg_ms": 11.0304,
+          "best_ms": 10.618,
+          "best_in_gibs": 23.8637,
+          "best_out_gibs": 23.8637,
+          "in_gibs": 23.1514,
+          "out_gibs": 23.1514
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 52.1571,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 253.542,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.08853,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 32.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.36769,
+      "throughput_out_gibs": 0.466595,
+      "compression_fold": 2.93122,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.999478,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 2.14207,
+      "init_s": 0.00432734,
+      "flush_s": 3.31e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.8094,
+          "best_ms": 5.21221,
+          "best_in_gibs": 1.49888,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.63358,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 202.887,
+          "best_ms": 199.565,
+          "best_in_gibs": 2.93608,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.88799,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.9694,
+          "best_ms": 9.02557,
+          "best_in_gibs": 65.1826,
+          "best_out_gibs": 0.0,
+          "in_gibs": 39.3009,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 32.11,
+      "status": "pass",
+      "throughput_in_gibs": 3.17389,
+      "throughput_out_gibs": 1.28513,
+      "compression_fold": 2.46971,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.18625,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.923059,
+      "init_s": 0.451162,
+      "flush_s": 2.12e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.46327,
+          "best_ms": 0.167041,
+          "best_in_gibs": 46.77,
+          "best_out_gibs": 46.77,
+          "in_gibs": 39.2579,
+          "out_gibs": 39.2579
+        },
+        "h2d": {
+          "avg_ms": 2.30731,
+          "best_ms": 0.315776,
+          "best_in_gibs": 24.7406,
+          "best_out_gibs": 24.7406,
+          "in_gibs": 24.8766,
+          "out_gibs": 24.8766
+        },
+        "scatter": {
+          "avg_ms": 0.370356,
+          "best_ms": 0.053408,
+          "best_in_gibs": 146.28,
+          "best_out_gibs": 146.28,
+          "in_gibs": 154.981,
+          "out_gibs": 154.981
+        },
+        "compress": {
+          "avg_ms": 35.7284,
+          "best_ms": 34.7004,
+          "best_in_gibs": 16.8856,
+          "best_out_gibs": 6.8041,
+          "in_gibs": 16.3998,
+          "out_gibs": 6.63936
+        },
+        "aggregate": {
+          "avg_ms": 1.16394,
+          "best_ms": 0.946528,
+          "best_in_gibs": 249.443,
+          "best_out_gibs": 249.443,
+          "in_gibs": 203.802,
+          "out_gibs": 203.802
+        },
+        "d2h": {
+          "avg_ms": 10.5337,
+          "best_ms": 10.3401,
+          "best_in_gibs": 22.9813,
+          "best_out_gibs": 22.9813,
+          "in_gibs": 22.5196,
+          "out_gibs": 22.5196
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 49.3742,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 241.769,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.27497,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 32.31,
+      "status": "pass",
+      "throughput_in_gibs": 1.38851,
+      "throughput_out_gibs": 0.45995,
+      "compression_fold": 3.01883,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.97047,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 2.10995,
+      "init_s": 0.00416604,
+      "flush_s": 4.42e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.8859,
+          "best_ms": 5.18856,
+          "best_in_gibs": 1.50572,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.61609,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 196.147,
+          "best_ms": 191.601,
+          "best_in_gibs": 3.05812,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.98723,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.6734,
+          "best_ms": 9.16679,
+          "best_in_gibs": 64.1743,
+          "best_out_gibs": 0.0,
+          "in_gibs": 40.091,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 32.15,
+      "status": "pass",
+      "throughput_in_gibs": 3.00767,
+      "throughput_out_gibs": 1.22627,
+      "compression_fold": 2.4527,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.19448,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.974072,
+      "init_s": 0.449337,
+      "flush_s": 4.51e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.19094,
+          "best_ms": 0.173804,
+          "best_in_gibs": 44.9501,
+          "best_out_gibs": 44.9501,
+          "in_gibs": 48.2349,
+          "out_gibs": 48.2349
+        },
+        "h2d": {
+          "avg_ms": 2.3107,
+          "best_ms": 0.314752,
+          "best_in_gibs": 24.8211,
+          "best_out_gibs": 24.8211,
+          "in_gibs": 24.8401,
+          "out_gibs": 24.8401
+        },
+        "scatter": {
+          "avg_ms": 0.355017,
+          "best_ms": 0.053504,
+          "best_in_gibs": 146.017,
+          "best_out_gibs": 146.017,
+          "in_gibs": 162.752,
+          "out_gibs": 162.752
+        },
+        "compress": {
+          "avg_ms": 64.1458,
+          "best_ms": 62.4873,
+          "best_in_gibs": 9.37691,
+          "best_out_gibs": 3.8222,
+          "in_gibs": 9.13446,
+          "out_gibs": 3.72395
+        },
+        "aggregate": {
+          "avg_ms": 1.22751,
+          "best_ms": 0.997088,
+          "best_in_gibs": 240.648,
+          "best_out_gibs": 240.648,
+          "in_gibs": 194.601,
+          "out_gibs": 194.601
+        },
+        "d2h": {
+          "avg_ms": 10.3721,
+          "best_ms": 10.0948,
+          "best_in_gibs": 23.6619,
+          "best_out_gibs": 23.6619,
+          "in_gibs": 23.0305,
+          "out_gibs": 23.0305
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 76.2814,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 383.293,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 27.2895,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 32.14,
+      "status": "pass",
+      "throughput_in_gibs": 1.45483,
+      "throughput_out_gibs": 0.447772,
+      "compression_fold": 3.24905,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.901707,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 2.01376,
+      "init_s": 0.00416157,
+      "flush_s": 3.43e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.8142,
+          "best_ms": 4.8139,
+          "best_in_gibs": 1.6229,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.87768,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 189.234,
+          "best_ms": 185.095,
+          "best_in_gibs": 3.16561,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.09637,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.9054,
+          "best_ms": 8.16143,
+          "best_in_gibs": 72.0777,
+          "best_out_gibs": 0.0,
+          "in_gibs": 42.3042,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 32.15,
+      "status": "pass",
+      "throughput_in_gibs": 2.7069,
+      "throughput_out_gibs": 0.971297,
+      "compression_fold": 2.78689,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.05124,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.0823,
+      "init_s": 0.44431,
+      "flush_s": 3.33e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.62494,
+          "best_ms": 0.272542,
+          "best_in_gibs": 28.6653,
+          "best_out_gibs": 28.6653,
+          "in_gibs": 35.352,
+          "out_gibs": 35.352
+        },
+        "h2d": {
+          "avg_ms": 2.30597,
+          "best_ms": 0.315072,
+          "best_in_gibs": 24.7959,
+          "best_out_gibs": 24.7959,
+          "in_gibs": 24.891,
+          "out_gibs": 24.891
+        },
+        "scatter": {
+          "avg_ms": 0.351778,
+          "best_ms": 0.053664,
+          "best_in_gibs": 145.582,
+          "best_out_gibs": 145.582,
+          "in_gibs": 164.251,
+          "out_gibs": 164.251
+        },
+        "compress": {
+          "avg_ms": 107.075,
+          "best_ms": 106.149,
+          "best_in_gibs": 5.51997,
+          "best_out_gibs": 1.98088,
+          "in_gibs": 5.47224,
+          "out_gibs": 1.96348
+        },
+        "aggregate": {
+          "avg_ms": 1.12836,
+          "best_ms": 0.899392,
+          "best_in_gibs": 232.676,
+          "best_out_gibs": 232.676,
+          "in_gibs": 186.322,
+          "out_gibs": 186.322
+        },
+        "d2h": {
+          "avg_ms": 9.26914,
+          "best_ms": 8.98464,
+          "best_in_gibs": 23.2916,
+          "best_out_gibs": 23.2916,
+          "in_gibs": 22.6816,
+          "out_gibs": 22.6816
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 118.982,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 591.791,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 71.9452,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 32.16,
+      "status": "pass",
+      "throughput_in_gibs": 1.47522,
+      "throughput_out_gibs": 0.435679,
+      "compression_fold": 3.38602,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.86523,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.98594,
+      "init_s": 0.00444772,
+      "flush_s": 3.04e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.7944,
+          "best_ms": 5.09283,
+          "best_in_gibs": 1.53402,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.88287,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 183.317,
+          "best_ms": 179.294,
+          "best_in_gibs": 3.26802,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.19631,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.3261,
+          "best_ms": 8.22729,
+          "best_in_gibs": 71.4992,
+          "best_out_gibs": 0.0,
+          "in_gibs": 44.1423,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 32.86,
+      "status": "pass",
+      "throughput_in_gibs": 2.47416,
+      "throughput_out_gibs": 0.799814,
+      "compression_fold": 3.7121,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.947071,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.18411,
+      "init_s": 0.83831,
+      "flush_s": 3.39e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.23153,
+          "best_ms": 0.33724,
+          "best_in_gibs": 46.332,
+          "best_out_gibs": 46.332,
+          "in_gibs": 48.5488,
+          "out_gibs": 48.5488
+        },
+        "h2d": {
+          "avg_ms": 2.39411,
+          "best_ms": 0.668736,
+          "best_in_gibs": 23.365,
+          "best_out_gibs": 23.365,
+          "in_gibs": 24.9948,
+          "out_gibs": 24.9948
+        },
+        "scatter": {
+          "avg_ms": 0.359073,
+          "best_ms": 0.191168,
+          "best_in_gibs": 163.469,
+          "best_out_gibs": 163.469,
+          "in_gibs": 169.329,
+          "out_gibs": 169.329
+        },
+        "compress": {
+          "avg_ms": 165.74,
+          "best_ms": 116.588,
+          "best_in_gibs": 10.0514,
+          "best_out_gibs": 1.81465,
+          "in_gibs": 7.07056,
+          "out_gibs": 1.90468
+        },
+        "aggregate": {
+          "avg_ms": 2.07857,
+          "best_ms": 0.854592,
+          "best_in_gibs": 247.564,
+          "best_out_gibs": 247.564,
+          "in_gibs": 151.874,
+          "out_gibs": 151.874
+        },
+        "d2h": {
+          "avg_ms": 13.4478,
+          "best_ms": 9.09875,
+          "best_in_gibs": 23.2523,
+          "best_out_gibs": 23.2523,
+          "in_gibs": 23.4745,
+          "out_gibs": 23.4745
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 170.733,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 543.389,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 154.531,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 32.33,
+      "status": "pass",
+      "throughput_in_gibs": 1.35224,
+      "throughput_out_gibs": 0.449657,
+      "compression_fold": 3.60872,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.974203,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 2.16655,
+      "init_s": 0.0041213,
+      "flush_s": 4.79e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.9409,
+          "best_ms": 6.40734,
+          "best_in_gibs": 2.43861,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.7507,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 353.57,
+          "best_ms": 337.805,
+          "best_in_gibs": 3.46909,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.3144,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 26.5679,
+          "best_ms": 13.7013,
+          "best_in_gibs": 85.8665,
+          "best_out_gibs": 0.0,
+          "in_gibs": 44.282,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 32.39,
+      "status": "pass",
+      "throughput_in_gibs": 2.71442,
+      "throughput_out_gibs": 0.38744,
+      "compression_fold": 7.00606,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.418165,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 1.0793,
+      "init_s": 0.464924,
+      "flush_s": 2.4e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.68411,
+          "best_ms": 0.268344,
+          "best_in_gibs": 29.1137,
+          "best_out_gibs": 29.1137,
+          "in_gibs": 34.1098,
+          "out_gibs": 34.1098
+        },
+        "h2d": {
+          "avg_ms": 2.30097,
+          "best_ms": 0.314944,
+          "best_in_gibs": 24.806,
+          "best_out_gibs": 24.806,
+          "in_gibs": 24.9451,
+          "out_gibs": 24.9451
+        },
+        "scatter": {
+          "avg_ms": 1.38322,
+          "best_ms": 0.053664,
+          "best_in_gibs": 145.582,
+          "best_out_gibs": 145.582,
+          "in_gibs": 41.772,
+          "out_gibs": 41.772
+        },
+        "compress": {
+          "avg_ms": 117.832,
+          "best_ms": 115.44,
+          "best_in_gibs": 5.07567,
+          "best_out_gibs": 0.718747,
+          "in_gibs": 4.97264,
+          "out_gibs": 0.704907
+        },
+        "aggregate": {
+          "avg_ms": 0.534349,
+          "best_ms": 0.321408,
+          "best_in_gibs": 258.44,
+          "best_out_gibs": 258.44,
+          "in_gibs": 155.443,
+          "out_gibs": 155.443
+        },
+        "d2h": {
+          "avg_ms": 3.71617,
+          "best_ms": 3.54547,
+          "best_in_gibs": 23.4002,
+          "best_out_gibs": 23.4002,
+          "in_gibs": 22.3512,
+          "out_gibs": 22.3512
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 123.961,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 616.455,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 81.3974,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 33.39,
+      "status": "pass",
+      "throughput_in_gibs": 0.895176,
+      "throughput_out_gibs": 0.0936852,
+      "compression_fold": 9.55515,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.306608,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 3.27275,
+      "init_s": 0.00439985,
+      "flush_s": 4.87e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 23.0952,
+          "best_ms": 5.9779,
+          "best_in_gibs": 1.3069,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.48731,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 359.742,
+          "best_ms": 355.573,
+          "best_in_gibs": 1.64787,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.62877,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.64493,
+          "best_ms": 5.52776,
+          "best_in_gibs": 106.775,
+          "best_out_gibs": 0.0,
+          "in_gibs": 77.2053,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 32.37,
+      "status": "pass",
+      "throughput_in_gibs": 2.18161,
+      "throughput_out_gibs": 0.320357,
+      "compression_fold": 6.80994,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.430208,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 1.3429,
+      "init_s": 0.448336,
+      "flush_s": 3.87e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.18836,
+          "best_ms": 0.1679,
+          "best_in_gibs": 46.5307,
+          "best_out_gibs": 46.5307,
+          "in_gibs": 48.3396,
+          "out_gibs": 48.3396
+        },
+        "h2d": {
+          "avg_ms": 2.30785,
+          "best_ms": 0.316256,
+          "best_in_gibs": 24.7031,
+          "best_out_gibs": 24.7031,
+          "in_gibs": 24.8708,
+          "out_gibs": 24.8708
+        },
+        "scatter": {
+          "avg_ms": 2.25928,
+          "best_ms": 0.145088,
+          "best_in_gibs": 161.54,
+          "best_out_gibs": 161.54,
+          "in_gibs": 25.8243,
+          "out_gibs": 25.8243
+        },
+        "compress": {
+          "avg_ms": 196.55,
+          "best_ms": 195.353,
+          "best_in_gibs": 2.99937,
+          "best_out_gibs": 0.440221,
+          "in_gibs": 2.98112,
+          "out_gibs": 0.436304
+        },
+        "aggregate": {
+          "avg_ms": 0.532499,
+          "best_ms": 0.325824,
+          "best_in_gibs": 263.407,
+          "best_out_gibs": 263.407,
+          "in_gibs": 161.043,
+          "out_gibs": 161.043
+        },
+        "d2h": {
+          "avg_ms": 4.49466,
+          "best_ms": 3.71277,
+          "best_in_gibs": 23.1534,
+          "best_out_gibs": 23.1534,
+          "in_gibs": 19.0794,
+          "out_gibs": 19.0794
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 276.911,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 992.866,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 161.616,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 33.33,
+      "status": "pass",
+      "throughput_in_gibs": 0.916407,
+      "throughput_out_gibs": 0.10385,
+      "compression_fold": 8.82433,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.332001,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 3.19693,
+      "init_s": 0.00435495,
+      "flush_s": 2.65e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.6958,
+          "best_ms": 6.28145,
+          "best_in_gibs": 1.24374,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.53108,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 349.844,
+          "best_ms": 346.807,
+          "best_in_gibs": 1.68952,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.67486,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.53046,
+          "best_ms": 5.67127,
+          "best_in_gibs": 103.872,
+          "best_out_gibs": 0.0,
+          "in_gibs": 78.2269,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 32.32,
+      "status": "pass",
+      "throughput_in_gibs": 2.2104,
+      "throughput_out_gibs": 0.299793,
+      "compression_fold": 7.37307,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.39735,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 1.32541,
+      "init_s": 0.458851,
+      "flush_s": 4.41e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.18074,
+          "best_ms": 0.169252,
+          "best_in_gibs": 46.159,
+          "best_out_gibs": 46.159,
+          "in_gibs": 48.6514,
+          "out_gibs": 48.6514
+        },
+        "h2d": {
+          "avg_ms": 2.30616,
+          "best_ms": 0.31584,
+          "best_in_gibs": 24.7356,
+          "best_out_gibs": 24.7356,
+          "in_gibs": 24.889,
+          "out_gibs": 24.889
+        },
+        "scatter": {
+          "avg_ms": 2.8171,
+          "best_ms": 0.058368,
+          "best_in_gibs": 133.849,
+          "best_out_gibs": 133.849,
+          "in_gibs": 20.5104,
+          "out_gibs": 20.5104
+        },
+        "compress": {
+          "avg_ms": 194.675,
+          "best_ms": 187.353,
+          "best_in_gibs": 3.12745,
+          "best_out_gibs": 0.425464,
+          "in_gibs": 3.00982,
+          "out_gibs": 0.407483
+        },
+        "aggregate": {
+          "avg_ms": 0.327136,
+          "best_ms": 0.295904,
+          "best_in_gibs": 266.661,
+          "best_out_gibs": 266.661,
+          "in_gibs": 242.489,
+          "out_gibs": 242.489
+        },
+        "d2h": {
+          "avg_ms": 4.20076,
+          "best_ms": 3.46131,
+          "best_in_gibs": 22.9443,
+          "best_out_gibs": 22.9443,
+          "in_gibs": 18.8839,
+          "out_gibs": 18.8839
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 263.025,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 983.244,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 162.055,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 33.13,
+      "status": "pass",
+      "throughput_in_gibs": 0.972797,
+      "throughput_out_gibs": 0.103566,
+      "compression_fold": 9.39303,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.3119,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 3.01161,
+      "init_s": 0.00433557,
+      "flush_s": 2.93e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.5609,
+          "best_ms": 5.98769,
+          "best_in_gibs": 1.30476,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.54622,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 315.722,
+          "best_ms": 310.891,
+          "best_in_gibs": 1.88471,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.85586,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.96679,
+          "best_ms": 4.77621,
+          "best_in_gibs": 123.217,
+          "best_out_gibs": 0.0,
+          "in_gibs": 84.4739,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 32.49,
+      "status": "pass",
+      "throughput_in_gibs": 2.14301,
+      "throughput_out_gibs": 0.305545,
+      "compression_fold": 7.01371,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.417709,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 1.36709,
+      "init_s": 0.450017,
+      "flush_s": 3.42e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.18557,
+          "best_ms": 0.168131,
+          "best_in_gibs": 46.4667,
+          "best_out_gibs": 46.4667,
+          "in_gibs": 48.4533,
+          "out_gibs": 48.4533
+        },
+        "h2d": {
+          "avg_ms": 2.3034,
+          "best_ms": 0.317856,
+          "best_in_gibs": 24.5787,
+          "best_out_gibs": 24.5787,
+          "in_gibs": 24.9188,
+          "out_gibs": 24.9188
+        },
+        "scatter": {
+          "avg_ms": 2.74989,
+          "best_ms": 0.143936,
+          "best_in_gibs": 162.833,
+          "best_out_gibs": 162.833,
+          "in_gibs": 21.1498,
+          "out_gibs": 21.1498
+        },
+        "compress": {
+          "avg_ms": 207.598,
+          "best_ms": 195.963,
+          "best_in_gibs": 2.99004,
+          "best_out_gibs": 0.424973,
+          "in_gibs": 2.82246,
+          "out_gibs": 0.402076
+        },
+        "aggregate": {
+          "avg_ms": 0.395027,
+          "best_ms": 0.336768,
+          "best_in_gibs": 247.738,
+          "best_out_gibs": 247.738,
+          "in_gibs": 211.302,
+          "out_gibs": 211.302
+        },
+        "d2h": {
+          "avg_ms": 4.49094,
+          "best_ms": 3.68544,
+          "best_in_gibs": 22.6378,
+          "best_out_gibs": 22.6378,
+          "in_gibs": 18.5864,
+          "out_gibs": 18.5864
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 317.481,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 1049.32,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 173.789,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 32.72,
+      "status": "pass",
+      "throughput_in_gibs": 1.12212,
+      "throughput_out_gibs": 0.12693,
+      "compression_fold": 8.8405,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.331394,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 2.61085,
+      "init_s": 0.00432961,
+      "flush_s": 3.91e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.8839,
+          "best_ms": 5.3897,
+          "best_in_gibs": 1.44953,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.61654,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 303.661,
+          "best_ms": 296.148,
+          "best_in_gibs": 1.97853,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.92958,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.48977,
+          "best_ms": 5.25548,
+          "best_in_gibs": 111.926,
+          "best_out_gibs": 0.0,
+          "in_gibs": 78.5373,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 32.4,
+      "status": "pass",
+      "throughput_in_gibs": 2.10171,
+      "throughput_out_gibs": 0.287836,
+      "compression_fold": 7.30175,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.401231,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 1.39396,
+      "init_s": 0.450622,
+      "flush_s": 2.33e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.1839,
+          "best_ms": 0.169938,
+          "best_in_gibs": 45.9726,
+          "best_out_gibs": 45.9726,
+          "in_gibs": 48.5217,
+          "out_gibs": 48.5217
+        },
+        "h2d": {
+          "avg_ms": 2.30599,
+          "best_ms": 0.315744,
+          "best_in_gibs": 24.7431,
+          "best_out_gibs": 24.7431,
+          "in_gibs": 24.8908,
+          "out_gibs": 24.8908
+        },
+        "scatter": {
+          "avg_ms": 2.59135,
+          "best_ms": 0.056832,
+          "best_in_gibs": 137.467,
+          "best_out_gibs": 137.467,
+          "in_gibs": 22.4802,
+          "out_gibs": 22.4802
+        },
+        "compress": {
+          "avg_ms": 209.657,
+          "best_ms": 192.122,
+          "best_in_gibs": 3.04983,
+          "best_out_gibs": 0.420809,
+          "in_gibs": 2.79475,
+          "out_gibs": 0.382579
+        },
+        "aggregate": {
+          "avg_ms": 0.54007,
+          "best_ms": 0.33744,
+          "best_in_gibs": 237.786,
+          "best_out_gibs": 237.786,
+          "in_gibs": 148.518,
+          "out_gibs": 148.518
+        },
+        "d2h": {
+          "avg_ms": 4.30202,
+          "best_ms": 3.50662,
+          "best_in_gibs": 22.8724,
+          "best_out_gibs": 22.8724,
+          "in_gibs": 18.6448,
+          "out_gibs": 18.6448
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 317.658,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 1060.07,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 184.193,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 32.83,
+      "status": "pass",
+      "throughput_in_gibs": 1.10156,
+      "throughput_out_gibs": 0.119266,
+      "compression_fold": 9.23614,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.317198,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 2.65958,
+      "init_s": 0.00435926,
+      "flush_s": 3.85e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.0024,
+          "best_ms": 5.26174,
+          "best_in_gibs": 1.48478,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.58976,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 313.072,
+          "best_ms": 306.171,
+          "best_in_gibs": 1.91376,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.87157,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.78981,
+          "best_ms": 4.804,
+          "best_in_gibs": 122.445,
+          "best_out_gibs": 0.0,
+          "in_gibs": 86.6337,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 32.24,
+      "status": "pass",
+      "throughput_in_gibs": 2.61734,
+      "throughput_out_gibs": 0.368564,
+      "compression_fold": 7.10144,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.412549,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 1.11934,
+      "init_s": 0.450083,
+      "flush_s": 6.6e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.9454,
+          "best_ms": 0.271485,
+          "best_in_gibs": 28.7769,
+          "best_out_gibs": 28.7769,
+          "in_gibs": 29.5286,
+          "out_gibs": 29.5286
+        },
+        "h2d": {
+          "avg_ms": 2.30502,
+          "best_ms": 0.317024,
+          "best_in_gibs": 24.6432,
+          "best_out_gibs": 24.6432,
+          "in_gibs": 24.9013,
+          "out_gibs": 24.9013
+        },
+        "scatter": {
+          "avg_ms": 0.646106,
+          "best_ms": 0.05328,
+          "best_in_gibs": 146.631,
+          "best_out_gibs": 146.631,
+          "in_gibs": 89.428,
+          "out_gibs": 89.428
+        },
+        "compress": {
+          "avg_ms": 126.534,
+          "best_ms": 124.254,
+          "best_in_gibs": 4.71564,
+          "best_out_gibs": 0.663798,
+          "in_gibs": 4.63066,
+          "out_gibs": 0.651923
+        },
+        "aggregate": {
+          "avg_ms": 0.56192,
+          "best_ms": 0.355424,
+          "best_in_gibs": 229.747,
+          "best_out_gibs": 229.747,
+          "in_gibs": 146.801,
+          "out_gibs": 146.801
+        },
+        "d2h": {
+          "avg_ms": 3.70755,
+          "best_ms": 3.52816,
+          "best_in_gibs": 23.464,
+          "best_out_gibs": 23.464,
+          "in_gibs": 22.2493,
+          "out_gibs": 22.2493
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 131.983,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 660.086,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 90.3683,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 32.78,
+      "status": "pass",
+      "throughput_in_gibs": 1.10777,
+      "throughput_out_gibs": 0.129694,
+      "compression_fold": 8.54143,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.342997,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 2.64467,
+      "init_s": 0.00442342,
+      "flush_s": 2.77e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.8536,
+          "best_ms": 4.98584,
+          "best_in_gibs": 1.56694,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.86741,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 321.086,
+          "best_ms": 318.793,
+          "best_in_gibs": 1.83798,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.82486,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.15427,
+          "best_ms": 5.1467,
+          "best_in_gibs": 114.292,
+          "best_out_gibs": 0.0,
+          "in_gibs": 82.2203,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 32.27,
+      "status": "pass",
+      "throughput_in_gibs": 2.70769,
+      "throughput_out_gibs": 0.380565,
+      "compression_fold": 7.11493,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.411766,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.08199,
+      "init_s": 0.457806,
+      "flush_s": 3.62e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.18522,
+          "best_ms": 0.168781,
+          "best_in_gibs": 46.2878,
+          "best_out_gibs": 46.2878,
+          "in_gibs": 48.4678,
+          "out_gibs": 48.4678
+        },
+        "h2d": {
+          "avg_ms": 2.30678,
+          "best_ms": 0.315072,
+          "best_in_gibs": 24.7959,
+          "best_out_gibs": 24.7959,
+          "in_gibs": 24.8823,
+          "out_gibs": 24.8823
+        },
+        "scatter": {
+          "avg_ms": 0.524555,
+          "best_ms": 0.05344,
+          "best_in_gibs": 146.192,
+          "best_out_gibs": 146.192,
+          "in_gibs": 110.15,
+          "out_gibs": 110.15
+        },
+        "compress": {
+          "avg_ms": 127.805,
+          "best_ms": 125.646,
+          "best_in_gibs": 4.66341,
+          "best_out_gibs": 0.655201,
+          "in_gibs": 4.58463,
+          "out_gibs": 0.644297
+        },
+        "aggregate": {
+          "avg_ms": 0.549613,
+          "best_ms": 0.334848,
+          "best_in_gibs": 246.823,
+          "best_out_gibs": 246.823,
+          "in_gibs": 149.822,
+          "out_gibs": 149.822
+        },
+        "d2h": {
+          "avg_ms": 3.68316,
+          "best_ms": 3.50506,
+          "best_in_gibs": 23.558,
+          "best_out_gibs": 23.558,
+          "in_gibs": 22.357,
+          "out_gibs": 22.357
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 132.569,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 666.414,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 86.8859,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 32.76,
+      "status": "pass",
+      "throughput_in_gibs": 1.1032,
+      "throughput_out_gibs": 0.127192,
+      "compression_fold": 8.67351,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.337774,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 2.65562,
+      "init_s": 0.00437285,
+      "flush_s": 2.45e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.822,
+          "best_ms": 5.02172,
+          "best_in_gibs": 1.55574,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.87566,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 323.634,
+          "best_ms": 310.675,
+          "best_in_gibs": 1.88601,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.81049,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.49867,
+          "best_ms": 5.0196,
+          "best_in_gibs": 117.186,
+          "best_out_gibs": 0.0,
+          "in_gibs": 78.4441,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 33.58,
+      "status": "pass",
+      "throughput_in_gibs": 1.75162,
+      "throughput_out_gibs": 0.245684,
+      "compression_fold": 8.55547,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.410921,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.67256,
+      "init_s": 0.812508,
+      "flush_s": 2.71e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.29436,
+          "best_ms": 0.345169,
+          "best_in_gibs": 45.2677,
+          "best_out_gibs": 45.2677,
+          "in_gibs": 46.1924,
+          "out_gibs": 46.1924
+        },
+        "h2d": {
+          "avg_ms": 2.39656,
+          "best_ms": 0.649984,
+          "best_in_gibs": 24.0391,
+          "best_out_gibs": 24.0391,
+          "in_gibs": 24.9693,
+          "out_gibs": 24.9693
+        },
+        "scatter": {
+          "avg_ms": 0.850764,
+          "best_ms": 0.191008,
+          "best_in_gibs": 163.606,
+          "best_out_gibs": 163.606,
+          "in_gibs": 71.4671,
+          "out_gibs": 71.4671
+        },
+        "compress": {
+          "avg_ms": 334.747,
+          "best_ms": 148.614,
+          "best_in_gibs": 7.88539,
+          "best_out_gibs": 0.55685,
+          "in_gibs": 3.50078,
+          "out_gibs": 0.409159
+        },
+        "aggregate": {
+          "avg_ms": 1.33006,
+          "best_ms": 0.344576,
+          "best_in_gibs": 240.166,
+          "best_out_gibs": 240.166,
+          "in_gibs": 102.976,
+          "out_gibs": 102.976
+        },
+        "d2h": {
+          "avg_ms": 5.93477,
+          "best_ms": 3.5552,
+          "best_in_gibs": 23.2773,
+          "best_out_gibs": 23.2773,
+          "in_gibs": 23.0783,
+          "out_gibs": 23.0783
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 427.967,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 1027.19,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 389.265,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 33.08,
+      "status": "pass",
+      "throughput_in_gibs": 0.99123,
+      "throughput_out_gibs": 0.135416,
+      "compression_fold": 8.78388,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.400236,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 2.95561,
+      "init_s": 0.00426628,
+      "flush_s": 3.72e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.9825,
+          "best_ms": 6.49724,
+          "best_in_gibs": 2.40487,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.74093,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 629.299,
+          "best_ms": 625.057,
+          "best_in_gibs": 1.87483,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.86219,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.3306,
+          "best_ms": 7.61154,
+          "best_in_gibs": 154.562,
+          "best_out_gibs": 0.0,
+          "in_gibs": 88.2522,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 32.41,
+      "status": "pass",
+      "throughput_in_gibs": 1.3258,
+      "throughput_out_gibs": 0.800734,
+      "compression_fold": 1.65573,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.76942,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 2.20975,
+      "init_s": 0.00438138,
+      "flush_s": 3.18e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.9831,
+          "best_ms": 5.93788,
+          "best_in_gibs": 1.31571,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.49944,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 130.929,
+          "best_ms": 122.908,
+          "best_in_gibs": 4.76727,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.47522,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 25.3693,
+          "best_ms": 15.2535,
+          "best_in_gibs": 38.4508,
+          "best_out_gibs": 0.0,
+          "in_gibs": 23.1189,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 32.37,
+      "status": "pass",
+      "throughput_in_gibs": 1.33404,
+      "throughput_out_gibs": 0.857453,
+      "compression_fold": 1.55582,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.88305,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 2.19609,
+      "init_s": 0.00448328,
+      "flush_s": 4.84e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.3055,
+          "best_ms": 6.02108,
+          "best_in_gibs": 1.29753,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.57537,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 136.071,
+          "best_ms": 128.982,
+          "best_in_gibs": 4.54279,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.30612,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 25.5521,
+          "best_ms": 15.3153,
+          "best_in_gibs": 38.277,
+          "best_out_gibs": 0.0,
+          "in_gibs": 22.9423,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 32.38,
+      "status": "pass",
+      "throughput_in_gibs": 1.31125,
+      "throughput_out_gibs": 0.806595,
+      "compression_fold": 1.62566,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.80215,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 2.23427,
+      "init_s": 0.00435222,
+      "flush_s": 3.48e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.6581,
+          "best_ms": 6.22346,
+          "best_in_gibs": 1.25533,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.53529,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 141.233,
+          "best_ms": 134.784,
+          "best_in_gibs": 4.34723,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.14874,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 25.2491,
+          "best_ms": 14.9168,
+          "best_in_gibs": 39.29,
+          "best_out_gibs": 0.0,
+          "in_gibs": 23.212,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 31.99,
+      "status": "pass",
+      "throughput_in_gibs": 1.62311,
+      "throughput_out_gibs": 0.861905,
+      "compression_fold": 1.88317,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.55572,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 1.80498,
+      "init_s": 0.0044418,
+      "flush_s": 2.15e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.756,
+          "best_ms": 5.25351,
+          "best_in_gibs": 1.4871,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.64589,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 128.853,
+          "best_ms": 123.306,
+          "best_in_gibs": 4.75191,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.54734,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 22.3102,
+          "best_ms": 13.8594,
+          "best_in_gibs": 42.2825,
+          "best_out_gibs": 0.0,
+          "in_gibs": 26.2665,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 31.96,
+      "status": "pass",
+      "throughput_in_gibs": 1.61769,
+      "throughput_out_gibs": 0.858827,
+      "compression_fold": 1.8836,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.55536,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 1.81103,
+      "init_s": 0.00446945,
+      "flush_s": 3.84e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.9307,
+          "best_ms": 5.33842,
+          "best_in_gibs": 1.46345,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.60593,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 129.359,
+          "best_ms": 123.467,
+          "best_in_gibs": 4.74571,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.52953,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 21.6248,
+          "best_ms": 12.7388,
+          "best_in_gibs": 45.9993,
+          "best_out_gibs": 0.0,
+          "in_gibs": 27.0973,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 31.95,
+      "status": "pass",
+      "throughput_in_gibs": 1.63819,
+      "throughput_out_gibs": 0.920055,
+      "compression_fold": 1.78053,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.6454,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 1.78837,
+      "init_s": 0.00400409,
+      "flush_s": 6.81e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.7299,
+          "best_ms": 4.99357,
+          "best_in_gibs": 1.56451,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.89988,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 136.415,
+          "best_ms": 128.577,
+          "best_in_gibs": 4.55711,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.29525,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 22.6166,
+          "best_ms": 13.6007,
+          "best_in_gibs": 43.0828,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25.9082,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 31.96,
+      "status": "pass",
+      "throughput_in_gibs": 1.64201,
+      "throughput_out_gibs": 0.922149,
+      "compression_fold": 1.78063,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.64531,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.78421,
+      "init_s": 0.00409244,
+      "flush_s": 4.53e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.6958,
+          "best_ms": 5.25375,
+          "best_in_gibs": 1.48703,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.90892,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 136.127,
+          "best_ms": 129.587,
+          "best_in_gibs": 4.52156,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.30435,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 22.0559,
+          "best_ms": 12.7452,
+          "best_in_gibs": 45.9739,
+          "best_out_gibs": 0.0,
+          "in_gibs": 26.5665,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 32.23,
+      "status": "pass",
+      "throughput_in_gibs": 1.44914,
+      "throughput_out_gibs": 0.976035,
+      "compression_fold": 1.78166,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.97323,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 2.02168,
+      "init_s": 0.00409904,
+      "flush_s": 2.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.9839,
+          "best_ms": 6.48399,
+          "best_in_gibs": 2.40978,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.7406,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 276.624,
+          "best_ms": 258.399,
+          "best_in_gibs": 4.53514,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.23635,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 53.9507,
+          "best_ms": 25.2598,
+          "best_in_gibs": 46.3933,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.7214,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 32.79,
+      "status": "pass",
+      "throughput_in_gibs": 1.0952,
+      "throughput_out_gibs": 0.0396568,
+      "compression_fold": 27.617,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.106083,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 2.67502,
+      "init_s": 0.00442154,
+      "flush_s": 2.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.7919,
+          "best_ms": 5.89973,
+          "best_in_gibs": 1.32421,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.5204,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 245.196,
+          "best_ms": 241.113,
+          "best_in_gibs": 2.43013,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.38967,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.04097,
+          "best_ms": 4.23115,
+          "best_in_gibs": 138.617,
+          "best_out_gibs": 0.0,
+          "in_gibs": 116.348,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 32.15,
+      "status": "pass",
+      "throughput_in_gibs": 1.4177,
+      "throughput_out_gibs": 0.0341145,
+      "compression_fold": 41.5572,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0704978,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 2.0665,
+      "init_s": 0.00438771,
+      "flush_s": 3.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.3644,
+          "best_ms": 5.90328,
+          "best_in_gibs": 1.32342,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.56858,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 130.321,
+          "best_ms": 126.69,
+          "best_in_gibs": 4.62497,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.4961,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.5685,
+          "best_ms": 3.91386,
+          "best_in_gibs": 149.782,
+          "best_out_gibs": 0.0,
+          "in_gibs": 128.319,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 32.13,
+      "status": "pass",
+      "throughput_in_gibs": 1.45722,
+      "throughput_out_gibs": 0.026805,
+      "compression_fold": 54.3638,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0538904,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 2.01046,
+      "init_s": 0.00426876,
+      "flush_s": 3.28e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 22.7,
+          "best_ms": 5.94734,
+          "best_in_gibs": 1.31361,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.53061,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 116.637,
+          "best_ms": 113.882,
+          "best_in_gibs": 5.14512,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.02362,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.16556,
+          "best_ms": 3.77704,
+          "best_in_gibs": 155.17,
+          "best_out_gibs": 0.0,
+          "in_gibs": 140.697,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 31.54,
+      "status": "pass",
+      "throughput_in_gibs": 2.02716,
+      "throughput_out_gibs": 0.0276994,
+      "compression_fold": 73.1844,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0400316,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 1.44522,
+      "init_s": 0.00412719,
+      "flush_s": 3.84e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.0223,
+          "best_ms": 5.29525,
+          "best_in_gibs": 1.47538,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.58531,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 72.3919,
+          "best_ms": 68.2643,
+          "best_in_gibs": 8.58337,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.09396,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.14362,
+          "best_ms": 3.88322,
+          "best_in_gibs": 150.908,
+          "best_out_gibs": 0.0,
+          "in_gibs": 141.425,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 31.59,
+      "status": "pass",
+      "throughput_in_gibs": 2.02222,
+      "throughput_out_gibs": 0.0297758,
+      "compression_fold": 67.9147,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0431377,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 1.44875,
+      "init_s": 0.00406932,
+      "flush_s": 4.89e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 15.9205,
+          "best_ms": 5.3419,
+          "best_in_gibs": 1.46249,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.60822,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 74.3,
+          "best_ms": 71.8592,
+          "best_in_gibs": 8.15396,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.8861,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.00108,
+          "best_ms": 3.66664,
+          "best_in_gibs": 159.813,
+          "best_out_gibs": 0.0,
+          "in_gibs": 146.454,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 31.58,
+      "status": "pass",
+      "throughput_in_gibs": 1.97488,
+      "throughput_out_gibs": 0.0463345,
+      "compression_fold": 42.6223,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0687361,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 1.48348,
+      "init_s": 0.00402833,
+      "flush_s": 3.87e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.804,
+          "best_ms": 5.02643,
+          "best_in_gibs": 1.55428,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.88036,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 91.9312,
+          "best_ms": 86.8646,
+          "best_in_gibs": 6.74541,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.37365,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.49037,
+          "best_ms": 3.85636,
+          "best_in_gibs": 151.945,
+          "best_out_gibs": 0.0,
+          "in_gibs": 130.492,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 31.59,
+      "status": "pass",
+      "throughput_in_gibs": 1.99565,
+      "throughput_out_gibs": 0.0467568,
+      "compression_fold": 42.6815,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0686407,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.46804,
+      "init_s": 0.00412496,
+      "flush_s": 3.78e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 14.7526,
+          "best_ms": 4.93308,
+          "best_in_gibs": 1.5837,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.89388,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 90.2404,
+          "best_ms": 85.5993,
+          "best_in_gibs": 6.84512,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.49307,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.20008,
+          "best_ms": 3.69392,
+          "best_in_gibs": 158.625,
+          "best_out_gibs": 0.0,
+          "in_gibs": 139.509,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 31.72,
+      "status": "pass",
+      "throughput_in_gibs": 1.85782,
+      "throughput_out_gibs": 0.052199,
+      "compression_fold": 42.7094,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.082315,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.57695,
+      "init_s": 0.00413857,
+      "flush_s": 3.6e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 16.0686,
+          "best_ms": 6.41206,
+          "best_in_gibs": 2.43682,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.72089,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 176.514,
+          "best_ms": 171.371,
+          "best_in_gibs": 6.83823,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.639,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.57584,
+          "best_ms": 4.21995,
+          "best_in_gibs": 277.702,
+          "best_out_gibs": 0.0,
+          "in_gibs": 210.172,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 1.0,
+      "status": "pass",
+      "throughput_in_gibs": 0.350937,
+      "throughput_out_gibs": 0.35128,
+      "compression_fold": 0.999024,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312805,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0890473,
+      "init_s": 0.400519,
+      "flush_s": 2.6e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00120793,
+          "best_ms": 0.000743,
+          "best_in_gibs": 20.5367,
+          "best_out_gibs": 20.5367,
+          "in_gibs": 12.6322,
+          "out_gibs": 12.6322
+        },
+        "h2d": {
+          "avg_ms": 0.012896,
+          "best_ms": 0.012896,
+          "best_in_gibs": 1.18322,
+          "best_out_gibs": 1.18322,
+          "in_gibs": 1.18322,
+          "out_gibs": 1.18322
+        },
+        "scatter": {
+          "avg_ms": 0.0106818,
+          "best_ms": 0.010112,
+          "best_in_gibs": 1.50898,
+          "best_out_gibs": 1.50898,
+          "in_gibs": 1.42848,
+          "out_gibs": 1.42848
+        },
+        "aggregate": {
+          "avg_ms": 0.119584,
+          "best_ms": 0.119584,
+          "best_in_gibs": 261.323,
+          "best_out_gibs": 261.323,
+          "in_gibs": 261.323,
+          "out_gibs": 261.323
+        },
+        "d2h": {
+          "avg_ms": 1.34224,
+          "best_ms": 1.34224,
+          "best_in_gibs": 23.282,
+          "best_out_gibs": 23.282,
+          "in_gibs": 23.282,
+          "out_gibs": 23.282
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.5185,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.39243,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 71.9248,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 6.84,
+      "status": "pass",
+      "throughput_in_gibs": 0.00462183,
+      "throughput_out_gibs": 0.00462635,
+      "compression_fold": 0.999024,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312805,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 6.76139,
+      "init_s": 0.00417971,
+      "flush_s": 1.58e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.28708,
+          "best_ms": 3.02383,
+          "best_in_gibs": 0.00504617,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.00464205,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.40129,
+          "best_ms": 7.40129,
+          "best_in_gibs": 4.22223,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.22223,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.47559,
+          "best_ms": 6.47559,
+          "best_in_gibs": 4.82581,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.82581,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 1.16,
+      "status": "pass",
+      "throughput_in_gibs": 0.596438,
+      "throughput_out_gibs": 0.596729,
+      "compression_fold": 0.999511,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312653,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0523944,
+      "init_s": 0.421248,
+      "flush_s": 1.58e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00235866,
+          "best_ms": 0.001396,
+          "best_in_gibs": 21.8607,
+          "best_out_gibs": 21.8607,
+          "in_gibs": 12.9385,
+          "out_gibs": 12.9385
+        },
+        "h2d": {
+          "avg_ms": 0.0121702,
+          "best_ms": 0.010048,
+          "best_in_gibs": 3.03718,
+          "best_out_gibs": 3.03718,
+          "in_gibs": 2.50757,
+          "out_gibs": 2.50757
+        },
+        "scatter": {
+          "avg_ms": 0.0107945,
+          "best_ms": 0.010048,
+          "best_in_gibs": 3.03718,
+          "best_out_gibs": 3.03718,
+          "in_gibs": 2.82715,
+          "out_gibs": 2.82715
+        },
+        "aggregate": {
+          "avg_ms": 0.13712,
+          "best_ms": 0.13712,
+          "best_in_gibs": 227.903,
+          "best_out_gibs": 227.903,
+          "in_gibs": 227.903,
+          "out_gibs": 227.903
+        },
+        "d2h": {
+          "avg_ms": 1.32848,
+          "best_ms": 1.32848,
+          "best_in_gibs": 23.5231,
+          "best_out_gibs": 23.5231,
+          "in_gibs": 23.5231,
+          "out_gibs": 23.5231
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.45468,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.37903,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 37.0992,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.51,
+      "status": "pass",
+      "throughput_in_gibs": 0.00917483,
+      "throughput_out_gibs": 0.00917932,
+      "compression_fold": 0.999511,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312653,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 3.40606,
+      "init_s": 0.0043666,
+      "flush_s": 2.35e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.29919,
+          "best_ms": 2.98784,
+          "best_in_gibs": 0.0102139,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.00925003,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.15941,
+          "best_ms": 6.15941,
+          "best_in_gibs": 5.07354,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.07354,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.09473,
+          "best_ms": 6.09473,
+          "best_in_gibs": 5.12738,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.12738,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 1.0,
+      "status": "pass",
+      "throughput_in_gibs": 0.930771,
+      "throughput_out_gibs": 0.930999,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0335743,
+      "init_s": 0.425116,
+      "flush_s": 2.19e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00444607,
+          "best_ms": 0.003009,
+          "best_in_gibs": 20.2842,
+          "best_out_gibs": 20.2842,
+          "in_gibs": 13.7279,
+          "out_gibs": 13.7279
+        },
+        "h2d": {
+          "avg_ms": 0.0196652,
+          "best_ms": 0.011552,
+          "best_in_gibs": 5.28351,
+          "best_out_gibs": 5.28351,
+          "in_gibs": 3.10372,
+          "out_gibs": 3.10372
+        },
+        "scatter": {
+          "avg_ms": 0.0142248,
+          "best_ms": 0.01008,
+          "best_in_gibs": 6.05507,
+          "best_out_gibs": 6.05507,
+          "in_gibs": 4.29077,
+          "out_gibs": 4.29077
+        },
+        "aggregate": {
+          "avg_ms": 0.130336,
+          "best_ms": 0.130336,
+          "best_in_gibs": 239.765,
+          "best_out_gibs": 239.765,
+          "in_gibs": 239.765,
+          "out_gibs": 239.765
+        },
+        "d2h": {
+          "avg_ms": 1.30589,
+          "best_ms": 1.30589,
+          "best_in_gibs": 23.9301,
+          "best_out_gibs": 23.9301,
+          "in_gibs": 23.9301,
+          "out_gibs": 23.9301
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.4299,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.37125,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 16.6875,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 1.82,
+      "status": "pass",
+      "throughput_in_gibs": 0.0180728,
+      "throughput_out_gibs": 0.0180773,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.72911,
+      "init_s": 0.00420526,
+      "flush_s": 1.72e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.32362,
+          "best_ms": 3.10243,
+          "best_in_gibs": 0.0196734,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0183641,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.61236,
+          "best_ms": 6.61236,
+          "best_in_gibs": 4.726,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.726,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.3081,
+          "best_ms": 6.3081,
+          "best_in_gibs": 4.95395,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.95395,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.89,
+      "status": "pass",
+      "throughput_in_gibs": 1.53048,
+      "throughput_out_gibs": 1.53067,
+      "compression_fold": 0.999877,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312538,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0204185,
+      "init_s": 0.387973,
+      "flush_s": 1.57e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00897737,
+          "best_ms": 0.006282,
+          "best_in_gibs": 19.4318,
+          "best_out_gibs": 19.4318,
+          "in_gibs": 13.5976,
+          "out_gibs": 13.5976
+        },
+        "h2d": {
+          "avg_ms": 0.0112817,
+          "best_ms": 0.010016,
+          "best_in_gibs": 12.1875,
+          "best_out_gibs": 12.1875,
+          "in_gibs": 10.8202,
+          "out_gibs": 10.8202
+        },
+        "scatter": {
+          "avg_ms": 0.0679253,
+          "best_ms": 0.010112,
+          "best_in_gibs": 12.0718,
+          "best_out_gibs": 12.0718,
+          "in_gibs": 1.79712,
+          "out_gibs": 1.79712
+        },
+        "aggregate": {
+          "avg_ms": 0.142912,
+          "best_ms": 0.142912,
+          "best_in_gibs": 218.666,
+          "best_out_gibs": 218.666,
+          "in_gibs": 218.666,
+          "out_gibs": 218.666
+        },
+        "d2h": {
+          "avg_ms": 1.29738,
+          "best_ms": 1.29738,
+          "best_in_gibs": 24.0871,
+          "best_out_gibs": 24.0871,
+          "in_gibs": 24.0871,
+          "out_gibs": 24.0871
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.43811,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.38629,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.87824,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 1.01,
+      "status": "pass",
+      "throughput_in_gibs": 0.0352879,
+      "throughput_out_gibs": 0.0352922,
+      "compression_fold": 0.999877,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312538,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.885574,
+      "init_s": 0.00419223,
+      "flush_s": 3.38e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.3544,
+          "best_ms": 3.02829,
+          "best_in_gibs": 0.0403099,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0363911,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.31941,
+          "best_ms": 6.31941,
+          "best_in_gibs": 4.94508,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.94508,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.24026,
+          "best_ms": 6.24026,
+          "best_in_gibs": 5.00781,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.00781,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.87,
+      "status": "pass",
+      "throughput_in_gibs": 1.45567,
+      "throughput_out_gibs": 1.45576,
+      "compression_fold": 0.999938,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312519,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0214678,
+      "init_s": 0.386112,
+      "flush_s": 1.7e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0186158,
+          "best_ms": 0.014445,
+          "best_in_gibs": 16.9014,
+          "best_out_gibs": 16.9014,
+          "in_gibs": 13.1147,
+          "out_gibs": 13.1147
+        },
+        "h2d": {
+          "avg_ms": 0.0159751,
+          "best_ms": 0.013504,
+          "best_in_gibs": 18.0791,
+          "best_out_gibs": 18.0791,
+          "in_gibs": 15.2826,
+          "out_gibs": 15.2826
+        },
+        "scatter": {
+          "avg_ms": 0.0377173,
+          "best_ms": 0.010304,
+          "best_in_gibs": 23.6938,
+          "best_out_gibs": 23.6938,
+          "in_gibs": 6.4729,
+          "out_gibs": 6.4729
+        },
+        "aggregate": {
+          "avg_ms": 0.218144,
+          "best_ms": 0.218144,
+          "best_in_gibs": 143.254,
+          "best_out_gibs": 143.254,
+          "in_gibs": 143.254,
+          "out_gibs": 143.254
+        },
+        "d2h": {
+          "avg_ms": 1.28118,
+          "best_ms": 1.28118,
+          "best_in_gibs": 24.3915,
+          "best_out_gibs": 24.3915,
+          "in_gibs": 24.3915,
+          "out_gibs": 24.3915
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.55229,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.49969,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.71482,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.55,
+      "status": "pass",
+      "throughput_in_gibs": 0.067287,
+      "throughput_out_gibs": 0.0672912,
+      "compression_fold": 0.999938,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312519,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.464428,
+      "init_s": 0.0042082,
+      "flush_s": 1.71e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.42077,
+          "best_ms": 3.18417,
+          "best_in_gibs": 0.0766732,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0713701,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.26181,
+          "best_ms": 6.26181,
+          "best_in_gibs": 4.99057,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.99057,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.42315,
+          "best_ms": 6.42315,
+          "best_in_gibs": 4.86521,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.86521,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.98,
+      "status": "pass",
+      "throughput_in_gibs": 1.64722,
+      "throughput_out_gibs": 1.64727,
+      "compression_fold": 0.999969,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.031251,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0189713,
+      "init_s": 0.390464,
+      "flush_s": 1.61e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0373742,
+          "best_ms": 0.030366,
+          "best_in_gibs": 16.0799,
+          "best_out_gibs": 16.0799,
+          "in_gibs": 13.0647,
+          "out_gibs": 13.0647
+        },
+        "h2d": {
+          "avg_ms": 0.0287551,
+          "best_ms": 0.027168,
+          "best_in_gibs": 17.9727,
+          "best_out_gibs": 17.9727,
+          "in_gibs": 16.9807,
+          "out_gibs": 16.9807
+        },
+        "scatter": {
+          "avg_ms": 0.0163349,
+          "best_ms": 0.010368,
+          "best_in_gibs": 47.095,
+          "best_out_gibs": 47.095,
+          "in_gibs": 29.892,
+          "out_gibs": 29.892
+        },
+        "aggregate": {
+          "avg_ms": 0.349504,
+          "best_ms": 0.349504,
+          "best_in_gibs": 89.4124,
+          "best_out_gibs": 89.4124,
+          "in_gibs": 89.4124,
+          "out_gibs": 89.4124
+        },
+        "d2h": {
+          "avg_ms": 1.3199,
+          "best_ms": 1.3199,
+          "best_in_gibs": 23.676,
+          "best_out_gibs": 23.676,
+          "in_gibs": 23.676,
+          "out_gibs": 23.676
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.71332,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.67302,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.20599,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.35,
+      "status": "pass",
+      "throughput_in_gibs": 0.122874,
+      "throughput_out_gibs": 0.122878,
+      "compression_fold": 0.999969,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.031251,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.254325,
+      "init_s": 0.00422311,
+      "flush_s": 2.3e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.53226,
+          "best_ms": 3.1707,
+          "best_in_gibs": 0.153998,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.138235,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.55618,
+          "best_ms": 6.55618,
+          "best_in_gibs": 4.7665,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.7665,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.43382,
+          "best_ms": 6.43382,
+          "best_in_gibs": 4.85715,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.85715,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.89,
+      "status": "pass",
+      "throughput_in_gibs": 1.53296,
+      "throughput_out_gibs": 1.53298,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0203854,
+      "init_s": 0.380981,
+      "flush_s": 2.6e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0779806,
+          "best_ms": 0.060847,
+          "best_in_gibs": 16.0495,
+          "best_out_gibs": 16.0495,
+          "in_gibs": 12.5231,
+          "out_gibs": 12.5231
+        },
+        "h2d": {
+          "avg_ms": 0.0509323,
+          "best_ms": 0.048096,
+          "best_in_gibs": 20.3044,
+          "best_out_gibs": 20.3044,
+          "in_gibs": 19.1737,
+          "out_gibs": 19.1737
+        },
+        "scatter": {
+          "avg_ms": 0.0164469,
+          "best_ms": 0.011392,
+          "best_in_gibs": 85.7235,
+          "best_out_gibs": 85.7235,
+          "in_gibs": 59.3766,
+          "out_gibs": 59.3766
+        },
+        "aggregate": {
+          "avg_ms": 0.632128,
+          "best_ms": 0.632128,
+          "best_in_gibs": 49.4362,
+          "best_out_gibs": 49.4362,
+          "in_gibs": 49.4362,
+          "out_gibs": 49.4362
+        },
+        "d2h": {
+          "avg_ms": 1.2904,
+          "best_ms": 1.2904,
+          "best_in_gibs": 24.2173,
+          "best_out_gibs": 24.2173,
+          "in_gibs": 24.2173,
+          "out_gibs": 24.2173
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.94056,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.90262,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.10181,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.23,
+      "status": "pass",
+      "throughput_in_gibs": 0.219316,
+      "throughput_out_gibs": 0.21932,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.142488,
+      "init_s": 0.0041225,
+      "flush_s": 2.32e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.56766,
+          "best_ms": 3.16824,
+          "best_in_gibs": 0.308235,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.273726,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.30024,
+          "best_ms": 6.30024,
+          "best_in_gibs": 4.96013,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.96013,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.77971,
+          "best_ms": 6.77971,
+          "best_in_gibs": 4.60934,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.60934,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.87,
+      "status": "pass",
+      "throughput_in_gibs": 1.6349,
+      "throughput_out_gibs": 1.63492,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0191144,
+      "init_s": 0.38231,
+      "flush_s": 2.25e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.077832,
+          "best_ms": 0.063418,
+          "best_in_gibs": 15.3988,
+          "best_out_gibs": 15.3988,
+          "in_gibs": 12.5471,
+          "out_gibs": 12.5471
+        },
+        "h2d": {
+          "avg_ms": 0.0509493,
+          "best_ms": 0.04976,
+          "best_in_gibs": 19.6255,
+          "best_out_gibs": 19.6255,
+          "in_gibs": 19.1673,
+          "out_gibs": 19.1673
+        },
+        "scatter": {
+          "avg_ms": 0.0162933,
+          "best_ms": 0.011488,
+          "best_in_gibs": 85.0072,
+          "best_out_gibs": 85.0072,
+          "in_gibs": 59.9363,
+          "out_gibs": 59.9363
+        },
+        "aggregate": {
+          "avg_ms": 0.626976,
+          "best_ms": 0.626976,
+          "best_in_gibs": 49.8424,
+          "best_out_gibs": 49.8424,
+          "in_gibs": 49.8424,
+          "out_gibs": 49.8424
+        },
+        "d2h": {
+          "avg_ms": 1.28986,
+          "best_ms": 1.28986,
+          "best_in_gibs": 24.2275,
+          "best_out_gibs": 24.2275,
+          "in_gibs": 24.2275,
+          "out_gibs": 24.2275
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.92158,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.8817,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.07089,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.24,
+      "status": "pass",
+      "throughput_in_gibs": 0.21489,
+      "throughput_out_gibs": 0.214894,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.145423,
+      "init_s": 0.00410545,
+      "flush_s": 1.58e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.67929,
+          "best_ms": 3.40598,
+          "best_in_gibs": 0.28672,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.265421,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.26934,
+          "best_ms": 6.26934,
+          "best_in_gibs": 4.98457,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.98457,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.80343,
+          "best_ms": 6.80343,
+          "best_in_gibs": 4.59327,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.59327,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 1.07,
+      "status": "pass",
+      "throughput_in_gibs": 0.345581,
+      "throughput_out_gibs": 0.0851509,
+      "compression_fold": 4.05845,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00769998,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0904275,
+      "init_s": 0.376829,
+      "flush_s": 1.58e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00119405,
+          "best_ms": 0.000762,
+          "best_in_gibs": 20.0247,
+          "best_out_gibs": 20.0247,
+          "in_gibs": 12.7791,
+          "out_gibs": 12.7791
+        },
+        "h2d": {
+          "avg_ms": 0.011968,
+          "best_ms": 0.010976,
+          "best_in_gibs": 1.3902,
+          "best_out_gibs": 1.3902,
+          "in_gibs": 1.27497,
+          "out_gibs": 1.27497
+        },
+        "scatter": {
+          "avg_ms": 0.0106613,
+          "best_ms": 0.010048,
+          "best_in_gibs": 1.51859,
+          "best_out_gibs": 1.51859,
+          "in_gibs": 1.43123,
+          "out_gibs": 1.43123
+        },
+        "compress": {
+          "avg_ms": 3.0752,
+          "best_ms": 3.0752,
+          "best_in_gibs": 10.1619,
+          "best_out_gibs": 2.49397,
+          "in_gibs": 10.1619,
+          "out_gibs": 2.49397
+        },
+        "aggregate": {
+          "avg_ms": 0.046528,
+          "best_ms": 0.046528,
+          "best_in_gibs": 164.835,
+          "best_out_gibs": 164.835,
+          "in_gibs": 164.835,
+          "out_gibs": 164.835
+        },
+        "d2h": {
+          "avg_ms": 0.39968,
+          "best_ms": 0.39968,
+          "best_in_gibs": 19.189,
+          "best_out_gibs": 19.189,
+          "in_gibs": 19.189,
+          "out_gibs": 19.189
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.73638,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.60958,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 72.3691,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 6.86,
+      "status": "pass",
+      "throughput_in_gibs": 0.00461165,
+      "throughput_out_gibs": 0.00169954,
+      "compression_fold": 2.71348,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0115166,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 6.77631,
+      "init_s": 0.00413001,
+      "flush_s": 1.49e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.29054,
+          "best_ms": 3.01435,
+          "best_in_gibs": 0.00506205,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.00463716,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.4424,
+          "best_ms": 17.4424,
+          "best_in_gibs": 1.79161,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.79161,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.55264,
+          "best_ms": 4.55264,
+          "best_in_gibs": 6.89766,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.89766,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.91,
+      "status": "pass",
+      "throughput_in_gibs": 0.563542,
+      "throughput_out_gibs": 0.070529,
+      "compression_fold": 7.99022,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00391103,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0554529,
+      "init_s": 0.396237,
+      "flush_s": 2.45e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00223812,
+          "best_ms": 0.001419,
+          "best_in_gibs": 21.5064,
+          "best_out_gibs": 21.5064,
+          "in_gibs": 13.6353,
+          "out_gibs": 13.6353
+        },
+        "h2d": {
+          "avg_ms": 0.0121835,
+          "best_ms": 0.010016,
+          "best_in_gibs": 3.04688,
+          "best_out_gibs": 3.04688,
+          "in_gibs": 2.50482,
+          "out_gibs": 2.50482
+        },
+        "scatter": {
+          "avg_ms": 0.0109281,
+          "best_ms": 0.010048,
+          "best_in_gibs": 3.03718,
+          "best_out_gibs": 3.03718,
+          "in_gibs": 2.79258,
+          "out_gibs": 2.79258
+        },
+        "compress": {
+          "avg_ms": 2.82781,
+          "best_ms": 2.82781,
+          "best_in_gibs": 11.051,
+          "best_out_gibs": 1.37766,
+          "in_gibs": 11.051,
+          "out_gibs": 1.37766
+        },
+        "aggregate": {
+          "avg_ms": 0.040224,
+          "best_ms": 0.040224,
+          "best_in_gibs": 96.8516,
+          "best_out_gibs": 96.8516,
+          "in_gibs": 96.8516,
+          "out_gibs": 96.8516
+        },
+        "d2h": {
+          "avg_ms": 0.225056,
+          "best_ms": 0.225056,
+          "best_in_gibs": 17.3102,
+          "best_out_gibs": 17.3102,
+          "in_gibs": 17.3102,
+          "out_gibs": 17.3102
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.44168,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.35623,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 37.0248,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.49,
+      "status": "pass",
+      "throughput_in_gibs": 0.00915067,
+      "throughput_out_gibs": 0.00333935,
+      "compression_fold": 2.74025,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0114041,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 3.41505,
+      "init_s": 0.00420253,
+      "flush_s": 2.16e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.30013,
+          "best_ms": 3.00931,
+          "best_in_gibs": 0.010141,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0092474,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.4375,
+          "best_ms": 16.4375,
+          "best_in_gibs": 1.90114,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.90114,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.49999,
+          "best_ms": 4.49999,
+          "best_in_gibs": 6.97498,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.97498,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 1.13,
+      "status": "pass",
+      "throughput_in_gibs": 0.889661,
+      "throughput_out_gibs": 0.0574097,
+      "compression_fold": 15.4967,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00201656,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0351257,
+      "init_s": 0.382844,
+      "flush_s": 1.6e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00446809,
+          "best_ms": 0.002947,
+          "best_in_gibs": 20.7109,
+          "best_out_gibs": 20.7109,
+          "in_gibs": 13.6602,
+          "out_gibs": 13.6602
+        },
+        "h2d": {
+          "avg_ms": 0.0198862,
+          "best_ms": 0.012384,
+          "best_in_gibs": 4.92855,
+          "best_out_gibs": 4.92855,
+          "in_gibs": 3.06922,
+          "out_gibs": 3.06922
+        },
+        "scatter": {
+          "avg_ms": 0.0140098,
+          "best_ms": 0.01008,
+          "best_in_gibs": 6.05507,
+          "best_out_gibs": 6.05507,
+          "in_gibs": 4.35659,
+          "out_gibs": 4.35659
+        },
+        "compress": {
+          "avg_ms": 2.86061,
+          "best_ms": 2.86061,
+          "best_in_gibs": 10.9243,
+          "best_out_gibs": 0.702268,
+          "in_gibs": 10.9243,
+          "out_gibs": 0.702268
+        },
+        "aggregate": {
+          "avg_ms": 0.036576,
+          "best_ms": 0.036576,
+          "best_in_gibs": 54.9244,
+          "best_out_gibs": 54.9244,
+          "in_gibs": 54.9244,
+          "out_gibs": 54.9244
+        },
+        "d2h": {
+          "avg_ms": 0.128896,
+          "best_ms": 0.128896,
+          "best_in_gibs": 15.5855,
+          "best_out_gibs": 15.5855,
+          "in_gibs": 15.5855,
+          "out_gibs": 15.5855
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.32978,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.26862,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 16.7505,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 1.8,
+      "status": "pass",
+      "throughput_in_gibs": 0.0179903,
+      "throughput_out_gibs": 0.00653279,
+      "compression_fold": 2.75384,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0113478,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.73705,
+      "init_s": 0.00426657,
+      "flush_s": 1.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.32516,
+          "best_ms": 3.08889,
+          "best_in_gibs": 0.0197595,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0183555,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.2805,
+          "best_ms": 15.2805,
+          "best_in_gibs": 2.04509,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.04509,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.43381,
+          "best_ms": 4.43381,
+          "best_in_gibs": 7.07822,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.07822,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 1.11,
+      "status": "pass",
+      "throughput_in_gibs": 1.33446,
+      "throughput_out_gibs": 0.0456731,
+      "compression_fold": 29.2176,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00106956,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0234177,
+      "init_s": 0.435283,
+      "flush_s": 2.14e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00906818,
+          "best_ms": 0.006348,
+          "best_in_gibs": 19.2297,
+          "best_out_gibs": 19.2297,
+          "in_gibs": 13.4614,
+          "out_gibs": 13.4614
+        },
+        "h2d": {
+          "avg_ms": 0.0111744,
+          "best_ms": 0.010016,
+          "best_in_gibs": 12.1875,
+          "best_out_gibs": 12.1875,
+          "in_gibs": 10.9241,
+          "out_gibs": 10.9241
+        },
+        "scatter": {
+          "avg_ms": 0.189536,
+          "best_ms": 0.189536,
+          "best_in_gibs": 0.644048,
+          "best_out_gibs": 0.644048,
+          "in_gibs": 0.644048,
+          "out_gibs": 0.644048
+        },
+        "compress": {
+          "avg_ms": 3.17715,
+          "best_ms": 3.17715,
+          "best_in_gibs": 9.83585,
+          "best_out_gibs": 0.335436,
+          "in_gibs": 9.83585,
+          "out_gibs": 0.335436
+        },
+        "aggregate": {
+          "avg_ms": 0.036672,
+          "best_ms": 0.036672,
+          "best_in_gibs": 29.0612,
+          "best_out_gibs": 29.0612,
+          "in_gibs": 29.0612,
+          "out_gibs": 29.0612
+        },
+        "d2h": {
+          "avg_ms": 0.104832,
+          "best_ms": 0.104832,
+          "best_in_gibs": 10.1661,
+          "best_out_gibs": 10.1661,
+          "in_gibs": 10.1661,
+          "out_gibs": 10.1661
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.66295,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.60856,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.7926,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.96,
+      "status": "pass",
+      "throughput_in_gibs": 0.0350747,
+      "throughput_out_gibs": 0.0127051,
+      "compression_fold": 2.76069,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0113197,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.890956,
+      "init_s": 0.00434944,
+      "flush_s": 1.79e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.34326,
+          "best_ms": 3.04919,
+          "best_in_gibs": 0.0400337,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0365123,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.9789,
+          "best_ms": 16.9789,
+          "best_in_gibs": 1.84052,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.84052,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.21152,
+          "best_ms": 4.21152,
+          "best_in_gibs": 7.45092,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.45092,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 1.17,
+      "status": "pass",
+      "throughput_in_gibs": 1.3673,
+      "throughput_out_gibs": 0.0260799,
+      "compression_fold": 52.4275,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000596061,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0228552,
+      "init_s": 0.384256,
+      "flush_s": 1.77e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0185253,
+          "best_ms": 0.014653,
+          "best_in_gibs": 16.6615,
+          "best_out_gibs": 16.6615,
+          "in_gibs": 13.1788,
+          "out_gibs": 13.1788
+        },
+        "h2d": {
+          "avg_ms": 0.0161951,
+          "best_ms": 0.015104,
+          "best_in_gibs": 16.164,
+          "best_out_gibs": 16.164,
+          "in_gibs": 15.075,
+          "out_gibs": 15.075
+        },
+        "scatter": {
+          "avg_ms": 0.051784,
+          "best_ms": 0.010304,
+          "best_in_gibs": 23.6938,
+          "best_out_gibs": 23.6938,
+          "in_gibs": 4.7146,
+          "out_gibs": 4.7146
+        },
+        "compress": {
+          "avg_ms": 3.86211,
+          "best_ms": 3.86211,
+          "best_in_gibs": 8.09143,
+          "best_out_gibs": 0.153838,
+          "in_gibs": 8.09143,
+          "out_gibs": 0.153838
+        },
+        "aggregate": {
+          "avg_ms": 0.034784,
+          "best_ms": 0.034784,
+          "best_in_gibs": 17.0808,
+          "best_out_gibs": 17.0808,
+          "in_gibs": 17.0808,
+          "out_gibs": 17.0808
+        },
+        "d2h": {
+          "avg_ms": 0.1296,
+          "best_ms": 0.1296,
+          "best_in_gibs": 4.58441,
+          "best_out_gibs": 4.58441,
+          "in_gibs": 4.58441,
+          "out_gibs": 4.58441
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 2.38906,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 2.34084,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.71108,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.56,
+      "status": "pass",
+      "throughput_in_gibs": 0.0665913,
+      "throughput_out_gibs": 0.0240913,
+      "compression_fold": 2.76412,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0113056,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.46928,
+      "init_s": 0.00411463,
+      "flush_s": 3.8e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.39173,
+          "best_ms": 3.15156,
+          "best_in_gibs": 0.0774667,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0719812,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.7322,
+          "best_ms": 16.7322,
+          "best_in_gibs": 1.86765,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.86765,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.45849,
+          "best_ms": 4.45849,
+          "best_in_gibs": 7.03733,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.03733,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.89,
+      "status": "pass",
+      "throughput_in_gibs": 1.35824,
+      "throughput_out_gibs": 0.0156171,
+      "compression_fold": 86.9718,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000359312,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0230076,
+      "init_s": 0.39831,
+      "flush_s": 2.04e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0370284,
+          "best_ms": 0.030289,
+          "best_in_gibs": 16.1207,
+          "best_out_gibs": 16.1207,
+          "in_gibs": 13.1867,
+          "out_gibs": 13.1867
+        },
+        "h2d": {
+          "avg_ms": 0.0290354,
+          "best_ms": 0.028128,
+          "best_in_gibs": 17.3593,
+          "best_out_gibs": 17.3593,
+          "in_gibs": 16.8168,
+          "out_gibs": 16.8168
+        },
+        "scatter": {
+          "avg_ms": 0.0184451,
+          "best_ms": 0.010272,
+          "best_in_gibs": 47.5352,
+          "best_out_gibs": 47.5352,
+          "in_gibs": 26.4721,
+          "out_gibs": 26.4721
+        },
+        "compress": {
+          "avg_ms": 5.38797,
+          "best_ms": 5.38797,
+          "best_in_gibs": 5.79996,
+          "best_out_gibs": 0.066508,
+          "in_gibs": 5.79996,
+          "out_gibs": 0.066508
+        },
+        "aggregate": {
+          "avg_ms": 0.036512,
+          "best_ms": 0.036512,
+          "best_in_gibs": 9.81439,
+          "best_out_gibs": 9.81439,
+          "in_gibs": 9.81439,
+          "out_gibs": 9.81439
+        },
+        "d2h": {
+          "avg_ms": 0.071392,
+          "best_ms": 0.071392,
+          "best_in_gibs": 5.01937,
+          "best_out_gibs": 5.01937,
+          "in_gibs": 5.01937,
+          "out_gibs": 5.01937
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 3.73103,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 3.68853,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.20138,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.35,
+      "status": "pass",
+      "throughput_in_gibs": 0.12172,
+      "throughput_out_gibs": 0.0440085,
+      "compression_fold": 2.76584,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0112986,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.256736,
+      "init_s": 0.00411111,
+      "flush_s": 2.12e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.47657,
+          "best_ms": 3.25618,
+          "best_in_gibs": 0.149955,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.140449,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.0473,
+          "best_ms": 15.0473,
+          "best_in_gibs": 2.07679,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.07679,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.69205,
+          "best_ms": 4.69205,
+          "best_in_gibs": 6.68703,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.68703,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.99,
+      "status": "pass",
+      "throughput_in_gibs": 1.17697,
+      "throughput_out_gibs": 0.00907443,
+      "compression_fold": 129.702,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000240937,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0265512,
+      "init_s": 0.404803,
+      "flush_s": 1.58e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0765824,
+          "best_ms": 0.061068,
+          "best_in_gibs": 15.9914,
+          "best_out_gibs": 15.9914,
+          "in_gibs": 12.7518,
+          "out_gibs": 12.7518
+        },
+        "h2d": {
+          "avg_ms": 0.050848,
+          "best_ms": 0.04944,
+          "best_in_gibs": 19.7525,
+          "best_out_gibs": 19.7525,
+          "in_gibs": 19.2055,
+          "out_gibs": 19.2055
+        },
+        "scatter": {
+          "avg_ms": 0.0166432,
+          "best_ms": 0.01152,
+          "best_in_gibs": 84.771,
+          "best_out_gibs": 84.771,
+          "in_gibs": 58.6764,
+          "out_gibs": 58.6764
+        },
+        "compress": {
+          "avg_ms": 8.06016,
+          "best_ms": 8.06016,
+          "best_in_gibs": 3.87709,
+          "best_out_gibs": 0.0298313,
+          "in_gibs": 3.87709,
+          "out_gibs": 0.0298313
+        },
+        "aggregate": {
+          "avg_ms": 0.03744,
+          "best_ms": 0.03744,
+          "best_in_gibs": 6.42215,
+          "best_out_gibs": 6.42215,
+          "in_gibs": 6.42215,
+          "out_gibs": 6.42215
+        },
+        "d2h": {
+          "avg_ms": 0.037856,
+          "best_ms": 0.037856,
+          "best_in_gibs": 6.35157,
+          "best_out_gibs": 6.35157,
+          "in_gibs": 6.35157,
+          "out_gibs": 6.35157
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 6.49841,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 6.45425,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.04423,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.24,
+      "status": "pass",
+      "throughput_in_gibs": 0.209708,
+      "throughput_out_gibs": 0.0757972,
+      "compression_fold": 2.7667,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.011295,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.149016,
+      "init_s": 0.00444499,
+      "flush_s": 1.75e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.64035,
+          "best_ms": 3.26788,
+          "best_in_gibs": 0.298836,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.268261,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.8478,
+          "best_ms": 12.8478,
+          "best_in_gibs": 2.43233,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.43233,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.27416,
+          "best_ms": 4.27416,
+          "best_in_gibs": 7.34082,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.34082,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.9,
+      "status": "pass",
+      "throughput_in_gibs": 1.16691,
+      "throughput_out_gibs": 0.00899683,
+      "compression_fold": 129.702,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000240937,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0267802,
+      "init_s": 0.398068,
+      "flush_s": 2.84e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0793578,
+          "best_ms": 0.061285,
+          "best_in_gibs": 15.9348,
+          "best_out_gibs": 15.9348,
+          "in_gibs": 12.3058,
+          "out_gibs": 12.3058
+        },
+        "h2d": {
+          "avg_ms": 0.0496853,
+          "best_ms": 0.047072,
+          "best_in_gibs": 20.7461,
+          "best_out_gibs": 20.7461,
+          "in_gibs": 19.6549,
+          "out_gibs": 19.6549
+        },
+        "scatter": {
+          "avg_ms": 0.0162827,
+          "best_ms": 0.011424,
+          "best_in_gibs": 85.4834,
+          "best_out_gibs": 85.4834,
+          "in_gibs": 59.9756,
+          "out_gibs": 59.9756
+        },
+        "compress": {
+          "avg_ms": 8.0457,
+          "best_ms": 8.0457,
+          "best_in_gibs": 3.88406,
+          "best_out_gibs": 0.0298849,
+          "in_gibs": 3.88406,
+          "out_gibs": 0.0298849
+        },
+        "aggregate": {
+          "avg_ms": 0.037504,
+          "best_ms": 0.037504,
+          "best_in_gibs": 6.41119,
+          "best_out_gibs": 6.41119,
+          "in_gibs": 6.41119,
+          "out_gibs": 6.41119
+        },
+        "d2h": {
+          "avg_ms": 0.136864,
+          "best_ms": 0.136864,
+          "best_in_gibs": 1.75682,
+          "best_out_gibs": 1.75682,
+          "in_gibs": 1.75682,
+          "out_gibs": 1.75682
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 6.5984,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 6.5571,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.13044,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.23,
+      "status": "pass",
+      "throughput_in_gibs": 0.209874,
+      "throughput_out_gibs": 0.0758573,
+      "compression_fold": 2.7667,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.011295,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.148899,
+      "init_s": 0.00410616,
+      "flush_s": 2.11e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.64483,
+          "best_ms": 3.31799,
+          "best_in_gibs": 0.294323,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.267931,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.3542,
+          "best_ms": 13.3542,
+          "best_in_gibs": 2.3401,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.3401,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.45552,
+          "best_ms": 4.45552,
+          "best_in_gibs": 7.04202,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.04202,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.95,
+      "status": "pass",
+      "throughput_in_gibs": 0.341592,
+      "throughput_out_gibs": 0.0419278,
+      "compression_fold": 8.14716,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00383569,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0914833,
+      "init_s": 0.381821,
+      "flush_s": 1.58e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00119363,
+          "best_ms": 0.000779,
+          "best_in_gibs": 19.5877,
+          "best_out_gibs": 19.5877,
+          "in_gibs": 12.7836,
+          "out_gibs": 12.7836
+        },
+        "h2d": {
+          "avg_ms": 0.01232,
+          "best_ms": 0.01232,
+          "best_in_gibs": 1.23854,
+          "best_out_gibs": 1.23854,
+          "in_gibs": 1.23854,
+          "out_gibs": 1.23854
+        },
+        "scatter": {
+          "avg_ms": 0.0105938,
+          "best_ms": 0.010016,
+          "best_in_gibs": 1.52344,
+          "best_out_gibs": 1.52344,
+          "in_gibs": 1.44035,
+          "out_gibs": 1.44035
+        },
+        "compress": {
+          "avg_ms": 3.38371,
+          "best_ms": 3.38371,
+          "best_in_gibs": 9.23542,
+          "best_out_gibs": 1.12455,
+          "in_gibs": 9.23542,
+          "out_gibs": 1.12455
+        },
+        "aggregate": {
+          "avg_ms": 0.039072,
+          "best_ms": 0.039072,
+          "best_in_gibs": 97.3884,
+          "best_out_gibs": 97.3884,
+          "in_gibs": 97.3884,
+          "out_gibs": 97.3884
+        },
+        "d2h": {
+          "avg_ms": 0.229376,
+          "best_ms": 0.229376,
+          "best_in_gibs": 16.5892,
+          "best_out_gibs": 16.5892,
+          "in_gibs": 16.5892,
+          "out_gibs": 16.5892
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 3.56958,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 3.45361,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 72.3087,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 6.86,
+      "status": "pass",
+      "throughput_in_gibs": 0.00460232,
+      "throughput_out_gibs": 0.000408717,
+      "compression_fold": 11.2604,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00277521,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 6.79005,
+      "init_s": 0.00405223,
+      "flush_s": 1.5e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.29399,
+          "best_ms": 2.98404,
+          "best_in_gibs": 0.00511346,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.00463231,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.0589,
+          "best_ms": 25.0589,
+          "best_in_gibs": 1.24706,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.24706,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.62278,
+          "best_ms": 3.62278,
+          "best_in_gibs": 8.68916,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.68916,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.92,
+      "status": "pass",
+      "throughput_in_gibs": 0.540867,
+      "throughput_out_gibs": 0.0639773,
+      "compression_fold": 8.45404,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00369646,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0577777,
+      "init_s": 0.388641,
+      "flush_s": 2.52e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00234215,
+          "best_ms": 0.001414,
+          "best_in_gibs": 21.5824,
+          "best_out_gibs": 21.5824,
+          "in_gibs": 13.0298,
+          "out_gibs": 13.0298
+        },
+        "h2d": {
+          "avg_ms": 0.0121589,
+          "best_ms": 0.010016,
+          "best_in_gibs": 3.04688,
+          "best_out_gibs": 3.04688,
+          "in_gibs": 2.50989,
+          "out_gibs": 2.50989
+        },
+        "scatter": {
+          "avg_ms": 0.0109277,
+          "best_ms": 0.01008,
+          "best_in_gibs": 3.02754,
+          "best_out_gibs": 3.02754,
+          "in_gibs": 2.79268,
+          "out_gibs": 2.79268
+        },
+        "compress": {
+          "avg_ms": 4.86026,
+          "best_ms": 4.86026,
+          "best_in_gibs": 6.4297,
+          "best_out_gibs": 0.757405,
+          "in_gibs": 6.4297,
+          "out_gibs": 0.757405
+        },
+        "aggregate": {
+          "avg_ms": 0.042016,
+          "best_ms": 0.042016,
+          "best_in_gibs": 87.6138,
+          "best_out_gibs": 87.6138,
+          "in_gibs": 87.6138,
+          "out_gibs": 87.6138
+        },
+        "d2h": {
+          "avg_ms": 0.252256,
+          "best_ms": 0.252256,
+          "best_in_gibs": 14.593,
+          "best_out_gibs": 14.593,
+          "in_gibs": 14.593,
+          "out_gibs": 14.593
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 5.04348,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 4.96864,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 37.1868,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.53,
+      "status": "pass",
+      "throughput_in_gibs": 0.0091287,
+      "throughput_out_gibs": 0.00078283,
+      "compression_fold": 11.6611,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00267984,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 3.42327,
+      "init_s": 0.00417043,
+      "flush_s": 1.51e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.30019,
+          "best_ms": 3.04689,
+          "best_in_gibs": 0.010016,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.00924721,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.8871,
+          "best_ms": 24.8871,
+          "best_in_gibs": 1.25567,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.25567,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.62982,
+          "best_ms": 3.62982,
+          "best_in_gibs": 8.6555,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.6555,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.96,
+      "status": "pass",
+      "throughput_in_gibs": 0.791826,
+      "throughput_out_gibs": 0.0918259,
+      "compression_fold": 8.62312,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00362398,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0394658,
+      "init_s": 0.401653,
+      "flush_s": 2.12e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00458985,
+          "best_ms": 0.003017,
+          "best_in_gibs": 20.2304,
+          "best_out_gibs": 20.2304,
+          "in_gibs": 13.2979,
+          "out_gibs": 13.2979
+        },
+        "h2d": {
+          "avg_ms": 0.0190882,
+          "best_ms": 0.010048,
+          "best_in_gibs": 6.07436,
+          "best_out_gibs": 6.07436,
+          "in_gibs": 3.19753,
+          "out_gibs": 3.19753
+        },
+        "scatter": {
+          "avg_ms": 0.0163844,
+          "best_ms": 0.010048,
+          "best_in_gibs": 6.07436,
+          "best_out_gibs": 6.07436,
+          "in_gibs": 3.72519,
+          "out_gibs": 3.72519
+        },
+        "compress": {
+          "avg_ms": 8.98483,
+          "best_ms": 8.98483,
+          "best_in_gibs": 3.47808,
+          "best_out_gibs": 0.402493,
+          "in_gibs": 3.47808,
+          "out_gibs": 0.402493
+        },
+        "aggregate": {
+          "avg_ms": 0.039072,
+          "best_ms": 0.039072,
+          "best_in_gibs": 92.5556,
+          "best_out_gibs": 92.5556,
+          "in_gibs": 92.5556,
+          "out_gibs": 92.5556
+        },
+        "d2h": {
+          "avg_ms": 0.187904,
+          "best_ms": 0.187904,
+          "best_in_gibs": 19.2456,
+          "best_out_gibs": 19.2456,
+          "in_gibs": 19.2456,
+          "out_gibs": 19.2456
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 9.09438,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 9.03311,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 15.0837,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 1.86,
+      "status": "pass",
+      "throughput_in_gibs": 0.0179346,
+      "throughput_out_gibs": 0.00150596,
+      "compression_fold": 11.9091,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00262405,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.74245,
+      "init_s": 0.00428926,
+      "flush_s": 2.1e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.31488,
+          "best_ms": 3.08602,
+          "best_in_gibs": 0.019778,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0184125,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.9135,
+          "best_ms": 25.9135,
+          "best_in_gibs": 1.20594,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.20594,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.61982,
+          "best_ms": 3.61982,
+          "best_in_gibs": 8.67097,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.67097,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.95,
+      "status": "pass",
+      "throughput_in_gibs": 0.874329,
+      "throughput_out_gibs": 0.100633,
+      "compression_fold": 8.68828,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0035968,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0357417,
+      "init_s": 0.390498,
+      "flush_s": 2.05e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0090403,
+          "best_ms": 0.005997,
+          "best_in_gibs": 20.3552,
+          "best_out_gibs": 20.3552,
+          "in_gibs": 13.5029,
+          "out_gibs": 13.5029
+        },
+        "h2d": {
+          "avg_ms": 0.0112019,
+          "best_ms": 0.010016,
+          "best_in_gibs": 12.1875,
+          "best_out_gibs": 12.1875,
+          "in_gibs": 10.8973,
+          "out_gibs": 10.8973
+        },
+        "scatter": {
+          "avg_ms": 0.054896,
+          "best_ms": 0.010176,
+          "best_in_gibs": 11.9959,
+          "best_out_gibs": 11.9959,
+          "in_gibs": 2.22366,
+          "out_gibs": 2.22366
+        },
+        "compress": {
+          "avg_ms": 15.0906,
+          "best_ms": 15.0906,
+          "best_in_gibs": 2.07083,
+          "best_out_gibs": 0.238093,
+          "in_gibs": 2.07083,
+          "out_gibs": 0.238093
+        },
+        "aggregate": {
+          "avg_ms": 0.041856,
+          "best_ms": 0.041856,
+          "best_in_gibs": 85.8412,
+          "best_out_gibs": 85.8412,
+          "in_gibs": 85.8412,
+          "out_gibs": 85.8412
+        },
+        "d2h": {
+          "avg_ms": 0.231776,
+          "best_ms": 0.231776,
+          "best_in_gibs": 15.5019,
+          "best_out_gibs": 15.5019,
+          "in_gibs": 15.5019,
+          "out_gibs": 15.5019
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 15.1985,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 15.1466,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.01314,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.99,
+      "status": "pass",
+      "throughput_in_gibs": 0.0346203,
+      "throughput_out_gibs": 0.00287906,
+      "compression_fold": 12.0249,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00259878,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.902649,
+      "init_s": 0.00422364,
+      "flush_s": 1.69e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.3499,
+          "best_ms": 3.04352,
+          "best_in_gibs": 0.0401083,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.03644,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.3801,
+          "best_ms": 26.3801,
+          "best_in_gibs": 1.1846,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.1846,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.61065,
+          "best_ms": 3.61065,
+          "best_in_gibs": 8.68876,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.68876,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.89,
+      "status": "pass",
+      "throughput_in_gibs": 0.679751,
+      "throughput_out_gibs": 0.0779317,
+      "compression_fold": 8.7224,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00358273,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0459727,
+      "init_s": 0.388244,
+      "flush_s": 1.58e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0187909,
+          "best_ms": 0.014338,
+          "best_in_gibs": 17.0275,
+          "best_out_gibs": 17.0275,
+          "in_gibs": 12.9925,
+          "out_gibs": 12.9925
+        },
+        "h2d": {
+          "avg_ms": 0.0161491,
+          "best_ms": 0.015104,
+          "best_in_gibs": 16.164,
+          "best_out_gibs": 16.164,
+          "in_gibs": 15.1179,
+          "out_gibs": 15.1179
+        },
+        "scatter": {
+          "avg_ms": 0.053976,
+          "best_ms": 0.010208,
+          "best_in_gibs": 23.9166,
+          "best_out_gibs": 23.9166,
+          "in_gibs": 4.52313,
+          "out_gibs": 4.52313
+        },
+        "compress": {
+          "avg_ms": 26.5004,
+          "best_ms": 26.5004,
+          "best_in_gibs": 1.17923,
+          "best_out_gibs": 0.135123,
+          "in_gibs": 1.17923,
+          "out_gibs": 0.135123
+        },
+        "aggregate": {
+          "avg_ms": 0.05104,
+          "best_ms": 0.05104,
+          "best_in_gibs": 70.1569,
+          "best_out_gibs": 70.1569,
+          "in_gibs": 70.1569,
+          "out_gibs": 70.1569
+        },
+        "d2h": {
+          "avg_ms": 0.249184,
+          "best_ms": 0.249184,
+          "best_in_gibs": 14.3701,
+          "best_out_gibs": 14.3701,
+          "in_gibs": 14.3701,
+          "out_gibs": 14.3701
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 26.6779,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 26.6343,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.7477,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.56,
+      "status": "pass",
+      "throughput_in_gibs": 0.0651604,
+      "throughput_out_gibs": 0.00539245,
+      "compression_fold": 12.0836,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00258614,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.479586,
+      "init_s": 0.00420209,
+      "flush_s": 1.99e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.38811,
+          "best_ms": 3.1267,
+          "best_in_gibs": 0.0780825,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.072058,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.6997,
+          "best_ms": 27.6997,
+          "best_in_gibs": 1.12817,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.12817,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.59181,
+          "best_ms": 3.59181,
+          "best_in_gibs": 8.73433,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.73433,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 1.11,
+      "status": "pass",
+      "throughput_in_gibs": 0.452009,
+      "throughput_out_gibs": 0.0517199,
+      "compression_fold": 8.73955,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0035757,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0691358,
+      "init_s": 0.401128,
+      "flush_s": 1.6e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0380455,
+          "best_ms": 0.030248,
+          "best_in_gibs": 16.1426,
+          "best_out_gibs": 16.1426,
+          "in_gibs": 12.8341,
+          "out_gibs": 12.8341
+        },
+        "h2d": {
+          "avg_ms": 0.0287757,
+          "best_ms": 0.02624,
+          "best_in_gibs": 18.6083,
+          "best_out_gibs": 18.6083,
+          "in_gibs": 16.9685,
+          "out_gibs": 16.9685
+        },
+        "scatter": {
+          "avg_ms": 0.0140534,
+          "best_ms": 0.01024,
+          "best_in_gibs": 47.6837,
+          "best_out_gibs": 47.6837,
+          "in_gibs": 34.7446,
+          "out_gibs": 34.7446
+        },
+        "compress": {
+          "avg_ms": 50.2979,
+          "best_ms": 50.2979,
+          "best_in_gibs": 0.621299,
+          "best_out_gibs": 0.0710712,
+          "in_gibs": 0.621299,
+          "out_gibs": 0.0710712
+        },
+        "aggregate": {
+          "avg_ms": 0.065536,
+          "best_ms": 0.065536,
+          "best_in_gibs": 54.546,
+          "best_out_gibs": 54.546,
+          "in_gibs": 54.546,
+          "out_gibs": 54.546
+        },
+        "d2h": {
+          "avg_ms": 0.228864,
+          "best_ms": 0.228864,
+          "best_in_gibs": 15.6194,
+          "best_out_gibs": 15.6194,
+          "in_gibs": 15.6194,
+          "out_gibs": 15.6194
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 50.4715,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 50.4287,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.25979,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.35,
+      "status": "pass",
+      "throughput_in_gibs": 0.115675,
+      "throughput_out_gibs": 0.00955146,
+      "compression_fold": 12.1107,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00258036,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.270153,
+      "init_s": 0.00419824,
+      "flush_s": 3.45e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.50759,
+          "best_ms": 3.24425,
+          "best_in_gibs": 0.150506,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.139207,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.7475,
+          "best_ms": 26.7475,
+          "best_in_gibs": 1.16833,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.16833,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.61201,
+          "best_ms": 3.61201,
+          "best_in_gibs": 8.68548,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.68548,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 1.09,
+      "status": "pass",
+      "throughput_in_gibs": 0.452134,
+      "throughput_out_gibs": 0.0516899,
+      "compression_fold": 8.74706,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00357263,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0691166,
+      "init_s": 0.378073,
+      "flush_s": 1.68e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0779455,
+          "best_ms": 0.061195,
+          "best_in_gibs": 15.9582,
+          "best_out_gibs": 15.9582,
+          "in_gibs": 12.5288,
+          "out_gibs": 12.5288
+        },
+        "h2d": {
+          "avg_ms": 0.0511701,
+          "best_ms": 0.049472,
+          "best_in_gibs": 19.7397,
+          "best_out_gibs": 19.7397,
+          "in_gibs": 19.0846,
+          "out_gibs": 19.0846
+        },
+        "scatter": {
+          "avg_ms": 0.0162581,
+          "best_ms": 0.011424,
+          "best_in_gibs": 85.4834,
+          "best_out_gibs": 85.4834,
+          "in_gibs": 60.0661,
+          "out_gibs": 60.0661
+        },
+        "compress": {
+          "avg_ms": 50.2689,
+          "best_ms": 50.2689,
+          "best_in_gibs": 0.621656,
+          "best_out_gibs": 0.0710605,
+          "in_gibs": 0.621656,
+          "out_gibs": 0.0710605
+        },
+        "aggregate": {
+          "avg_ms": 0.100384,
+          "best_ms": 0.100384,
+          "best_in_gibs": 35.5847,
+          "best_out_gibs": 35.5847,
+          "in_gibs": 35.5847,
+          "out_gibs": 35.5847
+        },
+        "d2h": {
+          "avg_ms": 0.2264,
+          "best_ms": 0.2264,
+          "best_in_gibs": 15.778,
+          "best_out_gibs": 15.778,
+          "in_gibs": 15.778,
+          "out_gibs": 15.778
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 50.4805,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 50.4426,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.08639,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.24,
+      "status": "pass",
+      "throughput_in_gibs": 0.196745,
+      "throughput_out_gibs": 0.0162262,
+      "compression_fold": 12.1251,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00257729,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.158835,
+      "init_s": 0.00422839,
+      "flush_s": 1.93e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.58662,
+          "best_ms": 3.27421,
+          "best_in_gibs": 0.298259,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.272279,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.1537,
+          "best_ms": 25.1537,
+          "best_in_gibs": 1.24236,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.24236,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.62117,
+          "best_ms": 3.62117,
+          "best_in_gibs": 8.66352,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.66352,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.92,
+      "status": "pass",
+      "throughput_in_gibs": 0.449053,
+      "throughput_out_gibs": 0.0513376,
+      "compression_fold": 8.74706,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00357263,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0695909,
+      "init_s": 0.389457,
+      "flush_s": 2.23e-07,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0795667,
+          "best_ms": 0.061211,
+          "best_in_gibs": 15.954,
+          "best_out_gibs": 15.954,
+          "in_gibs": 12.2735,
+          "out_gibs": 12.2735
+        },
+        "h2d": {
+          "avg_ms": 0.04912,
+          "best_ms": 0.04784,
+          "best_in_gibs": 20.4131,
+          "best_out_gibs": 20.4131,
+          "in_gibs": 19.8812,
+          "out_gibs": 19.8812
+        },
+        "scatter": {
+          "avg_ms": 0.0167915,
+          "best_ms": 0.011424,
+          "best_in_gibs": 85.4834,
+          "best_out_gibs": 85.4834,
+          "in_gibs": 58.1582,
+          "out_gibs": 58.1582
+        },
+        "compress": {
+          "avg_ms": 50.2625,
+          "best_ms": 50.2625,
+          "best_in_gibs": 0.621736,
+          "best_out_gibs": 0.0710697,
+          "in_gibs": 0.621736,
+          "out_gibs": 0.0710697
+        },
+        "aggregate": {
+          "avg_ms": 0.098432,
+          "best_ms": 0.098432,
+          "best_in_gibs": 36.2904,
+          "best_out_gibs": 36.2904,
+          "in_gibs": 36.2904,
+          "out_gibs": 36.2904
+        },
+        "d2h": {
+          "avg_ms": 0.223424,
+          "best_ms": 0.223424,
+          "best_in_gibs": 15.9881,
+          "best_out_gibs": 15.9881,
+          "in_gibs": 15.9881,
+          "out_gibs": 15.9881
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 50.47,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 50.4249,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.1704,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.25,
+      "status": "pass",
+      "throughput_in_gibs": 0.188144,
+      "throughput_out_gibs": 0.0155169,
+      "compression_fold": 12.1251,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00257729,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.166096,
+      "init_s": 0.00414232,
+      "flush_s": 2.86e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.63513,
+          "best_ms": 3.34417,
+          "best_in_gibs": 0.29202,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.268646,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 31.0747,
+          "best_ms": 31.0747,
+          "best_in_gibs": 1.00564,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.00564,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.60704,
+          "best_ms": 3.60704,
+          "best_in_gibs": 8.69746,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.69746,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 6.88,
+      "status": "pass",
+      "throughput_in_gibs": 0.00460451,
+      "throughput_out_gibs": 0.00307792,
+      "compression_fold": 1.49598,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0208893,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 6.78683,
+      "init_s": 0.00438752,
+      "flush_s": 1.73e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.2959,
+          "best_ms": 2.97581,
+          "best_in_gibs": 0.00512761,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.00462963,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.6589,
+          "best_ms": 15.6589,
+          "best_in_gibs": 1.99567,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.99567,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.41781,
+          "best_ms": 5.41781,
+          "best_in_gibs": 5.77364,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.77364,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.68,
+      "status": "pass",
+      "throughput_in_gibs": 0.0091236,
+      "throughput_out_gibs": 0.00611266,
+      "compression_fold": 1.49257,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.020937,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 3.42518,
+      "init_s": 0.0045863,
+      "flush_s": 3.63e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.31124,
+          "best_ms": 2.99507,
+          "best_in_gibs": 0.0101893,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.00921636,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.8011,
+          "best_ms": 13.8011,
+          "best_in_gibs": 2.26431,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.26431,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.34093,
+          "best_ms": 5.34093,
+          "best_in_gibs": 5.85389,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.85389,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 1.83,
+      "status": "pass",
+      "throughput_in_gibs": 0.0178928,
+      "throughput_out_gibs": 0.0120015,
+      "compression_fold": 1.49088,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209608,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.74651,
+      "init_s": 0.00416973,
+      "flush_s": 2.2e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.3456,
+          "best_ms": 3.02349,
+          "best_in_gibs": 0.020187,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0182434,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.6481,
+          "best_ms": 13.6481,
+          "best_in_gibs": 2.2897,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.2897,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.30078,
+          "best_ms": 5.30078,
+          "best_in_gibs": 5.8968,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.8968,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 1.01,
+      "status": "pass",
+      "throughput_in_gibs": 0.0349326,
+      "throughput_out_gibs": 0.0234443,
+      "compression_fold": 1.49003,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209727,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.894579,
+      "init_s": 0.00395886,
+      "flush_s": 3.16e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.3652,
+          "best_ms": 3.03371,
+          "best_in_gibs": 0.0402379,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0362743,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.6309,
+          "best_ms": 13.6309,
+          "best_in_gibs": 2.29258,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.29258,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.25326,
+          "best_ms": 5.25326,
+          "best_in_gibs": 5.94942,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.94942,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.59,
+      "status": "pass",
+      "throughput_in_gibs": 0.0667691,
+      "throughput_out_gibs": 0.0448024,
+      "compression_fold": 1.4903,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209689,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.468031,
+      "init_s": 0.00384225,
+      "flush_s": 1.83e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.39385,
+          "best_ms": 3.03452,
+          "best_in_gibs": 0.0804545,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0719361,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.8597,
+          "best_ms": 14.8597,
+          "best_in_gibs": 2.103,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.103,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.12784,
+          "best_ms": 5.12784,
+          "best_in_gibs": 6.09493,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.09493,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.36,
+      "status": "pass",
+      "throughput_in_gibs": 0.122413,
+      "throughput_out_gibs": 0.082132,
+      "compression_fold": 1.49044,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.020967,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.255284,
+      "init_s": 0.00400554,
+      "flush_s": 1.45e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.46604,
+          "best_ms": 3.07919,
+          "best_in_gibs": 0.158575,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.140876,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.5462,
+          "best_ms": 14.5462,
+          "best_in_gibs": 2.14833,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.14833,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.18099,
+          "best_ms": 5.18099,
+          "best_in_gibs": 6.0324,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.0324,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.26,
+      "status": "pass",
+      "throughput_in_gibs": 0.211512,
+      "throughput_out_gibs": 0.141906,
+      "compression_fold": 1.4905,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209661,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.147746,
+      "init_s": 0.00403614,
+      "flush_s": 2.09e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.54454,
+          "best_ms": 3.20177,
+          "best_in_gibs": 0.305007,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.275512,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.9824,
+          "best_ms": 14.9824,
+          "best_in_gibs": 2.08578,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.08578,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.06974,
+          "best_ms": 5.06974,
+          "best_in_gibs": 6.16477,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.16477,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.27,
+      "status": "pass",
+      "throughput_in_gibs": 0.212142,
+      "throughput_out_gibs": 0.142329,
+      "compression_fold": 1.4905,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209661,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.147307,
+      "init_s": 0.00389967,
+      "flush_s": 3.01e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.60026,
+          "best_ms": 3.29459,
+          "best_in_gibs": 0.296414,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.271248,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.0585,
+          "best_ms": 13.0585,
+          "best_in_gibs": 2.39308,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.39308,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.98822,
+          "best_ms": 4.98822,
+          "best_in_gibs": 6.26553,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.26553,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 6.82,
+      "status": "pass",
+      "throughput_in_gibs": 0.00464877,
+      "throughput_out_gibs": 0.000152654,
+      "compression_fold": 30.4531,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102617,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 6.7222,
+      "init_s": 0.00407131,
+      "flush_s": 1.75e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.26332,
+          "best_ms": 2.97327,
+          "best_in_gibs": 0.00513199,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.00467585,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 20.547,
+          "best_ms": 20.547,
+          "best_in_gibs": 1.5209,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.5209,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.42226,
+          "best_ms": 3.42226,
+          "best_in_gibs": 9.14032,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.14032,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.48,
+      "status": "pass",
+      "throughput_in_gibs": 0.00919209,
+      "throughput_out_gibs": 0.000326811,
+      "compression_fold": 28.1267,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00111105,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 3.39966,
+      "init_s": 0.00405713,
+      "flush_s": 2.72e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.2763,
+          "best_ms": 3.03814,
+          "best_in_gibs": 0.0100448,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.00931465,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 26.4522,
+          "best_ms": 26.4522,
+          "best_in_gibs": 1.18137,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.18137,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.34715,
+          "best_ms": 3.34715,
+          "best_in_gibs": 9.34086,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.34086,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 1.82,
+      "status": "pass",
+      "throughput_in_gibs": 0.0180883,
+      "throughput_out_gibs": 0.000595904,
+      "compression_fold": 30.3544,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102951,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.72764,
+      "init_s": 0.00424959,
+      "flush_s": 1.97e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.28185,
+          "best_ms": 3.03991,
+          "best_in_gibs": 0.0200779,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0185978,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.8824,
+          "best_ms": 29.8824,
+          "best_in_gibs": 1.04577,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.04577,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.5564,
+          "best_ms": 3.5564,
+          "best_in_gibs": 8.78913,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.78913,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.98,
+      "status": "pass",
+      "throughput_in_gibs": 0.0347821,
+      "throughput_out_gibs": 0.0010989,
+      "compression_fold": 31.6518,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000987306,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.898451,
+      "init_s": 0.00399501,
+      "flush_s": 2.77e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.31166,
+          "best_ms": 3.0753,
+          "best_in_gibs": 0.0396937,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0368608,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.6353,
+          "best_ms": 32.6353,
+          "best_in_gibs": 0.957553,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.957553,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.31352,
+          "best_ms": 3.31352,
+          "best_in_gibs": 9.4322,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.4322,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.58,
+      "status": "pass",
+      "throughput_in_gibs": 0.0646016,
+      "throughput_out_gibs": 0.00203313,
+      "compression_fold": 31.7745,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000983492,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.483734,
+      "init_s": 0.0039936,
+      "flush_s": 2.54e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.37001,
+          "best_ms": 3.08913,
+          "best_in_gibs": 0.0790321,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0724452,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.7284,
+          "best_ms": 34.7284,
+          "best_in_gibs": 0.899839,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.899839,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.28476,
+          "best_ms": 3.28476,
+          "best_in_gibs": 9.51478,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.51478,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.35,
+      "status": "pass",
+      "throughput_in_gibs": 0.118452,
+      "throughput_out_gibs": 0.00372067,
+      "compression_fold": 31.8363,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000981584,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.263819,
+      "init_s": 0.00419703,
+      "flush_s": 2.93e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.41946,
+          "best_ms": 3.21657,
+          "best_in_gibs": 0.151802,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.142795,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.0527,
+          "best_ms": 27.0527,
+          "best_in_gibs": 1.15515,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.15515,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.42772,
+          "best_ms": 3.42772,
+          "best_in_gibs": 9.11797,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.11797,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.23,
+      "status": "pass",
+      "throughput_in_gibs": 0.197167,
+      "throughput_out_gibs": 0.00618713,
+      "compression_fold": 31.8673,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000980631,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.158495,
+      "init_s": 0.00417317,
+      "flush_s": 1.6e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.59951,
+          "best_ms": 3.35018,
+          "best_in_gibs": 0.291496,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.271304,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.0862,
+          "best_ms": 25.0862,
+          "best_in_gibs": 1.24571,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.24571,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.36347,
+          "best_ms": 3.36347,
+          "best_in_gibs": 9.29214,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.29214,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.23,
+      "status": "pass",
+      "throughput_in_gibs": 0.197104,
+      "throughput_out_gibs": 0.00618517,
+      "compression_fold": 31.8673,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000980631,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.158545,
+      "init_s": 0.00412381,
+      "flush_s": 2.73e-07,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.58693,
+          "best_ms": 3.32624,
+          "best_in_gibs": 0.293594,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.272256,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.9386,
+          "best_ms": 25.9386,
+          "best_in_gibs": 1.20477,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.20477,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.33644,
+          "best_ms": 3.33644,
+          "best_in_gibs": 9.36741,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.36741,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Records a benchmark baseline on a CoreWeave cluster NVIDIA L40 (sm_89) at commit 5af7ead (post-#151), using the repo's own harness `scripts/sweep/sweep.py`.

## Tiers and run counts
One file = one host+commit snapshot across tiers (sweep.py's intended accumulation behavior). **328 runs total, all `pass`:**

| Tier | Runs | Sink | Notes |
|------|-----:|------|-------|
| io       |  72 | `fs`      | single + multiscale_dim0 × {none,zstd}×{gpu,cpu} + blosc×cpu, chunks {32K,256K,2M}, writing to a real filesystem |
| backend  | 256 | `discard` | single scenarios × {none,lz4,zstd} × 8 chunks × {gpu,cpu}, plus blosc-lz4/blosc-zstd × cpu × 8 chunks |

The backend tier uses the **discard sink** (no `-o`): no disk I/O, so it isolates the compute/compression pipeline rather than storage.

## Node note
The io runs and backend runs were recorded in separate Slurm jobs; both happened to land on the same node this time (`cw-us-e4a2-l40-234-159`). In general these baseline runs may span different L40 nodes — the GPU model (NVIDIA L40, sm_89) and the commit (5af7ead) are what the snapshot is keyed on. The `machine` block reflects the first (io) job and is preserved across resume.

## Headline: discard-sink GPU throughput (GiB/s), none vs zstd

The number this tier is really for — single-array GPU streaming throughput across chunk sizes.

**orca2_single**

| chunk | none | zstd |
|------:|-----:|-----:|
| 16K  | 7.86 | 6.20 |
| 32K  | 7.87 | 4.08 |
| 64K  | 7.85 | 4.23 |
| 128K | 8.11 | 2.72 |
| 256K | 8.00 | 2.65 |
| 512K | 7.36 | 4.27 |
| 1M   | 7.77 | 3.95 |
| 2M   | 8.04 | 3.98 |

**256cube_single**

| chunk | none | zstd |
|------:|-----:|-----:|
| 16K  | 5.83 | 5.78 |
| 32K  | 5.77 | 4.76 |
| 64K  | 5.82 | 4.62 |
| 128K | 5.85 | 4.66 |
| 256K | 5.49 | 5.23 |
| 512K | 5.76 | 5.11 |
| 1M   | 5.58 | 4.96 |
| 2M   | 5.72 | 4.23 |

`none` throughput is flat across chunk size (memory/transfer bound); zstd's penalty is large on orca2 and modest on 256cube, which compresses cheaply.