### PR TITLE
Remove dead header and a redundant edge record

### DIFF
--- a/src/gpu/CMakeLists.txt
+++ b/src/gpu/CMakeLists.txt
@@ -16,7 +16,7 @@ add_src_lib(stream
         schedule.c schedule.h
         flush.compress_agg.c flush.compress_agg.h
         flush.d2h_deliver.c flush.d2h_deliver.h
-        flush.handoff.h flush.helpers.h
+        flush.handoff.h
     LINKS
         transpose compress aggregate lod stream_config lod_plan index_ops
         dimension crc32c shard_delivery writer platform threadpool chucky_log

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -1,5 +1,4 @@
 #include "gpu/flush.compress_agg.h"
-#include "gpu/flush.helpers.h"
 
 #include "defs.limits.h"
 #include "gpu/aggregate.h"

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -1,5 +1,4 @@
 #include "gpu/flush.d2h_deliver.h"
-#include "gpu/flush.helpers.h"
 
 #include "gpu/metric.cuda.h"
 #include "gpu/prelude.cuda.h"

--- a/src/gpu/flush.helpers.h
+++ b/src/gpu/flush.helpers.h
@@ -1,6 +1,0 @@
-#pragma once
-
-#include "gpu/stream.internal.h"
-#include "stream/dim_info.h"
-
-// (no per-LOD helpers remain — the unified kick handles mask-scan inline.)

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -624,10 +624,13 @@ schedule_accumulate_epoch(struct stream_engine* e, struct stream_context* ctx)
     return writer_ok();
 
   // Release pool-filled once after the last epoch's scatter; compute-stream
-  // ordering means this subsumes per-epoch ready signals.
-  CHECK(Error,
-        gpu_pool_release_produce(
-          &e->pools.p, e->sched.fill, e->streams.compute) == 0);
+  // ordering means this subsumes per-epoch ready signals. The drain-after-kick
+  // path releases inside schedule_flush_accumulated, so skip it here to avoid
+  // re-recording the same edge on the same stream.
+  if (e->sched.depth != SCHEDULE_DRAIN_AFTER_KICK)
+    CHECK(Error,
+          gpu_pool_release_produce(
+            &e->pools.p, e->sched.fill, e->streams.compute) == 0);
 
   if (e->sched.depth == SCHEDULE_DRAIN_AFTER_KICK) {
     struct writer_result r = schedule_flush_accumulated(e, ctx);


### PR DESCRIPTION
Two small, behavior-neutral cleanups flagged during the orchestration-migration reviews (#143/#148/#149/#151).

- **Remove dead `flush.helpers.h`.** The header had no remaining users after the scheduler work; deleted the file, its two `#include`s, and the CMakeLists entry. Verified no symbol it declared is referenced anywhere.
- **Drop a redundant `POOL_FILLED` record.** On the drain-after-kick (multiarray sync) schedule, `schedule_accumulate_epoch` recorded the pool-filled edge and then `schedule_flush_accumulated` recorded it again on the same stream. Skip the first on that path; the flush-accumulated release is the load-bearing one before its kick. The pipelined and drain-before-kick paths are unchanged.

Validation (L40, sm_89, RelWithDebInfo): `ctest -E "(s3)"` 48/48; zero new warnings.
