### PR TITLE
Drain sink on stream destroy + destroy run-out test

### DIFF
--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -317,8 +317,13 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
 
     for (int lv = 0; lv < v->levels->nlod; ++lv) {
       if (v->shard[lv].epoch_in_shard > 0) {
-        if (finalize_shards(&v->shard[lv], v->sink, v->shard_alignment))
+        if (finalize_shards(&v->shard[lv], v->sink, v->shard_alignment)) {
+          // finalize_shards can queue footer write_direct jobs that reference
+          // footer_buf_pool, then fail. Drain before returning so destroy can
+          // free that pool with no IO still pointing into it.
+          shard_sink_drain(v->sink);
           return writer_error();
+        }
       }
     }
 

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -313,9 +313,7 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
     }
 
     if (v->sink->has_error && v->sink->has_error(v->sink)) {
-      // A prior (mid-stream) finalize may have queued footer write_direct jobs
-      // that reference footer_buf_pool before the error surfaced; drain before
-      // bailing so destroy can free that pool with no IO pointing into it.
+      // Drain queued IO before bailing; it points into buffers destroy frees.
       shard_sink_drain(v->sink);
       return writer_error();
     }
@@ -323,9 +321,7 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
     for (int lv = 0; lv < v->levels->nlod; ++lv) {
       if (v->shard[lv].epoch_in_shard > 0) {
         if (finalize_shards(&v->shard[lv], v->sink, v->shard_alignment)) {
-          // finalize_shards can queue footer write_direct jobs that reference
-          // footer_buf_pool, then fail. Drain before returning so destroy can
-          // free that pool with no IO still pointing into it.
+          // Drain queued IO before bailing; it points into buffers destroy frees.
           shard_sink_drain(v->sink);
           return writer_error();
         }

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -312,8 +312,13 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
       v->sink->wait_fence(v->sink, v->io_done[1]);
     }
 
-    if (v->sink->has_error && v->sink->has_error(v->sink))
+    if (v->sink->has_error && v->sink->has_error(v->sink)) {
+      // A prior (mid-stream) finalize may have queued footer write_direct jobs
+      // that reference footer_buf_pool before the error surfaced; drain before
+      // bailing so destroy can free that pool with no IO pointing into it.
+      shard_sink_drain(v->sink);
       return writer_error();
+    }
 
     for (int lv = 0; lv < v->levels->nlod; ++lv) {
       if (v->shard[lv].epoch_in_shard > 0) {

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -301,12 +301,6 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
     s->flushed = 1;
   }
 
-  // A flush that errored after finalize_shards queued footer write_direct
-  // jobs returns before draining the sink. Drain unconditionally so no queued
-  // IO still references footer_buf_pool when shard_state_destroy frees it.
-  if (s->shard_sink)
-    shard_sink_drain(s->shard_sink);
-
   for (int lv = 0; lv < s->levels.nlod; ++lv) {
     shard_state_destroy(&s->shard[lv]);
     free(s->h_tail_bytes[lv]);

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -298,6 +298,13 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
     struct writer_result r = cpu_stream_flush_body(&v);
     if (r.error)
       log_error("CPU stream auto-flush failed during destroy");
+    // The flush may have bailed (e.g. the sink already errored) before its own
+    // drain, leaving footer jobs that reference footer_buf_pool queued. The
+    // sink is still alive here (we just flushed through it), so drain before
+    // the teardown below frees that pool. Only safe on this path: a caller
+    // that already flushed may have torn its sink down before destroy.
+    if (s->shard_sink)
+      shard_sink_drain(s->shard_sink);
     s->flushed = 1;
   }
 

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -298,14 +298,7 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
     struct writer_result r = cpu_stream_flush_body(&v);
     if (r.error)
       log_error("CPU stream auto-flush failed during destroy");
-    // The flush may have bailed (e.g. the sink already errored) before its own
-    // drain, leaving footer jobs that reference footer_buf_pool queued; drain
-    // before the teardown below frees that pool. This is gated on !flushed:
-    // the contract is that the caller keeps the sink alive until destroy,
-    // except that after a SUCCESSFUL flush it may tear the sink down (then
-    // flushed==1 and neither the auto-flush nor this drain runs). A caller that
-    // frees its sink after a FAILED flush violates the contract — the
-    // auto-flush above would already fault on the freed sink before this drain.
+    // A bailed flush can leave queued IO pointing into buffers teardown frees.
     if (s->shard_sink)
       shard_sink_drain(s->shard_sink);
     s->flushed = 1;

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -299,10 +299,13 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
     if (r.error)
       log_error("CPU stream auto-flush failed during destroy");
     // The flush may have bailed (e.g. the sink already errored) before its own
-    // drain, leaving footer jobs that reference footer_buf_pool queued. The
-    // sink is still alive here (we just flushed through it), so drain before
-    // the teardown below frees that pool. Only safe on this path: a caller
-    // that already flushed may have torn its sink down before destroy.
+    // drain, leaving footer jobs that reference footer_buf_pool queued; drain
+    // before the teardown below frees that pool. This is gated on !flushed:
+    // the contract is that the caller keeps the sink alive until destroy,
+    // except that after a SUCCESSFUL flush it may tear the sink down (then
+    // flushed==1 and neither the auto-flush nor this drain runs). A caller that
+    // frees its sink after a FAILED flush violates the contract — the
+    // auto-flush above would already fault on the freed sink before this drain.
     if (s->shard_sink)
       shard_sink_drain(s->shard_sink);
     s->flushed = 1;

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -301,6 +301,12 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
     s->flushed = 1;
   }
 
+  // A flush that errored after finalize_shards queued footer write_direct
+  // jobs returns before draining the sink. Drain unconditionally so no queued
+  // IO still references footer_buf_pool when shard_state_destroy frees it.
+  if (s->shard_sink)
+    shard_sink_drain(s->shard_sink);
+
   for (int lv = 0; lv < s->levels.nlod; ++lv) {
     shard_state_destroy(&s->shard[lv]);
     free(s->h_tail_bytes[lv]);

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -351,6 +351,10 @@ delivery_main(void* arg)
     j->result = r;
     j->done = 1;
     platform_cond_broadcast(d->cv);
+    // Test hook: park here so a later job stays queued; stop_join then has to
+    // run it out. Wakes on stop so teardown still completes.
+    while (d->hold && !d->stop)
+      platform_cond_wait(d->cv, d->mu);
   }
   platform_mutex_unlock(d->mu);
 }
@@ -436,6 +440,17 @@ gpu_delivery_stop_join(struct gpu_delivery* d)
   d->cv = NULL;
   platform_mutex_free(d->mu);
   d->mu = NULL;
+}
+
+void
+gpu_delivery_set_hold(struct gpu_delivery* d, int on)
+{
+  if (!d->thread)
+    return;
+  platform_mutex_lock(d->mu);
+  d->hold = on;
+  platform_cond_broadcast(d->cv);
+  platform_mutex_unlock(d->mu);
 }
 
 // --- Helpers ---

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -351,8 +351,7 @@ delivery_main(void* arg)
     j->result = r;
     j->done = 1;
     platform_cond_broadcast(d->cv);
-    // Test hook: park here so a later job stays queued; stop_join then has to
-    // run it out. Wakes on stop so teardown still completes.
+    // Test hook: park so a later job stays queued for teardown to run out.
     while (d->hold && !d->stop)
       platform_cond_wait(d->cv, d->mu);
   }

--- a/src/gpu/schedule.h
+++ b/src/gpu/schedule.h
@@ -120,8 +120,7 @@ struct gpu_delivery
   struct platform_cond* cv;
   CUcontext cuda; // captured at init; made current on the worker
   int stop;
-  int hold; // test-only: worker parks after each job until stop is set, so a
-            // later job stays queued and stop_join must run it out
+  int hold; // test-only: park the worker so a job stays queued for teardown
   struct delivery_job job[2]; // by fc
 };
 
@@ -151,8 +150,7 @@ gpu_delivery_join(struct gpu_delivery* d, int fc);
 void
 gpu_delivery_stop_join(struct gpu_delivery* d);
 
-// Test-only: when on, the worker parks after completing each job until stop is
-// set. Lets a test guarantee a job is still queued when stop_join runs.
+// Test-only: park the worker so a test can keep a job queued through teardown.
 void
 gpu_delivery_set_hold(struct gpu_delivery* d, int on);
 

--- a/src/gpu/schedule.h
+++ b/src/gpu/schedule.h
@@ -120,6 +120,8 @@ struct gpu_delivery
   struct platform_cond* cv;
   CUcontext cuda; // captured at init; made current on the worker
   int stop;
+  int hold; // test-only: worker parks after each job until stop is set, so a
+            // later job stays queued and stop_join must run it out
   struct delivery_job job[2]; // by fc
 };
 
@@ -148,6 +150,11 @@ gpu_delivery_join(struct gpu_delivery* d, int fc);
 // the published count below parked thresholds.
 void
 gpu_delivery_stop_join(struct gpu_delivery* d);
+
+// Test-only: when on, the worker parks after completing each job until stop is
+// set. Lets a test guarantee a job is still queued when stop_join runs.
+void
+gpu_delivery_set_hold(struct gpu_delivery* d, int on);
 
 // Depth selection from the array's configuration. gate_ord NULL means
 // drains host-order the tail uploads (multiarray); call after the array's

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -277,9 +277,7 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
     if (e->compress_agg.ar.shard[lv].epoch_in_shard > 0) {
       if (finalize_shards(
             &e->compress_agg.ar.shard[lv], ctx->sink, ctx->shard_alignment)) {
-        // finalize_shards can queue footer write_direct jobs that reference
-        // footer_buf_pool, then fail. Drain before returning so destroy can
-        // free that pool with no IO still pointing into it.
+        // Drain queued IO before bailing; it points into buffers destroy frees.
         shard_sink_drain(ctx->sink);
         return writer_error();
       }

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -276,8 +276,13 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
   for (int lv = 0; lv < ctx->levels.nlod; ++lv) {
     if (e->compress_agg.ar.shard[lv].epoch_in_shard > 0) {
       if (finalize_shards(
-            &e->compress_agg.ar.shard[lv], ctx->sink, ctx->shard_alignment))
+            &e->compress_agg.ar.shard[lv], ctx->sink, ctx->shard_alignment)) {
+        // finalize_shards can queue footer write_direct jobs that reference
+        // footer_buf_pool, then fail. Drain before returning so destroy can
+        // free that pool with no IO still pointing into it.
+        shard_sink_drain(ctx->sink);
         return writer_error();
+      }
     }
   }
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -360,9 +360,11 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   // but does not drain that queue. An auto-flush that bailed before its own
   // drain can also leave footer jobs (referencing footer_buf_pool) queued.
   // Drain now so engine_array_state_destroy frees that pool with no IO
-  // pointing into it. Guarded by did_autoflush: the sink is known alive only
-  // when destroy ran the flush; a caller that flushed itself may have torn
-  // its sink down already.
+  // pointing into it. Gated on did_autoflush: the contract is that the caller
+  // keeps the sink alive until destroy, except that after a SUCCESSFUL flush it
+  // may tear the sink down (then flushed==1, did_autoflush==0, and this is
+  // skipped). A caller that frees its sink after a FAILED flush violates the
+  // contract — the auto-flush above would already fault before this drain.
   if (did_autoflush && s->ctx.sink)
     shard_sink_drain(s->ctx.sink);
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -332,11 +332,13 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   // Auto-finalize any unwritten data so destroy is a safe commit point for
   // callers that didn't explicitly flush. Errors are logged but not
   // propagated — destroy returns void.
+  int did_autoflush = 0;
   if (!s->flushed) {
     struct writer_result r = stream_flush_body(&s->engine, &s->ctx);
     if (r.error)
       log_error("GPU stream auto-flush failed during destroy");
     s->flushed = 1;
+    did_autoflush = 1;
   }
 
   // A failed flush can leave delivery jobs queued; run them out before the
@@ -353,6 +355,16 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.compute);
   sync(s->engine.streams.compress);
   sync(s->engine.streams.d2h);
+
+  // stop_join flushes worker-posted footer/write jobs into the sink IO queue
+  // but does not drain that queue. An auto-flush that bailed before its own
+  // drain can also leave footer jobs (referencing footer_buf_pool) queued.
+  // Drain now so engine_array_state_destroy frees that pool with no IO
+  // pointing into it. Guarded by did_autoflush: the sink is known alive only
+  // when destroy ran the flush; a caller that flushed itself may have torn
+  // its sink down already.
+  if (did_autoflush && s->ctx.sink)
+    shard_sink_drain(s->ctx.sink);
 
   // s->ar owns the per-array allocations; the engine holds a bound copy of
   // the same pointers, so destroy strictly after engine teardown would

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -356,15 +356,8 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.compress);
   sync(s->engine.streams.d2h);
 
-  // stop_join flushes worker-posted footer/write jobs into the sink IO queue
-  // but does not drain that queue. An auto-flush that bailed before its own
-  // drain can also leave footer jobs (referencing footer_buf_pool) queued.
-  // Drain now so engine_array_state_destroy frees that pool with no IO
-  // pointing into it. Gated on did_autoflush: the contract is that the caller
-  // keeps the sink alive until destroy, except that after a SUCCESSFUL flush it
-  // may tear the sink down (then flushed==1, did_autoflush==0, and this is
-  // skipped). A caller that frees its sink after a FAILED flush violates the
-  // contract — the auto-flush above would already fault before this drain.
+  // Drain queued IO before teardown frees the buffers it points into. Only
+  // when we auto-flushed: a caller that flushed itself may have freed its sink.
   if (did_autoflush && s->ctx.sink)
     shard_sink_drain(s->ctx.sink);
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -354,13 +354,6 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.compress);
   sync(s->engine.streams.d2h);
 
-  // A flush that errored after finalize_shards queued footer write_direct
-  // jobs returns before draining the sink. Drain unconditionally so no queued
-  // IO still references footer_buf_pool when engine_array_state_destroy frees
-  // it below.
-  if (s->ctx.sink)
-    shard_sink_drain(s->ctx.sink);
-
   // s->ar owns the per-array allocations; the engine holds a bound copy of
   // the same pointers, so destroy strictly after engine teardown would
   // double-free — free once, here.

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -354,6 +354,13 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   sync(s->engine.streams.compress);
   sync(s->engine.streams.d2h);
 
+  // A flush that errored after finalize_shards queued footer write_direct
+  // jobs returns before draining the sink. Drain unconditionally so no queued
+  // IO still references footer_buf_pool when engine_array_state_destroy frees
+  // it below.
+  if (s->ctx.sink)
+    shard_sink_drain(s->ctx.sink);
+
   // s->ar owns the per-array allocations; the engine holds a bound copy of
   // the same pointers, so destroy strictly after engine teardown would
   // double-free — free once, here.

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -469,12 +469,9 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
   if (!ms)
     return;
 
-  // Snapshot which arrays destroy itself will auto-flush (were not already
-  // flushed by the caller). Only those sinks are guaranteed alive at drain time
-  // — matching the single-array did_autoflush gate, a caller may free a sink
-  // after its own successful flush. On alloc failure, fall back to draining all:
-  // the freed-sink case is a rarer contract violation than the #147 footer-job
-  // use-after-free this guards.
+  // Remember which arrays we will auto-flush: only their sinks are sure to be
+  // alive at drain time, since a caller may free a sink after flushing itself.
+  // On alloc failure, drain all — the rarer hazard.
   int* autoflush = NULL;
   if (ms->arrays && ms->n_arrays > 0) {
     autoflush = (int*)calloc((size_t)ms->n_arrays, sizeof(int));
@@ -492,15 +489,11 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
       log_error("CPU multiarray auto-flush failed during destroy");
   }
 
-  // A flush that errored after finalize_shards queued footer write_direct jobs
-  // (which reference each array's footer_buf_pool) can leave that IO pending in
-  // a sink's queue. Drain the sinks destroy auto-flushed before
-  // shard_state_destroy frees those pools below — the multiarray analogue of
-  // the single-array destroy fix (#147).
+  // Drain queued IO before teardown frees the buffers it points into.
   if (ms->arrays) {
     for (int i = 0; i < ms->n_arrays; ++i) {
       if (autoflush && !autoflush[i])
-        continue; // caller flushed this array; its sink may already be freed
+        continue;
       if (ms->arrays[i].sink)
         shard_sink_drain(ms->arrays[i].sink);
     }

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -482,8 +482,10 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
   // (which reference each array's footer_buf_pool) can leave that IO pending in
   // a sink's queue. Drain every sink before shard_state_destroy frees those
   // pools below — the multiarray analogue of the single-array destroy fix
-  // (#147). Sinks are caller-owned and must outlive destroy; the auto-flush
-  // above just used them, so they are alive.
+  // (#147). The drain is unconditional (no did_autoflush gate): multiarray
+  // destroy always re-runs flush_impl through the sinks, so its sinks must
+  // always outlive destroy — there is no free-sink-after-successful-flush
+  // carve-out like the single-array path.
   if (ms->arrays) {
     for (int i = 0; i < ms->n_arrays; ++i)
       if (ms->arrays[i].sink)

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -478,6 +478,18 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
       log_error("CPU multiarray auto-flush failed during destroy");
   }
 
+  // A flush that errored after finalize_shards queued footer write_direct jobs
+  // (which reference each array's footer_buf_pool) can leave that IO pending in
+  // a sink's queue. Drain every sink before shard_state_destroy frees those
+  // pools below — the multiarray analogue of the single-array destroy fix
+  // (#147). Sinks are caller-owned and must outlive destroy; the auto-flush
+  // above just used them, so they are alive.
+  if (ms->arrays) {
+    for (int i = 0; i < ms->n_arrays; ++i)
+      if (ms->arrays[i].sink)
+        shard_sink_drain(ms->arrays[i].sink);
+  }
+
   if (ms->arrays) {
     for (int i = 0; i < ms->n_arrays; ++i) {
       struct array_descriptor* desc = &ms->arrays[i];

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -469,6 +469,20 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
   if (!ms)
     return;
 
+  // Snapshot which arrays destroy itself will auto-flush (were not already
+  // flushed by the caller). Only those sinks are guaranteed alive at drain time
+  // — matching the single-array did_autoflush gate, a caller may free a sink
+  // after its own successful flush. On alloc failure, fall back to draining all:
+  // the freed-sink case is a rarer contract violation than the #147 footer-job
+  // use-after-free this guards.
+  int* autoflush = NULL;
+  if (ms->arrays && ms->n_arrays > 0) {
+    autoflush = (int*)calloc((size_t)ms->n_arrays, sizeof(int));
+    if (autoflush)
+      for (int i = 0; i < ms->n_arrays; ++i)
+        autoflush[i] = !ms->arrays[i].flushed;
+  }
+
   // Auto-finalize any unflushed arrays so destroy is a safe commit point
   // for callers that didn't explicitly flush. Errors are logged but not
   // propagated — destroy returns void.
@@ -480,17 +494,18 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
 
   // A flush that errored after finalize_shards queued footer write_direct jobs
   // (which reference each array's footer_buf_pool) can leave that IO pending in
-  // a sink's queue. Drain every sink before shard_state_destroy frees those
-  // pools below — the multiarray analogue of the single-array destroy fix
-  // (#147). The drain is unconditional (no did_autoflush gate): multiarray
-  // destroy always re-runs flush_impl through the sinks, so its sinks must
-  // always outlive destroy — there is no free-sink-after-successful-flush
-  // carve-out like the single-array path.
+  // a sink's queue. Drain the sinks destroy auto-flushed before
+  // shard_state_destroy frees those pools below — the multiarray analogue of
+  // the single-array destroy fix (#147).
   if (ms->arrays) {
-    for (int i = 0; i < ms->n_arrays; ++i)
+    for (int i = 0; i < ms->n_arrays; ++i) {
+      if (autoflush && !autoflush[i])
+        continue; // caller flushed this array; its sink may already be freed
       if (ms->arrays[i].sink)
         shard_sink_drain(ms->arrays[i].sink);
+    }
   }
+  free(autoflush);
 
   if (ms->arrays) {
     for (int i = 0; i < ms->n_arrays; ++i) {

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -294,6 +294,19 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
 
   sync_all(&ms->engine.streams);
 
+  // A flush that errored after finalize_shards queued footer write_direct jobs
+  // (which reference each array's footer_buf_pool) can leave that IO pending in
+  // a sink's queue. Stop the delivery worker and drain every sink before
+  // engine_array_state_destroy frees those pools below — the multiarray analogue
+  // of the single-array destroy fix (#147). Sinks are caller-owned and must
+  // outlive destroy; the auto-flush above just used them, so they are alive.
+  gpu_delivery_stop_join(&ms->engine.delivery);
+  if (ms->arrays) {
+    for (int a = 0; a < ms->n_arrays; ++a)
+      if (ms->arrays[a].ctx.sink)
+        shard_sink_drain(ms->arrays[a].ctx.sink);
+  }
+
   if (ms->arrays) {
     for (int a = 0; a < ms->n_arrays; ++a)
       destroy_array_descriptor(&ms->arrays[a]);

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -292,14 +292,22 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
       log_error("GPU multiarray auto-flush failed during destroy");
   }
 
+  // Ordering note: unlike the single-array path, this syncs before stop_join
+  // and never calls gpu_pool_release_all. That is safe only because multiarray
+  // binds every array with SCHEDULE_DRAIN_AFTER_KICK (gate_ord == NULL in
+  // init_array_descriptor): no tail gate is ever armed, so no kick can park and
+  // sync_all cannot hang. If multiarray ever adopts a gated/pipelined schedule,
+  // mirror the single-array order (stop_join -> release -> sync) here.
   sync_all(&ms->engine.streams);
 
   // A flush that errored after finalize_shards queued footer write_direct jobs
   // (which reference each array's footer_buf_pool) can leave that IO pending in
   // a sink's queue. Stop the delivery worker and drain every sink before
   // engine_array_state_destroy frees those pools below — the multiarray analogue
-  // of the single-array destroy fix (#147). Sinks are caller-owned and must
-  // outlive destroy; the auto-flush above just used them, so they are alive.
+  // of the single-array destroy fix (#147). The drain is unconditional (no
+  // did_autoflush gate): multiarray destroy always re-runs flush_impl through
+  // the sinks, so its sinks must always outlive destroy — there is no
+  // free-sink-after-successful-flush carve-out like the single-array path.
   gpu_delivery_stop_join(&ms->engine.delivery);
   if (ms->arrays) {
     for (int a = 0; a < ms->n_arrays; ++a)

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -283,6 +283,21 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
   if (!ms)
     return;
 
+  // Snapshot which arrays destroy itself will auto-flush (were not already
+  // flushed by the caller). Only those sinks are guaranteed alive at drain time
+  // — matching the single-array did_autoflush gate, a caller may free a sink
+  // after its own successful flush. Arrays the caller flushed are skipped (their
+  // flush already drained them, and their sink may already be gone). On alloc
+  // failure, fall back to draining all: the freed-sink case is a rarer contract
+  // violation than the #147 footer-job use-after-free this guards.
+  int* autoflush = NULL;
+  if (ms->arrays && ms->n_arrays > 0) {
+    autoflush = (int*)calloc((size_t)ms->n_arrays, sizeof(int));
+    if (autoflush)
+      for (int a = 0; a < ms->n_arrays; ++a)
+        autoflush[a] = !ms->arrays[a].flushed;
+  }
+
   // Auto-finalize any unflushed arrays so destroy is a safe commit point
   // for callers that didn't explicitly flush. Errors are logged but not
   // propagated — destroy returns void.
@@ -302,18 +317,19 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
 
   // A flush that errored after finalize_shards queued footer write_direct jobs
   // (which reference each array's footer_buf_pool) can leave that IO pending in
-  // a sink's queue. Stop the delivery worker and drain every sink before
-  // engine_array_state_destroy frees those pools below — the multiarray analogue
-  // of the single-array destroy fix (#147). The drain is unconditional (no
-  // did_autoflush gate): multiarray destroy always re-runs flush_impl through
-  // the sinks, so its sinks must always outlive destroy — there is no
-  // free-sink-after-successful-flush carve-out like the single-array path.
+  // a sink's queue. Stop the delivery worker and drain the sinks destroy
+  // auto-flushed before engine_array_state_destroy frees those pools below —
+  // the multiarray analogue of the single-array destroy fix (#147).
   gpu_delivery_stop_join(&ms->engine.delivery);
   if (ms->arrays) {
-    for (int a = 0; a < ms->n_arrays; ++a)
+    for (int a = 0; a < ms->n_arrays; ++a) {
+      if (autoflush && !autoflush[a])
+        continue; // caller flushed this array; its sink may already be freed
       if (ms->arrays[a].ctx.sink)
         shard_sink_drain(ms->arrays[a].ctx.sink);
+    }
   }
+  free(autoflush);
 
   if (ms->arrays) {
     for (int a = 0; a < ms->n_arrays; ++a)

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -283,13 +283,9 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
   if (!ms)
     return;
 
-  // Snapshot which arrays destroy itself will auto-flush (were not already
-  // flushed by the caller). Only those sinks are guaranteed alive at drain time
-  // — matching the single-array did_autoflush gate, a caller may free a sink
-  // after its own successful flush. Arrays the caller flushed are skipped (their
-  // flush already drained them, and their sink may already be gone). On alloc
-  // failure, fall back to draining all: the freed-sink case is a rarer contract
-  // violation than the #147 footer-job use-after-free this guards.
+  // Remember which arrays we will auto-flush: only their sinks are sure to be
+  // alive at drain time, since a caller may free a sink after flushing itself.
+  // On alloc failure, drain all — the rarer hazard.
   int* autoflush = NULL;
   if (ms->arrays && ms->n_arrays > 0) {
     autoflush = (int*)calloc((size_t)ms->n_arrays, sizeof(int));
@@ -307,24 +303,17 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
       log_error("GPU multiarray auto-flush failed during destroy");
   }
 
-  // Ordering note: unlike the single-array path, this syncs before stop_join
-  // and never calls gpu_pool_release_all. That is safe only because multiarray
-  // binds every array with SCHEDULE_DRAIN_AFTER_KICK (gate_ord == NULL in
-  // init_array_descriptor): no tail gate is ever armed, so no kick can park and
-  // sync_all cannot hang. If multiarray ever adopts a gated/pipelined schedule,
-  // mirror the single-array order (stop_join -> release -> sync) here.
+  // Safe to sync first only because no array here arms a tail gate, so nothing
+  // can park waiting to be released. A gated schedule would need the single-
+  // array teardown order instead.
   sync_all(&ms->engine.streams);
 
-  // A flush that errored after finalize_shards queued footer write_direct jobs
-  // (which reference each array's footer_buf_pool) can leave that IO pending in
-  // a sink's queue. Stop the delivery worker and drain the sinks destroy
-  // auto-flushed before engine_array_state_destroy frees those pools below —
-  // the multiarray analogue of the single-array destroy fix (#147).
+  // Drain queued IO before teardown frees the buffers it points into.
   gpu_delivery_stop_join(&ms->engine.delivery);
   if (ms->arrays) {
     for (int a = 0; a < ms->n_arrays; ++a) {
       if (autoflush && !autoflush[a])
-        continue; // caller flushed this array; its sink may already be freed
+        continue;
       if (ms->arrays[a].ctx.sink)
         shard_sink_drain(ms->arrays[a].ctx.sink);
     }

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -211,8 +211,12 @@ fs_slot_truncate(struct shard_writer* self, uint64_t logical_size)
   if (w->fd == PLATFORM_FD_INVALID)
     return 0;
 
-  // A real truncate failure (truncate_fn) marks the pool errored; mirror that
-  // so a subsequent flush bails at its has_error gate before its own drain.
+  // Test hook: synthesize the footer-queued-then-error state. A queued footer
+  // write_direct has already been posted by finalize_shards; fail here (and set
+  // io_error, so a later flush bails at its has_error gate) so the queued
+  // footer outlives the flush. This returns synchronously rather than via the
+  // io worker like a genuine ftruncate failure, but it is enough to drive the
+  // teardown-drain path under test.
   if (w->fail_next_truncate && atomic_exchange(w->fail_next_truncate, 0)) {
     atomic_store(w->io_error, 1);
     return 1;

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -397,6 +397,13 @@ shard_pool_fs_inject_failing_truncate(struct shard_pool* self)
   return 0;
 }
 
+void
+shard_pool_fs_set_error(struct shard_pool* self)
+{
+  struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
+  atomic_store(&p->io_error, 1);
+}
+
 struct gate_ctx
 {
   _Atomic int* gate;

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -26,8 +26,7 @@ struct shard_pool_fs
   _Atomic uint64_t queued_bytes;
   _Atomic uint64_t retired_bytes;
   _Atomic int io_error;
-  // Test hook: one-shot. The next fs_slot_truncate fails before queueing its
-  // job, leaving any footer write_direct jobs from finalize_shards queued.
+  // Test hook: one-shot, fail the next truncate.
   _Atomic int fail_next_truncate;
 };
 
@@ -211,12 +210,8 @@ fs_slot_truncate(struct shard_writer* self, uint64_t logical_size)
   if (w->fd == PLATFORM_FD_INVALID)
     return 0;
 
-  // Test hook: synthesize the footer-queued-then-error state. A queued footer
-  // write_direct has already been posted by finalize_shards; fail here (and set
-  // io_error, so a later flush bails at its has_error gate) so the queued
-  // footer outlives the flush. This returns synchronously rather than via the
-  // io worker like a genuine ftruncate failure, but it is enough to drive the
-  // teardown-drain path under test.
+  // Test hook: fail synchronously and mark the pool errored, so a footer write
+  // already queued by the caller outlives the flush that bails on the error.
   if (w->fail_next_truncate && atomic_exchange(w->fail_next_truncate, 0)) {
     atomic_store(w->io_error, 1);
     return 1;

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -26,6 +26,9 @@ struct shard_pool_fs
   _Atomic uint64_t queued_bytes;
   _Atomic uint64_t retired_bytes;
   _Atomic int io_error;
+  // Test hook: one-shot. The next fs_slot_truncate fails before queueing its
+  // job, leaving any footer write_direct jobs from finalize_shards queued.
+  _Atomic int fail_next_truncate;
 };
 
 // --- Writer slot for a single shard file ---
@@ -39,6 +42,7 @@ struct fs_slot
   _Atomic uint64_t* retired_bytes; // points to shard_pool_fs.retired_bytes
   _Atomic uint64_t* queued_bytes;  // points to shard_pool_fs.queued_bytes
   _Atomic int* io_error;           // points to shard_pool_fs.io_error
+  _Atomic int* fail_next_truncate; // points to shard_pool_fs.fail_next_truncate
 };
 
 struct pwrite_job
@@ -206,6 +210,13 @@ fs_slot_truncate(struct shard_writer* self, uint64_t logical_size)
   struct fs_slot* w = (struct fs_slot*)self;
   if (w->fd == PLATFORM_FD_INVALID)
     return 0;
+
+  // A real truncate failure (truncate_fn) marks the pool errored; mirror that
+  // so a subsequent flush bails at its has_error gate before its own drain.
+  if (w->fail_next_truncate && atomic_exchange(w->fail_next_truncate, 0)) {
+    atomic_store(w->io_error, 1);
+    return 1;
+  }
 
   if (w->queue) {
     struct truncate_job* j =
@@ -378,6 +389,14 @@ shard_pool_fs_inject_failing_job(struct shard_pool* self)
   return io_queue_post(p->queue, fail_fn, (void*)&p->io_error, NULL);
 }
 
+int
+shard_pool_fs_inject_failing_truncate(struct shard_pool* self)
+{
+  struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
+  atomic_store(&p->fail_next_truncate, 1);
+  return 0;
+}
+
 struct gate_ctx
 {
   _Atomic int* gate;
@@ -452,6 +471,7 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
     s->retired_bytes = &p->retired_bytes;
     s->queued_bytes = &p->queued_bytes;
     s->io_error = &p->io_error;
+    s->fail_next_truncate = &p->fail_next_truncate;
   }
 
   return &p->base;

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -24,15 +24,11 @@ shard_pool_fs_inject_failing_job(struct shard_pool* pool);
 int
 shard_pool_fs_inject_blocking_job(struct shard_pool* pool, _Atomic int* gate);
 
-// Test helper: one-shot. The next truncate fails before queueing its job,
-// so finalize_shards errors after it has already queued footer write_direct
-// jobs that reference footer_buf_pool. Exercises the destroy-time drain that
-// guards those buffers against a flush that bailed before its own drain.
+// Test helper: one-shot, fail the next truncate so a flush errors with IO
+// still queued. Exercises the destroy-time drain that guards those buffers.
 int
 shard_pool_fs_inject_failing_truncate(struct shard_pool* pool);
 
-// Test helper: mark the pool errored immediately (synchronous, no queue).
-// Lets a test make every subsequent shard delivery short-circuit on
-// has_error so a kicked batch's delivery fails and stays queued at destroy.
+// Test helper: mark the pool errored so later deliveries fail and stay queued.
 void
 shard_pool_fs_set_error(struct shard_pool* pool);

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -23,3 +23,10 @@ shard_pool_fs_inject_failing_job(struct shard_pool* pool);
 // Caller owns gate. Returns 0 on successful enqueue.
 int
 shard_pool_fs_inject_blocking_job(struct shard_pool* pool, _Atomic int* gate);
+
+// Test helper: one-shot. The next truncate fails before queueing its job,
+// so finalize_shards errors after it has already queued footer write_direct
+// jobs that reference footer_buf_pool. Exercises the destroy-time drain that
+// guards those buffers against a flush that bailed before its own drain.
+int
+shard_pool_fs_inject_failing_truncate(struct shard_pool* pool);

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -30,3 +30,9 @@ shard_pool_fs_inject_blocking_job(struct shard_pool* pool, _Atomic int* gate);
 // guards those buffers against a flush that bailed before its own drain.
 int
 shard_pool_fs_inject_failing_truncate(struct shard_pool* pool);
+
+// Test helper: mark the pool errored immediately (synchronous, no queue).
+// Lets a test make every subsequent shard delivery short-circuit on
+// has_error so a kicked batch's delivery fails and stays queued at destroy.
+void
+shard_pool_fs_set_error(struct shard_pool* pool);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,6 +178,7 @@ add_gpu_test_exe(test_destroy_drain  test_destroy_drain.c  LINKS CUDA::cuda_driv
 add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
 add_gpu_test_exe(test_destroy_midstream test_destroy_midstream.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
 add_test_exe(test_flush_drain_cpu test_flush_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
+add_test_exe(test_flush_error_drain_cpu test_flush_error_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
 add_gpu_test_exe(test_multiarray_flush_mock  test_multiarray_flush_mock.c  LINKS CUDA::cuda_driver CUDA::cudart_static multiarray_gpu stream writer chucky_log)
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   zarr_array ngff_multiscale zarr_group zarr_metadata store_s3 store_api lod_plan dimension platform_cmd chucky_log)
 add_test_exe(test_store_s3       test_store_s3.c       store_s3 store_api platform_cmd chucky_log)

--- a/tests/test_destroy_midstream.c
+++ b/tests/test_destroy_midstream.c
@@ -142,6 +142,121 @@ Cleanup:
   return rc;
 }
 
+// Two pipelined batches kicked (both enqueued on the delivery worker), then
+// the sink is forced into an error state so each batch's delivery
+// short-circuits and fails. destroy's auto-flush aborts on the first failed
+// drain without joining the second batch's worker job, so a delivery job is
+// still queued when stop_join runs — the teardown run-out path. Asserts no
+// hang and (under ASAN) no use-after-free.
+static int
+test_destroy_runs_out_queued_delivery(const char* tmpdir)
+{
+  log_info("=== test_destroy_runs_out_queued_delivery ===");
+
+  struct dimension dims[3] = {
+    { .size = 12,
+      .chunk_size = 4,
+      .chunks_per_shard = 3,
+      .name = "z",
+      .storage_position = 0 },
+    { .size = 64,
+      .chunk_size = 16,
+      .chunks_per_shard = 2,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 64,
+      .chunk_size = 16,
+      .chunks_per_shard = 2,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  const size_t epoch_elements = 4 * 64 * 64;
+  const size_t append_elements = 4 * epoch_elements; // two full batches at K=2
+
+  struct store* store = NULL;
+  struct shard_pool* pool = NULL;
+  struct zarr_array* arr = NULL;
+  struct tile_stream_gpu* s = NULL;
+  uint16_t* src = NULL;
+  test_thread* thr = NULL;
+  int rc = 1;
+
+  store = store_fs_create(tmpdir, 1);
+  CHECK(Cleanup, store);
+  CHECK(Cleanup, store->mkdirs(store, ".") == 0);
+  CHECK(Cleanup, store->mkdirs(store, "0") == 0);
+
+  pool = store->create_pool(store, 8);
+  CHECK(Cleanup, pool);
+
+  struct zarr_array_config acfg = {
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_ZSTD },
+  };
+  arr = zarr_array_create_with_pool(store, pool, 0, "0", &acfg);
+  CHECK(Cleanup, arr);
+
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = epoch_elements * sizeof(uint16_t),
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_ZSTD },
+    .epochs_per_batch = 2,
+  };
+  s = tile_stream_gpu_create(&cfg, zarr_array_as_shard_sink(arr));
+  CHECK(Cleanup, s);
+
+  src = (uint16_t*)malloc(append_elements * sizeof(uint16_t));
+  CHECK(Cleanup, src);
+  for (size_t i = 0; i < append_elements; ++i)
+    src[i] = (uint16_t)(i * 31);
+
+  // Force the sink errored before the kicks so every delivery the worker
+  // attempts short-circuits on has_error and fails fast.
+  shard_pool_fs_set_error(pool);
+
+  {
+    struct slice input = { .beg = src, .end = src + append_elements };
+    // Append succeeds (the kick path does not check has_error); both batches
+    // are kicked and enqueued on the delivery worker, each failing on the
+    // sink error.
+    writer_append(tile_stream_gpu_writer(s), input);
+  }
+
+  // Destroy on another thread so a hung run-out shows up as a timeout rather
+  // than wedging the test.
+  struct destroy_args da = { .s = s };
+  atomic_store(&da.done, 0);
+  CHECK(Cleanup, test_thread_start(&thr, destroy_thread_fn, &da) == 0);
+  s = NULL;
+
+  if (wait_for_done(&da.done, POST_RELEASE_TIMEOUT_MS)) {
+    log_error("destroy hung with a delivery job still queued");
+    goto Cleanup;
+  }
+
+  test_thread_join(thr);
+  thr = NULL;
+
+  // The sink is errored by construction; the point of the test is the clean
+  // teardown, which ASAN validates.
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  free(src);
+  tile_stream_gpu_destroy(s);
+  test_thread_join(thr);
+  zarr_array_destroy(arr);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return rc;
+}
+
 // One full batch appended (slot kicked; its delivery ran on the worker and
 // queued sink IO), sink IO gated: destroy must block until the IO drains,
 // then finish clean.
@@ -281,6 +396,13 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/midstream_%d", tmpdir, rep);
     test_mkdir(sub);
     ecode |= test_destroy_with_delivery_in_flight(sub, rep);
+  }
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/runout", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_destroy_runs_out_queued_delivery(sub);
   }
 
   {

--- a/tests/test_destroy_midstream.c
+++ b/tests/test_destroy_midstream.c
@@ -3,7 +3,7 @@
 // references — including when sink IO is stalled at that moment.
 
 #include "gpu/prelude.cuda.h"
-#include "gpu/stream.internal.h" // white-box: hold the delivery worker
+#include "gpu/stream.internal.h" // white-box access for test hooks
 #include "platform/platform.h"
 #include "store.h"
 #include "stream.gpu.h"
@@ -143,13 +143,9 @@ Cleanup:
   return rc;
 }
 
-// Two pipelined batches kicked (both enqueued on the delivery worker), the
-// sink forced into an error state, and the worker held after each job so the
-// second batch's delivery stays queued. destroy's auto-flush aborts on the
-// first failed drain without joining the second job; stop_join then has to run
-// that still-queued job out — the teardown run-out path. The hold makes the
-// queued-at-stop_join state deterministic rather than timing-dependent.
-// Asserts no hang and (under ASAN) no use-after-free.
+// Destroy must run out a delivery still queued when teardown begins, with no
+// hang and (under ASAN) no use-after-free. Holding the worker makes the queued
+// state deterministic rather than timing-dependent.
 static int
 test_destroy_runs_out_queued_delivery(const char* tmpdir)
 {
@@ -217,25 +213,18 @@ test_destroy_runs_out_queued_delivery(const char* tmpdir)
   for (size_t i = 0; i < append_elements; ++i)
     src[i] = (uint16_t)(i * 31);
 
-  // Hold the worker after each completed job so the second batch's delivery is
-  // still queued when stop_join runs, exercising the run-out line. No-op if the
-  // worker is absent (drains run inline; no run-out line to hit).
+  // Hold the worker so a delivery stays queued through teardown.
   gpu_delivery_set_hold(&s->engine.delivery, 1);
 
-  // Force the sink errored before the kicks so every delivery the worker
-  // attempts short-circuits on has_error and fails fast.
+  // Error the sink first so every delivery fails fast.
   shard_pool_fs_set_error(pool);
 
   {
     struct slice input = { .beg = src, .end = src + append_elements };
-    // Append succeeds (the kick path does not check has_error); both batches
-    // are kicked and enqueued on the delivery worker, each failing on the
-    // sink error.
     writer_append(tile_stream_gpu_writer(s), input);
   }
 
-  // Destroy on another thread so a hung run-out shows up as a timeout rather
-  // than wedging the test.
+  // Destroy on another thread so a hang surfaces as a timeout, not a wedge.
   struct destroy_args da = { .s = s };
   atomic_store(&da.done, 0);
   CHECK(Cleanup, test_thread_start(&thr, destroy_thread_fn, &da) == 0);
@@ -249,8 +238,6 @@ test_destroy_runs_out_queued_delivery(const char* tmpdir)
   test_thread_join(thr);
   thr = NULL;
 
-  // The sink is errored by construction; the point of the test is the clean
-  // teardown, which ASAN validates.
   rc = 0;
   log_info("  PASS");
 

--- a/tests/test_destroy_midstream.c
+++ b/tests/test_destroy_midstream.c
@@ -3,6 +3,7 @@
 // references — including when sink IO is stalled at that moment.
 
 #include "gpu/prelude.cuda.h"
+#include "gpu/stream.internal.h" // white-box: hold the delivery worker
 #include "platform/platform.h"
 #include "store.h"
 #include "stream.gpu.h"
@@ -142,12 +143,13 @@ Cleanup:
   return rc;
 }
 
-// Two pipelined batches kicked (both enqueued on the delivery worker), then
-// the sink is forced into an error state so each batch's delivery
-// short-circuits and fails. destroy's auto-flush aborts on the first failed
-// drain without joining the second batch's worker job, so a delivery job is
-// still queued when stop_join runs — the teardown run-out path. Asserts no
-// hang and (under ASAN) no use-after-free.
+// Two pipelined batches kicked (both enqueued on the delivery worker), the
+// sink forced into an error state, and the worker held after each job so the
+// second batch's delivery stays queued. destroy's auto-flush aborts on the
+// first failed drain without joining the second job; stop_join then has to run
+// that still-queued job out — the teardown run-out path. The hold makes the
+// queued-at-stop_join state deterministic rather than timing-dependent.
+// Asserts no hang and (under ASAN) no use-after-free.
 static int
 test_destroy_runs_out_queued_delivery(const char* tmpdir)
 {
@@ -214,6 +216,11 @@ test_destroy_runs_out_queued_delivery(const char* tmpdir)
   CHECK(Cleanup, src);
   for (size_t i = 0; i < append_elements; ++i)
     src[i] = (uint16_t)(i * 31);
+
+  // Hold the worker after each completed job so the second batch's delivery is
+  // still queued when stop_join runs, exercising the run-out line. No-op if the
+  // worker is absent (drains run inline; no run-out line to hit).
+  gpu_delivery_set_hold(&s->engine.delivery, 1);
 
   // Force the sink errored before the kicks so every delivery the worker
   // attempts short-circuits on has_error and fails fast.

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -1,0 +1,146 @@
+// Regression test (#147): a writer_flush that errors after finalize_shards
+// has queued footer write_direct jobs returns before its own drain. Those
+// jobs reference stream-owned footer_buf_pool. tile_stream_cpu_destroy must
+// drain the sink unconditionally before shard_state_destroy frees that pool,
+// or the IO worker reads freed heap (use-after-free; ASAN catches it).
+
+#include "platform/platform.h"
+#include "store.h"
+#include "stream.cpu.h"
+#include "test_platform.h"
+#include "util/prelude.h"
+#include "writer.h"
+#include "zarr/shard_pool.h"
+#include "zarr/shard_pool_fs.h"
+#include "zarr/zarr_array.h"
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int
+test_destroy_drains_after_flush_error(const char* tmpdir)
+{
+  log_info("=== test_destroy_drains_after_flush_error (cpu) ===");
+
+  // Unbounded append dim with chunks_per_shard=2 and one appended epoch:
+  // the shard is partial at flush time, so finalize_shards queues a footer
+  // write_direct and then calls truncate, which the injected hook fails.
+  struct dimension dims[3] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 2,
+      .name = "t",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  const size_t epoch_elements = 8 * 8;
+
+  struct store* store = NULL;
+  struct shard_pool* pool = NULL;
+  struct zarr_array* arr = NULL;
+  struct tile_stream_cpu* s = NULL;
+  uint16_t* src = NULL;
+  int rc = 1;
+
+  store = store_fs_create(tmpdir, /*unbuffered=*/1);
+  CHECK(Cleanup, store);
+  CHECK(Cleanup, store->mkdirs(store, ".") == 0);
+  CHECK(Cleanup, store->mkdirs(store, "0") == 0);
+
+  pool = store->create_pool(store, 8);
+  CHECK(Cleanup, pool);
+
+  struct zarr_array_config acfg = {
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  arr = zarr_array_create_with_pool(store, pool, 0, "0", &acfg);
+  CHECK(Cleanup, arr);
+
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = epoch_elements * sizeof(uint16_t),
+    .epochs_per_batch = 1,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  s = tile_stream_cpu_create(&cfg, zarr_array_as_shard_sink(arr));
+  CHECK(Cleanup, s);
+
+  src = (uint16_t*)calloc(epoch_elements, sizeof(uint16_t));
+  CHECK(Cleanup, src);
+
+  {
+    struct slice input = { .beg = src, .end = src + epoch_elements };
+    struct writer_result r = writer_append(tile_stream_cpu_writer(s), input);
+    CHECK(Cleanup, r.error == 0);
+  }
+
+  // Make the next truncate fail. finalize_shards queues the footer
+  // write_direct first, then truncate fails, so the flush body returns error
+  // before reaching its own drain.
+  CHECK(Cleanup, shard_pool_fs_inject_failing_truncate(pool) == 0);
+
+  {
+    struct writer_result r = writer_flush(tile_stream_cpu_writer(s));
+    if (!r.error) {
+      log_error("flush unexpectedly succeeded — fault hook not in effect");
+      goto Cleanup;
+    }
+  }
+
+  // Destroy with the footer jobs still queued and the pool errored. The
+  // unconditional drain must run them out before footer_buf_pool is freed.
+  tile_stream_cpu_destroy(s);
+  s = NULL;
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  free(src);
+  tile_stream_cpu_destroy(s);
+  zarr_array_destroy(arr);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return rc;
+}
+
+int
+main(int ac, char* av[])
+{
+  (void)ac;
+  (void)av;
+
+  int ecode = 0;
+  char tmpdir[4096];
+  CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  log_info("temp dir: %s", tmpdir);
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/flush_error_drain_cpu", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_destroy_drains_after_flush_error(sub);
+  }
+
+  test_tmpdir_remove(tmpdir);
+
+Fail:
+  return ecode;
+}

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -1,8 +1,8 @@
-// Regression test (#147): a writer_flush that errors after finalize_shards
-// has queued footer write_direct jobs returns before its own drain. Those
-// jobs reference stream-owned footer_buf_pool. tile_stream_cpu_destroy must
-// drain the sink unconditionally before shard_state_destroy frees that pool,
-// or the IO worker reads freed heap (use-after-free; ASAN catches it).
+// Regression test (#147): when a flush errors after finalize_shards has
+// queued footer write_direct jobs, it must drain the sink before returning.
+// Those jobs reference stream-owned footer_buf_pool, which shard_state_destroy
+// later frees. If the flush returns without draining, the IO worker reads
+// freed heap on destroy (use-after-free; ASAN catches it).
 
 #include "platform/platform.h"
 #include "store.h"
@@ -92,8 +92,8 @@ test_destroy_drains_after_flush_error(const char* tmpdir)
   }
 
   // Make the next truncate fail. finalize_shards queues the footer
-  // write_direct first, then truncate fails, so the flush body returns error
-  // before reaching its own drain.
+  // write_direct first, then truncate fails, so the flush body errors out of
+  // its finalize loop with a footer job referencing footer_buf_pool queued.
   CHECK(Cleanup, shard_pool_fs_inject_failing_truncate(pool) == 0);
 
   {
@@ -104,8 +104,8 @@ test_destroy_drains_after_flush_error(const char* tmpdir)
     }
   }
 
-  // Destroy with the footer jobs still queued and the pool errored. The
-  // unconditional drain must run them out before footer_buf_pool is freed.
+  // Destroy frees footer_buf_pool. The errored flush above must have drained
+  // the queued footer jobs, or this reads freed heap under ASAN.
   tile_stream_cpu_destroy(s);
   s = NULL;
 

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -1,8 +1,6 @@
-// Regression test (#147): when a flush errors after finalize_shards has
-// queued footer write_direct jobs, it must drain the sink before returning.
-// Those jobs reference stream-owned footer_buf_pool, which shard_state_destroy
-// later frees. If the flush returns without draining, the IO worker reads
-// freed heap on destroy (use-after-free; ASAN catches it).
+// Regression test (#147): a flush that errors with footer IO still queued must
+// drain the sink before returning, or destroy frees buffers the IO worker still
+// reads (use-after-free; ASAN catches it).
 
 #include "platform/platform.h"
 #include "store.h"
@@ -24,9 +22,8 @@ test_destroy_drains_after_flush_error(const char* tmpdir)
 {
   log_info("=== test_destroy_drains_after_flush_error (cpu) ===");
 
-  // Unbounded append dim with chunks_per_shard=2 and one appended epoch:
-  // the shard is partial at flush time, so finalize_shards queues a footer
-  // write_direct and then calls truncate, which the injected hook fails.
+  // One epoch into a 2-per-shard append dim leaves a partial shard, so flush
+  // queues a footer write then truncates — and the injected hook fails truncate.
   struct dimension dims[3] = {
     { .size = 0,
       .chunk_size = 1,
@@ -91,9 +88,7 @@ test_destroy_drains_after_flush_error(const char* tmpdir)
     CHECK(Cleanup, r.error == 0);
   }
 
-  // Make the next truncate fail. finalize_shards queues the footer
-  // write_direct first, then truncate fails, so the flush body errors out of
-  // its finalize loop with a footer job referencing footer_buf_pool queued.
+  // Fail the next truncate so flush errors with a footer write still queued.
   CHECK(Cleanup, shard_pool_fs_inject_failing_truncate(pool) == 0);
 
   {
@@ -104,8 +99,8 @@ test_destroy_drains_after_flush_error(const char* tmpdir)
     }
   }
 
-  // Destroy frees footer_buf_pool. The errored flush above must have drained
-  // the queued footer jobs, or this reads freed heap under ASAN.
+  // Destroy frees the footer buffers; the errored flush must have drained the
+  // queued IO, or this reads freed heap under ASAN.
   tile_stream_cpu_destroy(s);
   s = NULL;
 


### PR DESCRIPTION
Closes #147.
Closes #152.

Finishing a stream writes out the last partial shards, which queues their footers to be written in the background. If that step fails partway through, the queued writes still point at buffers the stream is about to free — so a background writer could read freed memory and corrupt an otherwise-good shard.

Fix: drain the queued writes before freeing the buffers they reference.
- Drain on the flush error paths (GPU and CPU), where the destination is still live.
- On destroy, drain as a safety net — but only when destroy ran the flush itself. A caller that flushed successfully may tear its destination down first, so destroy must not touch it in that case.
- Apply the same drain to the multi-array writers, which had the same gap (draining only the arrays destroy flushed).

Tests:
- A CPU test forces a flush failure with writes still queued and checks, under AddressSanitizer, that destroy cleans up without touching freed memory.
- #152: the teardown test never actually left work queued at teardown, so it wasn't exercising that path. It now holds the delivery worker so a job is still pending when the stream is destroyed, and checks teardown runs it out without hanging or reading freed memory.