### PR TITLE
Measure how long individual appends take

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ install(
 # integration path. cudart_static / nvcomp are baked into the chucky archive
 # but a bare -l flag cannot locate them without -L into the toolkit.
 set(CHUCKY_VARIANT_DESCRIPTION "CPU only")
-set(CHUCKY_PC_LIBS_PRIVATE "-llz4 -lzstd -laws-c-s3 -ldl -lrt -lpthread")
+set(CHUCKY_PC_LIBS_PRIVATE "-lm -llz4 -lzstd -laws-c-s3 -ldl -lrt -lpthread")
 if(CHUCKY_ENABLE_GPU)
     set(CHUCKY_VARIANT_DESCRIPTION "GPU + CPU")
     string(APPEND CHUCKY_PC_LIBS_PRIVATE " -lcudart_static -lnvcomp")

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -382,6 +382,24 @@ print_bench_json_pass(const struct stream_metrics* m,
   jw_float(&jw, (double)append_ms_at(m, 0.99));
   jw_key(&jw, "append_ms_p999");
   jw_float(&jw, (double)append_ms_at(m, 0.999));
+  // The buckets themselves, so a reader can ask their own question — such as
+  // how many appends missed their frame budget. No single percentile answers
+  // that, because where the slow tail starts depends on the append size.
+  jw_key(&jw, "append_ms_histogram");
+  jw_array_begin(&jw);
+  for (int i = 0; i < APPEND_LATENCY_BUCKETS; ++i) {
+    if (m->append_ms_buckets[i] == 0)
+      continue;
+    jw_object_begin(&jw);
+    jw_key(&jw, "upto_ms");
+    jw_float(&jw,
+             APPEND_LATENCY_MIN_MS *
+               pow(10.0, (double)(i + 1) / APPEND_LATENCY_PER_DECADE));
+    jw_key(&jw, "n");
+    jw_uint(&jw, m->append_ms_buckets[i]);
+    jw_object_end(&jw);
+  }
+  jw_array_end(&jw);
   jw_key(&jw, "append_count");
   jw_uint(&jw, m->append_count);
   jw_key(&jw, "max_append_ms");

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -23,8 +23,8 @@ print_append_latency(const struct stream_metrics* m)
     print_report("  max append ms:   %.2f", (double)m->max_append_ms);
     return;
   }
-  print_report("  append ms:       p50 %.2f  p90 %.2f  p99 %.2f  p99.9 %.2f"
-               "  max %.2f  (%llu appends)",
+  print_report("  append ms:       p50 %.3f  p90 %.3f  p99 %.3f  p99.9 %.3f"
+               "  max %.3f  (%llu appends)",
                (double)append_ms_at(m, 0.50),
                (double)append_ms_at(m, 0.90),
                (double)append_ms_at(m, 0.99),
@@ -381,14 +381,16 @@ print_bench_json_pass(const struct stream_metrics* m,
     jw_object_end(&jw);
   }
   jw_object_end(&jw);
-  jw_key(&jw, "append_ms_p50");
-  jw_float(&jw, (double)append_ms_at(m, 0.50));
-  jw_key(&jw, "append_ms_p90");
-  jw_float(&jw, (double)append_ms_at(m, 0.90));
-  jw_key(&jw, "append_ms_p99");
-  jw_float(&jw, (double)append_ms_at(m, 0.99));
-  jw_key(&jw, "append_ms_p999");
-  jw_float(&jw, (double)append_ms_at(m, 0.999));
+  if (m->append_count > 0) {
+    jw_key(&jw, "append_ms_p50");
+    jw_float(&jw, (double)append_ms_at(m, 0.50));
+    jw_key(&jw, "append_ms_p90");
+    jw_float(&jw, (double)append_ms_at(m, 0.90));
+    jw_key(&jw, "append_ms_p99");
+    jw_float(&jw, (double)append_ms_at(m, 0.99));
+    jw_key(&jw, "append_ms_p999");
+    jw_float(&jw, (double)append_ms_at(m, 0.999));
+  }
   // The buckets themselves, so a reader can ask their own question — such as
   // how many appends missed their frame budget. No single percentile answers
   // that, because where the slow tail starts depends on the append size.
@@ -399,9 +401,7 @@ print_bench_json_pass(const struct stream_metrics* m,
       continue;
     jw_object_begin(&jw);
     jw_key(&jw, "upto_ms");
-    jw_float(&jw,
-             APPEND_LATENCY_MIN_MS *
-               pow(10.0, (double)(i + 1) / APPEND_LATENCY_PER_DECADE));
+    jw_float(&jw, (double)append_bucket_ms(m, i));
     jw_key(&jw, "n");
     jw_uint(&jw, m->append_ms_buckets[i]);
     jw_object_end(&jw);

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -17,6 +17,23 @@ gb_per_s(double bytes, double ms)
 // --- Report + pipeline helpers ---
 
 void
+print_append_latency(const struct stream_metrics* m)
+{
+  if (m->append_count == 0) {
+    print_report("  max append ms:   %.2f", (double)m->max_append_ms);
+    return;
+  }
+  print_report("  append ms:       p50 %.2f  p90 %.2f  p99 %.2f  p99.9 %.2f"
+               "  max %.2f  (%llu appends)",
+               (double)append_ms_at(m, 0.50),
+               (double)append_ms_at(m, 0.90),
+               (double)append_ms_at(m, 0.99),
+               (double)append_ms_at(m, 0.999),
+               (double)m->max_append_ms,
+               (unsigned long long)m->append_count);
+}
+
+void
 print_metric_row(const struct stream_metric* m)
 {
   if (m->count <= 0)
@@ -163,17 +180,7 @@ print_bench_report(const struct stream_metrics* metrics,
                    "(stage totals under-report)",
                    (unsigned long long)metrics->scatter_samples_lost,
                    (unsigned long long)metrics->lod_samples_lost);
-    if (metrics->append_count > 0)
-      print_report("  append ms:       p50 %.2f  p90 %.2f  p99 %.2f  p99.9 %.2f"
-                   "  max %.2f  (%llu appends)",
-                   (double)append_ms_at(metrics, 0.50),
-                   (double)append_ms_at(metrics, 0.90),
-                   (double)append_ms_at(metrics, 0.99),
-                   (double)append_ms_at(metrics, 0.999),
-                   (double)metrics->max_append_ms,
-                   (unsigned long long)metrics->append_count);
-    else
-      print_report("  max append ms:   %.2f", (double)metrics->max_append_ms);
+    print_append_latency(metrics);
     char pbuf[32];
     format_bytes(pbuf, sizeof(pbuf), (uint64_t)metrics->peak_pending_bytes);
     print_report("  peak pending:    %s", pbuf);

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -1,6 +1,7 @@
 #include "bench_report.h"
 
 #include "util/format_bytes.h"
+#include "util/metric.h"
 #include "zarr/json_writer.h"
 
 // --- Throughput helpers ---
@@ -162,7 +163,17 @@ print_bench_report(const struct stream_metrics* metrics,
                    "(stage totals under-report)",
                    (unsigned long long)metrics->scatter_samples_lost,
                    (unsigned long long)metrics->lod_samples_lost);
-    print_report("  max append ms:   %.2f", (double)metrics->max_append_ms);
+    if (metrics->append_count > 0)
+      print_report("  append ms:       p50 %.2f  p90 %.2f  p99 %.2f  p99.9 %.2f"
+                   "  max %.2f  (%llu appends)",
+                   (double)append_ms_at(metrics, 0.50),
+                   (double)append_ms_at(metrics, 0.90),
+                   (double)append_ms_at(metrics, 0.99),
+                   (double)append_ms_at(metrics, 0.999),
+                   (double)metrics->max_append_ms,
+                   (unsigned long long)metrics->append_count);
+    else
+      print_report("  max append ms:   %.2f", (double)metrics->max_append_ms);
     char pbuf[32];
     format_bytes(pbuf, sizeof(pbuf), (uint64_t)metrics->peak_pending_bytes);
     print_report("  peak pending:    %s", pbuf);
@@ -363,6 +374,16 @@ print_bench_json_pass(const struct stream_metrics* m,
     jw_object_end(&jw);
   }
   jw_object_end(&jw);
+  jw_key(&jw, "append_ms_p50");
+  jw_float(&jw, (double)append_ms_at(m, 0.50));
+  jw_key(&jw, "append_ms_p90");
+  jw_float(&jw, (double)append_ms_at(m, 0.90));
+  jw_key(&jw, "append_ms_p99");
+  jw_float(&jw, (double)append_ms_at(m, 0.99));
+  jw_key(&jw, "append_ms_p999");
+  jw_float(&jw, (double)append_ms_at(m, 0.999));
+  jw_key(&jw, "append_count");
+  jw_uint(&jw, m->append_count);
   jw_key(&jw, "max_append_ms");
   jw_float(&jw, (double)m->max_append_ms);
   jw_key(&jw, "peak_pending_mib");

--- a/bench/bench_report.h
+++ b/bench/bench_report.h
@@ -21,6 +21,10 @@ struct sink_stats
 void
 print_metric_row(const struct stream_metric* m);
 
+// How long individual appends took.
+void
+print_append_latency(const struct stream_metrics* m);
+
 void
 log_bench_header(const struct tile_stream_layout* layout,
                  enum dtype dtype,

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -504,8 +504,6 @@ run_bench(const struct bench_config* cfg)
   if (is_multiscale && nlod > 0)
     print_report("  LOD levels:  %d", nlod);
 
-  struct platform_clock clock = { 0 };
-  platform_toc(&clock);
   if (cfg->append_elements > 0) {
     char abuf[32];
     format_bytes(
@@ -513,6 +511,9 @@ run_bench(const struct bench_config* cfg)
     print_report(
       "  append size: %zu elements = %s", cfg->append_elements, abuf);
   }
+
+  struct platform_clock clock = { 0 };
+  platform_toc(&clock);
   CHECK(Fail,
         pump_data_prefill_blocked(bench_writer(&h),
                                   total_elements,
@@ -733,7 +734,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
 int
 bench_stream_main(int ac, char* av[], struct bench_spec spec)
 {
-  struct bench_cli_args a;
+  struct bench_cli_args a = { 0 };
   if (parse_bench_cli_args(ac, av, &a))
     return 1;
 
@@ -1123,7 +1124,7 @@ Fail:
 int
 bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
 {
-  struct bench_cli_args a;
+  struct bench_cli_args a = { 0 };
   if (parse_bench_cli_args(ac, av, &a))
     return 1;
 
@@ -1149,6 +1150,7 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
     .append_reduce_method =
       a.reduce == lod_reduce_median ? lod_reduce_max : a.reduce,
     .backend = BENCH_GPU, // two-streams is GPU-only
+    .append_elements = a.append_elements,
     .dtype = a.dtype,
     .chunk_ratios = spec.chunk_ratios,
     .target_chunk_bytes =

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -809,9 +809,11 @@ pump_data_interleaved(struct writer* w0,
                       struct writer* w1,
                       size_t total_elements,
                       fill_fn fill,
-                      size_t bpe)
+                      size_t bpe,
+                      size_t block_elements)
 {
-  const size_t nelements = 32 * 1024 * 1024;
+  const size_t nelements =
+    block_elements > 0 ? block_elements : (size_t)32 * 1024 * 1024;
   size_t alloc = nelements * (bpe > 2 ? bpe : 2);
   uint16_t* data = (uint16_t*)calloc(1, alloc);
   if (!data)
@@ -986,7 +988,9 @@ run_bench_two_streams(const struct bench_config* cfg)
   // Interleaved pump
   struct platform_clock clock = { 0 };
   platform_toc(&clock);
-  CHECK(Fail, pump_data_interleaved(w0, w1, total_elements, fill, bpe) == 0);
+  CHECK(Fail,
+        pump_data_interleaved(
+          w0, w1, total_elements, fill, bpe, cfg->append_elements) == 0);
 
   // Flush zarr sinks before measuring wall time
   struct platform_clock flush_clock = { 0 };
@@ -1077,7 +1081,7 @@ run_bench_two_streams(const struct bench_config* cfg)
       print_metric_row(&m[k].drain_dispatch);
       print_metric_row(&m[k].io_fence_stall);
       print_metric_row(&m[k].backpressure);
-      print_report("  max append ms:   %.2f", (double)m[k].max_append_ms);
+      print_append_latency(&m[k]);
       char pbuf[32];
       format_bytes(pbuf, sizeof(pbuf), (uint64_t)m[k].peak_pending_bytes);
       print_report("  peak pending:    %s", pbuf);

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -506,9 +506,19 @@ run_bench(const struct bench_config* cfg)
 
   struct platform_clock clock = { 0 };
   platform_toc(&clock);
+  if (cfg->append_elements > 0) {
+    char abuf[32];
+    format_bytes(
+      abuf, sizeof(abuf), (uint64_t)(cfg->append_elements * dtype_bpe(dtype)));
+    print_report(
+      "  append size: %zu elements = %s", cfg->append_elements, abuf);
+  }
   CHECK(Fail,
-        pump_data_prefill(
-          bench_writer(&h), total_elements, fill, dtype_bpe(dtype)) == 0);
+        pump_data_prefill_blocked(bench_writer(&h),
+                                  total_elements,
+                                  fill,
+                                  dtype_bpe(dtype),
+                                  cfg->append_elements) == 0);
 
   size_t pending_bytes = bench_zarr_pending_bytes(&zarr);
 
@@ -605,6 +615,7 @@ struct bench_cli_args
   size_t target_batch_bytes;
   size_t memory_budget;
   uint64_t frames;
+  size_t append_elements; // 0 = default block
   int json_output;
   const char* output_path;
   const char* s3_bucket;
@@ -669,6 +680,8 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
         return 1;
     } else if (strcmp(av[i], "--frames") == 0 && i + 1 < ac) {
       out->frames = (uint64_t)strtoull(av[++i], NULL, 10);
+    } else if (strcmp(av[i], "--append-elements") == 0 && i + 1 < ac) {
+      out->append_elements = (size_t)strtoull(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--json") == 0) {
       out->json_output = 1;
     } else if (strcmp(av[i], "--chunk-bytes") == 0 && i + 1 < ac) {
@@ -765,6 +778,7 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
     .min_shard_bytes = spec.min_shard_bytes,
     .target_concurrent_shards = spec.target_concurrent_shards,
     .min_append_shards = spec.min_append_shards,
+    .append_elements = a.append_elements,
     .json_output = a.json_output,
     .io_bw_mbps = a.io_bw_mbps,
     .io_latency_us = a.io_latency_us,

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -49,6 +49,8 @@ struct bench_config
                               // append dim (0 = no minimum). Forces
                               // shard-switching in benchmarks that would
                               // otherwise collapse to a single shard.
+  size_t append_elements;     // elements per append; 0 = default block. Set to
+                              // one frame to measure per-frame latency.
   int json_output;            // print JSON to stdout after run
   uint64_t io_bw_mbps;        // 0 = no bandwidth cap (MiB/s)
   uint64_t io_latency_us;     // 0 = no fixed per-job latency

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ add_src_lib(codec_types SOURCES types.codec.c types.codec.h)
 add_src_lib(stream_config SOURCES stream/config.c stream/config.h stream/layouts.h
     stream/dim_info.c stream/dim_info.h
     stream/types.aggregate.c types.stream.h stream/types.aggregate.h types.lod.h defs.limits.h
-    LINKS codec_types lod_plan index_ops platform chucky_log
+    LINKS m codec_types lod_plan index_ops platform chucky_log
 )
 
 # --- Backend subdirectories ---
@@ -97,6 +97,7 @@ list(
 set(_with_blosc $<BOOL:${HAVE_BLOSC}>)
 set(_with_gpu $<BOOL:${CHUCKY_ENABLE_GPU}>)
 set(_chucky_public_deps
+    m
     Threads::Threads
     Lz4::Lz4
     Zstd::Zstd

--- a/src/defs.limits.h
+++ b/src/defs.limits.h
@@ -14,6 +14,12 @@
 // batch — a per-batch slot is overwritten by every epoch after the first.
 #define LOD_TIMING_SLOTS 8
 
+// Buckets spanning 1us to 100s, twenty per decade, so a reported time is within
+// about 12% of the truth.
+#define APPEND_LATENCY_BUCKETS 160
+#define APPEND_LATENCY_MIN_MS 0.001
+#define APPEND_LATENCY_PER_DECADE 20
+
 // More than the two staging slots, so a scatter measurement can outlive the
 // dispatch that produced it and still be read after it completes.
 #define SCATTER_TIMING_SLOTS 4

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -336,7 +336,8 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
   float ms = (float)(platform_toc(&clk) * 1000.0);
   if (ms > s->engine.metrics.max_append_ms)
     s->engine.metrics.max_append_ms = ms;
-  record_append_ms(&s->engine.metrics, ms);
+  if (r.rest.beg != input.beg)
+    record_append_ms(&s->engine.metrics, ms);
   if (s->flushed && r.rest.beg != input.beg)
     s->flushed = 0;
   return r;

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -336,6 +336,7 @@ tile_stream_gpu_append(struct writer* self, struct slice input)
   float ms = (float)(platform_toc(&clk) * 1000.0);
   if (ms > s->engine.metrics.max_append_ms)
     s->engine.metrics.max_append_ms = ms;
+  record_append_ms(&s->engine.metrics, ms);
   if (s->flushed && r.rest.beg != input.beg)
     s->flushed = 0;
   return r;

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -73,6 +73,12 @@ struct stream_metrics
   float max_append_ms;       // longest single append
   size_t peak_pending_bytes; // high-water mark of bytes awaiting write
 
+  // How long individual appends took, as counts per time bucket. A caller
+  // asking whether it can keep up needs the slow tail, not the average, and
+  // there are far too many appends to keep every one.
+  uint32_t append_ms_buckets[APPEND_LATENCY_BUCKETS];
+  uint64_t append_count;
+
   // Measurements dropped before they could be read. Non-zero means the stage
   // totals above are under-reported.
   uint64_t scatter_samples_lost;

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -76,7 +76,7 @@ struct stream_metrics
   // How long individual appends took, as counts per time bucket. A caller
   // asking whether it can keep up needs the slow tail, not the average, and
   // there are far too many appends to keep every one.
-  uint32_t append_ms_buckets[APPEND_LATENCY_BUCKETS];
+  uint64_t append_ms_buckets[APPEND_LATENCY_BUCKETS];
   uint64_t append_count;
 
   // Measurements dropped before they could be read. Non-zero means the stage

--- a/src/util/metric.h
+++ b/src/util/metric.h
@@ -25,27 +25,36 @@ record_append_ms(struct stream_metrics* m, float ms)
   m->append_count++;
 }
 
-// Duration within which the given fraction of appends completed. Rounded up to
-// a bucket boundary, so it overstates rather than understates, and never
-// exceeds the longest append actually seen. Returns 0 when nothing was
-// recorded.
+// The upper edge of bucket i, or the longest append seen when that is smaller.
+// The topmost bucket has no upper edge, so it reports the longest append.
+static inline float
+append_bucket_ms(const struct stream_metrics* m, int i)
+{
+  if (i >= APPEND_LATENCY_BUCKETS - 1)
+    return m->max_append_ms;
+  const float edge =
+    (float)(APPEND_LATENCY_MIN_MS *
+            pow(10.0, (double)(i + 1) / APPEND_LATENCY_PER_DECADE));
+  return edge < m->max_append_ms ? edge : m->max_append_ms;
+}
+
+// Duration within which the given fraction of appends completed. Never exceeds
+// the longest append seen. Returns 0 when nothing was recorded.
 static inline float
 append_ms_at(const struct stream_metrics* m, double fraction)
 {
   if (m->append_count == 0)
     return 0.0f;
-  const uint64_t want = (uint64_t)(fraction * (double)m->append_count + 0.5);
+  uint64_t want = (uint64_t)ceil(fraction * (double)m->append_count);
+  if (want == 0)
+    want = 1;
   uint64_t seen = 0;
   for (int i = 0; i < APPEND_LATENCY_BUCKETS; ++i) {
     seen += m->append_ms_buckets[i];
-    if (seen >= want || i == APPEND_LATENCY_BUCKETS - 1) {
-      const float edge =
-        (float)(APPEND_LATENCY_MIN_MS *
-                pow(10.0, (double)(i + 1) / APPEND_LATENCY_PER_DECADE));
-      return edge < m->max_append_ms ? edge : m->max_append_ms;
-    }
+    if (seen >= want)
+      return append_bucket_ms(m, i);
   }
-  return 0.0f;
+  return m->max_append_ms;
 }
 
 static inline void

--- a/src/util/metric.h
+++ b/src/util/metric.h
@@ -17,7 +17,7 @@ record_append_ms(struct stream_metrics* m, float ms)
   int i = 0;
   if (ms > (float)APPEND_LATENCY_MIN_MS) {
     const double decades = log10((double)ms / APPEND_LATENCY_MIN_MS);
-    i = (int)(decades * APPEND_LATENCY_PER_DECADE + 0.5);
+    i = (int)(decades * APPEND_LATENCY_PER_DECADE);
     if (i >= APPEND_LATENCY_BUCKETS)
       i = APPEND_LATENCY_BUCKETS - 1;
   }
@@ -25,8 +25,10 @@ record_append_ms(struct stream_metrics* m, float ms)
   m->append_count++;
 }
 
-// Duration at or below which the given fraction of appends completed. Returns
-// 0 when nothing was recorded.
+// Duration within which the given fraction of appends completed. Rounded up to
+// a bucket boundary, so it overstates rather than understates, and never
+// exceeds the longest append actually seen. Returns 0 when nothing was
+// recorded.
 static inline float
 append_ms_at(const struct stream_metrics* m, double fraction)
 {
@@ -36,9 +38,12 @@ append_ms_at(const struct stream_metrics* m, double fraction)
   uint64_t seen = 0;
   for (int i = 0; i < APPEND_LATENCY_BUCKETS; ++i) {
     seen += m->append_ms_buckets[i];
-    if (seen >= want || i == APPEND_LATENCY_BUCKETS - 1)
-      return (float)(APPEND_LATENCY_MIN_MS *
-                     pow(10.0, (double)i / APPEND_LATENCY_PER_DECADE));
+    if (seen >= want || i == APPEND_LATENCY_BUCKETS - 1) {
+      const float edge =
+        (float)(APPEND_LATENCY_MIN_MS *
+                pow(10.0, (double)(i + 1) / APPEND_LATENCY_PER_DECADE));
+      return edge < m->max_append_ms ? edge : m->max_append_ms;
+    }
   }
   return 0.0f;
 }

--- a/src/util/metric.h
+++ b/src/util/metric.h
@@ -3,10 +3,45 @@
 
 #include "types.stream.h"
 
+#include <math.h>
+
 #include <stddef.h>
 
 struct stream_metric
 mk_stream_metric(const char* name, enum metric_owner owner);
+
+// Record one append's duration.
+static inline void
+record_append_ms(struct stream_metrics* m, float ms)
+{
+  int i = 0;
+  if (ms > (float)APPEND_LATENCY_MIN_MS) {
+    const double decades = log10((double)ms / APPEND_LATENCY_MIN_MS);
+    i = (int)(decades * APPEND_LATENCY_PER_DECADE + 0.5);
+    if (i >= APPEND_LATENCY_BUCKETS)
+      i = APPEND_LATENCY_BUCKETS - 1;
+  }
+  m->append_ms_buckets[i]++;
+  m->append_count++;
+}
+
+// Duration at or below which the given fraction of appends completed. Returns
+// 0 when nothing was recorded.
+static inline float
+append_ms_at(const struct stream_metrics* m, double fraction)
+{
+  if (m->append_count == 0)
+    return 0.0f;
+  const uint64_t want = (uint64_t)(fraction * (double)m->append_count + 0.5);
+  uint64_t seen = 0;
+  for (int i = 0; i < APPEND_LATENCY_BUCKETS; ++i) {
+    seen += m->append_ms_buckets[i];
+    if (seen >= want || i == APPEND_LATENCY_BUCKETS - 1)
+      return (float)(APPEND_LATENCY_MIN_MS *
+                     pow(10.0, (double)i / APPEND_LATENCY_PER_DECADE));
+  }
+  return 0.0f;
+}
 
 static inline void
 accumulate_metric_ms(struct stream_metric* m,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -192,6 +192,7 @@ add_test_exe(test_dimension   test_dimension.c   stream_config dimension chucky_
 add_test_exe(test_lz4_warning test_lz4_warning.c stream_config dimension platform chucky_log)
 add_test_exe(test_chucky_log  test_chucky_log.c  chucky_log)
 add_test_exe(test_strbuf      test_strbuf.c      strbuf chucky_log)
+add_test_exe(test_append_latency test_append_latency.c stream_config chucky_log)
 add_gpu_test_exe(test_lod         test_lod.c         LINKS CUDA::cuda_driver CUDA::cudart_static lod lod_plan index_ops morton_util)
 add_gpu_test_exe(test_lod_dtypes  test_lod_dtypes.cu LINKS CUDA::cuda_driver CUDA::cudart_static lod lod_plan)
 add_gpu_test_exe(test_multiscale  test_multiscale.c  LINKS CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd test_data test_shard_sink)

--- a/tests/test_append_latency.c
+++ b/tests/test_append_latency.c
@@ -1,0 +1,134 @@
+#include "chucky_log.h"
+#include "util/metric.h"
+#include "util/prelude.h"
+
+#include <math.h>
+
+static int
+test_no_samples_reports_nothing(void)
+{
+  log_info("=== test_no_samples_reports_nothing ===");
+  struct stream_metrics m = { 0 };
+  CHECK(Fail, m.append_count == 0);
+  CHECK(Fail, append_ms_at(&m, 0.5) == 0.0f);
+  CHECK(Fail, append_ms_at(&m, 0.999) == 0.0f);
+  return 0;
+Fail:
+  return 1;
+}
+
+static void
+record(struct stream_metrics* m, float ms)
+{
+  if (ms > m->max_append_ms)
+    m->max_append_ms = ms;
+  record_append_ms(m, ms);
+}
+
+// Every sample must land in a bucket whose range contains it, or a reported
+// time can come out above the longest append seen.
+static int
+test_every_sample_lands_in_a_containing_bucket(void)
+{
+  log_info("=== test_every_sample_lands_in_a_containing_bucket ===");
+  for (int k = 0; k < 4000; ++k) {
+    const float ms = (float)(APPEND_LATENCY_MIN_MS * pow(10.0, k / 400.0));
+    struct stream_metrics m = { 0 };
+    record(&m, ms);
+    CHECK(Fail, m.append_count == 1);
+    const float got = append_ms_at(&m, 1.0);
+    CHECK(Fail, got >= ms * 0.999f);
+    CHECK(Fail, got <= m.max_append_ms);
+  }
+  return 0;
+Fail:
+  return 1;
+}
+
+static int
+test_no_percentile_exceeds_the_longest_append(void)
+{
+  log_info("=== test_no_percentile_exceeds_the_longest_append ===");
+  const float samples[] = { 0.0004f, 0.02f,  0.13f,  1.0f,   2.51f,
+                            17.8f,   60.74f, 68.54f, 144.31f };
+  struct stream_metrics m = { 0 };
+  for (size_t i = 0; i < sizeof(samples) / sizeof(samples[0]); ++i)
+    record(&m, samples[i]);
+  const double fractions[] = { 0.01, 0.5, 0.9, 0.99, 0.999, 1.0 };
+  for (size_t i = 0; i < sizeof(fractions) / sizeof(fractions[0]); ++i) {
+    const float got = append_ms_at(&m, fractions[i]);
+    CHECK(Fail, got > 0.0f);
+    CHECK(Fail, got <= m.max_append_ms);
+  }
+  return 0;
+Fail:
+  return 1;
+}
+
+// Asking for a fraction must not return a faster time than that fraction of
+// appends actually achieved.
+static int
+test_fraction_is_not_rounded_down(void)
+{
+  log_info("=== test_fraction_is_not_rounded_down ===");
+  for (int n = 1; n <= 40; ++n) {
+    struct stream_metrics m = { 0 };
+    for (int i = 0; i < n; ++i)
+      record(&m, (float)(0.01 * (i + 1)));
+    const float got = append_ms_at(&m, 0.9);
+    uint64_t at_or_below = 0;
+    for (int i = 0; i < APPEND_LATENCY_BUCKETS; ++i) {
+      if (append_bucket_ms(&m, i) <= got)
+        at_or_below += m.append_ms_buckets[i];
+    }
+    CHECK(Fail, at_or_below * 100 >= (uint64_t)n * 90);
+  }
+  return 0;
+Fail:
+  return 1;
+}
+
+static int
+test_slowest_bucket_reports_the_longest_append(void)
+{
+  log_info("=== test_slowest_bucket_reports_the_longest_append ===");
+  struct stream_metrics m = { 0 };
+  record(&m, 1.0f);
+  record(&m, 1.0e7f); // past the last bucket's lower edge
+  CHECK(Fail, append_ms_at(&m, 1.0) == m.max_append_ms);
+  return 0;
+Fail:
+  return 1;
+}
+
+static int
+test_samples_below_the_floor_are_counted(void)
+{
+  log_info("=== test_samples_below_the_floor_are_counted ===");
+  struct stream_metrics m = { 0 };
+  record(&m, 0.0f);
+  record(&m, -1.0f);
+  record(&m, 1e-9f);
+  CHECK(Fail, m.append_count == 3);
+  CHECK(Fail, m.append_ms_buckets[0] == 3);
+  return 0;
+Fail:
+  return 1;
+}
+
+int
+main(void)
+{
+  int err = 0;
+  err |= test_no_samples_reports_nothing();
+  err |= test_every_sample_lands_in_a_containing_bucket();
+  err |= test_no_percentile_exceeds_the_longest_append();
+  err |= test_fraction_is_not_rounded_down();
+  err |= test_slowest_bucket_reports_the_longest_append();
+  err |= test_samples_below_the_floor_are_counted();
+  if (err)
+    log_error("FAILED");
+  else
+    log_info("PASSED");
+  return err;
+}

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -179,7 +179,18 @@ pump_data_prefill(struct writer* w,
                   fill_fn fill,
                   size_t bpe)
 {
-  const size_t nelements = PUMP_BLOCK_ELEMENTS;
+  return pump_data_prefill_blocked(w, total_elements, fill, bpe, 0);
+}
+
+int
+pump_data_prefill_blocked(struct writer* w,
+                          size_t total_elements,
+                          fill_fn fill,
+                          size_t bpe,
+                          size_t block_elements)
+{
+  const size_t nelements =
+    block_elements > 0 ? block_elements : PUMP_BLOCK_ELEMENTS;
   size_t alloc = nelements * (bpe > 2 ? bpe : 2);
   uint16_t* data = (uint16_t*)calloc(1, alloc);
   if (!data)

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -136,7 +136,7 @@ dim_total_elements(const struct dimension* dims, uint8_t rank)
 static const size_t PUMP_BLOCK_ELEMENTS = 32 * 1024 * 1024;
 
 // Regenerate each appended block. Tests that verify content rely on the
-// per-append variation; benchmarks should use pump_data_prefill instead.
+// per-append variation; benchmarks should use the prefill pump instead.
 int
 pump_data_bpe(struct writer* w, size_t total_elements, fill_fn fill, size_t bpe)
 {
@@ -173,15 +173,6 @@ pump_data(struct writer* w, size_t total_elements, fill_fn fill)
 
 // Fill one block and reuse it for every append, so the measured loop is the
 // writer rather than the generator.
-int
-pump_data_prefill(struct writer* w,
-                  size_t total_elements,
-                  fill_fn fill,
-                  size_t bpe)
-{
-  return pump_data_prefill_blocked(w, total_elements, fill, bpe, 0);
-}
-
 int
 pump_data_prefill_blocked(struct writer* w,
                           size_t total_elements,

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -43,15 +43,9 @@ pump_data_bpe(struct writer* w,
               fill_fn fill,
               size_t bpe);
 
-// Fill one block once and reuse it for every append.
-int
-pump_data_prefill(struct writer* w,
-                  size_t total_elements,
-                  fill_fn fill,
-                  size_t bpe);
-
-// Hand over block_elements at a time instead of the default block. Pass the
-// size of one frame to measure what a caller feeding frames would see.
+// Fill one block once and reuse it for every append. block_elements is how much
+// is handed over per append; 0 uses a default. Pass one frame's worth to see
+// what a caller feeding frames would see.
 int
 pump_data_prefill_blocked(struct writer* w,
                           size_t total_elements,

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -49,3 +49,12 @@ pump_data_prefill(struct writer* w,
                   size_t total_elements,
                   fill_fn fill,
                   size_t bpe);
+
+// Hand over block_elements at a time instead of the default block. Pass the
+// size of one frame to measure what a caller feeding frames would see.
+int
+pump_data_prefill_blocked(struct writer* w,
+                          size_t total_elements,
+                          fill_fn fill,
+                          size_t bpe,
+                          size_t block_elements);


### PR DESCRIPTION
Closes #101.

Benchmarks recorded only the slowest single append, and each append handed over a
64 MiB block covering many frames. That could not answer the question people
have, which is whether one frame is accepted before the next arrives.

Appends are now timed individually and reported as a spread, with the bucket
counts in the JSON so a reader can ask their own question — such as how many
appends missed their frame budget, which no fixed percentile answers.
`--append-elements N` sets how much is handed over per append, so the numbers can
describe frames rather than blocks, and the benchmark prints the append size. The
old slowest-append figure is unchanged.

Measured on an L40, same configuration, 200 frames:

| append size | appends | p50 | p90 | p99 | p99.9 | max | GiB/s | over 10 ms |
|---|---|---|---|---|---|---|---|---|
| 64 MiB block | 300 | 2.512 | 2.818 | 56.234 | 68.427 | 68.43 | 9.20 | 23 of 300 |
| one 256x256 plane | 153,600 | 0.016 | 0.126 | 0.141 | 0.141 | 60.22 | 3.00 | 1 of 153,600 |

A frame-sized append is typically accepted in 16 microseconds, far inside a 10 ms
budget, and only one of 153,600 exceeded it. The same data as 64 MiB blocks misses
that budget 23 times out of 300. Handing over one frame at a time also costs
throughput, 9.2 GiB/s down to 3.0, so the two rows are not otherwise comparable —
every append triggers its own transfer and kernel launch regardless of size.

Times are kept as counts per time bucket rather than one value per append, since a
frame-sized run makes 153,600 of them. Buckets are twenty per decade, so a
reported time is within about 12% of the truth and is rounded up.

Three things a reader should know. An append can block: it waits for a staging
buffer, and the backpressure path waits for the sink, so these are real waits and
not just the cost of queueing work. Retries inside a blocked append are not
attributed to it, so the slow tail is understated when the sink cannot keep up.
And only the single-array GPU path records this — the CPU and multi-array paths
report no append figures at all rather than zeros.
