### PR TITLE
Fix an overstated benchmark byte count

### DIFF
--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -201,14 +201,10 @@ json_stage_metric(struct json_writer* jw,
   // Which timeline this belongs to. Times may be summed only within one owner.
   jw_key(jw, "owner");
   jw_string(jw, metric_owner_name(sm->owner));
-  // total_ms and count are the primitives every other field is derived from;
-  // without them a sweep file cannot be re-analyzed.
   jw_key(jw, "total_ms");
   jw_float(jw, (double)sm->ms);
   jw_key(jw, "count");
   jw_uint(jw, (uint64_t)sm->count);
-  // Raw totals as well as the rates: bytes are safe to sum across stages,
-  // unlike times, which belong to different threads.
   jw_key(jw, "in_bytes");
   jw_uint(jw, (uint64_t)sm->input_bytes);
   jw_key(jw, "out_bytes");
@@ -335,8 +331,7 @@ print_bench_json_pass(const struct stream_metrics* m,
   jw_uint(&jw, m->scatter_samples_lost);
   jw_key(&jw, "lod_samples_lost");
   jw_uint(&jw, m->lod_samples_lost);
-  // StagingFree is the producer's own append-side wait — the stall that
-  // explains dropped frames. Keys come from the engine's metric names.
+  // Keyed by metric name.
   jw_key(&jw, "owners");
   jw_object_begin(&jw);
   jw_key(&jw, "flush_stall");

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -70,15 +70,11 @@ record_flush_metrics(const struct flush_handoff* handoff,
                      CUevent t_d2h_start,
                      CUevent t_d2h_ready)
 {
-  // An empty batch dispatched no kernels and moved no bytes, so its events
-  // bracket nothing. Screening on that is what the old sub-10us magnitude
-  // filter was really for, and unlike the filter it cannot discard a stage
-  // that genuinely ran fast.
+  // An empty batch dispatched no kernels and moved no bytes, so it has no
+  // interval to report.
   if (handoff->layout.total_batch_chunks == 0)
     return;
 
-  // LOD timing is per epoch and collected by the producer (lod_collect_timing);
-  // a batch-wide read here only ever saw the batch's last epoch.
   const size_t pool_bytes = (uint64_t)handoff->n_epochs * levels->total_chunks *
                             layout->chunk_stride * dtype_bpe(config->dtype);
 
@@ -91,16 +87,14 @@ record_flush_metrics(const struct flush_handoff* handoff,
   for (size_t i = 0; i < n_perm; ++i)
     agg_bytes += slot->h_permuted_sizes[i];
 
-  // Pass-through runs no codec, so there is no compress interval to report;
-  // its start/end events bracket nothing and would read as an infinite rate.
+  // Pass-through runs no codec, so it has no compress interval to report.
   if (!handoff->passthrough)
     accumulate_metric_cu_if_ready(&metrics->compress,
                                   handoff->t_compress_start,
                                   handoff->t_compress_end,
                                   pool_bytes,
                                   agg_bytes);
-  // The gap the aggregate interval no longer covers. Carries no bytes; it is
-  // a wait, and on the page-aligned path it is the cost of the tail gate.
+  // A wait, so it carries no bytes.
   accumulate_metric_cu_if_ready(&metrics->tail_gate,
                                 handoff->t_compress_end,
                                 handoff->t_aggregate_start,
@@ -169,9 +163,7 @@ d2h_deliver_drain_copy(struct d2h_deliver_stage* stage,
 {
   const struct batch_aggregate_layout* alayout = &handoff->layout;
   int dispatch_err = 0;
-  // Marks the payload transfer itself. The kick-time start event sits before
-  // the host handoff to the delivery worker, so measuring from there reports
-  // batch turnaround rather than transfer rate.
+  // Bounds the payload transfer, excluding the handoff that precedes it.
   if (cuEventRecord(stage->t_d2h_drain_start[handoff->fc],
                     stage->drain_stream) != CUDA_SUCCESS)
     return 1;

--- a/src/gpu/metric.cuda.h
+++ b/src/gpu/metric.cuda.h
@@ -4,11 +4,8 @@
 #include "util/metric.h"
 #include <cuda.h>
 
-// Accumulate only once the interval has finished on the device. Returns 1 while
-// it is still outstanding so the caller can keep the sample and retry, rather
-// than reading a zero and discarding it. No magnitude filter: the caller owns
-// deciding which intervals are real, so a genuinely sub-10us stage still
-// counts.
+// Accumulate a completed interval. Returns 1 without accumulating while the
+// interval is still outstanding, leaving the sample for the caller to retry.
 static inline int
 accumulate_metric_cu_if_ready(struct stream_metric* m,
                               CUevent start,

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -138,8 +138,7 @@ Error:
 
 // --- D2H kick / drain ---
 
-// Poll time already attributed to the ordering edges. The drain block below
-// contains those polls, so it subtracts this to avoid counting them twice.
+// Wait time already attributed to the ordering edges.
 static float
 edge_stall_total_ms(const struct stream_metrics* m)
 {
@@ -255,8 +254,6 @@ schedule_d2h_drain(struct d2h_deliver_stage* stage,
         goto Done;
     }
 
-    // What is left after the polls is the worker's own dispatch and
-    // bookkeeping, so this and the edge stalls can be added together.
     float block_ms = platform_toc(&kick_clk) * 1000.0f;
     float own_ms = block_ms - (edge_stall_total_ms(metrics) - polls_before);
     accumulate_metric_ms(

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -83,7 +83,8 @@ struct lod_timing
   size_t reduced_bytes;
   size_t morton_bytes;
   size_t pool_bytes;
-  size_t accum_bytes;
+  size_t folded_bytes;
+  size_t emitted_bytes;
 };
 
 // Engine-owned LOD resources shared across all arrays in a multiarray stream

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -35,12 +35,8 @@ struct staging_slot
   int h2d_pending;         // dispatched, interval not yet folded into metrics
 };
 
-// One scatter measurement. Owns both ends of its interval: reusing the
-// STAGING_SCATTER_DONE ordering edge as the end tied a sample's lifetime to the
-// staging slot, and the host reads slot state at a point that only waits on
-// STAGING_H2D_DONE — so the scatter was usually still running and the sample
-// was lost. Rotating more of these than there are staging slots lets a sample
-// wait for its own completion instead.
+// One scatter measurement, owning both ends of its own interval so it can
+// outlive the staging slot that produced it.
 struct scatter_timing
 {
   CUevent t_start;
@@ -75,10 +71,8 @@ struct lod_timing
   int pending;         // recorded, not yet folded into metrics
   int has_append_fold; // the append-fold phase ran this epoch
 
-  // Captured when the epoch is recorded, not when it is read. The ring is
-  // engine-owned and shared across arrays while the geometry these come from
-  // is per-array and swapped on bind, so a sample outstanding across an array
-  // switch would otherwise be folded in with the wrong array's sizes.
+  // Captured when the epoch is recorded. The geometry they come from is
+  // per-array and does not outlive a switch to another array.
   size_t epoch_bytes;
   size_t reduced_bytes;
   size_t morton_bytes;

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -770,7 +770,8 @@ lod_run_epoch(struct lod_state* lod,
     // The reduce writes levels 1..nlod-1; level 0 is its input.
     t->reduced_bytes = ends ? (ends[nlod - 1] - ends[0]) * bpe : 0;
     t->pool_bytes = levels->total_chunks * layout->chunk_stride * bpe;
-    t->accum_bytes = lod->append_accum.element_capacity * bpe;
+    t->folded_bytes = 0;
+    t->emitted_bytes = 0;
   }
 
   CU(Error, cuEventRecord(t->t_start, compute));
@@ -826,6 +827,14 @@ lod_run_epoch(struct lod_state* lod,
         lod, sh, dtype, append_reduce_method, compute, &active_levels_mask) ==
         0);
     t->has_append_fold = 1;
+    const size_t bpe = dtype_bpe(dtype);
+    for (int lv = 1; lv < p->levels.nlod; ++lv) {
+      const size_t level_bytes = p->levels.level[lv].fixed_dims_count *
+                                 p->levels.level[lv].lod_nelem * bpe;
+      t->folded_bytes += level_bytes;
+      if (active_levels_mask & (1u << lv))
+        t->emitted_bytes += level_bytes;
+    }
   }
 
   CU(Error, cuEventRecord(t->t_append_end, compute));
@@ -869,8 +878,8 @@ lod_collect_timing(struct lod_shared_state* sh, struct stream_metrics* metrics)
       accumulate_metric_cu_if_ready(&metrics->lod_append_fold,
                                     t->t_reduce_end,
                                     t->t_append_end,
-                                    t->accum_bytes,
-                                    t->accum_bytes);
+                                    t->folded_bytes,
+                                    t->emitted_bytes);
     accumulate_metric_cu_if_ready(&metrics->lod_morton_chunk,
                                   t->t_append_end,
                                   t->t_end,

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -10,9 +10,8 @@
 #include <stdint.h>
 
 // Which resource's timeline a measurement belongs to. Times may be added
-// together only within one owner. Named by role rather than by thread: the
-// drain runs on the delivery worker when the pipeline is deep and on the
-// producer when it is not.
+// together only within one owner. Named by role, not by thread, because the
+// drain does not always run on the same one.
 enum metric_owner
 {
   METRIC_OWNER_NONE = 0,


### PR DESCRIPTION
One benchmark stage reported a byte count that was too high, so its speed looked
better than it was. The append-dimension fold reads every reduced level each
epoch but only writes the levels whose turn has come; it was reporting every
level as written every time, which came out as writing exactly as much as it read.
A step that reduces data cannot do that. It now counts only the levels it wrote,
which drops the reported output to 45% of the input — a figure that matches the
level firing periods exactly, so it can be checked by hand rather than taken on
trust.

Also here: a pass over comments in the metric code. Several described how the
code worked, or narrated a recent change, or named symbols that a rename would
leave stale. Those are now cut back to what each thing is responsible for, and to
the few constraints a reader cannot infer from the code.
