### PR TITLE
benchmarking: version selects a migration path

### DIFF
--- a/scripts/sweep/models.py
+++ b/scripts/sweep/models.py
@@ -58,14 +58,60 @@ def validate_results(data: dict) -> ResultsFile:
 # ---------------------------------------------------------------------------
 
 
+# One version per sweep, since every run in a file comes from one binary. Bump
+# when a metric is renamed, removed, or changes meaning; adding one does not
+# need a bump. Version 1 predates the rule and is not a single shape, so
+# migrating from it cannot assume which keys are present.
+CURRENT_VERSION = 2
+
+# Renames of an unchanged quantity, safe to carry forward.
+_RENAMED_STAGES_1_TO_2 = {"lod_dim0_fold": "lod_append_fold"}
+
+# Keys whose value cannot be recovered, by the version that retired them.
+RETIRED_AT = {2: ("kick_sync_ms", "kick_sync_count")}
+
+
+def _migrate_1_to_2(data: dict) -> None:
+    for run in data.get("runs", []):
+        stages = run.get("stages")
+        if not isinstance(stages, dict):
+            continue
+        for old_name, new_name in _RENAMED_STAGES_1_TO_2.items():
+            if old_name in stages and new_name not in stages:
+                stages[new_name] = stages.pop(old_name)
+
+
+_MIGRATIONS = {1: _migrate_1_to_2}
+
+
 def migrate_run(run: dict) -> dict:
     """Fill defaults for fields added after the initial schema."""
     run.setdefault("sink", "discard")
     return run
 
 
+def retired_metrics(data: dict) -> tuple[str, ...]:
+    """Keys this file carries that must not be compared against later sweeps."""
+    origin = data.get("migrated_from", data.get("version", 1))
+    out: list[str] = []
+    for version, keys in sorted(RETIRED_AT.items()):
+        if origin < version:
+            out.extend(keys)
+    return tuple(out)
+
+
 def migrate_results(data: dict) -> dict:
-    """In-place migration of a results dict to the current schema."""
+    """Bring one results file to the current schema, in place.
+
+    Keys whose meaning changed are left as they are; converting them would
+    invent data. Use retired_metrics to find them.
+    """
+    version = data.get("version", 1)
+    data.setdefault("migrated_from", version)
+    while version < CURRENT_VERSION and version in _MIGRATIONS:
+        _MIGRATIONS[version](data)
+        version += 1
+        data["version"] = version
     for run in data.get("runs", []):
         migrate_run(run)
     return data

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -31,6 +31,7 @@ import click
 from pydantic import BaseModel, model_validator
 from rich.console import Console
 from models import (
+    CURRENT_VERSION,
     VALID_BACKENDS,
     VALID_CODECS,
     VALID_DTYPES,
@@ -491,7 +492,7 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             existing[rid] = r
     else:
         data = {
-            "version": 1,
+            "version": CURRENT_VERSION,
             "machine": {
                 "hostname": platform.node(),
                 "gpu": gpu_name(),

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -228,7 +228,7 @@ const LAYOUT = {
   stageThru: {W: 600, margin: {left: 100, right: 80, top: 40}},
 };
 
-const STAGE_ORDER = ["memcpy","h2d","scatter","lod_gather","lod_reduce","lod_dim0_fold","lod_morton","lod_morton_chunk","compress","aggregate","d2h","sink"];
+const STAGE_ORDER = ["memcpy","h2d","scatter","lod_gather","lod_reduce","lod_append_fold","lod_morton_chunk","compress","aggregate","d2h","sink"];
 
 const GROUP_LABELS = { single: "Single", multiscale: "Multiscale", dim0: "Dim0" };
 const GROUP_ORDER = ["single", "multiscale", "dim0"];


### PR DESCRIPTION
Benchmark results are saved as JSON files, one per batch of runs, and each file
carries a version number. That number was never updated, so it could not be used
to tell which files are comparable — not even after one timing measurement was
renamed and another changed meaning. This makes the version decide how a file is
read: older files are brought up to date as they load, which includes applying a
stage rename from earlier. One measurement cannot be brought forward, because the
newer value is the older one minus a wait that was never recorded at the time, and
the difference is large; it is now marked as not comparable rather than quietly
charted next to newer runs. Because every file reports the current version once
loaded, anything that needs a file's original version reads that separately. This
also fixes the report page, where one stage sorted after all the others because
the template still referred to it by its old name.
