### PR TITLE
gpu: snapshot per-batch LOD timing across batch boundary

### DIFF
--- a/src/defs.limits.h
+++ b/src/defs.limits.h
@@ -6,6 +6,13 @@
 #define HALF_MAX_RANK (MAX_RANK / 2)
 #define LOD_MAX_NDIM HALF_MAX_RANK
 #define LOD_MAX_LEVELS 32
+
+// Generations of per-fc LOD timing events. The delivery worker reads a
+// drained batch's timing while the producer re-records the next same-fc
+// batch's events; at the worst case three batches are live at once (one
+// draining, one kicked-and-pending, one filling), so each owns its own
+// generation for its whole lifetime (#154).
+#define LOD_TIMING_SLOTS 3
 #define MAX_ZARR_RANK (HALF_MAX_RANK)
 
 // S3

--- a/src/defs.limits.h
+++ b/src/defs.limits.h
@@ -7,11 +7,8 @@
 #define LOD_MAX_NDIM HALF_MAX_RANK
 #define LOD_MAX_LEVELS 32
 
-// Generations of per-fc LOD timing events. The delivery worker reads a
-// drained batch's timing while the producer re-records the next same-fc
-// batch's events; at the worst case three batches are live at once (one
-// draining, one kicked-and-pending, one filling), so each owns its own
-// generation for its whole lifetime (#154).
+// Worst case three batches are live at once (draining, kicked-and-pending,
+// filling), so each needs its own timing buffer (#154).
 #define LOD_TIMING_SLOTS 3
 #define MAX_ZARR_RANK (HALF_MAX_RANK)
 

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -710,6 +710,7 @@ compress_agg_fill_handoff(struct compress_agg_stage* stage,
   out->fc = fc;
   out->n_epochs = in->n_epochs;
   out->lod_timing_slot = in->lod_timing_slot;
+  out->has_lod_timing = in->has_lod_timing;
   out->active_levels_mask = in->active_levels_mask;
   out->batch_active_masks = in->batch_active_masks;
   out->nlod = nlod;

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -709,6 +709,7 @@ compress_agg_fill_handoff(struct compress_agg_stage* stage,
   const uint8_t nlod = stage->ar.nlod;
   out->fc = fc;
   out->n_epochs = in->n_epochs;
+  out->lod_timing_slot = in->lod_timing_slot;
   out->active_levels_mask = in->active_levels_mask;
   out->batch_active_masks = in->batch_active_masks;
   out->nlod = nlod;

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -73,7 +73,7 @@ record_flush_metrics(const struct flush_handoff* handoff,
   const uint32_t n_epochs = handoff->n_epochs;
 
   const struct lod_timing* t = &lod_shared->timing[handoff->lod_timing_slot];
-  if (levels->enable_multiscale && t->t_start) {
+  if (levels->enable_multiscale && handoff->has_lod_timing) {
     const size_t bytes_per_element = dtype_bpe(config->dtype);
     const size_t scatter_bytes = layout->epoch_elements * bytes_per_element;
     const size_t morton_bytes =

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -72,7 +72,7 @@ record_flush_metrics(const struct flush_handoff* handoff,
   const int fc = handoff->fc;
   const uint32_t n_epochs = handoff->n_epochs;
 
-  const struct lod_timing* t = &lod_shared->timing[fc];
+  const struct lod_timing* t = &lod_shared->timing[handoff->lod_timing_slot];
   if (levels->enable_multiscale && t->t_start) {
     const size_t bytes_per_element = dtype_bpe(config->dtype);
     const size_t scatter_bytes = layout->epoch_elements * bytes_per_element;

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -31,6 +31,7 @@ struct flush_handoff
   uint32_t per_lod_n_active[LOD_MAX_LEVELS]; // owned, for delivery sizing
   uint8_t nlod;
   int lod_timing_slot; // LOD timing generation this batch owns (#154)
+  int has_lod_timing;  // batch ran a timed LOD epoch; else skip LOD metrics (#154)
 
   CUevent t_aggregate_end;  // D2H waits on this
   CUevent t_compress_start; // for metrics

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -30,8 +30,8 @@ struct flush_handoff
   const uint32_t* batch_active_masks;        // borrowed [K] per-epoch masks
   uint32_t per_lod_n_active[LOD_MAX_LEVELS]; // owned, for delivery sizing
   uint8_t nlod;
-  int lod_timing_slot; // LOD timing generation this batch owns (#154)
-  int has_lod_timing;  // batch ran a timed LOD epoch; else skip LOD metrics (#154)
+  int lod_timing_slot;
+  int has_lod_timing;
 
   CUevent t_aggregate_end;  // D2H waits on this
   CUevent t_compress_start; // for metrics

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -30,6 +30,7 @@ struct flush_handoff
   const uint32_t* batch_active_masks;        // borrowed [K] per-epoch masks
   uint32_t per_lod_n_active[LOD_MAX_LEVELS]; // owned, for delivery sizing
   uint8_t nlod;
+  int lod_timing_slot; // LOD timing generation this batch owns (#154)
 
   CUevent t_aggregate_end;  // D2H waits on this
   CUevent t_compress_start; // for metrics

--- a/src/gpu/ordering.h
+++ b/src/gpu/ordering.h
@@ -9,8 +9,7 @@
 // Timing-only events are excluded (they must not masquerade as ordering):
 //   staging t_h2d_start/t_scatter_start; compress t_compress_start/end;
 //   d2h t_d2h_start; lod timing t_start/t_scatter_end/t_reduce_end/
-//   t_append_end/t_end. GPU_EDGE_LOD_DONE is a separate stable event
-//   (lod_shared.lod_done[fc]), not the timing t_end.
+//   t_append_end/t_end.
 
 #include <cuda.h>
 #include <stdint.h>
@@ -49,7 +48,7 @@ enum gpu_edge
   GPU_EDGE_POOL_FILLED, // compute -> compress: chunk-pool batch contents
                         // (single instance; one batch in flight at record)
   GPU_EDGE_LOD_DONE,    // compute -> compress: LOD chunks in pool
-                        // (bound to lod_shared.lod_done[fc]; multiscale only)
+                        // (multiscale only)
   GPU_EDGE_AGG_DONE,    // compress -> d2h: aggregate slot outputs ready
   GPU_EDGE_POOL_CONSUMED, // compress -> compute (alias of AGG_DONE):
                           // pool buf[fc] reuse / re-zero (#140)

--- a/src/gpu/ordering.h
+++ b/src/gpu/ordering.h
@@ -9,7 +9,8 @@
 // Timing-only events are excluded (they must not masquerade as ordering):
 //   staging t_h2d_start/t_scatter_start; compress t_compress_start/end;
 //   d2h t_d2h_start; lod timing t_start/t_scatter_end/t_reduce_end/
-//   t_append_end (t_end doubles as GPU_EDGE_LOD_DONE and is bound here).
+//   t_append_end/t_end. GPU_EDGE_LOD_DONE is a separate stable event
+//   (lod_shared.lod_done[fc]), not the timing t_end.
 
 #include <cuda.h>
 #include <stdint.h>
@@ -48,7 +49,7 @@ enum gpu_edge
   GPU_EDGE_POOL_FILLED, // compute -> compress: chunk-pool batch contents
                         // (single instance; one batch in flight at record)
   GPU_EDGE_LOD_DONE,    // compute -> compress: LOD chunks in pool
-                        // (bound to lod_shared timing t_end; multiscale only)
+                        // (bound to lod_shared.lod_done[fc]; multiscale only)
   GPU_EDGE_AGG_DONE,    // compress -> d2h: aggregate slot outputs ready
   GPU_EDGE_POOL_CONSUMED, // compress -> compute (alias of AGG_DONE):
                           // pool buf[fc] reuse / re-zero (#140)

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -451,6 +451,7 @@ make_compress_input(struct stream_engine* e, int fc, uint32_t n_epochs)
     .batch_active_masks = s->batch_active_masks,
     .epochs_per_batch = e->sched.epochs_per_batch,
     .lod_timing_slot = s->lod_timing_slot,
+    .has_lod_timing = s->has_lod_timing,
   };
 }
 
@@ -478,6 +479,9 @@ run_epoch_lod(struct stream_engine* e, struct stream_context* ctx)
     s->lod_timing_slot = e->lod_shared.next_timing_slot;
     e->lod_shared.next_timing_slot =
       (e->lod_shared.next_timing_slot + 1) % LOD_TIMING_SLOTS;
+    // Only a real (lod_active) epoch records into the slot; otherwise the
+    // drain must not read it as this batch's timing (#154).
+    s->has_lod_timing = e->sched.lod_active;
   }
 
   if (!e->sched.lod_active) {
@@ -740,6 +744,10 @@ schedule_flush_partial_append(struct stream_engine* e,
   struct schedule_slot* fs = &e->sched.slot[fc];
   fs->active_levels_mask = active_levels_mask;
   fs->batch_active_masks[0] = active_levels_mask;
+  // This batch runs no timed LOD epoch (lod_emit_partial_append records no
+  // timing), so the drain must skip LOD metrics rather than read whatever
+  // generation this slot last held (#154).
+  fs->has_lod_timing = 0;
 
   // Produce-phase writes within the generation acquired at the last swap
   // (the fill slot is still being filled).

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -450,6 +450,7 @@ make_compress_input(struct stream_engine* e, int fc, uint32_t n_epochs)
     .active_levels_mask = s->active_levels_mask,
     .batch_active_masks = s->batch_active_masks,
     .epochs_per_batch = e->sched.epochs_per_batch,
+    .lod_timing_slot = s->lod_timing_slot,
   };
 }
 
@@ -470,6 +471,15 @@ run_epoch_lod(struct stream_engine* e, struct stream_context* ctx)
   struct schedule_slot* s = &e->sched.slot[e->sched.fill];
   uint32_t active_mask;
 
+  // The batch owns one timing generation for its whole lifetime; pick a fresh
+  // one at the first epoch so the worker's drain read can't collide with the
+  // next same-fc batch's re-record (#154).
+  if (e->sched.accumulated == 0) {
+    s->lod_timing_slot = e->lod_shared.next_timing_slot;
+    e->lod_shared.next_timing_slot =
+      (e->lod_shared.next_timing_slot + 1) % LOD_TIMING_SLOTS;
+  }
+
   if (!e->sched.lod_active) {
     active_mask = 1;
   } else {
@@ -478,6 +488,7 @@ run_epoch_lod(struct stream_engine* e, struct stream_context* ctx)
                         &e->lod_shared,
                         &e->ord,
                         e->sched.fill,
+                        s->lod_timing_slot,
                         &ctx->levels,
                         stream_engine_pool_epoch(e, ctx, e->sched.accumulated),
                         ctx->config.dtype,

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -472,15 +472,12 @@ run_epoch_lod(struct stream_engine* e, struct stream_context* ctx)
   struct schedule_slot* s = &e->sched.slot[e->sched.fill];
   uint32_t active_mask;
 
-  // The batch owns one timing generation for its whole lifetime; pick a fresh
-  // one at the first epoch so the worker's drain read can't collide with the
-  // next same-fc batch's re-record (#154).
+  // Pick a fresh timing buffer at the first epoch so the worker's drain read
+  // can't collide with the next batch's re-record (#154).
   if (e->sched.accumulated == 0) {
     s->lod_timing_slot = e->lod_shared.next_timing_slot;
     e->lod_shared.next_timing_slot =
       (e->lod_shared.next_timing_slot + 1) % LOD_TIMING_SLOTS;
-    // Only a real (lod_active) epoch records into the slot; otherwise the
-    // drain must not read it as this batch's timing (#154).
     s->has_lod_timing = e->sched.lod_active;
   }
 
@@ -744,9 +741,7 @@ schedule_flush_partial_append(struct stream_engine* e,
   struct schedule_slot* fs = &e->sched.slot[fc];
   fs->active_levels_mask = active_levels_mask;
   fs->batch_active_masks[0] = active_levels_mask;
-  // This batch runs no timed LOD epoch (lod_emit_partial_append records no
-  // timing), so the drain must skip LOD metrics rather than read whatever
-  // generation this slot last held (#154).
+  // No timed epoch here, so the drain must skip stale timing metrics (#154).
   fs->has_lod_timing = 0;
 
   // Produce-phase writes within the generation acquired at the last swap

--- a/src/gpu/schedule.h
+++ b/src/gpu/schedule.h
@@ -72,6 +72,7 @@ struct schedule_slot
   uint32_t active_levels_mask;  // union of per-epoch active masks
   uint32_t* batch_active_masks; // [epochs_per_batch]; per-array allocation
   int lod_timing_slot;          // generation owned by the batch being filled
+  int has_lod_timing;           // batch ran a timed LOD epoch (#154)
   int kicked;
   uint64_t kick_seq;
   struct flush_handoff handoff;

--- a/src/gpu/schedule.h
+++ b/src/gpu/schedule.h
@@ -71,6 +71,7 @@ struct schedule_slot
 {
   uint32_t active_levels_mask;  // union of per-epoch active masks
   uint32_t* batch_active_masks; // [epochs_per_batch]; per-array allocation
+  int lod_timing_slot;          // generation owned by the batch being filled
   int kicked;
   uint64_t kick_seq;
   struct flush_handoff handoff;

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -121,6 +121,7 @@ struct compress_agg_input
   const uint32_t* batch_active_masks; // borrowed from schedule_slot [K]
   uint32_t epochs_per_batch;
   int lod_timing_slot; // the batch's owned LOD timing generation (#154)
+  int has_lod_timing;  // batch ran a timed LOD epoch (#154)
 };
 
 // Per-shard layout tables shared across arrays, sized to the max

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -64,17 +64,13 @@ struct lod_shared_state
   CUdeviceptr d_linear; // linear epoch buffer (device)
   CUdeviceptr d_morton; // morton-ordered LOD output (all levels packed)
 
-  // Per-fc ordering edge (GPU_EDGE_LOD_DONE). Stable per fc — recorded every
-  // epoch, never rotates — so the bound edge handle stays valid for waits.
+  // Recorded every epoch and never rotated, so a bound handle stays valid.
   CUevent lod_done[2];
 
-  // Pipeline timing read at drain. Rotated across batches so a batch's
-  // generation stays stable while the worker reads it and the producer
-  // re-records the next same-fc batch into a different one (#154). Each
-  // batch picks a generation at its first epoch and owns it through drain;
-  // the chosen index rides the flush handoff.
+  // Rotated across batches so the worker's read can't collide with the
+  // producer re-recording the next same-fc batch (#154).
   struct lod_timing timing[LOD_TIMING_SLOTS];
-  int next_timing_slot; // producer-only round-robin picker
+  int next_timing_slot;
 };
 
 // Per-array LOD state.  In multiarray, one instance per array; the active
@@ -120,8 +116,8 @@ struct compress_agg_input
   uint32_t active_levels_mask;
   const uint32_t* batch_active_masks; // borrowed from schedule_slot [K]
   uint32_t epochs_per_batch;
-  int lod_timing_slot; // the batch's owned LOD timing generation (#154)
-  int has_lod_timing;  // batch ran a timed LOD epoch (#154)
+  int lod_timing_slot;
+  int has_lod_timing;
 };
 
 // Per-shard layout tables shared across arrays, sized to the max

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -61,9 +61,20 @@ struct lod_timing
 // owned by the engine and sized for that one array.
 struct lod_shared_state
 {
-  CUdeviceptr d_linear;        // linear epoch buffer (device)
-  CUdeviceptr d_morton;        // morton-ordered LOD output (all levels packed)
-  struct lod_timing timing[2]; // double-buffered pipeline timing
+  CUdeviceptr d_linear; // linear epoch buffer (device)
+  CUdeviceptr d_morton; // morton-ordered LOD output (all levels packed)
+
+  // Per-fc ordering edge (GPU_EDGE_LOD_DONE). Stable per fc — recorded every
+  // epoch, never rotates — so the bound edge handle stays valid for waits.
+  CUevent lod_done[2];
+
+  // Pipeline timing read at drain. Rotated across batches so a batch's
+  // generation stays stable while the worker reads it and the producer
+  // re-records the next same-fc batch into a different one (#154). Each
+  // batch picks a generation at its first epoch and owns it through drain;
+  // the chosen index rides the flush handoff.
+  struct lod_timing timing[LOD_TIMING_SLOTS];
+  int next_timing_slot; // producer-only round-robin picker
 };
 
 // Per-array LOD state.  In multiarray, one instance per array; the active
@@ -109,6 +120,7 @@ struct compress_agg_input
   uint32_t active_levels_mask;
   const uint32_t* batch_active_masks; // borrowed from schedule_slot [K]
   uint32_t epochs_per_batch;
+  int lod_timing_slot; // the batch's owned LOD timing generation (#154)
 };
 
 // Per-shard layout tables shared across arrays, sized to the max

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -171,10 +171,10 @@ stream_engine_init(struct stream_engine* e,
                                 lim->lod_linear_bytes,
                                 lim->lod_morton_bytes,
                                 e->streams.compute) == 0);
-    // t_end doubles as GPU_EDGE_LOD_DONE; already seeded by the init above.
+    // lod_done is the stable per-fc ordering edge; already seeded above.
     for (int fc = 0; fc < 2; ++fc)
       gpu_ordering_bind(
-        &e->ord, GPU_EDGE_LOD_DONE, fc, e->lod_shared.timing[fc].t_end);
+        &e->ord, GPU_EDGE_LOD_DONE, fc, e->lod_shared.lod_done[fc]);
   }
 
   CU(Fail, cuStreamSynchronize(e->streams.compute));

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -394,18 +394,26 @@ lod_shared_state_init(struct lod_shared_state* sh,
   CU(Fail, cuMemAlloc(&sh->d_linear, linear_bytes));
   CU(Fail, cuMemAlloc(&sh->d_morton, morton_bytes));
 
+  sh->next_timing_slot = 0;
+
+  // Ordering-edge events, one per fc (GPU_EDGE_LOD_DONE binds these).
   for (int fc = 0; fc < 2; ++fc) {
-    CU(Fail, cuEventCreate(&sh->timing[fc].t_start, CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&sh->timing[fc].t_scatter_end, CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&sh->timing[fc].t_reduce_end, CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&sh->timing[fc].t_append_end, CU_EVENT_DEFAULT));
-    CU(Fail, cuEventCreate(&sh->timing[fc].t_end, CU_EVENT_DEFAULT));
-    // Seed events so initial waits complete immediately.
-    CU(Fail, cuEventRecord(sh->timing[fc].t_start, seed_stream));
-    CU(Fail, cuEventRecord(sh->timing[fc].t_scatter_end, seed_stream));
-    CU(Fail, cuEventRecord(sh->timing[fc].t_reduce_end, seed_stream));
-    CU(Fail, cuEventRecord(sh->timing[fc].t_append_end, seed_stream));
-    CU(Fail, cuEventRecord(sh->timing[fc].t_end, seed_stream));
+    CU(Fail, cuEventCreate(&sh->lod_done[fc], CU_EVENT_DEFAULT));
+    CU(Fail, cuEventRecord(sh->lod_done[fc], seed_stream));
+  }
+
+  // Timing generations. Seed so initial metric reads see a valid interval.
+  for (int g = 0; g < LOD_TIMING_SLOTS; ++g) {
+    CU(Fail, cuEventCreate(&sh->timing[g].t_start, CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&sh->timing[g].t_scatter_end, CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&sh->timing[g].t_reduce_end, CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&sh->timing[g].t_append_end, CU_EVENT_DEFAULT));
+    CU(Fail, cuEventCreate(&sh->timing[g].t_end, CU_EVENT_DEFAULT));
+    CU(Fail, cuEventRecord(sh->timing[g].t_start, seed_stream));
+    CU(Fail, cuEventRecord(sh->timing[g].t_scatter_end, seed_stream));
+    CU(Fail, cuEventRecord(sh->timing[g].t_reduce_end, seed_stream));
+    CU(Fail, cuEventRecord(sh->timing[g].t_append_end, seed_stream));
+    CU(Fail, cuEventRecord(sh->timing[g].t_end, seed_stream));
   }
 
   return 0;
@@ -424,12 +432,14 @@ lod_shared_state_destroy(struct lod_shared_state* sh)
   // Null-check each event individually: a partial init (e.g., cleanup after
   // lod_shared_state_init fails halfway through event creation) leaves some
   // handles zero, and cuEventDestroy on NULL returns an error.
-  for (int fc = 0; fc < 2; ++fc) {
-    cu_event_destroy(sh->timing[fc].t_start);
-    cu_event_destroy(sh->timing[fc].t_scatter_end);
-    cu_event_destroy(sh->timing[fc].t_reduce_end);
-    cu_event_destroy(sh->timing[fc].t_append_end);
-    cu_event_destroy(sh->timing[fc].t_end);
+  for (int fc = 0; fc < 2; ++fc)
+    cu_event_destroy(sh->lod_done[fc]);
+  for (int g = 0; g < LOD_TIMING_SLOTS; ++g) {
+    cu_event_destroy(sh->timing[g].t_start);
+    cu_event_destroy(sh->timing[g].t_scatter_end);
+    cu_event_destroy(sh->timing[g].t_reduce_end);
+    cu_event_destroy(sh->timing[g].t_append_end);
+    cu_event_destroy(sh->timing[g].t_end);
   }
   memset(sh, 0, sizeof(*sh));
 }
@@ -731,6 +741,7 @@ lod_run_epoch(struct lod_state* lod,
               struct lod_shared_state* sh,
               struct gpu_ordering* ord,
               int fc,
+              int timing_slot,
               const struct level_geometry* levels,
               struct gpu_pool_view pool_epoch,
               enum dtype dtype,
@@ -741,7 +752,7 @@ lod_run_epoch(struct lod_state* lod,
               uint32_t* out_active_mask)
 {
   struct lod_plan* p = &lod->plan;
-  struct lod_timing* t = &sh->timing[fc];
+  struct lod_timing* t = &sh->timing[timing_slot];
 
   CU(Error, cuEventRecord(t->t_start, compute));
 
@@ -804,7 +815,9 @@ lod_run_epoch(struct lod_state* lod,
           lod, sh, levels, pool_epoch, dtype, active_levels_mask, compute) ==
           0);
 
-  // t_end doubles as GPU_EDGE_LOD_DONE (bound at engine init).
+  // Timing endpoint for the batch's generation; the ordering edge records
+  // separately on the stable per-fc sh->lod_done[fc] (bound at engine init).
+  CU(Error, cuEventRecord(t->t_end, compute));
   CHECK(Error, gpu_edge_record(ord, GPU_EDGE_LOD_DONE, fc, compute) == 0);
 
   *out_active_mask = active_levels_mask;

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -396,13 +396,12 @@ lod_shared_state_init(struct lod_shared_state* sh,
 
   sh->next_timing_slot = 0;
 
-  // Ordering-edge events, one per fc (GPU_EDGE_LOD_DONE binds these).
   for (int fc = 0; fc < 2; ++fc) {
     CU(Fail, cuEventCreate(&sh->lod_done[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventRecord(sh->lod_done[fc], seed_stream));
   }
 
-  // Timing generations. Seed so initial metric reads see a valid interval.
+  // Seed so the first downstream wait and metric read complete immediately.
   for (int g = 0; g < LOD_TIMING_SLOTS; ++g) {
     CU(Fail, cuEventCreate(&sh->timing[g].t_start, CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&sh->timing[g].t_scatter_end, CU_EVENT_DEFAULT));
@@ -815,8 +814,6 @@ lod_run_epoch(struct lod_state* lod,
           lod, sh, levels, pool_epoch, dtype, active_levels_mask, compute) ==
           0);
 
-  // Timing endpoint for the batch's generation; the ordering edge records
-  // separately on the stable per-fc sh->lod_done[fc] (bound at engine init).
   CU(Error, cuEventRecord(t->t_end, compute));
   CHECK(Error, gpu_edge_record(ord, GPU_EDGE_LOD_DONE, fc, compute) == 0);
 

--- a/src/gpu/stream.lod.h
+++ b/src/gpu/stream.lod.h
@@ -17,11 +17,9 @@ lod_state_init(struct lod_state* lod,
 // linear_bytes / morton_bytes are the buffer sizes (multiarray passes the max
 // across arrays; single-array passes the array's own sizes).
 //
-// The lod_done ordering events and the timing generations are created AND
-// seeded on `seed_stream` so the first downstream wait (and metric read)
-// completes immediately. `seed_stream` must be the same compute stream that
-// later runs lod_run_epoch — seeding on an unrelated stream leaves the
-// initial waits unsatisfied.
+// `seed_stream` must be the same compute stream the epoch later runs on:
+// the events are seeded on it so the first wait completes immediately, and
+// seeding on an unrelated stream leaves those initial waits unsatisfied.
 //
 // Returns 0 on success; on failure, the struct is left safe to pass to
 // lod_shared_state_destroy.
@@ -56,9 +54,7 @@ lod_state_device_bytes(const struct computed_stream_layouts* cl,
 
 // Run LOD pipeline for one epoch: gather -> reduce -> append fold ->
 // morton-to-chunks. pool_epoch: acquired view of this epoch's chunk pool
-// region (all levels). timing_slot: the batch's owned timing generation
-// (sh->timing[timing_slot]); the ordering edge records on the stable
-// per-fc sh->lod_done[fc]. *out_active_mask: set to bitmask of active LOD
+// region (all levels). *out_active_mask: set to bitmask of active LOD
 // levels for this epoch. Returns 0 on success, non-zero on error.
 int
 lod_run_epoch(struct lod_state* lod,

--- a/src/gpu/stream.lod.h
+++ b/src/gpu/stream.lod.h
@@ -17,10 +17,11 @@ lod_state_init(struct lod_state* lod,
 // linear_bytes / morton_bytes are the buffer sizes (multiarray passes the max
 // across arrays; single-array passes the array's own sizes).
 //
-// The timing events are created AND seeded on `seed_stream` so the first
-// downstream wait completes immediately.  `seed_stream` must be the same
-// compute stream that later runs lod_run_epoch — seeding on an unrelated
-// stream leaves the initial waits unsatisfied.
+// The lod_done ordering events and the timing generations are created AND
+// seeded on `seed_stream` so the first downstream wait (and metric read)
+// completes immediately. `seed_stream` must be the same compute stream that
+// later runs lod_run_epoch — seeding on an unrelated stream leaves the
+// initial waits unsatisfied.
 //
 // Returns 0 on success; on failure, the struct is left safe to pass to
 // lod_shared_state_destroy.
@@ -55,13 +56,16 @@ lod_state_device_bytes(const struct computed_stream_layouts* cl,
 
 // Run LOD pipeline for one epoch: gather -> reduce -> append fold ->
 // morton-to-chunks. pool_epoch: acquired view of this epoch's chunk pool
-// region (all levels). *out_active_mask: set to bitmask of active LOD levels
-// for this epoch. Returns 0 on success, non-zero on error.
+// region (all levels). timing_slot: the batch's owned timing generation
+// (sh->timing[timing_slot]); the ordering edge records on the stable
+// per-fc sh->lod_done[fc]. *out_active_mask: set to bitmask of active LOD
+// levels for this epoch. Returns 0 on success, non-zero on error.
 int
 lod_run_epoch(struct lod_state* lod,
               struct lod_shared_state* sh,
               struct gpu_ordering* ord,
               int fc,
+              int timing_slot,
               const struct level_geometry* levels,
               struct gpu_pool_view pool_epoch,
               enum dtype dtype,


### PR DESCRIPTION
Closes #154.

The per-level (LOD) timing in the metrics could read slightly wrong values. A batch's timing was read after it finished, but by then the next batch could have reused and overwritten those timers. These numbers are only for reporting, so written data was never affected — only the timing readout could be off.

Fix: give each in-flight batch its own set of timers (enough for the most that can be active at once), so a batch's timing is read from its own set rather than a later batch's. The ordering signal that had been sharing one of those timers is split out, leaving the timers purely for measurement. Batches that do no per-level work (a trailing partial write) are marked so the reader skips their timers instead of reading stale ones.

Reporting only; no change to written data.