### PR TITLE
Stop double counting delivery worker waits

### DIFF
--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -198,6 +198,9 @@ json_stage_metric(struct json_writer* jw,
   double out_gibs = gb_per_s(sm->output_bytes, (double)sm->ms);
   jw_key(jw, name);
   jw_object_begin(jw);
+  // Which timeline this belongs to. Times may be summed only within one owner.
+  jw_key(jw, "owner");
+  jw_string(jw, metric_owner_name(sm->owner));
   // total_ms and count are the primitives every other field is derived from;
   // without them a sweep file cannot be re-analyzed.
   jw_key(jw, "total_ms");
@@ -334,6 +337,19 @@ print_bench_json_pass(const struct stream_metrics* m,
   jw_uint(&jw, m->lod_samples_lost);
   // StagingFree is the producer's own append-side wait — the stall that
   // explains dropped frames. Keys come from the engine's metric names.
+  jw_key(&jw, "owners");
+  jw_object_begin(&jw);
+  jw_key(&jw, "flush_stall");
+  jw_string(&jw, metric_owner_name(m->flush_stall.owner));
+  jw_key(&jw, "drain_dispatch");
+  jw_string(&jw, metric_owner_name(m->drain_dispatch.owner));
+  jw_key(&jw, "io_fence");
+  jw_string(&jw, metric_owner_name(m->io_fence_stall.owner));
+  jw_key(&jw, "backpressure");
+  jw_string(&jw, metric_owner_name(m->backpressure.owner));
+  jw_key(&jw, "tail_gate");
+  jw_string(&jw, metric_owner_name(m->tail_gate.owner));
+  jw_object_end(&jw);
   jw_key(&jw, "edge_stalls");
   jw_object_begin(&jw);
   for (size_t i = 0; i < sizeof(m->edge_stall) / sizeof(m->edge_stall[0]);
@@ -343,6 +359,8 @@ print_bench_json_pass(const struct stream_metrics* m,
       continue;
     jw_key(&jw, es->name);
     jw_object_begin(&jw);
+    jw_key(&jw, "owner");
+    jw_string(&jw, metric_owner_name(es->owner));
     jw_key(&jw, "total_ms");
     jw_float(&jw, (double)es->ms);
     jw_key(&jw, "count");

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -142,7 +142,7 @@ print_bench_report(const struct stream_metrics* metrics,
     if (metrics->edge_stall[i].count > 0)
       have_edge_stalls = 1;
   int have_stalls =
-    metrics->flush_stall.count > 0 || metrics->kick_sync_stall.count > 0 ||
+    metrics->flush_stall.count > 0 || metrics->drain_dispatch.count > 0 ||
     metrics->io_fence_stall.count > 0 || metrics->backpressure.count > 0 ||
     metrics->max_append_ms > 0 || metrics->peak_pending_bytes > 0 ||
     metrics->tail_gate.count > 0 || metrics->scatter_samples_lost > 0 ||
@@ -151,7 +151,7 @@ print_bench_report(const struct stream_metrics* metrics,
     fputc('\n', stderr);
     print_report("  --- Stall stats ---");
     print_metric_row(&metrics->flush_stall);
-    print_metric_row(&metrics->kick_sync_stall);
+    print_metric_row(&metrics->drain_dispatch);
     print_metric_row(&metrics->io_fence_stall);
     print_metric_row(&metrics->backpressure);
     print_metric_row(&metrics->tail_gate);
@@ -311,10 +311,10 @@ print_bench_json_pass(const struct stream_metrics* m,
   jw_float(&jw, (double)m->flush_stall.ms);
   jw_key(&jw, "flush_stall_count");
   jw_uint(&jw, (uint64_t)m->flush_stall.count);
-  jw_key(&jw, "kick_sync_ms");
-  jw_float(&jw, (double)m->kick_sync_stall.ms);
-  jw_key(&jw, "kick_sync_count");
-  jw_uint(&jw, (uint64_t)m->kick_sync_stall.count);
+  jw_key(&jw, "drain_dispatch_ms");
+  jw_float(&jw, (double)m->drain_dispatch.ms);
+  jw_key(&jw, "drain_dispatch_count");
+  jw_uint(&jw, (uint64_t)m->drain_dispatch.count);
   jw_key(&jw, "io_fence_ms");
   jw_float(&jw, (double)m->io_fence_stall.ms);
   jw_key(&jw, "io_fence_count");

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -1053,14 +1053,14 @@ run_bench_two_streams(const struct bench_config* cfg)
     print_metric_row(&m[k].sink);
 
     int have_stalls =
-      m[k].flush_stall.count > 0 || m[k].kick_sync_stall.count > 0 ||
+      m[k].flush_stall.count > 0 || m[k].drain_dispatch.count > 0 ||
       m[k].io_fence_stall.count > 0 || m[k].backpressure.count > 0 ||
       m[k].max_append_ms > 0 || m[k].peak_pending_bytes > 0;
     if (have_stalls) {
       fputc('\n', stderr);
       print_report("  --- Stall stats (stream-%d) ---", k);
       print_metric_row(&m[k].flush_stall);
-      print_metric_row(&m[k].kick_sync_stall);
+      print_metric_row(&m[k].drain_dispatch);
       print_metric_row(&m[k].io_fence_stall);
       print_metric_row(&m[k].backpressure);
       print_report("  max append ms:   %.2f", (double)m[k].max_append_ms);

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -241,21 +241,29 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
   }
 
   // Metrics.
-  s->metrics.memcpy = mk_stream_metric("memcpy");
-  s->metrics.scatter = mk_stream_metric("scatter");
-  s->metrics.compress = mk_stream_metric("compress");
-  s->metrics.aggregate = mk_stream_metric("aggregate");
-  s->metrics.sink = mk_stream_metric("sink");
+  s->metrics.memcpy = mk_stream_metric("memcpy", METRIC_OWNER_PRODUCER);
+  s->metrics.scatter = mk_stream_metric("scatter", METRIC_OWNER_COMPUTE);
+  s->metrics.compress = mk_stream_metric("compress", METRIC_OWNER_COMPRESS);
+  s->metrics.aggregate = mk_stream_metric("aggregate", METRIC_OWNER_COMPRESS);
+  s->metrics.sink = mk_stream_metric("sink", METRIC_OWNER_DRAIN);
   // GPU-only stall metrics: named but never populated on CPU path.
-  s->metrics.flush_stall = mk_stream_metric("flush_stall");
-  s->metrics.drain_dispatch = mk_stream_metric("drain_dispatch");
-  s->metrics.io_fence_stall = mk_stream_metric("io_fence");
-  s->metrics.backpressure = mk_stream_metric("backpressure");
+  s->metrics.flush_stall =
+    mk_stream_metric("flush_stall", METRIC_OWNER_PRODUCER);
+  s->metrics.drain_dispatch =
+    mk_stream_metric("drain_dispatch", METRIC_OWNER_DRAIN);
+  s->metrics.io_fence_stall =
+    mk_stream_metric("io_fence", METRIC_OWNER_PRODUCER);
+  s->metrics.backpressure =
+    mk_stream_metric("backpressure", METRIC_OWNER_PRODUCER);
   if (s->levels.enable_multiscale) {
-    s->metrics.lod_gather = mk_stream_metric("lod_gather");
-    s->metrics.lod_reduce = mk_stream_metric("lod_reduce");
-    s->metrics.lod_append_fold = mk_stream_metric("lod_append_fold");
-    s->metrics.lod_morton_chunk = mk_stream_metric("lod_morton");
+    s->metrics.lod_gather =
+      mk_stream_metric("lod_gather", METRIC_OWNER_COMPUTE);
+    s->metrics.lod_reduce =
+      mk_stream_metric("lod_reduce", METRIC_OWNER_COMPUTE);
+    s->metrics.lod_append_fold =
+      mk_stream_metric("lod_append_fold", METRIC_OWNER_COMPUTE);
+    s->metrics.lod_morton_chunk =
+      mk_stream_metric("lod_morton", METRIC_OWNER_COMPUTE);
   }
 
   // Precompute total_element_limit (configured stream length) so the body can

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -248,7 +248,7 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
   s->metrics.sink = mk_stream_metric("sink");
   // GPU-only stall metrics: named but never populated on CPU path.
   s->metrics.flush_stall = mk_stream_metric("flush_stall");
-  s->metrics.kick_sync_stall = mk_stream_metric("kick_sync");
+  s->metrics.drain_dispatch = mk_stream_metric("drain_dispatch");
   s->metrics.io_fence_stall = mk_stream_metric("io_fence");
   s->metrics.backpressure = mk_stream_metric("backpressure");
   if (s->levels.enable_multiscale) {

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -138,6 +138,18 @@ Error:
 
 // --- D2H kick / drain ---
 
+// Poll time already attributed to the ordering edges. The drain block below
+// contains those polls, so it subtracts this to avoid counting them twice.
+static float
+edge_stall_total_ms(const struct stream_metrics* m)
+{
+  float t = 0;
+  const size_t n = sizeof(m->edge_stall) / sizeof(m->edge_stall[0]);
+  for (size_t i = 0; i < n; ++i)
+    t += m->edge_stall[i].ms;
+  return t;
+}
+
 // Wait for any pending IO fence on the unified slot (across all LODs that
 // share it). Accumulates wall time into io_fence_stall.
 static void
@@ -214,6 +226,7 @@ schedule_d2h_drain(struct d2h_deliver_stage* stage,
   {
     struct platform_clock kick_clk = { 0 };
     platform_toc(&kick_clk);
+    const float polls_before = edge_stall_total_ms(metrics);
 
     if (handoff->passthrough) {
       struct gpu_pool_view hv;
@@ -242,8 +255,12 @@ schedule_d2h_drain(struct d2h_deliver_stage* stage,
         goto Done;
     }
 
-    float kick_ms = platform_toc(&kick_clk) * 1000.0f;
-    accumulate_metric_ms(&metrics->kick_sync_stall, kick_ms, 0, 0);
+    // What is left after the polls is the worker's own dispatch and
+    // bookkeeping, so this and the edge stalls can be added together.
+    float block_ms = platform_toc(&kick_clk) * 1000.0f;
+    float own_ms = block_ms - (edge_stall_total_ms(metrics) - polls_before);
+    accumulate_metric_ms(
+      &metrics->drain_dispatch, own_ms > 0 ? own_ms : 0.0f, 0, 0);
   }
 
   {

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -24,31 +24,33 @@ struct stream_metrics
 stream_engine_init_metrics(int enable_multiscale)
 {
   return (struct stream_metrics){
-    .memcpy = mk_stream_metric("Memcpy"),
-    .h2d = mk_stream_metric("H2D"),
-    .scatter = mk_stream_metric(enable_multiscale ? "Copy" : "Scatter"),
-    .lod_gather = mk_stream_metric("LOD Gather"),
-    .lod_reduce = mk_stream_metric("LOD Reduce"),
-    .lod_append_fold = mk_stream_metric("Append Fold"),
-    .lod_morton_chunk = mk_stream_metric("LOD to chunks"),
-    .compress = mk_stream_metric("Compress"),
-    .aggregate = mk_stream_metric("Aggregate"),
-    .d2h = mk_stream_metric("D2H"),
-    .sink = mk_stream_metric("Sink"),
-    .flush_stall = mk_stream_metric("FlushStall"),
-    .drain_dispatch = mk_stream_metric("DrainDisp"),
-    .io_fence_stall = mk_stream_metric("IOFence"),
-    .backpressure = mk_stream_metric("Backpres"),
-    .tail_gate = mk_stream_metric("TailGate"),
+    .memcpy = mk_stream_metric("Memcpy", METRIC_OWNER_PRODUCER),
+    .h2d = mk_stream_metric("H2D", METRIC_OWNER_H2D),
+    .scatter = mk_stream_metric(enable_multiscale ? "Copy" : "Scatter",
+                                METRIC_OWNER_COMPUTE),
+    .lod_gather = mk_stream_metric("LOD Gather", METRIC_OWNER_COMPUTE),
+    .lod_reduce = mk_stream_metric("LOD Reduce", METRIC_OWNER_COMPUTE),
+    .lod_append_fold = mk_stream_metric("Append Fold", METRIC_OWNER_COMPUTE),
+    .lod_morton_chunk = mk_stream_metric("LOD to chunks", METRIC_OWNER_COMPUTE),
+    .compress = mk_stream_metric("Compress", METRIC_OWNER_COMPRESS),
+    .aggregate = mk_stream_metric("Aggregate", METRIC_OWNER_COMPRESS),
+    .d2h = mk_stream_metric("D2H", METRIC_OWNER_D2H),
+    .sink = mk_stream_metric("Sink", METRIC_OWNER_DRAIN),
+    .flush_stall = mk_stream_metric("FlushStall", METRIC_OWNER_PRODUCER),
+    .drain_dispatch = mk_stream_metric("DrainDisp", METRIC_OWNER_DRAIN),
+    .io_fence_stall = mk_stream_metric("IOFence", METRIC_OWNER_PRODUCER),
+    .backpressure = mk_stream_metric("Backpres", METRIC_OWNER_PRODUCER),
+    .tail_gate = mk_stream_metric("TailGate", METRIC_OWNER_COMPRESS),
   };
 }
 
 void
 stream_engine_attach_edge_stalls(struct stream_engine* e)
 {
-  e->metrics.edge_stall[0] = mk_stream_metric("StagingFree");
-  e->metrics.edge_stall[1] = mk_stream_metric("ChunkIndex");
-  e->metrics.edge_stall[2] = mk_stream_metric("D2HDone");
+  e->metrics.edge_stall[0] =
+    mk_stream_metric("StagingFree", METRIC_OWNER_PRODUCER);
+  e->metrics.edge_stall[1] = mk_stream_metric("ChunkIndex", METRIC_OWNER_DRAIN);
+  e->metrics.edge_stall[2] = mk_stream_metric("D2HDone", METRIC_OWNER_DRAIN);
   gpu_ordering_attach_stall_metric(
     &e->ord, GPU_EDGE_STAGING_FREE, &e->metrics.edge_stall[0]);
   gpu_ordering_attach_stall_metric(

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -36,7 +36,7 @@ stream_engine_init_metrics(int enable_multiscale)
     .d2h = mk_stream_metric("D2H"),
     .sink = mk_stream_metric("Sink"),
     .flush_stall = mk_stream_metric("FlushStall"),
-    .kick_sync_stall = mk_stream_metric("KickSync"),
+    .drain_dispatch = mk_stream_metric("DrainDisp"),
     .io_fence_stall = mk_stream_metric("IOFence"),
     .backpressure = mk_stream_metric("Backpres"),
     .tail_gate = mk_stream_metric("TailGate"),

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -441,18 +441,23 @@ multiarray_tile_stream_cpu_create(
 
   if (enable_metrics) {
     ms->metrics_enabled = 1;
-    ms->metrics.scatter = mk_stream_metric("scatter");
-    ms->metrics.compress = mk_stream_metric("compress");
-    ms->metrics.aggregate = mk_stream_metric("aggregate");
-    ms->metrics.sink = mk_stream_metric("sink");
+    ms->metrics.scatter = mk_stream_metric("scatter", METRIC_OWNER_COMPUTE);
+    ms->metrics.compress = mk_stream_metric("compress", METRIC_OWNER_COMPRESS);
+    ms->metrics.aggregate =
+      mk_stream_metric("aggregate", METRIC_OWNER_COMPRESS);
+    ms->metrics.sink = mk_stream_metric("sink", METRIC_OWNER_DRAIN);
     int any_multiscale = 0;
     for (int i = 0; i < n_arrays; ++i)
       any_multiscale |= ms->arrays[i].levels.enable_multiscale;
     if (any_multiscale) {
-      ms->metrics.lod_gather = mk_stream_metric("lod_gather");
-      ms->metrics.lod_reduce = mk_stream_metric("lod_reduce");
-      ms->metrics.lod_append_fold = mk_stream_metric("lod_append_fold");
-      ms->metrics.lod_morton_chunk = mk_stream_metric("lod_morton");
+      ms->metrics.lod_gather =
+        mk_stream_metric("lod_gather", METRIC_OWNER_COMPUTE);
+      ms->metrics.lod_reduce =
+        mk_stream_metric("lod_reduce", METRIC_OWNER_COMPUTE);
+      ms->metrics.lod_append_fold =
+        mk_stream_metric("lod_append_fold", METRIC_OWNER_COMPUTE);
+      ms->metrics.lod_morton_chunk =
+        mk_stream_metric("lod_morton", METRIC_OWNER_COMPUTE);
     }
   }
 

--- a/src/stream/config.c
+++ b/src/stream/config.c
@@ -390,7 +390,30 @@ Fail:
 }
 
 struct stream_metric
-mk_stream_metric(const char* name)
+mk_stream_metric(const char* name, enum metric_owner owner)
 {
-  return (struct stream_metric){ .name = name, .best_ms = 1e30f };
+  return (
+    struct stream_metric){ .name = name, .owner = owner, .best_ms = 1e30f };
+}
+
+const char*
+metric_owner_name(enum metric_owner o)
+{
+  switch (o) {
+    case METRIC_OWNER_PRODUCER:
+      return "producer";
+    case METRIC_OWNER_DRAIN:
+      return "drain";
+    case METRIC_OWNER_H2D:
+      return "h2d";
+    case METRIC_OWNER_COMPUTE:
+      return "compute";
+    case METRIC_OWNER_COMPRESS:
+      return "compress";
+    case METRIC_OWNER_D2H:
+      return "d2h";
+    case METRIC_OWNER_NONE:
+      break;
+  }
+  return "unset";
 }

--- a/src/stream/config.h
+++ b/src/stream/config.h
@@ -26,4 +26,4 @@ computed_stream_layouts_free(struct computed_stream_layouts* cl);
 
 // Create a named stream_metric with best_ms initialized to a large value.
 struct stream_metric
-mk_stream_metric(const char* name);
+mk_stream_metric(const char* name, enum metric_owner owner);

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -9,9 +9,28 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// Which resource's timeline a measurement belongs to. Times may be added
+// together only within one owner. Named by role rather than by thread: the
+// drain runs on the delivery worker when the pipeline is deep and on the
+// producer when it is not.
+enum metric_owner
+{
+  METRIC_OWNER_NONE = 0,
+  METRIC_OWNER_PRODUCER,
+  METRIC_OWNER_DRAIN,
+  METRIC_OWNER_H2D,
+  METRIC_OWNER_COMPUTE,
+  METRIC_OWNER_COMPRESS,
+  METRIC_OWNER_D2H,
+};
+
+const char*
+metric_owner_name(enum metric_owner o);
+
 struct stream_metric
 {
   const char* name;
+  enum metric_owner owner;
   float ms;                 // cumulative
   float best_ms;            // fastest measurement; 1e30f = none yet
   double best_input_bytes;  // bytes at the fastest measurement, for its rate

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -12,17 +12,19 @@
 struct stream_metric
 {
   const char* name;
-  float ms;                // cumulative
-  float best_ms;           // best single measurement (1e30f = not yet measured)
-  double best_input_bytes; // input_bytes at the best-ms call (for best GiB/s)
-  double best_output_bytes; // output_bytes at the best-ms call
-  double input_bytes;       // cumulative bytes read by stage
-  double output_bytes;      // cumulative bytes written by stage
-  int count;
+  float ms;                 // cumulative
+  float best_ms;            // fastest measurement; 1e30f = none yet
+  double best_input_bytes;  // bytes at the fastest measurement, for its rate
+  double best_output_bytes; // likewise
+  double input_bytes;       // cumulative, read by the stage
+  double output_bytes;      // cumulative, written by the stage
+  int count;                // measurements taken, not work items
 };
 
 struct stream_metrics
 {
+  // Work done. Bytes may be summed across stages; times may not, since the
+  // stages run at the same time on separate streams.
   struct stream_metric memcpy;
   struct stream_metric h2d;
   struct stream_metric lod_gather;
@@ -35,48 +37,26 @@ struct stream_metrics
   struct stream_metric d2h;
   struct stream_metric sink;
 
-  // Wall-clock time a thread is blocked at each sync point. flush_stall,
-  // drain_dispatch and backpressure are GPU-only; io_fence_stall is populated
-  // on both paths.
-  //
-  // These belong to two different threads and must not be added together. On
-  // the pipelined schedule the drain runs on the delivery worker, so
-  // drain_dispatch, sink and the edge_stall entries are the worker's time and
-  // overlap the producer's. flush_stall is the producer's own cost: its join
-  // wait in drain_slot. On depth-1 schedules the drain runs inline, so
-  // flush_stall contains the worker set instead of overlapping it.
-  //
-  // Within the worker the entries are disjoint, so they can be added:
-  // edge_stall covers the waits, sink covers delivery, and drain_dispatch
-  // covers what is left.
-  struct stream_metric flush_stall; // producer join wait / inline drain
-                                    // (drain_slot in schedule.c)
-  // The drain block minus the waits the edge stalls already count: queuing the
-  // per-LOD copies and releasing the slot. Was reported as the whole block,
-  // which double-counted those waits.
-  struct stream_metric drain_dispatch;
-  struct stream_metric io_fence_stall; // GPU: wait_io_fences in
-                                       // schedule_d2h_kick. CPU: wait_fence
-                                       // before aggregate in
-                                       // cpu_pipeline_flush_batch.
-  struct stream_metric backpressure;   // wait at epoch boundary for IO to drain
-  // Host-poll blocked time attributed to GPU ordering edges (gpu/ordering.h:
-  // staging_free, chunk_index_ready, d2h_done). GPU engines wire these up;
-  // entries stay zero (count 0) elsewhere.
-  struct stream_metric edge_stall[3];
-  // Device-side wait on the previous batch's tail upload (the #142 gate),
-  // measured between compress-end and aggregate-start. Only ever non-zero on
-  // the page-aligned path; without it that wait is invisible, since it was
-  // deliberately excluded from `aggregate`.
-  struct stream_metric tail_gate;
+  // Time spent waiting. The producer and the delivery worker are separate
+  // threads, so their entries overlap and may not be summed together; the
+  // worker's own entries are disjoint and may be. When the drain runs on the
+  // producer instead of the worker, the producer entry contains the worker's
+  // rather than overlapping it. An entry a backend never fills keeps count 0,
+  // meaning not measured rather than no wait.
+  struct stream_metric flush_stall;    // producer: waiting for a drain
+  struct stream_metric drain_dispatch; // worker: its work between the waits
+  struct stream_metric io_fence_stall; // queued writes still holding a slot
+  struct stream_metric backpressure;   // sink queue over its watermark
+  struct stream_metric edge_stall[3];  // one declared ordering edge each; the
+                                       // name says which
+  struct stream_metric tail_gate; // previous batch's shard tail state; only
+                                  // sinks needing aligned shards wait here
 
-  float max_append_ms;       // longest tile_stream_gpu_append body
-  size_t peak_pending_bytes; // max sink->pending_bytes seen
+  float max_append_ms;       // longest single append
+  size_t peak_pending_bytes; // high-water mark of bytes awaiting write
 
-  // Timing measurements discarded because their ring wrapped before the host
-  // read them. Non-zero means the stage totals below it are under-reported —
-  // the failure this instrumentation exists to make visible, so it must not
-  // stay a debug-only log line.
+  // Measurements dropped before they could be read. Non-zero means the stage
+  // totals above are under-reported.
   uint64_t scatter_samples_lost;
   uint64_t lod_samples_lost;
 };

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -35,23 +35,26 @@ struct stream_metrics
   struct stream_metric d2h;
   struct stream_metric sink;
 
-  // Stall metrics — wall-clock time the host is blocked at each sync point.
-  // flush_stall, kick_sync_stall, backpressure are GPU-only. io_fence_stall
-  // is populated on both paths.
+  // Wall-clock time a thread is blocked at each sync point. flush_stall,
+  // drain_dispatch and backpressure are GPU-only; io_fence_stall is populated
+  // on both paths.
   //
-  // On the pipelined schedule the drain runs on the delivery worker:
-  // kick_sync_stall and sink then accumulate worker-side and OVERLAP
-  // producer time — do not sum them with wall time. flush_stall is the
-  // producer's join wait in drain_slot (the producer-visible cost). On
-  // depth-1 schedules the drain runs inline and flush_stall is a superset
-  // of kick_sync_stall + sink, as before.
+  // These belong to two different threads and must not be added together. On
+  // the pipelined schedule the drain runs on the delivery worker, so
+  // drain_dispatch, sink and the edge_stall entries are the worker's time and
+  // overlap the producer's. flush_stall is the producer's own cost: its join
+  // wait in drain_slot. On depth-1 schedules the drain runs inline, so
+  // flush_stall contains the worker set instead of overlapping it.
+  //
+  // Within the worker the entries are disjoint, so they can be added:
+  // edge_stall covers the waits, sink covers delivery, and drain_dispatch
+  // covers what is left.
   struct stream_metric flush_stall; // producer join wait / inline drain
                                     // (drain_slot in schedule.c)
-  // Passthrough: GPU_EDGE_D2H_DONE poll only. Compressed:
-  // GPU_EDGE_CHUNK_INDEX_READY poll + per-LOD bulk D2H dispatch +
-  // GPU_EDGE_D2H_DONE poll (the second poll includes DMA transfer wall
-  // time).
-  struct stream_metric kick_sync_stall;
+  // The drain block minus the waits the edge stalls already count: queuing the
+  // per-LOD copies and releasing the slot. Was reported as the whole block,
+  // which double-counted those waits.
+  struct stream_metric drain_dispatch;
   struct stream_metric io_fence_stall; // GPU: wait_io_fences in
                                        // schedule_d2h_kick. CPU: wait_fence
                                        // before aggregate in

--- a/src/util/metric.h
+++ b/src/util/metric.h
@@ -6,7 +6,7 @@
 #include <stddef.h>
 
 struct stream_metric
-mk_stream_metric(const char* name);
+mk_stream_metric(const char* name, enum metric_owner owner);
 
 static inline void
 accumulate_metric_ms(struct stream_metric* m,

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -112,11 +112,11 @@ test_ctx_setup(struct test_ctx* c,
   CHECK(Fail, c->batch_active_masks);
 
   memset(&c->metrics, 0, sizeof(c->metrics));
-  c->metrics.compress = mk_stream_metric("Compress");
-  c->metrics.aggregate = mk_stream_metric("Aggregate");
-  c->metrics.d2h = mk_stream_metric("D2H");
-  c->metrics.sink = mk_stream_metric("Sink");
-  c->metrics.lod_gather = mk_stream_metric("LOD Gather");
+  c->metrics.compress = mk_stream_metric("Compress", METRIC_OWNER_COMPRESS);
+  c->metrics.aggregate = mk_stream_metric("Aggregate", METRIC_OWNER_COMPRESS);
+  c->metrics.d2h = mk_stream_metric("D2H", METRIC_OWNER_D2H);
+  c->metrics.sink = mk_stream_metric("Sink", METRIC_OWNER_DRAIN);
+  c->metrics.lod_gather = mk_stream_metric("LOD Gather", METRIC_OWNER_COMPUTE);
 
   memset(&c->lod, 0, sizeof(c->lod));
   memset(&c->lod_shared, 0, sizeof(c->lod_shared));

--- a/tests/test_flush_orchestration.c
+++ b/tests/test_flush_orchestration.c
@@ -137,11 +137,14 @@ orch_ctx_setup(struct orch_ctx* c,
   memset(&c->s->engine.lod, 0, sizeof(c->s->engine.lod));
 
   memset(&c->s->engine.metrics, 0, sizeof(c->s->engine.metrics));
-  c->s->engine.metrics.compress = mk_stream_metric("Compress");
-  c->s->engine.metrics.aggregate = mk_stream_metric("Aggregate");
-  c->s->engine.metrics.d2h = mk_stream_metric("D2H");
-  c->s->engine.metrics.sink = mk_stream_metric("Sink");
-  c->s->engine.metrics.lod_gather = mk_stream_metric("LOD Gather");
+  c->s->engine.metrics.compress =
+    mk_stream_metric("Compress", METRIC_OWNER_COMPRESS);
+  c->s->engine.metrics.aggregate =
+    mk_stream_metric("Aggregate", METRIC_OWNER_COMPRESS);
+  c->s->engine.metrics.d2h = mk_stream_metric("D2H", METRIC_OWNER_D2H);
+  c->s->engine.metrics.sink = mk_stream_metric("Sink", METRIC_OWNER_DRAIN);
+  c->s->engine.metrics.lod_gather =
+    mk_stream_metric("LOD Gather", METRIC_OWNER_COMPUTE);
 
   memset(&c->s->engine.metadata_update_clock,
          0,


### PR DESCRIPTION
The delivery worker's timers overlapped, so its measured time added up to about
190% of wall clock. A single thread cannot exceed 100% of its own timeline.

`kick_sync` timed the whole drain block. The `ChunkIndex` and `D2HDone` edge
stalls time the two polls inside that block. Counting all three counted the
same waits twice. In a 256cube zstd run, `kick_sync` was 1917 ms and
`ChunkIndex` plus `D2HDone` was 1916 ms.

The drain block now subtracts the poll time the edge stalls already own, so the
worker's timers are disjoint and can be added together.

Renamed `kick_sync` to `drain_dispatch`, since what it measures has changed and
the old name suggested a producer-side wait when it was always worker-side. The
JSON key changes from `kick_sync_ms` to `drain_dispatch_ms`. Comparing a new
sweep against an older one on the old key would compare two different
quantities, so the rename makes that break visible.

Worker time as a share of wall clock, before and after:

- 256cube zstd: 190.0% to 94.2%
- multiscale: 191.8% to 95.9%
- codec none: 184.4% to 92.0%

`drain_dispatch` comes out around 0.3 us per drain, over 25 drains. That is
small but recorded on every drain, and it closes the worker's time budget. It
would grow with more resolution levels, since each adds a copy to queue.

## Testing

RelWithDebInfo, sm_89, on an L40. `ctest -E "(s3)"` passes 49/49. The build has
no warnings. Three bench shapes run: 256cube zstd, 256cube multiscale, and
256cube `--codec none`.
