### PR TITLE
Add an L40 sweep at 46fa2e8

### DIFF
--- a/bench/results/reef-l40-46fa2e8-20260701.json
+++ b/bench/results/reef-l40-46fa2e8-20260701.json
@@ -1,0 +1,28711 @@
+{
+  "version": 1,
+  "machine": {
+    "hostname": "cw-us-e4a2-l40-234-049",
+    "gpu": "NVIDIA L40",
+    "commit": "46fa2e8",
+    "date": "2026-07-01T17:00:05"
+  },
+  "runs": [
+    {
+      "id": "orca2_single__none__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 3.36,
+      "status": "pass",
+      "throughput_in_gibs": 13.8972,
+      "throughput_out_gibs": 13.9135,
+      "compression_fold": 0.998829,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51975,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.252974,
+      "init_s": 0.441169,
+      "flush_s": 5.36e-07,
+      "memory_estimate_total_bytes": 2686423454,
+      "memory_estimate_pinned_bytes": 1477574704,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.832564,
+          "best_ms": 0.262061,
+          "best_in_gibs": 59.6235,
+          "best_out_gibs": 59.6235,
+          "in_gibs": 56.302,
+          "out_gibs": 56.302
+        },
+        "h2d": {
+          "avg_ms": 2.14887,
+          "best_ms": 0.624864,
+          "best_in_gibs": 25.0054,
+          "best_out_gibs": 25.0054,
+          "in_gibs": 21.9134,
+          "out_gibs": 21.9134
+        },
+        "scatter": {
+          "avg_ms": 0.125839,
+          "best_ms": 0.099904,
+          "best_in_gibs": 156.4,
+          "best_out_gibs": 156.4,
+          "in_gibs": 152.821,
+          "out_gibs": 152.821
+        },
+        "aggregate": {
+          "avg_ms": 2.59277,
+          "best_ms": 0.522752,
+          "best_in_gibs": 269.009,
+          "best_out_gibs": 269.009,
+          "in_gibs": 193.705,
+          "out_gibs": 193.705
+        },
+        "d2h": {
+          "avg_ms": 23.2624,
+          "best_ms": 5.73229,
+          "best_in_gibs": 24.5321,
+          "best_out_gibs": 24.5321,
+          "in_gibs": 21.5899,
+          "out_gibs": 21.5899
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 31.8092,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 163.966,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.70875,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.32,
+      "status": "pass",
+      "throughput_in_gibs": 13.8767,
+      "throughput_out_gibs": 13.8849,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.253348,
+      "init_s": 0.429622,
+      "flush_s": 6.03e-07,
+      "memory_estimate_total_bytes": 2685399926,
+      "memory_estimate_pinned_bytes": 1476994096,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.823999,
+          "best_ms": 0.257594,
+          "best_in_gibs": 60.6575,
+          "best_out_gibs": 60.6575,
+          "in_gibs": 56.8872,
+          "out_gibs": 56.8872
+        },
+        "h2d": {
+          "avg_ms": 2.14821,
+          "best_ms": 0.624608,
+          "best_in_gibs": 25.0157,
+          "best_out_gibs": 25.0157,
+          "in_gibs": 21.9201,
+          "out_gibs": 21.9201
+        },
+        "scatter": {
+          "avg_ms": 0.152534,
+          "best_ms": 0.100224,
+          "best_in_gibs": 155.901,
+          "best_out_gibs": 155.901,
+          "in_gibs": 126.075,
+          "out_gibs": 126.075
+        },
+        "aggregate": {
+          "avg_ms": 2.68388,
+          "best_ms": 0.542048,
+          "best_in_gibs": 259.433,
+          "best_out_gibs": 259.433,
+          "in_gibs": 187.129,
+          "out_gibs": 187.129
+        },
+        "d2h": {
+          "avg_ms": 23.2344,
+          "best_ms": 5.73498,
+          "best_in_gibs": 24.5206,
+          "best_out_gibs": 24.5206,
+          "in_gibs": 21.6159,
+          "out_gibs": 21.6159
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 31.0209,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 167.846,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.76188,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.1,
+      "status": "pass",
+      "throughput_in_gibs": 14.3287,
+      "throughput_out_gibs": 14.3329,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51666,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.245356,
+      "init_s": 0.413222,
+      "flush_s": 4.39e-07,
+      "memory_estimate_total_bytes": 2684874142,
+      "memory_estimate_pinned_bytes": 1476689968,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.847376,
+          "best_ms": 0.262271,
+          "best_in_gibs": 59.5758,
+          "best_out_gibs": 59.5758,
+          "in_gibs": 55.3178,
+          "out_gibs": 55.3178
+        },
+        "h2d": {
+          "avg_ms": 2.14417,
+          "best_ms": 0.624608,
+          "best_in_gibs": 25.0157,
+          "best_out_gibs": 25.0157,
+          "in_gibs": 21.9615,
+          "out_gibs": 21.9615
+        },
+        "scatter": {
+          "avg_ms": 0.12579,
+          "best_ms": 0.10064,
+          "best_in_gibs": 155.256,
+          "best_out_gibs": 155.256,
+          "in_gibs": 152.881,
+          "out_gibs": 152.881
+        },
+        "aggregate": {
+          "avg_ms": 2.77863,
+          "best_ms": 0.562592,
+          "best_in_gibs": 249.959,
+          "best_out_gibs": 249.959,
+          "in_gibs": 180.748,
+          "out_gibs": 180.748
+        },
+        "d2h": {
+          "avg_ms": 23.2248,
+          "best_ms": 5.72765,
+          "best_in_gibs": 24.552,
+          "best_out_gibs": 24.552,
+          "in_gibs": 21.6248,
+          "out_gibs": 21.6248
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 30.578,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 170.012,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.64526,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 3.19,
+      "status": "pass",
+      "throughput_in_gibs": 13.7106,
+      "throughput_out_gibs": 13.7128,
+      "compression_fold": 0.99984,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51619,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.256416,
+      "init_s": 0.439363,
+      "flush_s": 3.2e-07,
+      "memory_estimate_total_bytes": 2684629878,
+      "memory_estimate_pinned_bytes": 1476556336,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.831757,
+          "best_ms": 0.255244,
+          "best_in_gibs": 61.2159,
+          "best_out_gibs": 61.2159,
+          "in_gibs": 56.3566,
+          "out_gibs": 56.3566
+        },
+        "h2d": {
+          "avg_ms": 2.14877,
+          "best_ms": 0.624896,
+          "best_in_gibs": 25.0042,
+          "best_out_gibs": 25.0042,
+          "in_gibs": 21.9144,
+          "out_gibs": 21.9144
+        },
+        "scatter": {
+          "avg_ms": 0.148049,
+          "best_ms": 0.100096,
+          "best_in_gibs": 156.1,
+          "best_out_gibs": 156.1,
+          "in_gibs": 129.894,
+          "out_gibs": 129.894
+        },
+        "aggregate": {
+          "avg_ms": 2.88733,
+          "best_ms": 0.615616,
+          "best_in_gibs": 228.43,
+          "best_out_gibs": 228.43,
+          "in_gibs": 173.944,
+          "out_gibs": 173.944
+        },
+        "d2h": {
+          "avg_ms": 23.2296,
+          "best_ms": 5.72928,
+          "best_in_gibs": 24.545,
+          "best_out_gibs": 24.545,
+          "in_gibs": 21.6203,
+          "out_gibs": 21.6203
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 30.3034,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 170.577,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.67774,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.47,
+      "status": "pass",
+      "throughput_in_gibs": 13.8416,
+      "throughput_out_gibs": 13.8427,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.25399,
+      "init_s": 0.438538,
+      "flush_s": 4.62e-07,
+      "memory_estimate_total_bytes": 2684495262,
+      "memory_estimate_pinned_bytes": 1476476976,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.16238,
+          "best_ms": 0.251828,
+          "best_in_gibs": 62.0463,
+          "best_out_gibs": 62.0463,
+          "in_gibs": 40.3266,
+          "out_gibs": 40.3266
+        },
+        "h2d": {
+          "avg_ms": 2.13418,
+          "best_ms": 0.62672,
+          "best_in_gibs": 24.9314,
+          "best_out_gibs": 24.9314,
+          "in_gibs": 22.0643,
+          "out_gibs": 22.0643
+        },
+        "scatter": {
+          "avg_ms": 0.14256,
+          "best_ms": 0.099904,
+          "best_in_gibs": 156.4,
+          "best_out_gibs": 156.4,
+          "in_gibs": 158.315,
+          "out_gibs": 158.315
+        },
+        "aggregate": {
+          "avg_ms": 2.9636,
+          "best_ms": 0.6296,
+          "best_in_gibs": 223.356,
+          "best_out_gibs": 223.356,
+          "in_gibs": 169.467,
+          "out_gibs": 169.467
+        },
+        "d2h": {
+          "avg_ms": 23.0613,
+          "best_ms": 5.72736,
+          "best_in_gibs": 24.5532,
+          "best_out_gibs": 24.5532,
+          "in_gibs": 21.7781,
+          "out_gibs": 21.7781
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 30.1928,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 176.521,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 6.16453,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.06,
+      "status": "pass",
+      "throughput_in_gibs": 14.1399,
+      "throughput_out_gibs": 14.7061,
+      "compression_fold": 0.999961,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65639,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.248631,
+      "init_s": 0.427859,
+      "flush_s": 5.979e-06,
+      "memory_estimate_total_bytes": 2684426654,
+      "memory_estimate_pinned_bytes": 1476436016,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.9652,
+          "best_ms": 0.281734,
+          "best_in_gibs": 55.4601,
+          "best_out_gibs": 55.4601,
+          "in_gibs": 57.8156,
+          "out_gibs": 57.8156
+        },
+        "h2d": {
+          "avg_ms": 2.56898,
+          "best_ms": 1.24493,
+          "best_in_gibs": 25.1019,
+          "best_out_gibs": 25.1019,
+          "in_gibs": 21.9358,
+          "out_gibs": 21.9358
+        },
+        "scatter": {
+          "avg_ms": 0.430496,
+          "best_ms": 0.430496,
+          "best_in_gibs": 145.181,
+          "best_out_gibs": 145.181,
+          "in_gibs": 145.181,
+          "out_gibs": 145.181
+        },
+        "aggregate": {
+          "avg_ms": 3.21905,
+          "best_ms": 1.26422,
+          "best_in_gibs": 222.468,
+          "best_out_gibs": 222.468,
+          "in_gibs": 162.26,
+          "out_gibs": 162.26
+        },
+        "d2h": {
+          "avg_ms": 24.0611,
+          "best_ms": 11.4439,
+          "best_in_gibs": 24.5763,
+          "best_out_gibs": 24.5763,
+          "in_gibs": 21.7081,
+          "out_gibs": 21.7081
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 38.7986,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 177.31,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.4028,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.06,
+      "status": "pass",
+      "throughput_in_gibs": 14.0246,
+      "throughput_out_gibs": 14.5858,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65631,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.250676,
+      "init_s": 0.481668,
+      "flush_s": 4.98e-07,
+      "memory_estimate_total_bytes": 2684390142,
+      "memory_estimate_pinned_bytes": 1476413488,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.00413,
+          "best_ms": 0.304653,
+          "best_in_gibs": 51.2879,
+          "best_out_gibs": 51.2879,
+          "in_gibs": 55.5743,
+          "out_gibs": 55.5743
+        },
+        "h2d": {
+          "avg_ms": 2.56163,
+          "best_ms": 1.2449,
+          "best_in_gibs": 25.1025,
+          "best_out_gibs": 25.1025,
+          "in_gibs": 21.9987,
+          "out_gibs": 21.9987
+        },
+        "scatter": {
+          "avg_ms": 0.428224,
+          "best_ms": 0.428224,
+          "best_in_gibs": 145.952,
+          "best_out_gibs": 145.952,
+          "in_gibs": 145.952,
+          "out_gibs": 145.952
+        },
+        "aggregate": {
+          "avg_ms": 3.40761,
+          "best_ms": 1.59626,
+          "best_in_gibs": 176.194,
+          "best_out_gibs": 176.194,
+          "in_gibs": 153.281,
+          "out_gibs": 153.281
+        },
+        "d2h": {
+          "avg_ms": 24.054,
+          "best_ms": 11.4436,
+          "best_in_gibs": 24.577,
+          "best_out_gibs": 24.577,
+          "in_gibs": 21.7145,
+          "out_gibs": 21.7145
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 39.5196,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 177.75,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.35393,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.02,
+      "status": "pass",
+      "throughput_in_gibs": 13.9801,
+      "throughput_out_gibs": 14.5395,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.251473,
+      "init_s": 0.423644,
+      "flush_s": 3.58e-07,
+      "memory_estimate_total_bytes": 2684374014,
+      "memory_estimate_pinned_bytes": 1476404272,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.990481,
+          "best_ms": 0.286174,
+          "best_in_gibs": 54.5996,
+          "best_out_gibs": 54.5996,
+          "in_gibs": 56.3399,
+          "out_gibs": 56.3399
+        },
+        "h2d": {
+          "avg_ms": 2.54835,
+          "best_ms": 1.24621,
+          "best_in_gibs": 25.0761,
+          "best_out_gibs": 25.0761,
+          "in_gibs": 22.1133,
+          "out_gibs": 22.1133
+        },
+        "scatter": {
+          "avg_ms": 0.423296,
+          "best_ms": 0.423296,
+          "best_in_gibs": 147.651,
+          "best_out_gibs": 147.651,
+          "in_gibs": 147.651,
+          "out_gibs": 147.651
+        },
+        "aggregate": {
+          "avg_ms": 4.03905,
+          "best_ms": 2.75005,
+          "best_in_gibs": 102.271,
+          "best_out_gibs": 102.271,
+          "in_gibs": 129.318,
+          "out_gibs": 129.318
+        },
+        "d2h": {
+          "avg_ms": 24.0703,
+          "best_ms": 11.4435,
+          "best_in_gibs": 24.5772,
+          "best_out_gibs": 24.5772,
+          "in_gibs": 21.6998,
+          "out_gibs": 21.6998
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 42.2603,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 179.65,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.42641,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 3.09,
+      "status": "pass",
+      "throughput_in_gibs": 9.36445,
+      "throughput_out_gibs": 4.62648,
+      "compression_fold": 2.0241,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.73688,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.375422,
+      "init_s": 0.431615,
+      "flush_s": 2.92e-07,
+      "memory_estimate_total_bytes": 5113549214,
+      "memory_estimate_pinned_bytes": 1482883120,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.839681,
+          "best_ms": 0.247864,
+          "best_in_gibs": 63.0386,
+          "best_out_gibs": 63.0386,
+          "in_gibs": 55.8247,
+          "out_gibs": 55.8247
+        },
+        "h2d": {
+          "avg_ms": 2.00861,
+          "best_ms": 0.624576,
+          "best_in_gibs": 25.017,
+          "best_out_gibs": 25.017,
+          "in_gibs": 23.4436,
+          "out_gibs": 23.4436
+        },
+        "scatter": {
+          "avg_ms": 0.180017,
+          "best_ms": 0.100128,
+          "best_in_gibs": 156.05,
+          "best_out_gibs": 156.05,
+          "in_gibs": 157.813,
+          "out_gibs": 157.813
+        },
+        "compress": {
+          "avg_ms": 25.1824,
+          "best_ms": 8.19424,
+          "best_in_gibs": 17.1614,
+          "best_out_gibs": 8.89761,
+          "in_gibs": 19.9438,
+          "out_gibs": 9.82979
+        },
+        "aggregate": {
+          "avg_ms": 1.00054,
+          "best_ms": 0.30288,
+          "best_in_gibs": 240.72,
+          "best_out_gibs": 240.72,
+          "in_gibs": 247.404,
+          "out_gibs": 247.404
+        },
+        "d2h": {
+          "avg_ms": 11.4497,
+          "best_ms": 3.07773,
+          "best_in_gibs": 23.6893,
+          "best_out_gibs": 23.6893,
+          "in_gibs": 21.6196,
+          "out_gibs": 21.6196
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 52.173,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 276.902,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 30.0858,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.07,
+      "status": "pass",
+      "throughput_in_gibs": 9.49616,
+      "throughput_out_gibs": 4.51515,
+      "compression_fold": 2.10318,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.67158,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.370216,
+      "init_s": 0.441295,
+      "flush_s": 4.12e-07,
+      "memory_estimate_total_bytes": 4507661174,
+      "memory_estimate_pinned_bytes": 1482007600,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.81757,
+          "best_ms": 0.247191,
+          "best_in_gibs": 63.2102,
+          "best_out_gibs": 63.2102,
+          "in_gibs": 57.3345,
+          "out_gibs": 57.3345
+        },
+        "h2d": {
+          "avg_ms": 2.00577,
+          "best_ms": 0.624672,
+          "best_in_gibs": 25.0131,
+          "best_out_gibs": 25.0131,
+          "in_gibs": 23.4768,
+          "out_gibs": 23.4768
+        },
+        "scatter": {
+          "avg_ms": 0.179427,
+          "best_ms": 0.10032,
+          "best_in_gibs": 155.752,
+          "best_out_gibs": 155.752,
+          "in_gibs": 158.332,
+          "out_gibs": 158.332
+        },
+        "compress": {
+          "avg_ms": 26.4582,
+          "best_ms": 10.2466,
+          "best_in_gibs": 13.7241,
+          "best_out_gibs": 6.88564,
+          "in_gibs": 18.9821,
+          "out_gibs": 9.01415
+        },
+        "aggregate": {
+          "avg_ms": 0.993842,
+          "best_ms": 0.294528,
+          "best_in_gibs": 239.55,
+          "best_out_gibs": 239.55,
+          "in_gibs": 239.975,
+          "out_gibs": 239.975
+        },
+        "d2h": {
+          "avg_ms": 11.0378,
+          "best_ms": 2.93818,
+          "best_in_gibs": 24.013,
+          "best_out_gibs": 24.013,
+          "in_gibs": 21.6074,
+          "out_gibs": 21.6074
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 54.4033,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 278.501,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 31.7927,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.09,
+      "status": "pass",
+      "throughput_in_gibs": 9.72789,
+      "throughput_out_gibs": 4.65239,
+      "compression_fold": 2.09094,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.68136,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.361397,
+      "init_s": 0.415122,
+      "flush_s": 3.95e-07,
+      "memory_estimate_total_bytes": 4204703134,
+      "memory_estimate_pinned_bytes": 1481556016,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.81879,
+          "best_ms": 0.243768,
+          "best_in_gibs": 64.0978,
+          "best_out_gibs": 64.0978,
+          "in_gibs": 57.2491,
+          "out_gibs": 57.2491
+        },
+        "h2d": {
+          "avg_ms": 2.00134,
+          "best_ms": 0.624608,
+          "best_in_gibs": 25.0157,
+          "best_out_gibs": 25.0157,
+          "in_gibs": 23.5288,
+          "out_gibs": 23.5288
+        },
+        "scatter": {
+          "avg_ms": 0.179302,
+          "best_ms": 0.10016,
+          "best_in_gibs": 156,
+          "best_out_gibs": 156,
+          "in_gibs": 158.443,
+          "out_gibs": 158.443
+        },
+        "compress": {
+          "avg_ms": 28.4579,
+          "best_ms": 10.5868,
+          "best_in_gibs": 13.2831,
+          "best_out_gibs": 6.59134,
+          "in_gibs": 17.6482,
+          "out_gibs": 8.43514
+        },
+        "aggregate": {
+          "avg_ms": 1.03344,
+          "best_ms": 0.297376,
+          "best_in_gibs": 234.656,
+          "best_out_gibs": 234.656,
+          "in_gibs": 232.279,
+          "out_gibs": 232.279
+        },
+        "d2h": {
+          "avg_ms": 11.2747,
+          "best_ms": 2.88742,
+          "best_in_gibs": 24.1672,
+          "best_out_gibs": 24.1672,
+          "in_gibs": 21.2908,
+          "out_gibs": 21.2908
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 55.5655,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 273.315,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 33.612,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 3.24,
+      "status": "pass",
+      "throughput_in_gibs": 9.21877,
+      "throughput_out_gibs": 4.22649,
+      "compression_fold": 2.18119,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.61179,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.381355,
+      "init_s": 0.432224,
+      "flush_s": 2.72e-07,
+      "memory_estimate_total_bytes": 4053242742,
+      "memory_estimate_pinned_bytes": 1481348656,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.80339,
+          "best_ms": 0.250495,
+          "best_in_gibs": 62.3765,
+          "best_out_gibs": 62.3765,
+          "in_gibs": 58.3465,
+          "out_gibs": 58.3465
+        },
+        "h2d": {
+          "avg_ms": 1.93432,
+          "best_ms": 0.624608,
+          "best_in_gibs": 25.0157,
+          "best_out_gibs": 25.0157,
+          "in_gibs": 24.344,
+          "out_gibs": 24.344
+        },
+        "scatter": {
+          "avg_ms": 0.190356,
+          "best_ms": 0.100384,
+          "best_in_gibs": 155.652,
+          "best_out_gibs": 155.652,
+          "in_gibs": 149.242,
+          "out_gibs": 149.242
+        },
+        "compress": {
+          "avg_ms": 36.9565,
+          "best_ms": 18.8353,
+          "best_in_gibs": 7.46602,
+          "best_out_gibs": 3.57152,
+          "in_gibs": 13.5898,
+          "out_gibs": 6.22829
+        },
+        "aggregate": {
+          "avg_ms": 1.0908,
+          "best_ms": 0.306368,
+          "best_in_gibs": 219.575,
+          "best_out_gibs": 219.575,
+          "in_gibs": 211.015,
+          "out_gibs": 211.015
+        },
+        "d2h": {
+          "avg_ms": 10.1862,
+          "best_ms": 2.81395,
+          "best_in_gibs": 23.9061,
+          "best_out_gibs": 23.9061,
+          "in_gibs": 22.5969,
+          "out_gibs": 22.5969
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 74.9135,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 294.349,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 40.9817,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.14,
+      "status": "pass",
+      "throughput_in_gibs": 8.46867,
+      "throughput_out_gibs": 4.04796,
+      "compression_fold": 2.09208,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.68044,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.415133,
+      "init_s": 0.430685,
+      "flush_s": 4.03e-07,
+      "memory_estimate_total_bytes": 3977504158,
+      "memory_estimate_pinned_bytes": 1481236528,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.146,
+          "best_ms": 0.288132,
+          "best_in_gibs": 54.2286,
+          "best_out_gibs": 54.2286,
+          "in_gibs": 40.9033,
+          "out_gibs": 40.9033
+        },
+        "h2d": {
+          "avg_ms": 1.96614,
+          "best_ms": 0.62464,
+          "best_in_gibs": 25.0144,
+          "best_out_gibs": 25.0144,
+          "in_gibs": 23.95,
+          "out_gibs": 23.95
+        },
+        "scatter": {
+          "avg_ms": 0.222922,
+          "best_ms": 0.099936,
+          "best_in_gibs": 156.35,
+          "best_out_gibs": 156.35,
+          "in_gibs": 124.009,
+          "out_gibs": 124.009
+        },
+        "compress": {
+          "avg_ms": 41.8578,
+          "best_ms": 33.6852,
+          "best_in_gibs": 4.17468,
+          "best_out_gibs": 2.01145,
+          "in_gibs": 11.9985,
+          "out_gibs": 5.73423
+        },
+        "aggregate": {
+          "avg_ms": 1.12971,
+          "best_ms": 0.301856,
+          "best_in_gibs": 224.465,
+          "best_out_gibs": 224.465,
+          "in_gibs": 212.463,
+          "out_gibs": 212.463
+        },
+        "d2h": {
+          "avg_ms": 10.8499,
+          "best_ms": 2.85299,
+          "best_in_gibs": 23.7491,
+          "best_out_gibs": 23.7491,
+          "in_gibs": 22.1221,
+          "out_gibs": 22.1221
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 113.327,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 329.243,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 43.9911,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.47,
+      "status": "pass",
+      "throughput_in_gibs": 5.50758,
+      "throughput_out_gibs": 2.62722,
+      "compression_fold": 2.18021,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.67702,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.638325,
+      "init_s": 0.436269,
+      "flush_s": 2.47e-07,
+      "memory_estimate_total_bytes": 3939668382,
+      "memory_estimate_pinned_bytes": 1481195568,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.32703,
+          "best_ms": 0.407611,
+          "best_in_gibs": 38.3331,
+          "best_out_gibs": 38.3331,
+          "in_gibs": 42.0514,
+          "out_gibs": 42.0514
+        },
+        "h2d": {
+          "avg_ms": 2.34595,
+          "best_ms": 1.24496,
+          "best_in_gibs": 25.1012,
+          "best_out_gibs": 25.1012,
+          "in_gibs": 24.0212,
+          "out_gibs": 24.0212
+        },
+        "scatter": {
+          "avg_ms": 0.322555,
+          "best_ms": 0.258592,
+          "best_in_gibs": 120.847,
+          "best_out_gibs": 120.847,
+          "in_gibs": 145.324,
+          "out_gibs": 145.324
+        },
+        "compress": {
+          "avg_ms": 73.7512,
+          "best_ms": 36.0314,
+          "best_in_gibs": 7.80569,
+          "best_out_gibs": 1.89579,
+          "in_gibs": 7.08221,
+          "out_gibs": 3.24813
+        },
+        "aggregate": {
+          "avg_ms": 1.1877,
+          "best_ms": 0.235104,
+          "best_in_gibs": 290.544,
+          "best_out_gibs": 290.544,
+          "in_gibs": 201.695,
+          "out_gibs": 201.695
+        },
+        "d2h": {
+          "avg_ms": 10.9358,
+          "best_ms": 2.93126,
+          "best_in_gibs": 23.3033,
+          "best_out_gibs": 23.3033,
+          "in_gibs": 21.9055,
+          "out_gibs": 21.9055
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 195.105,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 553.375,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 72.7001,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.72,
+      "status": "pass",
+      "throughput_in_gibs": 3.60486,
+      "throughput_out_gibs": 1.40768,
+      "compression_fold": 2.66329,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.37283,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.975247,
+      "init_s": 0.440167,
+      "flush_s": 3.28e-07,
+      "memory_estimate_total_bytes": 3920730878,
+      "memory_estimate_pinned_bytes": 1481164848,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.17695,
+          "best_ms": 0.4101,
+          "best_in_gibs": 38.1005,
+          "best_out_gibs": 38.1005,
+          "in_gibs": 47.4139,
+          "out_gibs": 47.4139
+        },
+        "h2d": {
+          "avg_ms": 2.32309,
+          "best_ms": 1.24506,
+          "best_in_gibs": 25.0993,
+          "best_out_gibs": 25.0993,
+          "in_gibs": 24.2575,
+          "out_gibs": 24.2575
+        },
+        "scatter": {
+          "avg_ms": 0.316493,
+          "best_ms": 0.216992,
+          "best_in_gibs": 144.015,
+          "best_out_gibs": 144.015,
+          "in_gibs": 157.981,
+          "out_gibs": 157.981
+        },
+        "compress": {
+          "avg_ms": 122.422,
+          "best_ms": 58.9778,
+          "best_in_gibs": 4.76874,
+          "best_out_gibs": 0.947962,
+          "in_gibs": 4.26657,
+          "out_gibs": 1.60192
+        },
+        "aggregate": {
+          "avg_ms": 1.02569,
+          "best_ms": 0.318112,
+          "best_in_gibs": 175.752,
+          "best_out_gibs": 175.752,
+          "in_gibs": 191.199,
+          "out_gibs": 191.199
+        },
+        "d2h": {
+          "avg_ms": 9.00043,
+          "best_ms": 2.35722,
+          "best_in_gibs": 23.7181,
+          "best_out_gibs": 23.7181,
+          "in_gibs": 21.7889,
+          "out_gibs": 21.7889
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 330.398,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 888.277,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 124.633,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 4.46,
+      "status": "pass",
+      "throughput_in_gibs": 2.01753,
+      "throughput_out_gibs": 0.803848,
+      "compression_fold": 2.61024,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.40073,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 1.74254,
+      "init_s": 0.429946,
+      "flush_s": 3.41e-07,
+      "memory_estimate_total_bytes": 3911260158,
+      "memory_estimate_pinned_bytes": 1481147440,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.23568,
+          "best_ms": 0.240878,
+          "best_in_gibs": 64.8669,
+          "best_out_gibs": 64.8669,
+          "in_gibs": 45.1601,
+          "out_gibs": 45.1601
+        },
+        "h2d": {
+          "avg_ms": 2.34074,
+          "best_ms": 1.24486,
+          "best_in_gibs": 25.1031,
+          "best_out_gibs": 25.1031,
+          "in_gibs": 24.0747,
+          "out_gibs": 24.0747
+        },
+        "scatter": {
+          "avg_ms": 0.306976,
+          "best_ms": 0.185536,
+          "best_in_gibs": 168.431,
+          "best_out_gibs": 168.431,
+          "in_gibs": 162.879,
+          "out_gibs": 162.879
+        },
+        "compress": {
+          "avg_ms": 231.621,
+          "best_ms": 104.476,
+          "best_in_gibs": 2.692,
+          "best_out_gibs": 0.517294,
+          "in_gibs": 2.25507,
+          "out_gibs": 0.863911
+        },
+        "aggregate": {
+          "avg_ms": 1.31019,
+          "best_ms": 0.519776,
+          "best_in_gibs": 103.977,
+          "best_out_gibs": 103.977,
+          "in_gibs": 152.726,
+          "out_gibs": 152.726
+        },
+        "d2h": {
+          "avg_ms": 9.12262,
+          "best_ms": 2.23981,
+          "best_in_gibs": 24.1293,
+          "best_out_gibs": 24.1293,
+          "in_gibs": 21.9345,
+          "out_gibs": 21.9345
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 636.826,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 1654.52,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 266.172,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 3.42,
+      "status": "pass",
+      "throughput_in_gibs": 6.23865,
+      "throughput_out_gibs": 1.02246,
+      "compression_fold": 6.10162,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.576179,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.563524,
+      "init_s": 0.418802,
+      "flush_s": 4.78e-07,
+      "memory_estimate_total_bytes": 5280686821,
+      "memory_estimate_pinned_bytes": 1478385712,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.05844,
+          "best_ms": 0.251512,
+          "best_in_gibs": 62.1243,
+          "best_out_gibs": 62.1243,
+          "in_gibs": 44.2867,
+          "out_gibs": 44.2867
+        },
+        "h2d": {
+          "avg_ms": 1.89768,
+          "best_ms": 0.624608,
+          "best_in_gibs": 25.0157,
+          "best_out_gibs": 25.0157,
+          "in_gibs": 24.814,
+          "out_gibs": 24.814
+        },
+        "scatter": {
+          "avg_ms": 0.222121,
+          "best_ms": 0.100384,
+          "best_in_gibs": 155.652,
+          "best_out_gibs": 155.652,
+          "in_gibs": 160.787,
+          "out_gibs": 160.787
+        },
+        "compress": {
+          "avg_ms": 64.4149,
+          "best_ms": 15.6765,
+          "best_in_gibs": 8.97044,
+          "best_out_gibs": 1.30368,
+          "in_gibs": 7.79683,
+          "out_gibs": 1.26869
+        },
+        "aggregate": {
+          "avg_ms": 0.457211,
+          "best_ms": 0.056704,
+          "best_in_gibs": 360.418,
+          "best_out_gibs": 360.418,
+          "in_gibs": 178.742,
+          "out_gibs": 178.742
+        },
+        "d2h": {
+          "avg_ms": 3.88084,
+          "best_ms": 0.880576,
+          "best_in_gibs": 23.2089,
+          "best_out_gibs": 23.2089,
+          "in_gibs": 21.058,
+          "out_gibs": 21.058
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 142.137,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 460.628,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 74.0681,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 3.63,
+      "status": "pass",
+      "throughput_in_gibs": 4.41588,
+      "throughput_out_gibs": 0.712765,
+      "compression_fold": 6.19542,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.567455,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.796132,
+      "init_s": 0.424498,
+      "flush_s": 6.55e-07,
+      "memory_estimate_total_bytes": 5374672061,
+      "memory_estimate_pinned_bytes": 1477403696,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.841097,
+          "best_ms": 0.240556,
+          "best_in_gibs": 64.9537,
+          "best_out_gibs": 64.9537,
+          "in_gibs": 55.7308,
+          "out_gibs": 55.7308
+        },
+        "h2d": {
+          "avg_ms": 1.89708,
+          "best_ms": 0.624608,
+          "best_in_gibs": 25.0157,
+          "best_out_gibs": 25.0157,
+          "in_gibs": 24.8218,
+          "out_gibs": 24.8218
+        },
+        "scatter": {
+          "avg_ms": 0.221637,
+          "best_ms": 0.10032,
+          "best_in_gibs": 155.752,
+          "best_out_gibs": 155.752,
+          "in_gibs": 161.139,
+          "out_gibs": 161.139
+        },
+        "compress": {
+          "avg_ms": 98.0751,
+          "best_ms": 26.0789,
+          "best_in_gibs": 5.39229,
+          "best_out_gibs": 0.81676,
+          "in_gibs": 5.12089,
+          "out_gibs": 0.823513
+        },
+        "aggregate": {
+          "avg_ms": 0.317664,
+          "best_ms": 0.066112,
+          "best_in_gibs": 322.184,
+          "best_out_gibs": 322.184,
+          "in_gibs": 254.25,
+          "out_gibs": 254.25
+        },
+        "d2h": {
+          "avg_ms": 4.05329,
+          "best_ms": 0.900384,
+          "best_in_gibs": 23.6568,
+          "best_out_gibs": 23.6568,
+          "in_gibs": 19.9261,
+          "out_gibs": 19.9261
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 224.284,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 698.558,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 112.542,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.5,
+      "status": "pass",
+      "throughput_in_gibs": 4.39277,
+      "throughput_out_gibs": 0.656886,
+      "compression_fold": 6.68726,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.52572,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.800321,
+      "init_s": 0.429275,
+      "flush_s": 4.33e-07,
+      "memory_estimate_total_bytes": 5568217829,
+      "memory_estimate_pinned_bytes": 1476894768,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.31897,
+          "best_ms": 0.389193,
+          "best_in_gibs": 40.1472,
+          "best_out_gibs": 40.1472,
+          "in_gibs": 35.5392,
+          "out_gibs": 35.5392
+        },
+        "h2d": {
+          "avg_ms": 1.89386,
+          "best_ms": 0.624576,
+          "best_in_gibs": 25.017,
+          "best_out_gibs": 25.017,
+          "in_gibs": 24.8641,
+          "out_gibs": 24.8641
+        },
+        "scatter": {
+          "avg_ms": 0.213813,
+          "best_ms": 0.100096,
+          "best_in_gibs": 156.1,
+          "best_out_gibs": 156.1,
+          "in_gibs": 162.395,
+          "out_gibs": 162.395
+        },
+        "compress": {
+          "avg_ms": 98.2064,
+          "best_ms": 31.2508,
+          "best_in_gibs": 4.49989,
+          "best_out_gibs": 0.663362,
+          "in_gibs": 5.11405,
+          "out_gibs": 0.763246
+        },
+        "aggregate": {
+          "avg_ms": 0.288018,
+          "best_ms": 0.052768,
+          "best_in_gibs": 392.862,
+          "best_out_gibs": 392.862,
+          "in_gibs": 260.246,
+          "out_gibs": 260.246
+        },
+        "d2h": {
+          "avg_ms": 3.75331,
+          "best_ms": 0.871712,
+          "best_in_gibs": 23.7814,
+          "best_out_gibs": 23.7814,
+          "in_gibs": 19.9706,
+          "out_gibs": 19.9706
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 227.126,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 699.899,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 112.907,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 3.89,
+      "status": "pass",
+      "throughput_in_gibs": 2.93811,
+      "throughput_out_gibs": 0.444301,
+      "compression_fold": 6.6129,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.531632,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 1.19656,
+      "init_s": 0.418956,
+      "flush_s": 3.45e-07,
+      "memory_estimate_total_bytes": 5567787197,
+      "memory_estimate_pinned_bytes": 1476703792,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.08118,
+          "best_ms": 0.241578,
+          "best_in_gibs": 64.6789,
+          "best_out_gibs": 64.6789,
+          "in_gibs": 43.3554,
+          "out_gibs": 43.3554
+        },
+        "h2d": {
+          "avg_ms": 1.89585,
+          "best_ms": 0.624608,
+          "best_in_gibs": 25.0157,
+          "best_out_gibs": 25.0157,
+          "in_gibs": 24.838,
+          "out_gibs": 24.838
+        },
+        "scatter": {
+          "avg_ms": 0.221627,
+          "best_ms": 0.100192,
+          "best_in_gibs": 155.951,
+          "best_out_gibs": 155.951,
+          "in_gibs": 161.146,
+          "out_gibs": 161.146
+        },
+        "compress": {
+          "avg_ms": 155.467,
+          "best_ms": 24.6133,
+          "best_in_gibs": 5.71336,
+          "best_out_gibs": 0.853445,
+          "in_gibs": 3.23048,
+          "out_gibs": 0.487995
+        },
+        "aggregate": {
+          "avg_ms": 0.446464,
+          "best_ms": 0.052832,
+          "best_in_gibs": 397.602,
+          "best_out_gibs": 397.602,
+          "in_gibs": 169.928,
+          "out_gibs": 169.928
+        },
+        "d2h": {
+          "avg_ms": 3.80759,
+          "best_ms": 0.901664,
+          "best_in_gibs": 23.2971,
+          "best_out_gibs": 23.2971,
+          "in_gibs": 19.9252,
+          "out_gibs": 19.9252
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 339.187,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 1103.11,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 190.605,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 4.0,
+      "status": "pass",
+      "throughput_in_gibs": 2.85912,
+      "throughput_out_gibs": 0.41288,
+      "compression_fold": 6.92481,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.507685,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 1.22962,
+      "init_s": 0.422036,
+      "flush_s": 3.15e-07,
+      "memory_estimate_total_bytes": 5567528677,
+      "memory_estimate_pinned_bytes": 1476583472,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.835268,
+          "best_ms": 0.240922,
+          "best_in_gibs": 64.855,
+          "best_out_gibs": 64.855,
+          "in_gibs": 56.1197,
+          "out_gibs": 56.1197
+        },
+        "h2d": {
+          "avg_ms": 1.8942,
+          "best_ms": 0.624544,
+          "best_in_gibs": 25.0183,
+          "best_out_gibs": 25.0183,
+          "in_gibs": 24.8595,
+          "out_gibs": 24.8595
+        },
+        "scatter": {
+          "avg_ms": 0.221531,
+          "best_ms": 0.099808,
+          "best_in_gibs": 156.551,
+          "best_out_gibs": 156.551,
+          "in_gibs": 161.215,
+          "out_gibs": 161.215
+        },
+        "compress": {
+          "avg_ms": 160.104,
+          "best_ms": 29.9728,
+          "best_in_gibs": 4.69175,
+          "best_out_gibs": 0.667108,
+          "in_gibs": 3.13691,
+          "out_gibs": 0.45274
+        },
+        "aggregate": {
+          "avg_ms": 0.435214,
+          "best_ms": 0.0456,
+          "best_in_gibs": 438.489,
+          "best_out_gibs": 438.489,
+          "in_gibs": 166.552,
+          "out_gibs": 166.552
+        },
+        "d2h": {
+          "avg_ms": 3.65321,
+          "best_ms": 0.873696,
+          "best_in_gibs": 22.8856,
+          "best_out_gibs": 22.8856,
+          "in_gibs": 19.8416,
+          "out_gibs": 19.8416
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 353.427,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 1135.62,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 203.399,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 3.48,
+      "status": "pass",
+      "throughput_in_gibs": 4.64236,
+      "throughput_out_gibs": 0.651103,
+      "compression_fold": 7.41519,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.493076,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.757293,
+      "init_s": 0.432908,
+      "flush_s": 2.2e-07,
+      "memory_estimate_total_bytes": 5567394021,
+      "memory_estimate_pinned_bytes": 1476517936,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.973792,
+          "best_ms": 0.259235,
+          "best_in_gibs": 60.2735,
+          "best_out_gibs": 60.2735,
+          "in_gibs": 57.3054,
+          "out_gibs": 57.3054
+        },
+        "h2d": {
+          "avg_ms": 2.26811,
+          "best_ms": 1.24486,
+          "best_in_gibs": 25.1031,
+          "best_out_gibs": 25.1031,
+          "in_gibs": 24.8455,
+          "out_gibs": 24.8455
+        },
+        "scatter": {
+          "avg_ms": 0.381216,
+          "best_ms": 0.35744,
+          "best_in_gibs": 174.855,
+          "best_out_gibs": 174.855,
+          "in_gibs": 163.949,
+          "out_gibs": 163.949
+        },
+        "compress": {
+          "avg_ms": 93.1712,
+          "best_ms": 33.5718,
+          "best_in_gibs": 8.37757,
+          "best_out_gibs": 0.596359,
+          "in_gibs": 5.60604,
+          "out_gibs": 0.755801
+        },
+        "aggregate": {
+          "avg_ms": 0.441193,
+          "best_ms": 0.045664,
+          "best_in_gibs": 438.438,
+          "best_out_gibs": 438.438,
+          "in_gibs": 159.61,
+          "out_gibs": 159.61
+        },
+        "d2h": {
+          "avg_ms": 3.52597,
+          "best_ms": 0.925024,
+          "best_in_gibs": 21.6436,
+          "best_out_gibs": 21.6436,
+          "in_gibs": 19.9715,
+          "out_gibs": 19.9715
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 223.522,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 667.011,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 99.6118,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.68,
+      "status": "pass",
+      "throughput_in_gibs": 4.29737,
+      "throughput_out_gibs": 0.624209,
+      "compression_fold": 7.15989,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.510657,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.818088,
+      "init_s": 0.42852,
+      "flush_s": 3.49e-07,
+      "memory_estimate_total_bytes": 5567328581,
+      "memory_estimate_pinned_bytes": 1476487216,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.952901,
+          "best_ms": 0.256801,
+          "best_in_gibs": 60.8448,
+          "best_out_gibs": 60.8448,
+          "in_gibs": 58.5618,
+          "out_gibs": 58.5618
+        },
+        "h2d": {
+          "avg_ms": 2.26453,
+          "best_ms": 1.24496,
+          "best_in_gibs": 25.1012,
+          "best_out_gibs": 25.1012,
+          "in_gibs": 24.8849,
+          "out_gibs": 24.8849
+        },
+        "scatter": {
+          "avg_ms": 0.38,
+          "best_ms": 0.356416,
+          "best_in_gibs": 175.357,
+          "best_out_gibs": 175.357,
+          "in_gibs": 164.474,
+          "out_gibs": 164.474
+        },
+        "compress": {
+          "avg_ms": 102.15,
+          "best_ms": 54.1508,
+          "best_in_gibs": 5.19383,
+          "best_out_gibs": 0.376875,
+          "in_gibs": 5.11326,
+          "out_gibs": 0.714064
+        },
+        "aggregate": {
+          "avg_ms": 0.453408,
+          "best_ms": 0.06144,
+          "best_in_gibs": 332.163,
+          "best_out_gibs": 332.163,
+          "in_gibs": 160.875,
+          "out_gibs": 160.875
+        },
+        "d2h": {
+          "avg_ms": 3.68463,
+          "best_ms": 0.85728,
+          "best_in_gibs": 23.8057,
+          "best_out_gibs": 23.8057,
+          "in_gibs": 19.7963,
+          "out_gibs": 19.7963
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 256.838,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 730.345,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 108.683,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__gpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 3.6,
+      "status": "pass",
+      "throughput_in_gibs": 4.23271,
+      "throughput_out_gibs": 0.608241,
+      "compression_fold": 7.23729,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.505196,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.830585,
+      "init_s": 0.435495,
+      "flush_s": 3.6e-07,
+      "memory_estimate_total_bytes": 5567293893,
+      "memory_estimate_pinned_bytes": 1476469808,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.976778,
+          "best_ms": 0.251668,
+          "best_in_gibs": 62.0858,
+          "best_out_gibs": 62.0858,
+          "in_gibs": 57.1302,
+          "out_gibs": 57.1302
+        },
+        "h2d": {
+          "avg_ms": 2.26381,
+          "best_ms": 1.2449,
+          "best_in_gibs": 25.1025,
+          "best_out_gibs": 25.1025,
+          "in_gibs": 24.8927,
+          "out_gibs": 24.8927
+        },
+        "scatter": {
+          "avg_ms": 0.382325,
+          "best_ms": 0.35664,
+          "best_in_gibs": 175.247,
+          "best_out_gibs": 175.247,
+          "in_gibs": 163.473,
+          "out_gibs": 163.473
+        },
+        "compress": {
+          "avg_ms": 103.501,
+          "best_ms": 56.0418,
+          "best_in_gibs": 5.01857,
+          "best_out_gibs": 0.357495,
+          "in_gibs": 5.04651,
+          "out_gibs": 0.697248
+        },
+        "aggregate": {
+          "avg_ms": 0.56112,
+          "best_ms": 0.103168,
+          "best_in_gibs": 194.195,
+          "best_out_gibs": 194.195,
+          "in_gibs": 128.611,
+          "out_gibs": 128.611
+        },
+        "d2h": {
+          "avg_ms": 3.68547,
+          "best_ms": 0.890432,
+          "best_in_gibs": 22.4999,
+          "best_out_gibs": 22.4999,
+          "in_gibs": 19.5813,
+          "out_gibs": 19.5813
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 261.244,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 740.504,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 109.46,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 13.08,
+      "status": "pass",
+      "throughput_in_gibs": 14.62,
+      "throughput_out_gibs": 14.6343,
+      "compression_fold": 0.999024,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75366,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.256498,
+      "init_s": 0.433266,
+      "flush_s": 3.05e-07,
+      "memory_estimate_total_bytes": 2686423518,
+      "memory_estimate_pinned_bytes": 1477574704,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.10123,
+          "best_ms": 0.970422,
+          "best_in_gibs": 64.405,
+          "best_out_gibs": 64.405,
+          "in_gibs": 56.7545,
+          "out_gibs": 56.7545
+        },
+        "h2d": {
+          "avg_ms": 2.84629,
+          "best_ms": 2.48538,
+          "best_in_gibs": 25.1471,
+          "best_out_gibs": 25.1471,
+          "in_gibs": 21.9584,
+          "out_gibs": 21.9584
+        },
+        "scatter": {
+          "avg_ms": 0.505984,
+          "best_ms": 0.505984,
+          "best_in_gibs": 123.522,
+          "best_out_gibs": 123.522,
+          "in_gibs": 123.522,
+          "out_gibs": 123.522
+        },
+        "aggregate": {
+          "avg_ms": 2.70546,
+          "best_ms": 1.34131,
+          "best_in_gibs": 279.577,
+          "best_out_gibs": 279.577,
+          "in_gibs": 198.012,
+          "out_gibs": 198.012
+        },
+        "d2h": {
+          "avg_ms": 24.8842,
+          "best_ms": 15.2795,
+          "best_in_gibs": 24.5427,
+          "best_out_gibs": 24.5427,
+          "in_gibs": 21.5283,
+          "out_gibs": 21.5283
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 36.6939,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 173.047,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90954,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 13.04,
+      "status": "pass",
+      "throughput_in_gibs": 14.6481,
+      "throughput_out_gibs": 14.6552,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.256007,
+      "init_s": 0.41858,
+      "flush_s": 3.42e-07,
+      "memory_estimate_total_bytes": 2685390814,
+      "memory_estimate_pinned_bytes": 1476984880,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.10191,
+          "best_ms": 0.976384,
+          "best_in_gibs": 64.0117,
+          "best_out_gibs": 64.0117,
+          "in_gibs": 56.7195,
+          "out_gibs": 56.7195
+        },
+        "h2d": {
+          "avg_ms": 2.84539,
+          "best_ms": 2.48538,
+          "best_in_gibs": 25.1471,
+          "best_out_gibs": 25.1471,
+          "in_gibs": 21.9653,
+          "out_gibs": 21.9653
+        },
+        "scatter": {
+          "avg_ms": 0.510816,
+          "best_ms": 0.510816,
+          "best_in_gibs": 122.353,
+          "best_out_gibs": 122.353,
+          "in_gibs": 122.353,
+          "out_gibs": 122.353
+        },
+        "aggregate": {
+          "avg_ms": 2.88079,
+          "best_ms": 1.39558,
+          "best_in_gibs": 268.705,
+          "best_out_gibs": 268.705,
+          "in_gibs": 185.961,
+          "out_gibs": 185.961
+        },
+        "d2h": {
+          "avg_ms": 24.854,
+          "best_ms": 15.2723,
+          "best_in_gibs": 24.5543,
+          "best_out_gibs": 24.5543,
+          "in_gibs": 21.5545,
+          "out_gibs": 21.5545
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 36.0336,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 178.132,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.93402,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.16,
+      "status": "pass",
+      "throughput_in_gibs": 14.68,
+      "throughput_out_gibs": 14.6836,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75092,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.25545,
+      "init_s": 0.430645,
+      "flush_s": 3.8e-07,
+      "memory_estimate_total_bytes": 2684874206,
+      "memory_estimate_pinned_bytes": 1476689968,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.07318,
+          "best_ms": 0.940079,
+          "best_in_gibs": 66.4838,
+          "best_out_gibs": 66.4838,
+          "in_gibs": 58.238,
+          "out_gibs": 58.238
+        },
+        "h2d": {
+          "avg_ms": 2.85559,
+          "best_ms": 2.48531,
+          "best_in_gibs": 25.1477,
+          "best_out_gibs": 25.1477,
+          "in_gibs": 21.8869,
+          "out_gibs": 21.8869
+        },
+        "scatter": {
+          "avg_ms": 0.510176,
+          "best_ms": 0.510176,
+          "best_in_gibs": 122.507,
+          "best_out_gibs": 122.507,
+          "in_gibs": 122.507,
+          "out_gibs": 122.507
+        },
+        "aggregate": {
+          "avg_ms": 2.90485,
+          "best_ms": 1.45466,
+          "best_in_gibs": 257.793,
+          "best_out_gibs": 257.793,
+          "in_gibs": 184.42,
+          "out_gibs": 184.42
+        },
+        "d2h": {
+          "avg_ms": 24.845,
+          "best_ms": 15.2657,
+          "best_in_gibs": 24.5649,
+          "best_out_gibs": 24.5649,
+          "in_gibs": 21.5623,
+          "out_gibs": 21.5623
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 34.7847,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 180.561,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.92514,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 13.12,
+      "status": "pass",
+      "throughput_in_gibs": 14.7137,
+      "throughput_out_gibs": 14.7155,
+      "compression_fold": 0.999878,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75046,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.254864,
+      "init_s": 0.418762,
+      "flush_s": 3.82e-07,
+      "memory_estimate_total_bytes": 2684616158,
+      "memory_estimate_pinned_bytes": 1476542512,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.11714,
+          "best_ms": 0.957152,
+          "best_in_gibs": 65.2979,
+          "best_out_gibs": 65.2979,
+          "in_gibs": 55.9466,
+          "out_gibs": 55.9466
+        },
+        "h2d": {
+          "avg_ms": 2.84932,
+          "best_ms": 2.4857,
+          "best_in_gibs": 25.1439,
+          "best_out_gibs": 25.1439,
+          "in_gibs": 21.9351,
+          "out_gibs": 21.9351
+        },
+        "scatter": {
+          "avg_ms": 0.506752,
+          "best_ms": 0.506752,
+          "best_in_gibs": 123.334,
+          "best_out_gibs": 123.334,
+          "in_gibs": 123.334,
+          "out_gibs": 123.334
+        },
+        "aggregate": {
+          "avg_ms": 3.00437,
+          "best_ms": 1.48877,
+          "best_in_gibs": 251.886,
+          "best_out_gibs": 251.886,
+          "in_gibs": 178.312,
+          "out_gibs": 178.312
+        },
+        "d2h": {
+          "avg_ms": 24.8389,
+          "best_ms": 15.2601,
+          "best_in_gibs": 24.5739,
+          "best_out_gibs": 24.5739,
+          "in_gibs": 21.5676,
+          "out_gibs": 21.5676
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 35.0514,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 181.855,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.92401,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.31,
+      "status": "pass",
+      "throughput_in_gibs": 14.3847,
+      "throughput_out_gibs": 14.3856,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.260693,
+      "init_s": 0.548077,
+      "flush_s": 3.45e-07,
+      "memory_estimate_total_bytes": 3489836510,
+      "memory_estimate_pinned_bytes": 1879146544,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.07232,
+          "best_ms": 0.947466,
+          "best_in_gibs": 65.9654,
+          "best_out_gibs": 65.9654,
+          "in_gibs": 58.2846,
+          "out_gibs": 58.2846
+        },
+        "h2d": {
+          "avg_ms": 2.80241,
+          "best_ms": 2.48531,
+          "best_in_gibs": 25.1477,
+          "best_out_gibs": 25.1477,
+          "in_gibs": 22.3022,
+          "out_gibs": 22.3022
+        },
+        "scatter": {
+          "avg_ms": 0.506112,
+          "best_ms": 0.506112,
+          "best_in_gibs": 123.49,
+          "best_out_gibs": 123.49,
+          "in_gibs": 123.49,
+          "out_gibs": 123.49
+        },
+        "aggregate": {
+          "avg_ms": 4.42526,
+          "best_ms": 4.3385,
+          "best_in_gibs": 172.871,
+          "best_out_gibs": 172.871,
+          "in_gibs": 169.482,
+          "out_gibs": 169.482
+        },
+        "d2h": {
+          "avg_ms": 34.5479,
+          "best_ms": 30.6927,
+          "best_in_gibs": 24.4358,
+          "best_out_gibs": 24.4358,
+          "in_gibs": 21.709,
+          "out_gibs": 21.709
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 43.5494,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 180.878,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.92445,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 13.21,
+      "status": "pass",
+      "throughput_in_gibs": 14.4159,
+      "throughput_out_gibs": 14.4164,
+      "compression_fold": 0.999969,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75011,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.260129,
+      "init_s": 0.553273,
+      "flush_s": 4.22e-07,
+      "memory_estimate_total_bytes": 3489750494,
+      "memory_estimate_pinned_bytes": 1879097392,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.08279,
+          "best_ms": 0.944339,
+          "best_in_gibs": 66.1839,
+          "best_out_gibs": 66.1839,
+          "in_gibs": 57.7212,
+          "out_gibs": 57.7212
+        },
+        "h2d": {
+          "avg_ms": 2.80179,
+          "best_ms": 2.48534,
+          "best_in_gibs": 25.1474,
+          "best_out_gibs": 25.1474,
+          "in_gibs": 22.3071,
+          "out_gibs": 22.3071
+        },
+        "scatter": {
+          "avg_ms": 0.49968,
+          "best_ms": 0.49968,
+          "best_in_gibs": 125.08,
+          "best_out_gibs": 125.08,
+          "in_gibs": 125.08,
+          "out_gibs": 125.08
+        },
+        "aggregate": {
+          "avg_ms": 4.52696,
+          "best_ms": 4.46758,
+          "best_in_gibs": 167.876,
+          "best_out_gibs": 167.876,
+          "in_gibs": 165.674,
+          "out_gibs": 165.674
+        },
+        "d2h": {
+          "avg_ms": 34.54,
+          "best_ms": 30.6876,
+          "best_in_gibs": 24.4399,
+          "best_out_gibs": 24.4399,
+          "in_gibs": 21.7139,
+          "out_gibs": 21.7139
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 43.4716,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 181.343,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.91617,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.21,
+      "status": "pass",
+      "throughput_in_gibs": 14.3015,
+      "throughput_out_gibs": 14.3018,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75006,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.26221,
+      "init_s": 0.548233,
+      "flush_s": 3.14e-07,
+      "memory_estimate_total_bytes": 3489707486,
+      "memory_estimate_pinned_bytes": 1879072816,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.64975,
+          "best_ms": 0.956762,
+          "best_in_gibs": 65.3245,
+          "best_out_gibs": 65.3245,
+          "in_gibs": 37.8844,
+          "out_gibs": 37.8844
+        },
+        "h2d": {
+          "avg_ms": 2.78342,
+          "best_ms": 2.48534,
+          "best_in_gibs": 25.1474,
+          "best_out_gibs": 25.1474,
+          "in_gibs": 22.4544,
+          "out_gibs": 22.4544
+        },
+        "scatter": {
+          "avg_ms": 0.509984,
+          "best_ms": 0.509984,
+          "best_in_gibs": 122.553,
+          "best_out_gibs": 122.553,
+          "in_gibs": 122.553,
+          "out_gibs": 122.553
+        },
+        "aggregate": {
+          "avg_ms": 4.67355,
+          "best_ms": 4.63728,
+          "best_in_gibs": 161.733,
+          "best_out_gibs": 161.733,
+          "in_gibs": 160.477,
+          "out_gibs": 160.477
+        },
+        "d2h": {
+          "avg_ms": 34.5758,
+          "best_ms": 30.8326,
+          "best_in_gibs": 24.3249,
+          "best_out_gibs": 24.3249,
+          "in_gibs": 21.6914,
+          "out_gibs": 21.6914
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 44.1901,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 180.968,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.9258,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 13.19,
+      "status": "pass",
+      "throughput_in_gibs": 14.3637,
+      "throughput_out_gibs": 14.3639,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.261074,
+      "init_s": 0.537594,
+      "flush_s": 2.64e-07,
+      "memory_estimate_total_bytes": 3489690078,
+      "memory_estimate_pinned_bytes": 1879064624,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.09528,
+          "best_ms": 0.961367,
+          "best_in_gibs": 65.0116,
+          "best_out_gibs": 65.0116,
+          "in_gibs": 57.063,
+          "out_gibs": 57.063
+        },
+        "h2d": {
+          "avg_ms": 2.76553,
+          "best_ms": 2.48659,
+          "best_in_gibs": 25.1348,
+          "best_out_gibs": 25.1348,
+          "in_gibs": 22.5996,
+          "out_gibs": 22.5996
+        },
+        "scatter": {
+          "avg_ms": 0.515328,
+          "best_ms": 0.515328,
+          "best_in_gibs": 121.282,
+          "best_out_gibs": 121.282,
+          "in_gibs": 121.282,
+          "out_gibs": 121.282
+        },
+        "aggregate": {
+          "avg_ms": 5.17796,
+          "best_ms": 5.12051,
+          "best_in_gibs": 146.47,
+          "best_out_gibs": 146.47,
+          "in_gibs": 144.845,
+          "out_gibs": 144.845
+        },
+        "d2h": {
+          "avg_ms": 34.6135,
+          "best_ms": 30.9429,
+          "best_in_gibs": 24.2382,
+          "best_out_gibs": 24.2382,
+          "in_gibs": 21.6678,
+          "out_gibs": 21.6678
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 45.1672,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 182.38,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.93274,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 13.21,
+      "status": "pass",
+      "throughput_in_gibs": 10.8242,
+      "throughput_out_gibs": 4.19696,
+      "compression_fold": 2.57905,
+      "input_gib": 3.75,
+      "compressed_gib": 1.45402,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.346447,
+      "init_s": 0.429879,
+      "flush_s": 4.73e-07,
+      "memory_estimate_total_bytes": 5113549278,
+      "memory_estimate_pinned_bytes": 1482883120,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.0786,
+          "best_ms": 0.934001,
+          "best_in_gibs": 66.9164,
+          "best_out_gibs": 66.9164,
+          "in_gibs": 57.9452,
+          "out_gibs": 57.9452
+        },
+        "h2d": {
+          "avg_ms": 2.6281,
+          "best_ms": 2.48534,
+          "best_in_gibs": 25.1474,
+          "best_out_gibs": 25.1474,
+          "in_gibs": 23.7814,
+          "out_gibs": 23.7814
+        },
+        "scatter": {
+          "avg_ms": 0.465259,
+          "best_ms": 0.441088,
+          "best_in_gibs": 141.695,
+          "best_out_gibs": 141.695,
+          "in_gibs": 134.334,
+          "out_gibs": 134.334
+        },
+        "compress": {
+          "avg_ms": 21.7694,
+          "best_ms": 14.8238,
+          "best_in_gibs": 25.2971,
+          "best_out_gibs": 9.784,
+          "in_gibs": 24.6086,
+          "out_gibs": 9.5177
+        },
+        "aggregate": {
+          "avg_ms": 0.981582,
+          "best_ms": 0.58048,
+          "best_in_gibs": 249.856,
+          "best_out_gibs": 249.856,
+          "in_gibs": 211.082,
+          "out_gibs": 211.082
+        },
+        "d2h": {
+          "avg_ms": 9.79019,
+          "best_ms": 6.08758,
+          "best_in_gibs": 23.8249,
+          "best_out_gibs": 23.8249,
+          "in_gibs": 21.1635,
+          "out_gibs": 21.1635
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 29.502,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 246.87,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 22.7523,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 13.2,
+      "status": "pass",
+      "throughput_in_gibs": 11.1826,
+      "throughput_out_gibs": 3.87472,
+      "compression_fold": 2.88604,
+      "input_gib": 3.75,
+      "compressed_gib": 1.29936,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.335343,
+      "init_s": 0.422269,
+      "flush_s": 5.65e-07,
+      "memory_estimate_total_bytes": 4507652062,
+      "memory_estimate_pinned_bytes": 1481998384,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.56356,
+          "best_ms": 0.954042,
+          "best_in_gibs": 65.5107,
+          "best_out_gibs": 65.5107,
+          "in_gibs": 39.973,
+          "out_gibs": 39.973
+        },
+        "h2d": {
+          "avg_ms": 2.61408,
+          "best_ms": 2.48534,
+          "best_in_gibs": 25.1474,
+          "best_out_gibs": 25.1474,
+          "in_gibs": 23.909,
+          "out_gibs": 23.909
+        },
+        "scatter": {
+          "avg_ms": 0.463328,
+          "best_ms": 0.440544,
+          "best_in_gibs": 141.87,
+          "best_out_gibs": 141.87,
+          "in_gibs": 134.894,
+          "out_gibs": 134.894
+        },
+        "compress": {
+          "avg_ms": 21.4898,
+          "best_ms": 15.483,
+          "best_in_gibs": 24.2201,
+          "best_out_gibs": 8.38034,
+          "in_gibs": 24.9288,
+          "out_gibs": 8.62554
+        },
+        "aggregate": {
+          "avg_ms": 0.839173,
+          "best_ms": 0.520448,
+          "best_in_gibs": 249.31,
+          "best_out_gibs": 249.31,
+          "in_gibs": 220.885,
+          "out_gibs": 220.885
+        },
+        "d2h": {
+          "avg_ms": 8.73939,
+          "best_ms": 5.37123,
+          "best_in_gibs": 24.157,
+          "best_out_gibs": 24.157,
+          "in_gibs": 21.2098,
+          "out_gibs": 21.2098
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 28.3425,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 234.032,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 21.4918,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.22,
+      "status": "pass",
+      "throughput_in_gibs": 11.202,
+      "throughput_out_gibs": 3.86709,
+      "compression_fold": 2.89675,
+      "input_gib": 3.75,
+      "compressed_gib": 1.29455,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.334762,
+      "init_s": 0.425674,
+      "flush_s": 3.18e-07,
+      "memory_estimate_total_bytes": 4204703198,
+      "memory_estimate_pinned_bytes": 1481556016,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.05789,
+          "best_ms": 0.93303,
+          "best_in_gibs": 66.9861,
+          "best_out_gibs": 66.9861,
+          "in_gibs": 59.0799,
+          "out_gibs": 59.0799
+        },
+        "h2d": {
+          "avg_ms": 2.61166,
+          "best_ms": 2.48544,
+          "best_in_gibs": 25.1465,
+          "best_out_gibs": 25.1465,
+          "in_gibs": 23.9311,
+          "out_gibs": 23.9311
+        },
+        "scatter": {
+          "avg_ms": 0.464117,
+          "best_ms": 0.440224,
+          "best_in_gibs": 141.973,
+          "best_out_gibs": 141.973,
+          "in_gibs": 134.664,
+          "out_gibs": 134.664
+        },
+        "compress": {
+          "avg_ms": 23.7215,
+          "best_ms": 17.3495,
+          "best_in_gibs": 21.6145,
+          "best_out_gibs": 7.45633,
+          "in_gibs": 22.5834,
+          "out_gibs": 7.79061
+        },
+        "aggregate": {
+          "avg_ms": 0.897979,
+          "best_ms": 0.522784,
+          "best_in_gibs": 247.452,
+          "best_out_gibs": 247.452,
+          "in_gibs": 205.801,
+          "out_gibs": 205.801
+        },
+        "d2h": {
+          "avg_ms": 8.61087,
+          "best_ms": 5.35878,
+          "best_in_gibs": 24.1405,
+          "best_out_gibs": 24.1405,
+          "in_gibs": 21.4619,
+          "out_gibs": 21.4619
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 33.2337,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 245.947,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 24.8042,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 13.24,
+      "status": "pass",
+      "throughput_in_gibs": 11.1942,
+      "throughput_out_gibs": 3.68211,
+      "compression_fold": 3.04016,
+      "input_gib": 3.75,
+      "compressed_gib": 1.23349,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.334995,
+      "init_s": 0.425413,
+      "flush_s": 2.1e-07,
+      "memory_estimate_total_bytes": 4053229022,
+      "memory_estimate_pinned_bytes": 1481334832,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.13583,
+          "best_ms": 0.959358,
+          "best_in_gibs": 65.1477,
+          "best_out_gibs": 65.1477,
+          "in_gibs": 55.0257,
+          "out_gibs": 55.0257
+        },
+        "h2d": {
+          "avg_ms": 2.60426,
+          "best_ms": 2.48573,
+          "best_in_gibs": 25.1435,
+          "best_out_gibs": 25.1435,
+          "in_gibs": 23.9991,
+          "out_gibs": 23.9991
+        },
+        "scatter": {
+          "avg_ms": 0.466283,
+          "best_ms": 0.43968,
+          "best_in_gibs": 142.149,
+          "best_out_gibs": 142.149,
+          "in_gibs": 134.039,
+          "out_gibs": 134.039
+        },
+        "compress": {
+          "avg_ms": 29.6063,
+          "best_ms": 19.3198,
+          "best_in_gibs": 19.4101,
+          "best_out_gibs": 6.38221,
+          "in_gibs": 18.0946,
+          "out_gibs": 5.94966
+        },
+        "aggregate": {
+          "avg_ms": 0.800832,
+          "best_ms": 0.497952,
+          "best_in_gibs": 247.62,
+          "best_out_gibs": 247.62,
+          "in_gibs": 219.955,
+          "out_gibs": 219.955
+        },
+        "d2h": {
+          "avg_ms": 8.19448,
+          "best_ms": 5.05456,
+          "best_in_gibs": 24.3944,
+          "best_out_gibs": 24.3944,
+          "in_gibs": 21.4959,
+          "out_gibs": 21.4959
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 42.4756,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 246.064,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 30.2451,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.3,
+      "status": "pass",
+      "throughput_in_gibs": 11.0293,
+      "throughput_out_gibs": 3.36317,
+      "compression_fold": 3.27943,
+      "input_gib": 3.75,
+      "compressed_gib": 1.14349,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.340005,
+      "init_s": 0.529943,
+      "flush_s": 6.17e-07,
+      "memory_estimate_total_bytes": 5213842910,
+      "memory_estimate_pinned_bytes": 1885487152,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.0388,
+          "best_ms": 0.935086,
+          "best_in_gibs": 66.8388,
+          "best_out_gibs": 66.8388,
+          "in_gibs": 60.1655,
+          "out_gibs": 60.1655
+        },
+        "h2d": {
+          "avg_ms": 2.55399,
+          "best_ms": 2.48538,
+          "best_in_gibs": 25.1471,
+          "best_out_gibs": 25.1471,
+          "in_gibs": 24.4715,
+          "out_gibs": 24.4715
+        },
+        "scatter": {
+          "avg_ms": 0.464885,
+          "best_ms": 0.439296,
+          "best_in_gibs": 142.273,
+          "best_out_gibs": 142.273,
+          "in_gibs": 134.442,
+          "out_gibs": 134.442
+        },
+        "compress": {
+          "avg_ms": 42.1788,
+          "best_ms": 38.9803,
+          "best_in_gibs": 19.2405,
+          "best_out_gibs": 5.86585,
+          "in_gibs": 17.7814,
+          "out_gibs": 5.42103
+        },
+        "aggregate": {
+          "avg_ms": 1.17141,
+          "best_ms": 0.939136,
+          "best_in_gibs": 243.471,
+          "best_out_gibs": 243.471,
+          "in_gibs": 195.194,
+          "out_gibs": 195.194
+        },
+        "d2h": {
+          "avg_ms": 10.2637,
+          "best_ms": 9.39338,
+          "best_in_gibs": 24.3419,
+          "best_out_gibs": 24.3419,
+          "in_gibs": 22.2779,
+          "out_gibs": 22.2779
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 72.169,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 239.067,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 39.0268,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 13.4,
+      "status": "pass",
+      "throughput_in_gibs": 8.45261,
+      "throughput_out_gibs": 2.03228,
+      "compression_fold": 4.15917,
+      "input_gib": 3.75,
+      "compressed_gib": 0.901621,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.44365,
+      "init_s": 0.53533,
+      "flush_s": 3.37e-07,
+      "memory_estimate_total_bytes": 5163400670,
+      "memory_estimate_pinned_bytes": 1885438000,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.05427,
+          "best_ms": 0.952728,
+          "best_in_gibs": 65.6011,
+          "best_out_gibs": 65.6011,
+          "in_gibs": 59.2828,
+          "out_gibs": 59.2828
+        },
+        "h2d": {
+          "avg_ms": 2.54181,
+          "best_ms": 2.48528,
+          "best_in_gibs": 25.1481,
+          "best_out_gibs": 25.1481,
+          "in_gibs": 24.5888,
+          "out_gibs": 24.5888
+        },
+        "scatter": {
+          "avg_ms": 0.464544,
+          "best_ms": 0.439072,
+          "best_in_gibs": 142.346,
+          "best_out_gibs": 142.346,
+          "in_gibs": 134.541,
+          "out_gibs": 134.541
+        },
+        "compress": {
+          "avg_ms": 63.6353,
+          "best_ms": 59.6914,
+          "best_in_gibs": 12.5646,
+          "best_out_gibs": 3.02056,
+          "in_gibs": 11.7859,
+          "out_gibs": 2.83336
+        },
+        "aggregate": {
+          "avg_ms": 1.04114,
+          "best_ms": 0.778464,
+          "best_in_gibs": 231.612,
+          "best_out_gibs": 231.612,
+          "in_gibs": 173.177,
+          "out_gibs": 173.177
+        },
+        "d2h": {
+          "avg_ms": 8.20217,
+          "best_ms": 7.42938,
+          "best_in_gibs": 24.2687,
+          "best_out_gibs": 24.2687,
+          "in_gibs": 21.9821,
+          "out_gibs": 21.9821
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 116.094,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 341.743,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 59.7984,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.69,
+      "status": "pass",
+      "throughput_in_gibs": 5.38483,
+      "throughput_out_gibs": 1.21295,
+      "compression_fold": 4.43943,
+      "input_gib": 3.75,
+      "compressed_gib": 0.844703,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.696401,
+      "init_s": 0.539664,
+      "flush_s": 2.24e-07,
+      "memory_estimate_total_bytes": 5138159070,
+      "memory_estimate_pinned_bytes": 1885405232,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.07689,
+          "best_ms": 0.932373,
+          "best_in_gibs": 67.0333,
+          "best_out_gibs": 67.0333,
+          "in_gibs": 58.0374,
+          "out_gibs": 58.0374
+        },
+        "h2d": {
+          "avg_ms": 2.54418,
+          "best_ms": 2.48531,
+          "best_in_gibs": 25.1477,
+          "best_out_gibs": 25.1477,
+          "in_gibs": 24.5659,
+          "out_gibs": 24.5659
+        },
+        "scatter": {
+          "avg_ms": 0.465269,
+          "best_ms": 0.44,
+          "best_in_gibs": 142.045,
+          "best_out_gibs": 142.045,
+          "in_gibs": 134.331,
+          "out_gibs": 134.331
+        },
+        "compress": {
+          "avg_ms": 114.612,
+          "best_ms": 104.066,
+          "best_in_gibs": 7.20695,
+          "best_out_gibs": 1.62328,
+          "in_gibs": 6.54379,
+          "out_gibs": 1.47392
+        },
+        "aggregate": {
+          "avg_ms": 1.06357,
+          "best_ms": 0.786528,
+          "best_in_gibs": 214.778,
+          "best_out_gibs": 214.778,
+          "in_gibs": 158.832,
+          "out_gibs": 158.832
+        },
+        "d2h": {
+          "avg_ms": 7.69027,
+          "best_ms": 6.9912,
+          "best_in_gibs": 24.1631,
+          "best_out_gibs": 24.1631,
+          "in_gibs": 21.9666,
+          "out_gibs": 21.9666
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 227.163,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 595.933,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 104.261,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 14.23,
+      "status": "pass",
+      "throughput_in_gibs": 3.50677,
+      "throughput_out_gibs": 0.671858,
+      "compression_fold": 5.2195,
+      "input_gib": 3.75,
+      "compressed_gib": 0.718459,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 1.06936,
+      "init_s": 0.54889,
+      "flush_s": 3.79e-07,
+      "memory_estimate_total_bytes": 5125538270,
+      "memory_estimate_pinned_bytes": 1885388848,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.07502,
+          "best_ms": 0.954325,
+          "best_in_gibs": 65.4913,
+          "best_out_gibs": 65.4913,
+          "in_gibs": 58.1383,
+          "out_gibs": 58.1383
+        },
+        "h2d": {
+          "avg_ms": 2.53291,
+          "best_ms": 2.48534,
+          "best_in_gibs": 25.1474,
+          "best_out_gibs": 25.1474,
+          "in_gibs": 24.6752,
+          "out_gibs": 24.6752
+        },
+        "scatter": {
+          "avg_ms": 0.463925,
+          "best_ms": 0.440096,
+          "best_in_gibs": 142.014,
+          "best_out_gibs": 142.014,
+          "in_gibs": 134.72,
+          "out_gibs": 134.72
+        },
+        "compress": {
+          "avg_ms": 189.179,
+          "best_ms": 163.134,
+          "best_in_gibs": 4.59746,
+          "best_out_gibs": 0.880775,
+          "in_gibs": 3.96449,
+          "out_gibs": 0.759513
+        },
+        "aggregate": {
+          "avg_ms": 1.17151,
+          "best_ms": 0.8984,
+          "best_in_gibs": 159.933,
+          "best_out_gibs": 159.933,
+          "in_gibs": 122.649,
+          "out_gibs": 122.649
+        },
+        "d2h": {
+          "avg_ms": 6.57486,
+          "best_ms": 5.90781,
+          "best_in_gibs": 24.3211,
+          "best_out_gibs": 24.3211,
+          "in_gibs": 21.8536,
+          "out_gibs": 21.8536
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 392.839,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 967.004,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 183.338,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 13.38,
+      "status": "pass",
+      "throughput_in_gibs": 7.26409,
+      "throughput_out_gibs": 0.987991,
+      "compression_fold": 7.35239,
+      "input_gib": 3.75,
+      "compressed_gib": 0.510038,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.516238,
+      "init_s": 0.42523,
+      "flush_s": 2.28e-07,
+      "memory_estimate_total_bytes": 5280686885,
+      "memory_estimate_pinned_bytes": 1478385712,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.5131,
+          "best_ms": 0.908796,
+          "best_in_gibs": 68.7723,
+          "best_out_gibs": 68.7723,
+          "in_gibs": 41.3058,
+          "out_gibs": 41.3058
+        },
+        "h2d": {
+          "avg_ms": 2.52101,
+          "best_ms": 2.48656,
+          "best_in_gibs": 25.1351,
+          "best_out_gibs": 25.1351,
+          "in_gibs": 24.7916,
+          "out_gibs": 24.7916
+        },
+        "scatter": {
+          "avg_ms": 0.465792,
+          "best_ms": 0.442208,
+          "best_in_gibs": 141.336,
+          "best_out_gibs": 141.336,
+          "in_gibs": 134.18,
+          "out_gibs": 134.18
+        },
+        "compress": {
+          "avg_ms": 58.1034,
+          "best_ms": 39.9085,
+          "best_in_gibs": 9.3965,
+          "best_out_gibs": 1.26884,
+          "in_gibs": 9.22001,
+          "out_gibs": 1.24501
+        },
+        "aggregate": {
+          "avg_ms": 0.425157,
+          "best_ms": 0.193408,
+          "best_in_gibs": 261.817,
+          "best_out_gibs": 261.817,
+          "in_gibs": 170.148,
+          "out_gibs": 170.148
+        },
+        "d2h": {
+          "avg_ms": 3.53135,
+          "best_ms": 2.14563,
+          "best_in_gibs": 23.6003,
+          "best_out_gibs": 23.6003,
+          "in_gibs": 20.4849,
+          "out_gibs": 20.4849
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 100.255,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 415.026,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 60.8287,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 13.29,
+      "status": "pass",
+      "throughput_in_gibs": 8.42615,
+      "throughput_out_gibs": 0.98807,
+      "compression_fold": 8.52789,
+      "input_gib": 3.75,
+      "compressed_gib": 0.439734,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.445043,
+      "init_s": 0.42687,
+      "flush_s": 3.49e-07,
+      "memory_estimate_total_bytes": 5374662949,
+      "memory_estimate_pinned_bytes": 1477394480,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.67087,
+          "best_ms": 1.55161,
+          "best_in_gibs": 40.2806,
+          "best_out_gibs": 40.2806,
+          "in_gibs": 37.4057,
+          "out_gibs": 37.4057
+        },
+        "h2d": {
+          "avg_ms": 2.51193,
+          "best_ms": 2.48627,
+          "best_in_gibs": 25.138,
+          "best_out_gibs": 25.138,
+          "in_gibs": 24.8813,
+          "out_gibs": 24.8813
+        },
+        "scatter": {
+          "avg_ms": 0.467125,
+          "best_ms": 0.440832,
+          "best_in_gibs": 141.777,
+          "best_out_gibs": 141.777,
+          "in_gibs": 133.797,
+          "out_gibs": 133.797
+        },
+        "compress": {
+          "avg_ms": 48.0264,
+          "best_ms": 32.3835,
+          "best_in_gibs": 11.58,
+          "best_out_gibs": 1.35224,
+          "in_gibs": 11.1546,
+          "out_gibs": 1.30257
+        },
+        "aggregate": {
+          "avg_ms": 0.261815,
+          "best_ms": 0.170272,
+          "best_in_gibs": 257.178,
+          "best_out_gibs": 257.178,
+          "in_gibs": 238.938,
+          "out_gibs": 238.938
+        },
+        "d2h": {
+          "avg_ms": 3.09327,
+          "best_ms": 1.84944,
+          "best_in_gibs": 23.6776,
+          "best_out_gibs": 23.6776,
+          "in_gibs": 20.2237,
+          "out_gibs": 20.2237
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 80.7926,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 345.567,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 48.4565,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.33,
+      "status": "pass",
+      "throughput_in_gibs": 8.4751,
+      "throughput_out_gibs": 0.930052,
+      "compression_fold": 9.11249,
+      "input_gib": 3.75,
+      "compressed_gib": 0.411523,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.442473,
+      "init_s": 0.439934,
+      "flush_s": 3.55e-07,
+      "memory_estimate_total_bytes": 5568217893,
+      "memory_estimate_pinned_bytes": 1476894768,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.25342,
+          "best_ms": 0.939043,
+          "best_in_gibs": 66.5571,
+          "best_out_gibs": 66.5571,
+          "in_gibs": 49.8636,
+          "out_gibs": 49.8636
+        },
+        "h2d": {
+          "avg_ms": 2.51377,
+          "best_ms": 2.48566,
+          "best_in_gibs": 25.1442,
+          "best_out_gibs": 25.1442,
+          "in_gibs": 24.8631,
+          "out_gibs": 24.8631
+        },
+        "scatter": {
+          "avg_ms": 0.465856,
+          "best_ms": 0.439328,
+          "best_in_gibs": 142.263,
+          "best_out_gibs": 142.263,
+          "in_gibs": 134.162,
+          "out_gibs": 134.162
+        },
+        "compress": {
+          "avg_ms": 48.1685,
+          "best_ms": 31.4553,
+          "best_in_gibs": 11.9217,
+          "best_out_gibs": 1.30537,
+          "in_gibs": 11.1217,
+          "out_gibs": 1.21777
+        },
+        "aggregate": {
+          "avg_ms": 0.217723,
+          "best_ms": 0.125088,
+          "best_in_gibs": 328.255,
+          "best_out_gibs": 328.255,
+          "in_gibs": 269.416,
+          "out_gibs": 269.416
+        },
+        "d2h": {
+          "avg_ms": 2.88779,
+          "best_ms": 1.72112,
+          "best_in_gibs": 23.857,
+          "best_out_gibs": 23.857,
+          "in_gibs": 20.3125,
+          "out_gibs": 20.3125
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 78.8855,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 347.915,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 48.8793,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 13.66,
+      "status": "pass",
+      "throughput_in_gibs": 8.67928,
+      "throughput_out_gibs": 0.828379,
+      "compression_fold": 10.4774,
+      "input_gib": 3.75,
+      "compressed_gib": 0.357912,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.432064,
+      "init_s": 0.5848,
+      "flush_s": 3.77e-07,
+      "memory_estimate_total_bytes": 5567773477,
+      "memory_estimate_pinned_bytes": 1476689968,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.81109,
+          "best_ms": 1.14796,
+          "best_in_gibs": 54.4444,
+          "best_out_gibs": 54.4444,
+          "in_gibs": 34.5095,
+          "out_gibs": 34.5095
+        },
+        "h2d": {
+          "avg_ms": 2.51115,
+          "best_ms": 2.48669,
+          "best_in_gibs": 25.1338,
+          "best_out_gibs": 25.1338,
+          "in_gibs": 24.889,
+          "out_gibs": 24.889
+        },
+        "scatter": {
+          "avg_ms": 0.466379,
+          "best_ms": 0.438912,
+          "best_in_gibs": 142.398,
+          "best_out_gibs": 142.398,
+          "in_gibs": 134.011,
+          "out_gibs": 134.011
+        },
+        "compress": {
+          "avg_ms": 44.705,
+          "best_ms": 31.5744,
+          "best_in_gibs": 11.8767,
+          "best_out_gibs": 1.1321,
+          "in_gibs": 11.9833,
+          "out_gibs": 1.14226
+        },
+        "aggregate": {
+          "avg_ms": 0.224475,
+          "best_ms": 0.123552,
+          "best_in_gibs": 289.315,
+          "best_out_gibs": 289.315,
+          "in_gibs": 227.486,
+          "out_gibs": 227.486
+        },
+        "d2h": {
+          "avg_ms": 2.55123,
+          "best_ms": 1.52166,
+          "best_in_gibs": 23.491,
+          "best_out_gibs": 23.491,
+          "in_gibs": 20.0158,
+          "out_gibs": 20.0158
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 73.6836,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 324.328,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 45.7631,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 14.02,
+      "status": "pass",
+      "throughput_in_gibs": 9.35767,
+      "throughput_out_gibs": 0.642015,
+      "compression_fold": 14.5755,
+      "input_gib": 3.75,
+      "compressed_gib": 0.257281,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.400741,
+      "init_s": 0.681836,
+      "flush_s": 3.4e-07,
+      "memory_estimate_total_bytes": 7103024933,
+      "memory_estimate_pinned_bytes": 1879285808,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 2.40746,
+          "best_ms": 1.02185,
+          "best_in_gibs": 61.1636,
+          "best_out_gibs": 61.1636,
+          "in_gibs": 25.961,
+          "out_gibs": 25.961
+        },
+        "h2d": {
+          "avg_ms": 2.51271,
+          "best_ms": 2.48787,
+          "best_in_gibs": 25.1219,
+          "best_out_gibs": 25.1219,
+          "in_gibs": 24.8736,
+          "out_gibs": 24.8736
+        },
+        "scatter": {
+          "avg_ms": 0.71814,
+          "best_ms": 0.438624,
+          "best_in_gibs": 142.491,
+          "best_out_gibs": 142.491,
+          "in_gibs": 87.0303,
+          "out_gibs": 87.0303
+        },
+        "compress": {
+          "avg_ms": 48.9556,
+          "best_ms": 44.8954,
+          "best_in_gibs": 16.7055,
+          "best_out_gibs": 1.14512,
+          "in_gibs": 15.32,
+          "out_gibs": 1.05015
+        },
+        "aggregate": {
+          "avg_ms": 0.231763,
+          "best_ms": 0.177792,
+          "best_in_gibs": 289.161,
+          "best_out_gibs": 289.161,
+          "in_gibs": 221.823,
+          "out_gibs": 221.823
+        },
+        "d2h": {
+          "avg_ms": 3.30465,
+          "best_ms": 2.16714,
+          "best_in_gibs": 23.7228,
+          "best_out_gibs": 23.7228,
+          "in_gibs": 15.557,
+          "out_gibs": 15.557
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 75.8041,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 253.557,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 47.3892,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 13.51,
+      "status": "pass",
+      "throughput_in_gibs": 9.20909,
+      "throughput_out_gibs": 0.631629,
+      "compression_fold": 14.5799,
+      "input_gib": 3.75,
+      "compressed_gib": 0.257204,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.407207,
+      "init_s": 0.548555,
+      "flush_s": 2.99e-07,
+      "memory_estimate_total_bytes": 7102850853,
+      "memory_estimate_pinned_bytes": 1879203888,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.699,
+          "best_ms": 1.31988,
+          "best_in_gibs": 47.3528,
+          "best_out_gibs": 47.3528,
+          "in_gibs": 36.7862,
+          "out_gibs": 36.7862
+        },
+        "h2d": {
+          "avg_ms": 2.50216,
+          "best_ms": 2.48534,
+          "best_in_gibs": 25.1474,
+          "best_out_gibs": 25.1474,
+          "in_gibs": 24.9785,
+          "out_gibs": 24.9785
+        },
+        "scatter": {
+          "avg_ms": 0.464843,
+          "best_ms": 0.439584,
+          "best_in_gibs": 142.18,
+          "best_out_gibs": 142.18,
+          "in_gibs": 134.454,
+          "out_gibs": 134.454
+        },
+        "compress": {
+          "avg_ms": 57.9168,
+          "best_ms": 52.684,
+          "best_in_gibs": 14.2358,
+          "best_out_gibs": 0.975965,
+          "in_gibs": 12.9496,
+          "out_gibs": 0.887786
+        },
+        "aggregate": {
+          "avg_ms": 0.307347,
+          "best_ms": 0.19104,
+          "best_in_gibs": 269.147,
+          "best_out_gibs": 269.147,
+          "in_gibs": 167.295,
+          "out_gibs": 167.295
+        },
+        "d2h": {
+          "avg_ms": 2.53478,
+          "best_ms": 2.16314,
+          "best_in_gibs": 23.77,
+          "best_out_gibs": 23.77,
+          "in_gibs": 20.2849,
+          "out_gibs": 20.2849
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 94.5834,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 299.215,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 54.1492,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.44,
+      "status": "pass",
+      "throughput_in_gibs": 7.79842,
+      "throughput_out_gibs": 0.771433,
+      "compression_fold": 10.109,
+      "input_gib": 3.75,
+      "compressed_gib": 0.370957,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.480867,
+      "init_s": 0.557327,
+      "flush_s": 4.7e-07,
+      "memory_estimate_total_bytes": 7102763813,
+      "memory_estimate_pinned_bytes": 1879162928,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.04854,
+          "best_ms": 0.950803,
+          "best_in_gibs": 65.7339,
+          "best_out_gibs": 65.7339,
+          "in_gibs": 59.6066,
+          "out_gibs": 59.6066
+        },
+        "h2d": {
+          "avg_ms": 2.51012,
+          "best_ms": 2.48538,
+          "best_in_gibs": 25.1471,
+          "best_out_gibs": 25.1471,
+          "in_gibs": 24.8992,
+          "out_gibs": 24.8992
+        },
+        "scatter": {
+          "avg_ms": 0.464405,
+          "best_ms": 0.439008,
+          "best_in_gibs": 142.366,
+          "best_out_gibs": 142.366,
+          "in_gibs": 134.581,
+          "out_gibs": 134.581
+        },
+        "compress": {
+          "avg_ms": 72.3571,
+          "best_ms": 67.3621,
+          "best_in_gibs": 11.1339,
+          "best_out_gibs": 1.10121,
+          "in_gibs": 10.3653,
+          "out_gibs": 1.02519
+        },
+        "aggregate": {
+          "avg_ms": 0.581696,
+          "best_ms": 0.310848,
+          "best_in_gibs": 238.637,
+          "best_out_gibs": 238.637,
+          "in_gibs": 127.523,
+          "out_gibs": 127.523
+        },
+        "d2h": {
+          "avg_ms": 3.57509,
+          "best_ms": 3.13162,
+          "best_in_gibs": 23.6874,
+          "best_out_gibs": 23.6874,
+          "in_gibs": 20.7491,
+          "out_gibs": 20.7491
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 126.016,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 375.621,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 69.159,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__gpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 13.47,
+      "status": "pass",
+      "throughput_in_gibs": 7.56351,
+      "throughput_out_gibs": 0.714061,
+      "compression_fold": 10.5922,
+      "input_gib": 3.75,
+      "compressed_gib": 0.354033,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.495801,
+      "init_s": 0.544253,
+      "flush_s": 2.85e-07,
+      "memory_estimate_total_bytes": 7102724389,
+      "memory_estimate_pinned_bytes": 1879146544,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.06465,
+          "best_ms": 0.949372,
+          "best_in_gibs": 65.833,
+          "best_out_gibs": 65.833,
+          "in_gibs": 58.7048,
+          "out_gibs": 58.7048
+        },
+        "h2d": {
+          "avg_ms": 2.50881,
+          "best_ms": 2.48534,
+          "best_in_gibs": 25.1474,
+          "best_out_gibs": 25.1474,
+          "in_gibs": 24.9122,
+          "out_gibs": 24.9122
+        },
+        "scatter": {
+          "avg_ms": 0.464757,
+          "best_ms": 0.439392,
+          "best_in_gibs": 142.242,
+          "best_out_gibs": 142.242,
+          "in_gibs": 134.479,
+          "out_gibs": 134.479
+        },
+        "compress": {
+          "avg_ms": 75.4545,
+          "best_ms": 70.0696,
+          "best_in_gibs": 10.7036,
+          "best_out_gibs": 1.01041,
+          "in_gibs": 9.93977,
+          "out_gibs": 0.938299
+        },
+        "aggregate": {
+          "avg_ms": 0.685126,
+          "best_ms": 0.412896,
+          "best_in_gibs": 171.469,
+          "best_out_gibs": 171.469,
+          "in_gibs": 103.337,
+          "out_gibs": 103.337
+        },
+        "d2h": {
+          "avg_ms": 3.45157,
+          "best_ms": 2.97232,
+          "best_in_gibs": 23.8194,
+          "best_out_gibs": 23.8194,
+          "in_gibs": 20.5121,
+          "out_gibs": 20.5121
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 131.536,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 391.234,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 71.9094,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 31.35,
+      "status": "pass",
+      "throughput_in_gibs": 13.6796,
+      "throughput_out_gibs": 13.6929,
+      "compression_fold": 0.999024,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93255,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.214165,
+      "init_s": 0.438179,
+      "flush_s": 5.37e-07,
+      "memory_estimate_total_bytes": 2787172926,
+      "memory_estimate_pinned_bytes": 1527955504,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.00456,
+          "best_ms": 0.154083,
+          "best_in_gibs": 50.7032,
+          "best_out_gibs": 50.7032,
+          "in_gibs": 57.1842,
+          "out_gibs": 57.1842
+        },
+        "h2d": {
+          "avg_ms": 2.57468,
+          "best_ms": 0.372224,
+          "best_in_gibs": 20.9887,
+          "best_out_gibs": 20.9887,
+          "in_gibs": 22.2932,
+          "out_gibs": 22.2932
+        },
+        "scatter": {
+          "avg_ms": 0.240928,
+          "best_ms": 0.056384,
+          "best_in_gibs": 138.559,
+          "best_out_gibs": 138.559,
+          "in_gibs": 145.92,
+          "out_gibs": 145.92
+        },
+        "aggregate": {
+          "avg_ms": 3.01391,
+          "best_ms": 2.34506,
+          "best_in_gibs": 249.861,
+          "best_out_gibs": 249.861,
+          "in_gibs": 194.411,
+          "out_gibs": 194.411
+        },
+        "d2h": {
+          "avg_ms": 27.1112,
+          "best_ms": 24.0009,
+          "best_in_gibs": 24.4131,
+          "best_out_gibs": 24.4131,
+          "in_gibs": 21.6124,
+          "out_gibs": 21.6124
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 34.4108,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 133.367,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.71734,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 31.19,
+      "status": "pass",
+      "throughput_in_gibs": 13.7702,
+      "throughput_out_gibs": 13.7769,
+      "compression_fold": 0.999512,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93112,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.212756,
+      "init_s": 0.442524,
+      "flush_s": 2.59e-07,
+      "memory_estimate_total_bytes": 2786097214,
+      "memory_estimate_pinned_bytes": 1527341104,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.980613,
+          "best_ms": 0.147807,
+          "best_in_gibs": 52.8561,
+          "best_out_gibs": 52.8561,
+          "in_gibs": 58.5805,
+          "out_gibs": 58.5805
+        },
+        "h2d": {
+          "avg_ms": 2.58247,
+          "best_ms": 0.372736,
+          "best_in_gibs": 20.9599,
+          "best_out_gibs": 20.9599,
+          "in_gibs": 22.226,
+          "out_gibs": 22.226
+        },
+        "scatter": {
+          "avg_ms": 0.243024,
+          "best_ms": 0.05584,
+          "best_in_gibs": 139.909,
+          "best_out_gibs": 139.909,
+          "in_gibs": 144.662,
+          "out_gibs": 144.662
+        },
+        "aggregate": {
+          "avg_ms": 3.14178,
+          "best_ms": 2.67498,
+          "best_in_gibs": 219.044,
+          "best_out_gibs": 219.044,
+          "in_gibs": 186.499,
+          "out_gibs": 186.499
+        },
+        "d2h": {
+          "avg_ms": 27.0618,
+          "best_ms": 23.9548,
+          "best_in_gibs": 24.4602,
+          "best_out_gibs": 24.4602,
+          "in_gibs": 21.6518,
+          "out_gibs": 21.6518
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 33.4843,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 137.086,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.70021,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 31.43,
+      "status": "pass",
+      "throughput_in_gibs": 13.5917,
+      "throughput_out_gibs": 13.595,
+      "compression_fold": 0.999756,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.9304,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.21555,
+      "init_s": 0.44047,
+      "flush_s": 3.83e-07,
+      "memory_estimate_total_bytes": 2785559102,
+      "memory_estimate_pinned_bytes": 1527033904,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.08885,
+          "best_ms": 0.163667,
+          "best_in_gibs": 47.7341,
+          "best_out_gibs": 47.7341,
+          "in_gibs": 52.7573,
+          "out_gibs": 52.7573
+        },
+        "h2d": {
+          "avg_ms": 2.58113,
+          "best_ms": 0.3736,
+          "best_in_gibs": 20.9114,
+          "best_out_gibs": 20.9114,
+          "in_gibs": 22.2376,
+          "out_gibs": 22.2376
+        },
+        "scatter": {
+          "avg_ms": 0.280405,
+          "best_ms": 0.055776,
+          "best_in_gibs": 140.069,
+          "best_out_gibs": 140.069,
+          "in_gibs": 157.882,
+          "out_gibs": 157.882
+        },
+        "aggregate": {
+          "avg_ms": 3.27541,
+          "best_ms": 3.21088,
+          "best_in_gibs": 182.485,
+          "best_out_gibs": 182.485,
+          "in_gibs": 178.89,
+          "out_gibs": 178.89
+        },
+        "d2h": {
+          "avg_ms": 26.88,
+          "best_ms": 23.8969,
+          "best_in_gibs": 24.5194,
+          "best_out_gibs": 24.5194,
+          "in_gibs": 21.7983,
+          "out_gibs": 21.7983
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 32.6277,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 141.612,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.82515,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 31.3,
+      "status": "pass",
+      "throughput_in_gibs": 13.6917,
+      "throughput_out_gibs": 13.6934,
+      "compression_fold": 0.999878,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93005,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.213975,
+      "init_s": 0.451485,
+      "flush_s": 5.03e-07,
+      "memory_estimate_total_bytes": 2785290302,
+      "memory_estimate_pinned_bytes": 1526880304,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.02382,
+          "best_ms": 0.150187,
+          "best_in_gibs": 52.0185,
+          "best_out_gibs": 52.0185,
+          "in_gibs": 56.1081,
+          "out_gibs": 56.1081
+        },
+        "h2d": {
+          "avg_ms": 2.57074,
+          "best_ms": 0.372096,
+          "best_in_gibs": 20.9959,
+          "best_out_gibs": 20.9959,
+          "in_gibs": 22.3274,
+          "out_gibs": 22.3274
+        },
+        "scatter": {
+          "avg_ms": 0.239344,
+          "best_ms": 0.055808,
+          "best_in_gibs": 139.989,
+          "best_out_gibs": 139.989,
+          "in_gibs": 146.886,
+          "out_gibs": 146.886
+        },
+        "aggregate": {
+          "avg_ms": 3.37157,
+          "best_ms": 3.29402,
+          "best_in_gibs": 177.879,
+          "best_out_gibs": 177.879,
+          "in_gibs": 173.788,
+          "out_gibs": 173.788
+        },
+        "d2h": {
+          "avg_ms": 27.0367,
+          "best_ms": 24.0106,
+          "best_in_gibs": 24.4033,
+          "best_out_gibs": 24.4033,
+          "in_gibs": 21.6719,
+          "out_gibs": 21.6719
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 33.9194,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 140.649,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.76103,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 31.28,
+      "status": "pass",
+      "throughput_in_gibs": 13.6982,
+      "throughput_out_gibs": 13.699,
+      "compression_fold": 0.999939,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92987,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.213875,
+      "init_s": 0.444337,
+      "flush_s": 3.63e-07,
+      "memory_estimate_total_bytes": 2785155902,
+      "memory_estimate_pinned_bytes": 1526803504,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.999177,
+          "best_ms": 0.156215,
+          "best_in_gibs": 50.0112,
+          "best_out_gibs": 50.0112,
+          "in_gibs": 57.4922,
+          "out_gibs": 57.4922
+        },
+        "h2d": {
+          "avg_ms": 2.5723,
+          "best_ms": 0.371712,
+          "best_in_gibs": 21.0176,
+          "best_out_gibs": 21.0176,
+          "in_gibs": 22.3138,
+          "out_gibs": 22.3138
+        },
+        "scatter": {
+          "avg_ms": 0.239744,
+          "best_ms": 0.05552,
+          "best_in_gibs": 140.715,
+          "best_out_gibs": 140.715,
+          "in_gibs": 146.641,
+          "out_gibs": 146.641
+        },
+        "aggregate": {
+          "avg_ms": 3.43491,
+          "best_ms": 3.37123,
+          "best_in_gibs": 173.805,
+          "best_out_gibs": 173.805,
+          "in_gibs": 170.583,
+          "out_gibs": 170.583
+        },
+        "d2h": {
+          "avg_ms": 27.0332,
+          "best_ms": 24.0109,
+          "best_in_gibs": 24.4029,
+          "best_out_gibs": 24.4029,
+          "in_gibs": 21.6747,
+          "out_gibs": 21.6747
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 33.8451,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 141.081,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.66381,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 31.36,
+      "status": "pass",
+      "throughput_in_gibs": 13.5113,
+      "throughput_out_gibs": 13.5117,
+      "compression_fold": 0.999967,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92978,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.216833,
+      "init_s": 0.44396,
+      "flush_s": 4.76e-07,
+      "memory_estimate_total_bytes": 2785091262,
+      "memory_estimate_pinned_bytes": 1526767664,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.07895,
+          "best_ms": 0.149643,
+          "best_in_gibs": 52.2076,
+          "best_out_gibs": 52.2076,
+          "in_gibs": 53.2414,
+          "out_gibs": 53.2414
+        },
+        "h2d": {
+          "avg_ms": 2.58393,
+          "best_ms": 0.376384,
+          "best_in_gibs": 20.7567,
+          "best_out_gibs": 20.7567,
+          "in_gibs": 22.2134,
+          "out_gibs": 22.2134
+        },
+        "scatter": {
+          "avg_ms": 0.208597,
+          "best_ms": 0.056032,
+          "best_in_gibs": 139.429,
+          "best_out_gibs": 139.429,
+          "in_gibs": 149.81,
+          "out_gibs": 149.81
+        },
+        "aggregate": {
+          "avg_ms": 3.60085,
+          "best_ms": 3.5015,
+          "best_in_gibs": 167.339,
+          "best_out_gibs": 167.339,
+          "in_gibs": 162.722,
+          "out_gibs": 162.722
+        },
+        "d2h": {
+          "avg_ms": 26.9321,
+          "best_ms": 23.8941,
+          "best_in_gibs": 24.5223,
+          "best_out_gibs": 24.5223,
+          "in_gibs": 21.7561,
+          "out_gibs": 21.7561
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 32.9528,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 145.336,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 9.34454,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 31.24,
+      "status": "pass",
+      "throughput_in_gibs": 13.7035,
+      "throughput_out_gibs": 13.7037,
+      "compression_fold": 0.999985,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92973,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.213791,
+      "init_s": 0.439339,
+      "flush_s": 3.16e-07,
+      "memory_estimate_total_bytes": 2785055102,
+      "memory_estimate_pinned_bytes": 1526745904,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.982487,
+          "best_ms": 0.148163,
+          "best_in_gibs": 52.7291,
+          "best_out_gibs": 52.7291,
+          "in_gibs": 58.4688,
+          "out_gibs": 58.4688
+        },
+        "h2d": {
+          "avg_ms": 2.58888,
+          "best_ms": 0.373952,
+          "best_in_gibs": 20.8917,
+          "best_out_gibs": 20.8917,
+          "in_gibs": 22.171,
+          "out_gibs": 22.171
+        },
+        "scatter": {
+          "avg_ms": 0.238736,
+          "best_ms": 0.056672,
+          "best_in_gibs": 137.855,
+          "best_out_gibs": 137.855,
+          "in_gibs": 147.26,
+          "out_gibs": 147.26
+        },
+        "aggregate": {
+          "avg_ms": 3.79715,
+          "best_ms": 3.68179,
+          "best_in_gibs": 159.145,
+          "best_out_gibs": 159.145,
+          "in_gibs": 154.31,
+          "out_gibs": 154.31
+        },
+        "d2h": {
+          "avg_ms": 26.9648,
+          "best_ms": 23.8683,
+          "best_in_gibs": 24.5488,
+          "best_out_gibs": 24.5488,
+          "in_gibs": 21.7297,
+          "out_gibs": 21.7297
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 33.0131,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 141.557,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.7268,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 31.87,
+      "status": "pass",
+      "throughput_in_gibs": 10.9071,
+      "throughput_out_gibs": 13.0886,
+      "compression_fold": 0.999992,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.51565,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.268604,
+      "init_s": 0.794086,
+      "flush_s": 3.24e-07,
+      "memory_estimate_total_bytes": 5301637502,
+      "memory_estimate_pinned_bytes": 2785037104,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.01368,
+          "best_ms": 0.292172,
+          "best_in_gibs": 53.4788,
+          "best_out_gibs": 53.4788,
+          "in_gibs": 58.9826,
+          "out_gibs": 58.9826
+        },
+        "h2d": {
+          "avg_ms": 2.59682,
+          "best_ms": 0.668032,
+          "best_in_gibs": 23.3896,
+          "best_out_gibs": 23.3896,
+          "in_gibs": 23.0437,
+          "out_gibs": 23.0437
+        },
+        "scatter": {
+          "avg_ms": 0.423392,
+          "best_ms": 0.423392,
+          "best_in_gibs": 147.617,
+          "best_out_gibs": 147.617,
+          "in_gibs": 147.617,
+          "out_gibs": 147.617
+        },
+        "aggregate": {
+          "avg_ms": 7.02655,
+          "best_ms": 5.34998,
+          "best_in_gibs": 219.043,
+          "best_out_gibs": 219.043,
+          "in_gibs": 166.778,
+          "out_gibs": 166.778
+        },
+        "d2h": {
+          "avg_ms": 51.4041,
+          "best_ms": 47.9166,
+          "best_in_gibs": 24.4565,
+          "best_out_gibs": 24.4565,
+          "in_gibs": 22.7973,
+          "out_gibs": 22.7973
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 89.5058,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 173.89,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 7.17268,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 31.49,
+      "status": "pass",
+      "throughput_in_gibs": 8.77436,
+      "throughput_out_gibs": 4.71002,
+      "compression_fold": 1.86292,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.57264,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.333892,
+      "init_s": 0.448475,
+      "flush_s": 3.65e-07,
+      "memory_estimate_total_bytes": 5315428926,
+      "memory_estimate_pinned_bytes": 1533485104,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.00387,
+          "best_ms": 0.161862,
+          "best_in_gibs": 48.2664,
+          "best_out_gibs": 48.2664,
+          "in_gibs": 57.2231,
+          "out_gibs": 57.2231
+        },
+        "h2d": {
+          "avg_ms": 2.45325,
+          "best_ms": 0.315424,
+          "best_in_gibs": 24.7682,
+          "best_out_gibs": 24.7682,
+          "in_gibs": 23.3967,
+          "out_gibs": 23.3967
+        },
+        "scatter": {
+          "avg_ms": 0.810096,
+          "best_ms": 0.056736,
+          "best_in_gibs": 137.699,
+          "best_out_gibs": 137.699,
+          "in_gibs": 48.2196,
+          "out_gibs": 48.2196
+        },
+        "compress": {
+          "avg_ms": 31.17,
+          "best_ms": 30.754,
+          "best_in_gibs": 19.0524,
+          "best_out_gibs": 10.25,
+          "in_gibs": 18.7981,
+          "out_gibs": 10.0724
+        },
+        "aggregate": {
+          "avg_ms": 1.27267,
+          "best_ms": 1.21613,
+          "best_in_gibs": 258.886,
+          "best_out_gibs": 258.886,
+          "in_gibs": 246.691,
+          "out_gibs": 246.691
+        },
+        "d2h": {
+          "avg_ms": 14.6847,
+          "best_ms": 13.0354,
+          "best_in_gibs": 24.1526,
+          "best_out_gibs": 24.1526,
+          "in_gibs": 21.3797,
+          "out_gibs": 21.3797
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 50.954,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 243.975,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 30.4648,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 31.4,
+      "status": "pass",
+      "throughput_in_gibs": 8.99439,
+      "throughput_out_gibs": 4.60072,
+      "compression_fold": 1.955,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.49856,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.325724,
+      "init_s": 0.437237,
+      "flush_s": 5.62e-07,
+      "memory_estimate_total_bytes": 4684290110,
+      "memory_estimate_pinned_bytes": 1532567600,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.980938,
+          "best_ms": 0.14933,
+          "best_in_gibs": 52.317,
+          "best_out_gibs": 52.317,
+          "in_gibs": 58.5612,
+          "out_gibs": 58.5612
+        },
+        "h2d": {
+          "avg_ms": 2.44791,
+          "best_ms": 0.315584,
+          "best_in_gibs": 24.7557,
+          "best_out_gibs": 24.7557,
+          "in_gibs": 23.4477,
+          "out_gibs": 23.4477
+        },
+        "scatter": {
+          "avg_ms": 0.24672,
+          "best_ms": 0.057952,
+          "best_in_gibs": 134.81,
+          "best_out_gibs": 134.81,
+          "in_gibs": 158.327,
+          "out_gibs": 158.327
+        },
+        "compress": {
+          "avg_ms": 31.9143,
+          "best_ms": 31.1126,
+          "best_in_gibs": 18.8328,
+          "best_out_gibs": 9.59883,
+          "in_gibs": 18.3597,
+          "out_gibs": 9.3822
+        },
+        "aggregate": {
+          "avg_ms": 1.24825,
+          "best_ms": 1.17379,
+          "best_in_gibs": 256.023,
+          "best_out_gibs": 256.023,
+          "in_gibs": 239.877,
+          "out_gibs": 239.877
+        },
+        "d2h": {
+          "avg_ms": 13.939,
+          "best_ms": 12.3568,
+          "best_in_gibs": 24.32,
+          "best_out_gibs": 24.32,
+          "in_gibs": 21.4812,
+          "out_gibs": 21.4812
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 50.6141,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 240.768,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 30.9812,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 31.53,
+      "status": "pass",
+      "throughput_in_gibs": 9.03796,
+      "throughput_out_gibs": 4.52953,
+      "compression_fold": 1.99534,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.46826,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.324154,
+      "init_s": 0.445706,
+      "flush_s": 2.96e-07,
+      "memory_estimate_total_bytes": 4368716350,
+      "memory_estimate_pinned_bytes": 1532104752,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.01247,
+          "best_ms": 0.155244,
+          "best_in_gibs": 50.324,
+          "best_out_gibs": 50.324,
+          "in_gibs": 56.7375,
+          "out_gibs": 56.7375
+        },
+        "h2d": {
+          "avg_ms": 2.40493,
+          "best_ms": 0.37264,
+          "best_in_gibs": 20.9653,
+          "best_out_gibs": 20.9653,
+          "in_gibs": 23.8668,
+          "out_gibs": 23.8668
+        },
+        "scatter": {
+          "avg_ms": 0.247864,
+          "best_ms": 0.059424,
+          "best_in_gibs": 131.47,
+          "best_out_gibs": 131.47,
+          "in_gibs": 157.597,
+          "out_gibs": 157.597
+        },
+        "compress": {
+          "avg_ms": 34.3743,
+          "best_ms": 32.9335,
+          "best_in_gibs": 17.7915,
+          "best_out_gibs": 8.81378,
+          "in_gibs": 17.0458,
+          "out_gibs": 8.53864
+        },
+        "aggregate": {
+          "avg_ms": 1.30124,
+          "best_ms": 1.14509,
+          "best_in_gibs": 251.584,
+          "best_out_gibs": 251.584,
+          "in_gibs": 225.562,
+          "out_gibs": 225.562
+        },
+        "d2h": {
+          "avg_ms": 13.7597,
+          "best_ms": 11.999,
+          "best_in_gibs": 24.0091,
+          "best_out_gibs": 24.0091,
+          "in_gibs": 21.3311,
+          "out_gibs": 21.3311
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 56.5814,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 235.075,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 32.817,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 31.47,
+      "status": "pass",
+      "throughput_in_gibs": 8.89025,
+      "throughput_out_gibs": 4.26765,
+      "compression_fold": 2.08317,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.40636,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.32954,
+      "init_s": 0.440141,
+      "flush_s": 4.44e-07,
+      "memory_estimate_total_bytes": 4210933822,
+      "memory_estimate_pinned_bytes": 1531877424,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.964963,
+          "best_ms": 0.134802,
+          "best_in_gibs": 57.9554,
+          "best_out_gibs": 57.9554,
+          "in_gibs": 59.5306,
+          "out_gibs": 59.5306
+        },
+        "h2d": {
+          "avg_ms": 2.33858,
+          "best_ms": 0.316128,
+          "best_in_gibs": 24.7131,
+          "best_out_gibs": 24.7131,
+          "in_gibs": 24.5439,
+          "out_gibs": 24.5439
+        },
+        "scatter": {
+          "avg_ms": 0.309771,
+          "best_ms": 0.144,
+          "best_in_gibs": 162.76,
+          "best_out_gibs": 162.76,
+          "in_gibs": 159.728,
+          "out_gibs": 159.728
+        },
+        "compress": {
+          "avg_ms": 42.6397,
+          "best_ms": 41.5043,
+          "best_in_gibs": 14.1175,
+          "best_out_gibs": 6.70409,
+          "in_gibs": 13.7416,
+          "out_gibs": 6.59481
+        },
+        "aggregate": {
+          "avg_ms": 1.39779,
+          "best_ms": 1.12787,
+          "best_in_gibs": 247.448,
+          "best_out_gibs": 247.448,
+          "in_gibs": 201.175,
+          "out_gibs": 201.175
+        },
+        "d2h": {
+          "avg_ms": 12.3096,
+          "best_ms": 11.463,
+          "best_in_gibs": 24.347,
+          "best_out_gibs": 24.347,
+          "in_gibs": 22.8439,
+          "out_gibs": 22.8439
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 61.4405,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 246.724,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 40.9511,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 31.5,
+      "status": "pass",
+      "throughput_in_gibs": 8.71721,
+      "throughput_out_gibs": 4.18451,
+      "compression_fold": 2.08321,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.40634,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.336081,
+      "init_s": 0.449072,
+      "flush_s": 2.76e-07,
+      "memory_estimate_total_bytes": 4132038462,
+      "memory_estimate_pinned_bytes": 1531759664,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.96777,
+          "best_ms": 0.133466,
+          "best_in_gibs": 58.5355,
+          "best_out_gibs": 58.5355,
+          "in_gibs": 59.358,
+          "out_gibs": 59.358
+        },
+        "h2d": {
+          "avg_ms": 2.3884,
+          "best_ms": 0.315776,
+          "best_in_gibs": 24.7406,
+          "best_out_gibs": 24.7406,
+          "in_gibs": 24.032,
+          "out_gibs": 24.032
+        },
+        "scatter": {
+          "avg_ms": 0.257296,
+          "best_ms": 0.09856,
+          "best_in_gibs": 79.2664,
+          "best_out_gibs": 79.2664,
+          "in_gibs": 151.819,
+          "out_gibs": 151.819
+        },
+        "compress": {
+          "avg_ms": 43.9859,
+          "best_ms": 41.5114,
+          "best_in_gibs": 14.1151,
+          "best_out_gibs": 6.84297,
+          "in_gibs": 13.321,
+          "out_gibs": 6.39367
+        },
+        "aggregate": {
+          "avg_ms": 1.36347,
+          "best_ms": 1.13942,
+          "best_in_gibs": 245.773,
+          "best_out_gibs": 245.773,
+          "in_gibs": 206.262,
+          "out_gibs": 206.262
+        },
+        "d2h": {
+          "avg_ms": 12.8424,
+          "best_ms": 11.6087,
+          "best_in_gibs": 24.0608,
+          "best_out_gibs": 24.0608,
+          "in_gibs": 21.8986,
+          "out_gibs": 21.8986
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 85.74,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 253.61,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 40.9786,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 31.71,
+      "status": "pass",
+      "throughput_in_gibs": 5.8168,
+      "throughput_out_gibs": 2.66339,
+      "compression_fold": 2.18399,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.34144,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.503659,
+      "init_s": 0.452137,
+      "flush_s": 3.27e-07,
+      "memory_estimate_total_bytes": 4092633022,
+      "memory_estimate_pinned_bytes": 1531723824,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.979207,
+          "best_ms": 0.134509,
+          "best_in_gibs": 58.0816,
+          "best_out_gibs": 58.0816,
+          "in_gibs": 58.6647,
+          "out_gibs": 58.6647
+        },
+        "h2d": {
+          "avg_ms": 2.39155,
+          "best_ms": 0.315328,
+          "best_in_gibs": 24.7758,
+          "best_out_gibs": 24.7758,
+          "in_gibs": 24.0003,
+          "out_gibs": 24.0003
+        },
+        "scatter": {
+          "avg_ms": 0.251304,
+          "best_ms": 0.069376,
+          "best_in_gibs": 112.611,
+          "best_out_gibs": 112.611,
+          "in_gibs": 155.439,
+          "out_gibs": 155.439
+        },
+        "compress": {
+          "avg_ms": 77.6062,
+          "best_ms": 71.4609,
+          "best_in_gibs": 8.19941,
+          "best_out_gibs": 3.73933,
+          "in_gibs": 7.55014,
+          "out_gibs": 3.4568
+        },
+        "aggregate": {
+          "avg_ms": 1.36315,
+          "best_ms": 1.14522,
+          "best_in_gibs": 233.332,
+          "best_out_gibs": 233.332,
+          "in_gibs": 196.801,
+          "out_gibs": 196.801
+        },
+        "d2h": {
+          "avg_ms": 12.1593,
+          "best_ms": 11.0172,
+          "best_in_gibs": 24.2759,
+          "best_out_gibs": 24.2759,
+          "in_gibs": 22.0628,
+          "out_gibs": 22.0628
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 157.272,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 420.504,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 71.0513,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 32.12,
+      "status": "pass",
+      "throughput_in_gibs": 3.53077,
+      "throughput_out_gibs": 1.55693,
+      "compression_fold": 2.26777,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.29188,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.829758,
+      "init_s": 0.440011,
+      "flush_s": 2.99e-07,
+      "memory_estimate_total_bytes": 4072908670,
+      "memory_estimate_pinned_bytes": 1531693872,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.26032,
+          "best_ms": 0.201342,
+          "best_in_gibs": 38.8021,
+          "best_out_gibs": 38.8021,
+          "in_gibs": 45.5797,
+          "out_gibs": 45.5797
+        },
+        "h2d": {
+          "avg_ms": 2.38841,
+          "best_ms": 0.315552,
+          "best_in_gibs": 24.7582,
+          "best_out_gibs": 24.7582,
+          "in_gibs": 24.0319,
+          "out_gibs": 24.0319
+        },
+        "scatter": {
+          "avg_ms": 0.247368,
+          "best_ms": 0.059456,
+          "best_in_gibs": 131.4,
+          "best_out_gibs": 131.4,
+          "in_gibs": 157.912,
+          "out_gibs": 157.912
+        },
+        "compress": {
+          "avg_ms": 142.777,
+          "best_ms": 127.092,
+          "best_in_gibs": 4.61034,
+          "best_out_gibs": 2.03044,
+          "in_gibs": 4.10387,
+          "out_gibs": 1.80958
+        },
+        "aggregate": {
+          "avg_ms": 1.36244,
+          "best_ms": 1.12573,
+          "best_in_gibs": 229.573,
+          "best_out_gibs": 229.573,
+          "in_gibs": 189.635,
+          "out_gibs": 189.635
+        },
+        "d2h": {
+          "avg_ms": 11.7137,
+          "best_ms": 10.6371,
+          "best_in_gibs": 24.2374,
+          "best_out_gibs": 24.2374,
+          "in_gibs": 22.0569,
+          "out_gibs": 22.0569
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 301.899,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 745.59,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 129.598,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 32.4,
+      "status": "pass",
+      "throughput_in_gibs": 3.55043,
+      "throughput_out_gibs": 1.56836,
+      "compression_fold": 2.71655,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.29415,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.825164,
+      "init_s": 0.797658,
+      "flush_s": 4.43e-07,
+      "memory_estimate_total_bytes": 7857648254,
+      "memory_estimate_pinned_bytes": 2794916656,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.975438,
+          "best_ms": 0.305673,
+          "best_in_gibs": 51.1167,
+          "best_out_gibs": 51.1167,
+          "in_gibs": 61.2951,
+          "out_gibs": 61.2951
+        },
+        "h2d": {
+          "avg_ms": 2.45895,
+          "best_ms": 0.650624,
+          "best_in_gibs": 24.0154,
+          "best_out_gibs": 24.0154,
+          "in_gibs": 24.3357,
+          "out_gibs": 24.3357
+        },
+        "scatter": {
+          "avg_ms": 0.352341,
+          "best_ms": 0.272224,
+          "best_in_gibs": 172.193,
+          "best_out_gibs": 172.193,
+          "in_gibs": 162.603,
+          "out_gibs": 162.603
+        },
+        "compress": {
+          "avg_ms": 213.49,
+          "best_ms": 134.639,
+          "best_in_gibs": 8.70385,
+          "best_out_gibs": 1.93196,
+          "in_gibs": 5.48914,
+          "out_gibs": 2.02059
+        },
+        "aggregate": {
+          "avg_ms": 2.66234,
+          "best_ms": 1.08317,
+          "best_in_gibs": 240.144,
+          "best_out_gibs": 240.144,
+          "in_gibs": 162.029,
+          "out_gibs": 162.029
+        },
+        "d2h": {
+          "avg_ms": 18.8247,
+          "best_ms": 10.7333,
+          "best_in_gibs": 24.2344,
+          "best_out_gibs": 24.2344,
+          "in_gibs": 22.9154,
+          "out_gibs": 22.9154
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 405.79,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 706.381,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 249.489,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 31.96,
+      "status": "pass",
+      "throughput_in_gibs": 3.92123,
+      "throughput_out_gibs": 0.779018,
+      "compression_fold": 5.03356,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.582031,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.747135,
+      "init_s": 0.445375,
+      "flush_s": 4e-07,
+      "memory_estimate_total_bytes": 5472895365,
+      "memory_estimate_pinned_bytes": 1528807472,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.02538,
+          "best_ms": 0.144646,
+          "best_in_gibs": 54.0112,
+          "best_out_gibs": 54.0112,
+          "in_gibs": 56.023,
+          "out_gibs": 56.023
+        },
+        "h2d": {
+          "avg_ms": 2.32281,
+          "best_ms": 0.319456,
+          "best_in_gibs": 24.4556,
+          "best_out_gibs": 24.4556,
+          "in_gibs": 24.7106,
+          "out_gibs": 24.7106
+        },
+        "scatter": {
+          "avg_ms": 0.316096,
+          "best_ms": 0.145216,
+          "best_in_gibs": 161.398,
+          "best_out_gibs": 161.398,
+          "in_gibs": 156.532,
+          "out_gibs": 156.532
+        },
+        "compress": {
+          "avg_ms": 126.924,
+          "best_ms": 124.217,
+          "best_in_gibs": 4.71705,
+          "best_out_gibs": 0.915543,
+          "in_gibs": 4.61643,
+          "out_gibs": 0.912622
+        },
+        "aggregate": {
+          "avg_ms": 0.464512,
+          "best_ms": 0.446464,
+          "best_in_gibs": 257.58,
+          "best_out_gibs": 257.58,
+          "in_gibs": 249.367,
+          "out_gibs": 249.367
+        },
+        "d2h": {
+          "avg_ms": 5.91742,
+          "best_ms": 4.86288,
+          "best_in_gibs": 23.7772,
+          "best_out_gibs": 23.7772,
+          "in_gibs": 19.5751,
+          "out_gibs": 19.5751
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 242.058,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 646.156,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 125.554,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 32.35,
+      "status": "pass",
+      "throughput_in_gibs": 2.64625,
+      "throughput_out_gibs": 0.507318,
+      "compression_fold": 5.21616,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.561656,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 1.10711,
+      "init_s": 0.484169,
+      "flush_s": 4.75e-07,
+      "memory_estimate_total_bytes": 5566707845,
+      "memory_estimate_pinned_bytes": 1527767088,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.084,
+          "best_ms": 0.137389,
+          "best_in_gibs": 56.8641,
+          "best_out_gibs": 56.8641,
+          "in_gibs": 52.9933,
+          "out_gibs": 52.9933
+        },
+        "h2d": {
+          "avg_ms": 2.31764,
+          "best_ms": 0.319552,
+          "best_in_gibs": 24.4483,
+          "best_out_gibs": 24.4483,
+          "in_gibs": 24.7657,
+          "out_gibs": 24.7657
+        },
+        "scatter": {
+          "avg_ms": 0.322536,
+          "best_ms": 0.145248,
+          "best_in_gibs": 161.362,
+          "best_out_gibs": 161.362,
+          "in_gibs": 163.499,
+          "out_gibs": 163.499
+        },
+        "compress": {
+          "avg_ms": 199.784,
+          "best_ms": 198.283,
+          "best_in_gibs": 2.95506,
+          "best_out_gibs": 0.555596,
+          "in_gibs": 2.93285,
+          "out_gibs": 0.56083
+        },
+        "aggregate": {
+          "avg_ms": 0.628397,
+          "best_ms": 0.420864,
+          "best_in_gibs": 266.41,
+          "best_out_gibs": 266.41,
+          "in_gibs": 178.303,
+          "out_gibs": 178.303
+        },
+        "d2h": {
+          "avg_ms": 5.79336,
+          "best_ms": 4.66522,
+          "best_in_gibs": 24.0337,
+          "best_out_gibs": 24.0337,
+          "in_gibs": 19.3403,
+          "out_gibs": 19.3403
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 383.195,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 1013.28,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 199.461,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 32.21,
+      "status": "pass",
+      "throughput_in_gibs": 2.68807,
+      "throughput_out_gibs": 0.463375,
+      "compression_fold": 5.80107,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.505026,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 1.08988,
+      "init_s": 0.43909,
+      "flush_s": 2.74e-07,
+      "memory_estimate_total_bytes": 5760185093,
+      "memory_estimate_pinned_bytes": 1527246896,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.994899,
+          "best_ms": 0.139093,
+          "best_in_gibs": 56.1675,
+          "best_out_gibs": 56.1675,
+          "in_gibs": 57.7394,
+          "out_gibs": 57.7394
+        },
+        "h2d": {
+          "avg_ms": 2.31432,
+          "best_ms": 0.323456,
+          "best_in_gibs": 24.1532,
+          "best_out_gibs": 24.1532,
+          "in_gibs": 24.8012,
+          "out_gibs": 24.8012
+        },
+        "scatter": {
+          "avg_ms": 0.312587,
+          "best_ms": 0.14384,
+          "best_in_gibs": 162.941,
+          "best_out_gibs": 162.941,
+          "in_gibs": 158.289,
+          "out_gibs": 158.289
+        },
+        "compress": {
+          "avg_ms": 197.109,
+          "best_ms": 190.747,
+          "best_in_gibs": 3.0718,
+          "best_out_gibs": 0.539639,
+          "in_gibs": 2.97266,
+          "out_gibs": 0.511707
+        },
+        "aggregate": {
+          "avg_ms": 0.412096,
+          "best_ms": 0.370912,
+          "best_in_gibs": 268.567,
+          "best_out_gibs": 268.567,
+          "in_gibs": 244.754,
+          "out_gibs": 244.754
+        },
+        "d2h": {
+          "avg_ms": 5.24465,
+          "best_ms": 4.21011,
+          "best_in_gibs": 24.0503,
+          "best_out_gibs": 24.0503,
+          "in_gibs": 19.2314,
+          "out_gibs": 19.2314
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 377.945,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 999.276,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 200.103,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 32.24,
+      "status": "pass",
+      "throughput_in_gibs": 2.58893,
+      "throughput_out_gibs": 0.434534,
+      "compression_fold": 5.95795,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.491727,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 1.13162,
+      "init_s": 0.44077,
+      "flush_s": 3.7e-07,
+      "memory_estimate_total_bytes": 5759724549,
+      "memory_estimate_pinned_bytes": 1527035952,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.999798,
+          "best_ms": 0.138726,
+          "best_in_gibs": 56.316,
+          "best_out_gibs": 56.316,
+          "in_gibs": 57.4565,
+          "out_gibs": 57.4565
+        },
+        "h2d": {
+          "avg_ms": 2.3111,
+          "best_ms": 0.318368,
+          "best_in_gibs": 24.5392,
+          "best_out_gibs": 24.5392,
+          "in_gibs": 24.8358,
+          "out_gibs": 24.8358
+        },
+        "scatter": {
+          "avg_ms": 0.309291,
+          "best_ms": 0.143648,
+          "best_in_gibs": 163.159,
+          "best_out_gibs": 163.159,
+          "in_gibs": 159.976,
+          "out_gibs": 159.976
+        },
+        "compress": {
+          "avg_ms": 205.545,
+          "best_ms": 191.38,
+          "best_in_gibs": 3.06165,
+          "best_out_gibs": 0.519343,
+          "in_gibs": 2.85065,
+          "out_gibs": 0.478113
+        },
+        "aggregate": {
+          "avg_ms": 0.463117,
+          "best_ms": 0.398176,
+          "best_in_gibs": 245.022,
+          "best_out_gibs": 245.022,
+          "in_gibs": 212.201,
+          "out_gibs": 212.201
+        },
+        "d2h": {
+          "avg_ms": 5.09371,
+          "best_ms": 4.13117,
+          "best_in_gibs": 23.8733,
+          "best_out_gibs": 23.8733,
+          "in_gibs": 19.2932,
+          "out_gibs": 19.2932
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 386.87,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 1042.04,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 212.196,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 32.21,
+      "status": "pass",
+      "throughput_in_gibs": 2.51446,
+      "throughput_out_gibs": 0.3886,
+      "compression_fold": 6.47057,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.452771,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 1.16513,
+      "init_s": 0.452721,
+      "flush_s": 3.9e-07,
+      "memory_estimate_total_bytes": 5759454597,
+      "memory_estimate_pinned_bytes": 1526910000,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.992481,
+          "best_ms": 0.143309,
+          "best_in_gibs": 54.5151,
+          "best_out_gibs": 54.5151,
+          "in_gibs": 57.8801,
+          "out_gibs": 57.8801
+        },
+        "h2d": {
+          "avg_ms": 2.31038,
+          "best_ms": 0.31712,
+          "best_in_gibs": 24.6358,
+          "best_out_gibs": 24.6358,
+          "in_gibs": 24.8435,
+          "out_gibs": 24.8435
+        },
+        "scatter": {
+          "avg_ms": 0.309813,
+          "best_ms": 0.144128,
+          "best_in_gibs": 162.616,
+          "best_out_gibs": 162.616,
+          "in_gibs": 159.706,
+          "out_gibs": 159.706
+        },
+        "compress": {
+          "avg_ms": 212.259,
+          "best_ms": 190.109,
+          "best_in_gibs": 3.08212,
+          "best_out_gibs": 0.479842,
+          "in_gibs": 2.76048,
+          "out_gibs": 0.426452
+        },
+        "aggregate": {
+          "avg_ms": 0.472416,
+          "best_ms": 0.3728,
+          "best_in_gibs": 242.654,
+          "best_out_gibs": 242.654,
+          "in_gibs": 191.607,
+          "out_gibs": 191.607
+        },
+        "d2h": {
+          "avg_ms": 4.68537,
+          "best_ms": 3.80413,
+          "best_in_gibs": 23.7458,
+          "best_out_gibs": 23.7458,
+          "in_gibs": 19.3194,
+          "out_gibs": 19.3194
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 402.205,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 1075.13,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 222.461,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 31.78,
+      "status": "pass",
+      "throughput_in_gibs": 3.91532,
+      "throughput_out_gibs": 0.589703,
+      "compression_fold": 6.63947,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.441253,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.748263,
+      "init_s": 0.437776,
+      "flush_s": 4.36e-07,
+      "memory_estimate_total_bytes": 5759322181,
+      "memory_estimate_pinned_bytes": 1526849584,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.45664,
+          "best_ms": 0.200696,
+          "best_in_gibs": 38.927,
+          "best_out_gibs": 38.927,
+          "in_gibs": 39.4366,
+          "out_gibs": 39.4366
+        },
+        "h2d": {
+          "avg_ms": 2.31336,
+          "best_ms": 0.319296,
+          "best_in_gibs": 24.4679,
+          "best_out_gibs": 24.4679,
+          "in_gibs": 24.8115,
+          "out_gibs": 24.8115
+        },
+        "scatter": {
+          "avg_ms": 0.23952,
+          "best_ms": 0.112608,
+          "best_in_gibs": 69.3778,
+          "best_out_gibs": 69.3778,
+          "in_gibs": 143.516,
+          "out_gibs": 143.516
+        },
+        "compress": {
+          "avg_ms": 128.418,
+          "best_ms": 125.539,
+          "best_in_gibs": 4.66737,
+          "best_out_gibs": 0.699878,
+          "in_gibs": 4.56275,
+          "out_gibs": 0.687067
+        },
+        "aggregate": {
+          "avg_ms": 0.590054,
+          "best_ms": 0.380576,
+          "best_in_gibs": 231.093,
+          "best_out_gibs": 231.093,
+          "in_gibs": 149.531,
+          "out_gibs": 149.531
+        },
+        "d2h": {
+          "avg_ms": 4.48748,
+          "best_ms": 3.69181,
+          "best_in_gibs": 23.7992,
+          "best_out_gibs": 23.7992,
+          "in_gibs": 19.6617,
+          "out_gibs": 19.6617
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 243.059,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 656.006,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 127.975,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 31.86,
+      "status": "pass",
+      "throughput_in_gibs": 3.90511,
+      "throughput_out_gibs": 0.571145,
+      "compression_fold": 6.83734,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.428484,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.750219,
+      "init_s": 0.434653,
+      "flush_s": 4.88e-07,
+      "memory_estimate_total_bytes": 5759256229,
+      "memory_estimate_pinned_bytes": 1526819632,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.18009,
+          "best_ms": 0.133595,
+          "best_in_gibs": 58.479,
+          "best_out_gibs": 58.479,
+          "in_gibs": 48.6782,
+          "out_gibs": 48.6782
+        },
+        "h2d": {
+          "avg_ms": 2.3048,
+          "best_ms": 0.321856,
+          "best_in_gibs": 24.2733,
+          "best_out_gibs": 24.2733,
+          "in_gibs": 24.9036,
+          "out_gibs": 24.9036
+        },
+        "scatter": {
+          "avg_ms": 0.261968,
+          "best_ms": 0.118528,
+          "best_in_gibs": 65.9127,
+          "best_out_gibs": 65.9127,
+          "in_gibs": 149.112,
+          "out_gibs": 149.112
+        },
+        "compress": {
+          "avg_ms": 129.189,
+          "best_ms": 126.83,
+          "best_in_gibs": 4.61985,
+          "best_out_gibs": 0.67594,
+          "in_gibs": 4.53552,
+          "out_gibs": 0.663277
+        },
+        "aggregate": {
+          "avg_ms": 0.576922,
+          "best_ms": 0.353888,
+          "best_in_gibs": 241.248,
+          "best_out_gibs": 241.248,
+          "in_gibs": 148.526,
+          "out_gibs": 148.526
+        },
+        "d2h": {
+          "avg_ms": 4.44746,
+          "best_ms": 3.61238,
+          "best_in_gibs": 23.6339,
+          "best_out_gibs": 23.6339,
+          "in_gibs": 19.2667,
+          "out_gibs": 19.2667
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 243.164,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 660.159,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 127.965,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__gpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 32.65,
+      "status": "pass",
+      "throughput_in_gibs": 2.50136,
+      "throughput_out_gibs": 0.365903,
+      "compression_fold": 8.20334,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.42856,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 1.17124,
+      "init_s": 0.785246,
+      "flush_s": 5.02e-07,
+      "memory_estimate_total_bytes": 10557441573,
+      "memory_estimate_pinned_bytes": 2785168176,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.34981,
+          "best_ms": 0.297101,
+          "best_in_gibs": 52.5915,
+          "best_out_gibs": 52.5915,
+          "in_gibs": 44.2948,
+          "out_gibs": 44.2948
+        },
+        "h2d": {
+          "avg_ms": 2.40862,
+          "best_ms": 0.671424,
+          "best_in_gibs": 23.2714,
+          "best_out_gibs": 23.2714,
+          "in_gibs": 24.8443,
+          "out_gibs": 24.8443
+        },
+        "scatter": {
+          "avg_ms": 0.355211,
+          "best_ms": 0.271584,
+          "best_in_gibs": 172.599,
+          "best_out_gibs": 172.599,
+          "in_gibs": 161.289,
+          "out_gibs": 161.289
+        },
+        "compress": {
+          "avg_ms": 336.493,
+          "best_ms": 151.463,
+          "best_in_gibs": 7.73703,
+          "best_out_gibs": 0.564374,
+          "in_gibs": 3.48261,
+          "out_gibs": 0.424509
+        },
+        "aggregate": {
+          "avg_ms": 1.34937,
+          "best_ms": 0.354816,
+          "best_in_gibs": 240.919,
+          "best_out_gibs": 240.919,
+          "in_gibs": 105.86,
+          "out_gibs": 105.86
+        },
+        "d2h": {
+          "avg_ms": 6.29889,
+          "best_ms": 3.5919,
+          "best_in_gibs": 23.7985,
+          "best_out_gibs": 23.7985,
+          "in_gibs": 22.6777,
+          "out_gibs": 22.6777
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 565.612,
+        "flush_stall_count": 3,
+        "kick_sync_ms": 1035.13,
+        "kick_sync_count": 3,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 428.911,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.93,
+      "status": "pass",
+      "throughput_in_gibs": 0.346904,
+      "throughput_out_gibs": 0.347243,
+      "compression_fold": 0.999024,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312805,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0900825,
+      "init_s": 0.385973,
+      "flush_s": 2.87e-07,
+      "memory_estimate_total_bytes": 2417757958,
+      "memory_estimate_pinned_bytes": 1343225904,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00121041,
+          "best_ms": 0.001016,
+          "best_in_gibs": 15.0185,
+          "best_out_gibs": 15.0185,
+          "in_gibs": 12.6062,
+          "out_gibs": 12.6062
+        },
+        "h2d": {
+          "avg_ms": 0.01208,
+          "best_ms": 0.0104,
+          "best_in_gibs": 1.46719,
+          "best_out_gibs": 1.46719,
+          "in_gibs": 1.26314,
+          "out_gibs": 1.26314
+        },
+        "scatter": {
+          "avg_ms": 0.0111932,
+          "best_ms": 0.01024,
+          "best_in_gibs": 1.49012,
+          "best_out_gibs": 1.49012,
+          "in_gibs": 1.36322,
+          "out_gibs": 1.36322
+        },
+        "aggregate": {
+          "avg_ms": 0.140992,
+          "best_ms": 0.140992,
+          "best_in_gibs": 221.644,
+          "best_out_gibs": 221.644,
+          "in_gibs": 221.644,
+          "out_gibs": 221.644
+        },
+        "d2h": {
+          "avg_ms": 1.29389,
+          "best_ms": 1.29389,
+          "best_in_gibs": 24.152,
+          "best_out_gibs": 24.152,
+          "in_gibs": 24.152,
+          "out_gibs": 24.152
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.51724,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.39244,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 72.7396,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.93,
+      "status": "pass",
+      "throughput_in_gibs": 0.579367,
+      "throughput_out_gibs": 0.57965,
+      "compression_fold": 0.999511,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312653,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0539382,
+      "init_s": 0.386028,
+      "flush_s": 4.83e-07,
+      "memory_estimate_total_bytes": 2416839942,
+      "memory_estimate_pinned_bytes": 1342701616,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00238494,
+          "best_ms": 0.002123,
+          "best_in_gibs": 14.3747,
+          "best_out_gibs": 14.3747,
+          "in_gibs": 12.7959,
+          "out_gibs": 12.7959
+        },
+        "h2d": {
+          "avg_ms": 0.0123574,
+          "best_ms": 0.010016,
+          "best_in_gibs": 3.04688,
+          "best_out_gibs": 3.04688,
+          "in_gibs": 2.46958,
+          "out_gibs": 2.46958
+        },
+        "scatter": {
+          "avg_ms": 0.0110799,
+          "best_ms": 0.010144,
+          "best_in_gibs": 3.00844,
+          "best_out_gibs": 3.00844,
+          "in_gibs": 2.75432,
+          "out_gibs": 2.75432
+        },
+        "aggregate": {
+          "avg_ms": 0.150752,
+          "best_ms": 0.150752,
+          "best_in_gibs": 207.294,
+          "best_out_gibs": 207.294,
+          "in_gibs": 207.294,
+          "out_gibs": 207.294
+        },
+        "d2h": {
+          "avg_ms": 1.29472,
+          "best_ms": 1.29472,
+          "best_in_gibs": 24.1365,
+          "best_out_gibs": 24.1365,
+          "in_gibs": 24.1365,
+          "out_gibs": 24.1365
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.47987,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.3982,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 37.2929,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.93,
+      "status": "pass",
+      "throughput_in_gibs": 0.962479,
+      "throughput_out_gibs": 0.962714,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0324682,
+      "init_s": 0.387882,
+      "flush_s": 2.43e-07,
+      "memory_estimate_total_bytes": 2416380678,
+      "memory_estimate_pinned_bytes": 1342439472,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00460189,
+          "best_ms": 0.003572,
+          "best_in_gibs": 17.0871,
+          "best_out_gibs": 17.0871,
+          "in_gibs": 13.2631,
+          "out_gibs": 13.2631
+        },
+        "h2d": {
+          "avg_ms": 0.0193949,
+          "best_ms": 0.010624,
+          "best_in_gibs": 5.74503,
+          "best_out_gibs": 5.74503,
+          "in_gibs": 3.14697,
+          "out_gibs": 3.14697
+        },
+        "scatter": {
+          "avg_ms": 0.0137971,
+          "best_ms": 0.010208,
+          "best_in_gibs": 5.97915,
+          "best_out_gibs": 5.97915,
+          "in_gibs": 4.42376,
+          "out_gibs": 4.42376
+        },
+        "aggregate": {
+          "avg_ms": 0.131744,
+          "best_ms": 0.131744,
+          "best_in_gibs": 237.202,
+          "best_out_gibs": 237.202,
+          "in_gibs": 237.202,
+          "out_gibs": 237.202
+        },
+        "d2h": {
+          "avg_ms": 1.28614,
+          "best_ms": 1.28614,
+          "best_in_gibs": 24.2974,
+          "best_out_gibs": 24.2974,
+          "in_gibs": 24.2974,
+          "out_gibs": 24.2974
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.44114,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.37228,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 15.5884,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.84,
+      "status": "pass",
+      "throughput_in_gibs": 1.42858,
+      "throughput_out_gibs": 1.42875,
+      "compression_fold": 0.999877,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312538,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0218749,
+      "init_s": 0.375529,
+      "flush_s": 4.73e-07,
+      "memory_estimate_total_bytes": 2416151302,
+      "memory_estimate_pinned_bytes": 1342308400,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0093346,
+          "best_ms": 0.008859,
+          "best_in_gibs": 13.7792,
+          "best_out_gibs": 13.7792,
+          "in_gibs": 13.0772,
+          "out_gibs": 13.0772
+        },
+        "h2d": {
+          "avg_ms": 0.0115267,
+          "best_ms": 0.010016,
+          "best_in_gibs": 12.1875,
+          "best_out_gibs": 12.1875,
+          "in_gibs": 10.5902,
+          "out_gibs": 10.5902
+        },
+        "scatter": {
+          "avg_ms": 0.211296,
+          "best_ms": 0.211296,
+          "best_in_gibs": 0.577722,
+          "best_out_gibs": 0.577722,
+          "in_gibs": 0.577722,
+          "out_gibs": 0.577722
+        },
+        "aggregate": {
+          "avg_ms": 0.16064,
+          "best_ms": 0.16064,
+          "best_in_gibs": 194.534,
+          "best_out_gibs": 194.534,
+          "in_gibs": 194.534,
+          "out_gibs": 194.534
+        },
+        "d2h": {
+          "avg_ms": 1.28262,
+          "best_ms": 1.28262,
+          "best_in_gibs": 24.3641,
+          "best_out_gibs": 24.3641,
+          "in_gibs": 24.3641,
+          "out_gibs": 24.3641
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.44736,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.39562,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 4.8538,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.86,
+      "status": "pass",
+      "throughput_in_gibs": 1.59027,
+      "throughput_out_gibs": 1.59037,
+      "compression_fold": 0.999938,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312519,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0196508,
+      "init_s": 0.38808,
+      "flush_s": 4.84e-07,
+      "memory_estimate_total_bytes": 2416036614,
+      "memory_estimate_pinned_bytes": 1342242864,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0182739,
+          "best_ms": 0.01454,
+          "best_in_gibs": 16.791,
+          "best_out_gibs": 16.791,
+          "in_gibs": 13.3601,
+          "out_gibs": 13.3601
+        },
+        "h2d": {
+          "avg_ms": 0.0164175,
+          "best_ms": 0.01536,
+          "best_in_gibs": 15.8946,
+          "best_out_gibs": 15.8946,
+          "in_gibs": 14.8707,
+          "out_gibs": 14.8707
+        },
+        "scatter": {
+          "avg_ms": 0.059128,
+          "best_ms": 0.010464,
+          "best_in_gibs": 23.3315,
+          "best_out_gibs": 23.3315,
+          "in_gibs": 4.12902,
+          "out_gibs": 4.12902
+        },
+        "aggregate": {
+          "avg_ms": 0.224736,
+          "best_ms": 0.224736,
+          "best_in_gibs": 139.052,
+          "best_out_gibs": 139.052,
+          "in_gibs": 139.052,
+          "out_gibs": 139.052
+        },
+        "d2h": {
+          "avg_ms": 1.30691,
+          "best_ms": 1.30691,
+          "best_in_gibs": 23.9113,
+          "best_out_gibs": 23.9113,
+          "in_gibs": 23.9113,
+          "out_gibs": 23.9113
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.53037,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.48693,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.70326,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.94,
+      "status": "pass",
+      "throughput_in_gibs": 1.59371,
+      "throughput_out_gibs": 1.59376,
+      "compression_fold": 0.999969,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.031251,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0196084,
+      "init_s": 0.385745,
+      "flush_s": 3.35e-07,
+      "memory_estimate_total_bytes": 2415979270,
+      "memory_estimate_pinned_bytes": 1342210096,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0387694,
+          "best_ms": 0.034938,
+          "best_in_gibs": 13.9756,
+          "best_out_gibs": 13.9756,
+          "in_gibs": 12.5945,
+          "out_gibs": 12.5945
+        },
+        "h2d": {
+          "avg_ms": 0.0293569,
+          "best_ms": 0.027328,
+          "best_in_gibs": 17.8674,
+          "best_out_gibs": 17.8674,
+          "in_gibs": 16.6326,
+          "out_gibs": 16.6326
+        },
+        "scatter": {
+          "avg_ms": 0.0154901,
+          "best_ms": 0.010496,
+          "best_in_gibs": 46.5207,
+          "best_out_gibs": 46.5207,
+          "in_gibs": 31.5221,
+          "out_gibs": 31.5221
+        },
+        "aggregate": {
+          "avg_ms": 0.365664,
+          "best_ms": 0.365664,
+          "best_in_gibs": 85.461,
+          "best_out_gibs": 85.461,
+          "in_gibs": 85.461,
+          "out_gibs": 85.461
+        },
+        "d2h": {
+          "avg_ms": 1.28835,
+          "best_ms": 1.28835,
+          "best_in_gibs": 24.2558,
+          "best_out_gibs": 24.2558,
+          "in_gibs": 24.2558,
+          "out_gibs": 24.2558
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.65923,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.60936,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.33028,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.86,
+      "status": "pass",
+      "throughput_in_gibs": 1.57035,
+      "throughput_out_gibs": 1.57038,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0199,
+      "init_s": 0.392765,
+      "flush_s": 4.73e-07,
+      "memory_estimate_total_bytes": 2415950598,
+      "memory_estimate_pinned_bytes": 1342193712,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0782273,
+          "best_ms": 0.072372,
+          "best_in_gibs": 13.4937,
+          "best_out_gibs": 13.4937,
+          "in_gibs": 12.4837,
+          "out_gibs": 12.4837
+        },
+        "h2d": {
+          "avg_ms": 0.0505653,
+          "best_ms": 0.048256,
+          "best_in_gibs": 20.2371,
+          "best_out_gibs": 20.2371,
+          "in_gibs": 19.3129,
+          "out_gibs": 19.3129
+        },
+        "scatter": {
+          "avg_ms": 0.0174912,
+          "best_ms": 0.011584,
+          "best_in_gibs": 84.3027,
+          "best_out_gibs": 84.3027,
+          "in_gibs": 55.8316,
+          "out_gibs": 55.8316
+        },
+        "aggregate": {
+          "avg_ms": 0.63712,
+          "best_ms": 0.63712,
+          "best_in_gibs": 49.0488,
+          "best_out_gibs": 49.0488,
+          "in_gibs": 49.0488,
+          "out_gibs": 49.0488
+        },
+        "d2h": {
+          "avg_ms": 1.28147,
+          "best_ms": 1.28147,
+          "best_in_gibs": 24.386,
+          "best_out_gibs": 24.386,
+          "in_gibs": 24.386,
+          "out_gibs": 24.386
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.98056,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.93053,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.11483,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.93,
+      "status": "pass",
+      "throughput_in_gibs": 1.47983,
+      "throughput_out_gibs": 1.47985,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0211173,
+      "init_s": 0.373837,
+      "flush_s": 5.37e-07,
+      "memory_estimate_total_bytes": 2415950598,
+      "memory_estimate_pinned_bytes": 1342193712,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0789684,
+          "best_ms": 0.075198,
+          "best_in_gibs": 12.9865,
+          "best_out_gibs": 12.9865,
+          "in_gibs": 12.3665,
+          "out_gibs": 12.3665
+        },
+        "h2d": {
+          "avg_ms": 0.0513653,
+          "best_ms": 0.049632,
+          "best_in_gibs": 19.6761,
+          "best_out_gibs": 19.6761,
+          "in_gibs": 19.0121,
+          "out_gibs": 19.0121
+        },
+        "scatter": {
+          "avg_ms": 0.0175637,
+          "best_ms": 0.011616,
+          "best_in_gibs": 84.0705,
+          "best_out_gibs": 84.0705,
+          "in_gibs": 55.6011,
+          "out_gibs": 55.6011
+        },
+        "aggregate": {
+          "avg_ms": 0.697568,
+          "best_ms": 0.697568,
+          "best_in_gibs": 44.7985,
+          "best_out_gibs": 44.7985,
+          "in_gibs": 44.7985,
+          "out_gibs": 44.7985
+        },
+        "d2h": {
+          "avg_ms": 1.2841,
+          "best_ms": 1.2841,
+          "best_in_gibs": 24.3362,
+          "best_out_gibs": 24.3362,
+          "in_gibs": 24.3362,
+          "out_gibs": 24.3362
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.97166,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.91146,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.16569,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.93,
+      "status": "pass",
+      "throughput_in_gibs": 0.342154,
+      "throughput_out_gibs": 0.0843065,
+      "compression_fold": 4.05845,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00769998,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0913332,
+      "init_s": 0.384538,
+      "flush_s": 5.31e-07,
+      "memory_estimate_total_bytes": 4575203078,
+      "memory_estimate_pinned_bytes": 1347944496,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00121129,
+          "best_ms": 0.001027,
+          "best_in_gibs": 14.8576,
+          "best_out_gibs": 14.8576,
+          "in_gibs": 12.5971,
+          "out_gibs": 12.5971
+        },
+        "h2d": {
+          "avg_ms": 0.0120533,
+          "best_ms": 0.010528,
+          "best_in_gibs": 1.44935,
+          "best_out_gibs": 1.44935,
+          "in_gibs": 1.26594,
+          "out_gibs": 1.26594
+        },
+        "scatter": {
+          "avg_ms": 0.0108277,
+          "best_ms": 0.010176,
+          "best_in_gibs": 1.49949,
+          "best_out_gibs": 1.49949,
+          "in_gibs": 1.40923,
+          "out_gibs": 1.40923
+        },
+        "compress": {
+          "avg_ms": 3.06528,
+          "best_ms": 3.06528,
+          "best_in_gibs": 10.1948,
+          "best_out_gibs": 2.50204,
+          "in_gibs": 10.1948,
+          "out_gibs": 2.50204
+        },
+        "aggregate": {
+          "avg_ms": 0.045728,
+          "best_ms": 0.045728,
+          "best_in_gibs": 167.719,
+          "best_out_gibs": 167.719,
+          "in_gibs": 167.719,
+          "out_gibs": 167.719
+        },
+        "d2h": {
+          "avg_ms": 0.411104,
+          "best_ms": 0.411104,
+          "best_in_gibs": 18.6557,
+          "best_out_gibs": 18.6557,
+          "in_gibs": 18.6557,
+          "out_gibs": 18.6557
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.75047,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.6194,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 72.4679,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.99,
+      "status": "pass",
+      "throughput_in_gibs": 0.564715,
+      "throughput_out_gibs": 0.0706758,
+      "compression_fold": 7.99022,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00391103,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0553377,
+      "init_s": 0.389476,
+      "flush_s": 3.79e-07,
+      "memory_estimate_total_bytes": 4036627718,
+      "memory_estimate_pinned_bytes": 1347158064,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00243411,
+          "best_ms": 0.001998,
+          "best_in_gibs": 15.2741,
+          "best_out_gibs": 15.2741,
+          "in_gibs": 12.5375,
+          "out_gibs": 12.5375
+        },
+        "h2d": {
+          "avg_ms": 0.0123817,
+          "best_ms": 0.010048,
+          "best_in_gibs": 3.03718,
+          "best_out_gibs": 3.03718,
+          "in_gibs": 2.46474,
+          "out_gibs": 2.46474
+        },
+        "scatter": {
+          "avg_ms": 0.0110158,
+          "best_ms": 0.010176,
+          "best_in_gibs": 2.99898,
+          "best_out_gibs": 2.99898,
+          "in_gibs": 2.77035,
+          "out_gibs": 2.77035
+        },
+        "compress": {
+          "avg_ms": 2.89014,
+          "best_ms": 2.89014,
+          "best_in_gibs": 10.8126,
+          "best_out_gibs": 1.34795,
+          "in_gibs": 10.8126,
+          "out_gibs": 1.34795
+        },
+        "aggregate": {
+          "avg_ms": 0.040992,
+          "best_ms": 0.040992,
+          "best_in_gibs": 95.0371,
+          "best_out_gibs": 95.0371,
+          "in_gibs": 95.0371,
+          "out_gibs": 95.0371
+        },
+        "d2h": {
+          "avg_ms": 0.194432,
+          "best_ms": 0.194432,
+          "best_in_gibs": 20.0366,
+          "best_out_gibs": 20.0366,
+          "in_gibs": 20.0366,
+          "out_gibs": 20.0366
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.37459,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.29359,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 37.6862,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.92,
+      "status": "pass",
+      "throughput_in_gibs": 0.921551,
+      "throughput_out_gibs": 0.0594676,
+      "compression_fold": 15.4967,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00201656,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0339102,
+      "init_s": 0.378734,
+      "flush_s": 4.26e-07,
+      "memory_estimate_total_bytes": 3767339782,
+      "memory_estimate_pinned_bytes": 1346764848,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0046084,
+          "best_ms": 0.004127,
+          "best_in_gibs": 14.7892,
+          "best_out_gibs": 14.7892,
+          "in_gibs": 13.2443,
+          "out_gibs": 13.2443
+        },
+        "h2d": {
+          "avg_ms": 0.018016,
+          "best_ms": 0.010176,
+          "best_in_gibs": 5.99795,
+          "best_out_gibs": 5.99795,
+          "in_gibs": 3.38783,
+          "out_gibs": 3.38783
+        },
+        "scatter": {
+          "avg_ms": 0.012282,
+          "best_ms": 0.010208,
+          "best_in_gibs": 5.97915,
+          "best_out_gibs": 5.97915,
+          "in_gibs": 4.96946,
+          "out_gibs": 4.96946
+        },
+        "compress": {
+          "avg_ms": 3.15968,
+          "best_ms": 3.15968,
+          "best_in_gibs": 9.89024,
+          "best_out_gibs": 0.635797,
+          "in_gibs": 9.89024,
+          "out_gibs": 0.635797
+        },
+        "aggregate": {
+          "avg_ms": 0.036672,
+          "best_ms": 0.036672,
+          "best_in_gibs": 54.7806,
+          "best_out_gibs": 54.7806,
+          "in_gibs": 54.7806,
+          "out_gibs": 54.7806
+        },
+        "d2h": {
+          "avg_ms": 0.186848,
+          "best_ms": 0.186848,
+          "best_in_gibs": 10.7516,
+          "best_out_gibs": 10.7516,
+          "in_gibs": 10.7516,
+          "out_gibs": 10.7516
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.38653,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.32549,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 15.564,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 1.11,
+      "status": "pass",
+      "throughput_in_gibs": 1.35187,
+      "throughput_out_gibs": 0.046269,
+      "compression_fold": 29.2176,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00106956,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0231161,
+      "init_s": 0.378594,
+      "flush_s": 3.46e-07,
+      "memory_estimate_total_bytes": 3632696070,
+      "memory_estimate_pinned_bytes": 1346568240,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00922552,
+          "best_ms": 0.007884,
+          "best_in_gibs": 15.4833,
+          "best_out_gibs": 15.4833,
+          "in_gibs": 13.2318,
+          "out_gibs": 13.2318
+        },
+        "h2d": {
+          "avg_ms": 0.0114925,
+          "best_ms": 0.010048,
+          "best_in_gibs": 12.1487,
+          "best_out_gibs": 12.1487,
+          "in_gibs": 10.6218,
+          "out_gibs": 10.6218
+        },
+        "scatter": {
+          "avg_ms": 0.0338702,
+          "best_ms": 0.010304,
+          "best_in_gibs": 11.8469,
+          "best_out_gibs": 11.8469,
+          "in_gibs": 3.60406,
+          "out_gibs": 3.60406
+        },
+        "compress": {
+          "avg_ms": 3.30109,
+          "best_ms": 3.30109,
+          "best_in_gibs": 9.46658,
+          "best_out_gibs": 0.322842,
+          "in_gibs": 9.46658,
+          "out_gibs": 0.322842
+        },
+        "aggregate": {
+          "avg_ms": 0.035808,
+          "best_ms": 0.035808,
+          "best_in_gibs": 29.7624,
+          "best_out_gibs": 29.7624,
+          "in_gibs": 29.7624,
+          "out_gibs": 29.7624
+        },
+        "d2h": {
+          "avg_ms": 0.10832,
+          "best_ms": 0.10832,
+          "best_in_gibs": 9.83873,
+          "best_out_gibs": 9.83873,
+          "in_gibs": 9.83873,
+          "out_gibs": 9.83873
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 1.66806,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 1.61606,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.21254,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.87,
+      "status": "pass",
+      "throughput_in_gibs": 1.40984,
+      "throughput_out_gibs": 0.0268912,
+      "compression_fold": 52.4275,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000596061,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0221656,
+      "init_s": 0.385015,
+      "flush_s": 4.52e-07,
+      "memory_estimate_total_bytes": 3565374214,
+      "memory_estimate_pinned_bytes": 1346469936,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0188759,
+          "best_ms": 0.01592,
+          "best_in_gibs": 15.3355,
+          "best_out_gibs": 15.3355,
+          "in_gibs": 12.934,
+          "out_gibs": 12.934
+        },
+        "h2d": {
+          "avg_ms": 0.0164302,
+          "best_ms": 0.014176,
+          "best_in_gibs": 17.2221,
+          "best_out_gibs": 17.2221,
+          "in_gibs": 14.8592,
+          "out_gibs": 14.8592
+        },
+        "scatter": {
+          "avg_ms": 0.0519232,
+          "best_ms": 0.010336,
+          "best_in_gibs": 23.6204,
+          "best_out_gibs": 23.6204,
+          "in_gibs": 4.70196,
+          "out_gibs": 4.70196
+        },
+        "compress": {
+          "avg_ms": 3.94506,
+          "best_ms": 3.94506,
+          "best_in_gibs": 7.92131,
+          "best_out_gibs": 0.150603,
+          "in_gibs": 7.92131,
+          "out_gibs": 0.150603
+        },
+        "aggregate": {
+          "avg_ms": 0.036448,
+          "best_ms": 0.036448,
+          "best_in_gibs": 16.301,
+          "best_out_gibs": 16.301,
+          "in_gibs": 16.301,
+          "out_gibs": 16.301
+        },
+        "d2h": {
+          "avg_ms": 0.1456,
+          "best_ms": 0.1456,
+          "best_in_gibs": 4.08063,
+          "best_out_gibs": 4.08063,
+          "in_gibs": 4.08063,
+          "out_gibs": 4.08063
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 2.40285,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 2.35606,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.78417,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 1.09,
+      "status": "pass",
+      "throughput_in_gibs": 1.32003,
+      "throughput_out_gibs": 0.0151777,
+      "compression_fold": 86.9718,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000359312,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0236736,
+      "init_s": 0.379247,
+      "flush_s": 3.75e-07,
+      "memory_estimate_total_bytes": 3531746054,
+      "memory_estimate_pinned_bytes": 1346437168,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0374958,
+          "best_ms": 0.035465,
+          "best_in_gibs": 13.768,
+          "best_out_gibs": 13.768,
+          "in_gibs": 13.0223,
+          "out_gibs": 13.0223
+        },
+        "h2d": {
+          "avg_ms": 0.0289791,
+          "best_ms": 0.027584,
+          "best_in_gibs": 17.7016,
+          "best_out_gibs": 17.7016,
+          "in_gibs": 16.8494,
+          "out_gibs": 16.8494
+        },
+        "scatter": {
+          "avg_ms": 0.0211164,
+          "best_ms": 0.010528,
+          "best_in_gibs": 46.3793,
+          "best_out_gibs": 46.3793,
+          "in_gibs": 23.1233,
+          "out_gibs": 23.1233
+        },
+        "compress": {
+          "avg_ms": 5.32221,
+          "best_ms": 5.32221,
+          "best_in_gibs": 5.87162,
+          "best_out_gibs": 0.0673298,
+          "in_gibs": 5.87162,
+          "out_gibs": 0.0673298
+        },
+        "aggregate": {
+          "avg_ms": 0.036832,
+          "best_ms": 0.036832,
+          "best_in_gibs": 9.72912,
+          "best_out_gibs": 9.72912,
+          "in_gibs": 9.72912,
+          "out_gibs": 9.72912
+        },
+        "d2h": {
+          "avg_ms": 0.07488,
+          "best_ms": 0.07488,
+          "best_in_gibs": 4.78557,
+          "best_out_gibs": 4.78557,
+          "in_gibs": 4.78557,
+          "out_gibs": 4.78557
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 3.73975,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 3.69594,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.22563,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.85,
+      "status": "pass",
+      "throughput_in_gibs": 1.19486,
+      "throughput_out_gibs": 0.00921235,
+      "compression_fold": 129.702,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000240937,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0261537,
+      "init_s": 0.385872,
+      "flush_s": 5.17e-07,
+      "memory_estimate_total_bytes": 3514915590,
+      "memory_estimate_pinned_bytes": 1346412592,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0764805,
+          "best_ms": 0.071885,
+          "best_in_gibs": 13.5851,
+          "best_out_gibs": 13.5851,
+          "in_gibs": 12.7688,
+          "out_gibs": 12.7688
+        },
+        "h2d": {
+          "avg_ms": 0.0510101,
+          "best_ms": 0.047648,
+          "best_in_gibs": 20.4954,
+          "best_out_gibs": 20.4954,
+          "in_gibs": 19.1445,
+          "out_gibs": 19.1445
+        },
+        "scatter": {
+          "avg_ms": 0.0171413,
+          "best_ms": 0.011552,
+          "best_in_gibs": 84.5362,
+          "best_out_gibs": 84.5362,
+          "in_gibs": 56.9712,
+          "out_gibs": 56.9712
+        },
+        "compress": {
+          "avg_ms": 8.09043,
+          "best_ms": 8.09043,
+          "best_in_gibs": 3.86259,
+          "best_out_gibs": 0.0297197,
+          "in_gibs": 3.86259,
+          "out_gibs": 0.0297197
+        },
+        "aggregate": {
+          "avg_ms": 0.037536,
+          "best_ms": 0.037536,
+          "best_in_gibs": 6.40572,
+          "best_out_gibs": 6.40572,
+          "in_gibs": 6.40572,
+          "out_gibs": 6.40572
+        },
+        "d2h": {
+          "avg_ms": 0.127808,
+          "best_ms": 0.127808,
+          "best_in_gibs": 1.8813,
+          "best_out_gibs": 1.8813,
+          "in_gibs": 1.8813,
+          "out_gibs": 1.8813
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 6.58583,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 6.54275,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.05905,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.97,
+      "status": "pass",
+      "throughput_in_gibs": 1.21203,
+      "throughput_out_gibs": 0.00934475,
+      "compression_fold": 129.702,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000240937,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0257831,
+      "init_s": 0.385226,
+      "flush_s": 3.4e-07,
+      "memory_estimate_total_bytes": 3514915590,
+      "memory_estimate_pinned_bytes": 1346412592,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0783638,
+          "best_ms": 0.073471,
+          "best_in_gibs": 13.2918,
+          "best_out_gibs": 13.2918,
+          "in_gibs": 12.4619,
+          "out_gibs": 12.4619
+        },
+        "h2d": {
+          "avg_ms": 0.0504203,
+          "best_ms": 0.048096,
+          "best_in_gibs": 20.3044,
+          "best_out_gibs": 20.3044,
+          "in_gibs": 19.3685,
+          "out_gibs": 19.3685
+        },
+        "scatter": {
+          "avg_ms": 0.0175445,
+          "best_ms": 0.011616,
+          "best_in_gibs": 84.0705,
+          "best_out_gibs": 84.0705,
+          "in_gibs": 55.6619,
+          "out_gibs": 55.6619
+        },
+        "compress": {
+          "avg_ms": 8.11056,
+          "best_ms": 8.11056,
+          "best_in_gibs": 3.853,
+          "best_out_gibs": 0.0296459,
+          "in_gibs": 3.853,
+          "out_gibs": 0.0296459
+        },
+        "aggregate": {
+          "avg_ms": 0.038496,
+          "best_ms": 0.038496,
+          "best_in_gibs": 6.24598,
+          "best_out_gibs": 6.24598,
+          "in_gibs": 6.24598,
+          "out_gibs": 6.24598
+        },
+        "d2h": {
+          "avg_ms": 0.129344,
+          "best_ms": 0.129344,
+          "best_in_gibs": 1.85896,
+          "best_out_gibs": 1.85896,
+          "in_gibs": 1.85896,
+          "out_gibs": 1.85896
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 6.59426,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 6.54662,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.13029,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 0.91,
+      "status": "pass",
+      "throughput_in_gibs": 0.342657,
+      "throughput_out_gibs": 0.0420585,
+      "compression_fold": 8.14716,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00383569,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.091199,
+      "init_s": 0.37596,
+      "flush_s": 4.34e-07,
+      "memory_estimate_total_bytes": 4768149581,
+      "memory_estimate_pinned_bytes": 1343946800,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00121772,
+          "best_ms": 0.000987,
+          "best_in_gibs": 15.4598,
+          "best_out_gibs": 15.4598,
+          "in_gibs": 12.5306,
+          "out_gibs": 12.5306
+        },
+        "h2d": {
+          "avg_ms": 0.01328,
+          "best_ms": 0.01328,
+          "best_in_gibs": 1.14901,
+          "best_out_gibs": 1.14901,
+          "in_gibs": 1.14901,
+          "out_gibs": 1.14901
+        },
+        "scatter": {
+          "avg_ms": 0.0109466,
+          "best_ms": 0.010176,
+          "best_in_gibs": 1.49949,
+          "best_out_gibs": 1.49949,
+          "in_gibs": 1.39393,
+          "out_gibs": 1.39393
+        },
+        "compress": {
+          "avg_ms": 3.44474,
+          "best_ms": 3.44474,
+          "best_in_gibs": 9.07181,
+          "best_out_gibs": 1.10463,
+          "in_gibs": 9.07181,
+          "out_gibs": 1.10463
+        },
+        "aggregate": {
+          "avg_ms": 0.04192,
+          "best_ms": 0.04192,
+          "best_in_gibs": 90.772,
+          "best_out_gibs": 90.772,
+          "in_gibs": 90.772,
+          "out_gibs": 90.772
+        },
+        "d2h": {
+          "avg_ms": 0.238496,
+          "best_ms": 0.238496,
+          "best_in_gibs": 15.9548,
+          "best_out_gibs": 15.9548,
+          "in_gibs": 15.9548,
+          "out_gibs": 15.9548
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 3.59296,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 3.47464,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 72.8708,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.93,
+      "status": "pass",
+      "throughput_in_gibs": 0.541777,
+      "throughput_out_gibs": 0.0640849,
+      "compression_fold": 8.45404,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00369646,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0576806,
+      "init_s": 0.386189,
+      "flush_s": 4.87e-07,
+      "memory_estimate_total_bytes": 4862537293,
+      "memory_estimate_pinned_bytes": 1343062064,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00232702,
+          "best_ms": 0.002014,
+          "best_in_gibs": 15.1527,
+          "best_out_gibs": 15.1527,
+          "in_gibs": 13.1144,
+          "out_gibs": 13.1144
+        },
+        "h2d": {
+          "avg_ms": 0.0124486,
+          "best_ms": 0.010048,
+          "best_in_gibs": 3.03718,
+          "best_out_gibs": 3.03718,
+          "in_gibs": 2.45148,
+          "out_gibs": 2.45148
+        },
+        "scatter": {
+          "avg_ms": 0.0110181,
+          "best_ms": 0.010208,
+          "best_in_gibs": 2.98957,
+          "best_out_gibs": 2.98957,
+          "in_gibs": 2.76976,
+          "out_gibs": 2.76976
+        },
+        "compress": {
+          "avg_ms": 4.9257,
+          "best_ms": 4.9257,
+          "best_in_gibs": 6.34428,
+          "best_out_gibs": 0.747343,
+          "in_gibs": 6.34428,
+          "out_gibs": 0.747343
+        },
+        "aggregate": {
+          "avg_ms": 0.044192,
+          "best_ms": 0.044192,
+          "best_in_gibs": 83.2998,
+          "best_out_gibs": 83.2998,
+          "in_gibs": 83.2998,
+          "out_gibs": 83.2998
+        },
+        "d2h": {
+          "avg_ms": 0.253056,
+          "best_ms": 0.253056,
+          "best_in_gibs": 14.5469,
+          "best_out_gibs": 14.5469,
+          "in_gibs": 14.5469,
+          "out_gibs": 14.5469
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 5.05596,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 4.97215,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 37.3342,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.93,
+      "status": "pass",
+      "throughput_in_gibs": 0.801135,
+      "throughput_out_gibs": 0.0929054,
+      "compression_fold": 8.62312,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00362398,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0390072,
+      "init_s": 0.394701,
+      "flush_s": 2.32e-07,
+      "memory_estimate_total_bytes": 5056302157,
+      "memory_estimate_pinned_bytes": 1342619696,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00462834,
+          "best_ms": 0.00418,
+          "best_in_gibs": 14.6017,
+          "best_out_gibs": 14.6017,
+          "in_gibs": 13.1873,
+          "out_gibs": 13.1873
+        },
+        "h2d": {
+          "avg_ms": 0.0201166,
+          "best_ms": 0.012384,
+          "best_in_gibs": 4.92855,
+          "best_out_gibs": 4.92855,
+          "in_gibs": 3.03406,
+          "out_gibs": 3.03406
+        },
+        "scatter": {
+          "avg_ms": 0.0151271,
+          "best_ms": 0.010208,
+          "best_in_gibs": 5.97915,
+          "best_out_gibs": 5.97915,
+          "in_gibs": 4.03481,
+          "out_gibs": 4.03481
+        },
+        "compress": {
+          "avg_ms": 8.67942,
+          "best_ms": 8.67942,
+          "best_in_gibs": 3.60047,
+          "best_out_gibs": 0.416656,
+          "in_gibs": 3.60047,
+          "out_gibs": 0.416656
+        },
+        "aggregate": {
+          "avg_ms": 0.040544,
+          "best_ms": 0.040544,
+          "best_in_gibs": 89.1953,
+          "best_out_gibs": 89.1953,
+          "in_gibs": 89.1953,
+          "out_gibs": 89.1953
+        },
+        "d2h": {
+          "avg_ms": 0.221248,
+          "best_ms": 0.221248,
+          "best_in_gibs": 16.3452,
+          "best_out_gibs": 16.3452,
+          "in_gibs": 16.3452,
+          "out_gibs": 16.3452
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 8.80935,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 8.73647,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.4291,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.88,
+      "status": "pass",
+      "throughput_in_gibs": 0.904017,
+      "throughput_out_gibs": 0.10405,
+      "compression_fold": 8.68828,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0035968,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0345679,
+      "init_s": 0.386741,
+      "flush_s": 4.38e-07,
+      "memory_estimate_total_bytes": 5055908941,
+      "memory_estimate_pinned_bytes": 1342439472,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.00904909,
+          "best_ms": 0.007601,
+          "best_in_gibs": 16.0598,
+          "best_out_gibs": 16.0598,
+          "in_gibs": 13.4898,
+          "out_gibs": 13.4898
+        },
+        "h2d": {
+          "avg_ms": 0.0114988,
+          "best_ms": 0.010016,
+          "best_in_gibs": 12.1875,
+          "best_out_gibs": 12.1875,
+          "in_gibs": 10.6159,
+          "out_gibs": 10.6159
+        },
+        "scatter": {
+          "avg_ms": 0.0408777,
+          "best_ms": 0.01024,
+          "best_in_gibs": 11.9209,
+          "best_out_gibs": 11.9209,
+          "in_gibs": 2.98623,
+          "out_gibs": 2.98623
+        },
+        "compress": {
+          "avg_ms": 14.5781,
+          "best_ms": 14.5781,
+          "best_in_gibs": 2.14362,
+          "best_out_gibs": 0.246463,
+          "in_gibs": 2.14362,
+          "out_gibs": 0.246463
+        },
+        "aggregate": {
+          "avg_ms": 0.041504,
+          "best_ms": 0.041504,
+          "best_in_gibs": 86.5692,
+          "best_out_gibs": 86.5692,
+          "in_gibs": 86.5692,
+          "out_gibs": 86.5692
+        },
+        "d2h": {
+          "avg_ms": 0.231168,
+          "best_ms": 0.231168,
+          "best_in_gibs": 15.5427,
+          "best_out_gibs": 15.5427,
+          "in_gibs": 15.5427,
+          "out_gibs": 15.5427
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 14.7151,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 14.6614,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 5.12454,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.93,
+      "status": "pass",
+      "throughput_in_gibs": 0.66183,
+      "throughput_out_gibs": 0.0758771,
+      "compression_fold": 8.7224,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00358273,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0472176,
+      "init_s": 0.409753,
+      "flush_s": 3.17e-07,
+      "memory_estimate_total_bytes": 5055679565,
+      "memory_estimate_pinned_bytes": 1342332976,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0188787,
+          "best_ms": 0.017121,
+          "best_in_gibs": 14.2597,
+          "best_out_gibs": 14.2597,
+          "in_gibs": 12.9321,
+          "out_gibs": 12.9321
+        },
+        "h2d": {
+          "avg_ms": 0.0166982,
+          "best_ms": 0.015104,
+          "best_in_gibs": 16.164,
+          "best_out_gibs": 16.164,
+          "in_gibs": 14.6208,
+          "out_gibs": 14.6208
+        },
+        "scatter": {
+          "avg_ms": 0.03828,
+          "best_ms": 0.010272,
+          "best_in_gibs": 23.7676,
+          "best_out_gibs": 23.7676,
+          "in_gibs": 6.37776,
+          "out_gibs": 6.37776
+        },
+        "compress": {
+          "avg_ms": 26.526,
+          "best_ms": 26.526,
+          "best_in_gibs": 1.17809,
+          "best_out_gibs": 0.134992,
+          "in_gibs": 1.17809,
+          "out_gibs": 0.134992
+        },
+        "aggregate": {
+          "avg_ms": 0.050048,
+          "best_ms": 0.050048,
+          "best_in_gibs": 71.5475,
+          "best_out_gibs": 71.5475,
+          "in_gibs": 71.5475,
+          "out_gibs": 71.5475
+        },
+        "d2h": {
+          "avg_ms": 0.20048,
+          "best_ms": 0.20048,
+          "best_in_gibs": 17.8612,
+          "best_out_gibs": 17.8612,
+          "in_gibs": 17.8612,
+          "out_gibs": 17.8612
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 26.6077,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 26.5529,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.90498,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 1.19,
+      "status": "pass",
+      "throughput_in_gibs": 0.456205,
+      "throughput_out_gibs": 0.0522,
+      "compression_fold": 8.73955,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0035757,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0684999,
+      "init_s": 0.401552,
+      "flush_s": 2.17e-07,
+      "memory_estimate_total_bytes": 5055568973,
+      "memory_estimate_pinned_bytes": 1342283824,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0373797,
+          "best_ms": 0.032318,
+          "best_in_gibs": 15.1086,
+          "best_out_gibs": 15.1086,
+          "in_gibs": 13.0627,
+          "out_gibs": 13.0627
+        },
+        "h2d": {
+          "avg_ms": 0.0289806,
+          "best_ms": 0.026976,
+          "best_in_gibs": 18.1006,
+          "best_out_gibs": 18.1006,
+          "in_gibs": 16.8485,
+          "out_gibs": 16.8485
+        },
+        "scatter": {
+          "avg_ms": 0.0185827,
+          "best_ms": 0.010464,
+          "best_in_gibs": 46.663,
+          "best_out_gibs": 46.663,
+          "in_gibs": 26.2762,
+          "out_gibs": 26.2762
+        },
+        "compress": {
+          "avg_ms": 50.3885,
+          "best_ms": 50.3885,
+          "best_in_gibs": 0.620181,
+          "best_out_gibs": 0.0709434,
+          "in_gibs": 0.620181,
+          "out_gibs": 0.0709434
+        },
+        "aggregate": {
+          "avg_ms": 0.066752,
+          "best_ms": 0.066752,
+          "best_in_gibs": 53.5524,
+          "best_out_gibs": 53.5524,
+          "in_gibs": 53.5524,
+          "out_gibs": 53.5524
+        },
+        "d2h": {
+          "avg_ms": 0.178144,
+          "best_ms": 0.178144,
+          "best_in_gibs": 20.0665,
+          "best_out_gibs": 20.0665,
+          "in_gibs": 20.0665,
+          "out_gibs": 20.0665
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 50.5069,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 50.4588,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.22576,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.91,
+      "status": "pass",
+      "throughput_in_gibs": 0.454449,
+      "throughput_out_gibs": 0.0519545,
+      "compression_fold": 8.74706,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00357263,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0687646,
+      "init_s": 0.389269,
+      "flush_s": 3.64e-07,
+      "memory_estimate_total_bytes": 5055513677,
+      "memory_estimate_pinned_bytes": 1342259248,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0802994,
+          "best_ms": 0.075568,
+          "best_in_gibs": 12.923,
+          "best_out_gibs": 12.923,
+          "in_gibs": 12.1615,
+          "out_gibs": 12.1615
+        },
+        "h2d": {
+          "avg_ms": 0.0502336,
+          "best_ms": 0.048416,
+          "best_in_gibs": 20.1702,
+          "best_out_gibs": 20.1702,
+          "in_gibs": 19.4404,
+          "out_gibs": 19.4404
+        },
+        "scatter": {
+          "avg_ms": 0.0176405,
+          "best_ms": 0.011584,
+          "best_in_gibs": 84.3027,
+          "best_out_gibs": 84.3027,
+          "in_gibs": 55.359,
+          "out_gibs": 55.359
+        },
+        "compress": {
+          "avg_ms": 50.2706,
+          "best_ms": 50.2706,
+          "best_in_gibs": 0.621636,
+          "best_out_gibs": 0.0710582,
+          "in_gibs": 0.621636,
+          "out_gibs": 0.0710582
+        },
+        "aggregate": {
+          "avg_ms": 0.10016,
+          "best_ms": 0.10016,
+          "best_in_gibs": 35.6643,
+          "best_out_gibs": 35.6643,
+          "in_gibs": 35.6643,
+          "out_gibs": 35.6643
+        },
+        "d2h": {
+          "avg_ms": 0.26064,
+          "best_ms": 0.26064,
+          "best_in_gibs": 13.7052,
+          "best_out_gibs": 13.7052,
+          "in_gibs": 13.7052,
+          "out_gibs": 13.7052
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 50.5253,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 50.4689,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.20227,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__gpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 1.11,
+      "status": "pass",
+      "throughput_in_gibs": 0.452857,
+      "throughput_out_gibs": 0.0517724,
+      "compression_fold": 8.74706,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00357263,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0690064,
+      "init_s": 0.38524,
+      "flush_s": 1.93e-07,
+      "memory_estimate_total_bytes": 5055513677,
+      "memory_estimate_pinned_bytes": 1342259248,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.0799068,
+          "best_ms": 0.073531,
+          "best_in_gibs": 13.281,
+          "best_out_gibs": 13.281,
+          "in_gibs": 12.2213,
+          "out_gibs": 12.2213
+        },
+        "h2d": {
+          "avg_ms": 0.0497739,
+          "best_ms": 0.04704,
+          "best_in_gibs": 20.7603,
+          "best_out_gibs": 20.7603,
+          "in_gibs": 19.62,
+          "out_gibs": 19.62
+        },
+        "scatter": {
+          "avg_ms": 0.0175979,
+          "best_ms": 0.011616,
+          "best_in_gibs": 84.0705,
+          "best_out_gibs": 84.0705,
+          "in_gibs": 55.4932,
+          "out_gibs": 55.4932
+        },
+        "compress": {
+          "avg_ms": 50.309,
+          "best_ms": 50.309,
+          "best_in_gibs": 0.621162,
+          "best_out_gibs": 0.071004,
+          "in_gibs": 0.621162,
+          "out_gibs": 0.071004
+        },
+        "aggregate": {
+          "avg_ms": 0.098816,
+          "best_ms": 0.098816,
+          "best_in_gibs": 36.1494,
+          "best_out_gibs": 36.1494,
+          "in_gibs": 36.1494,
+          "out_gibs": 36.1494
+        },
+        "d2h": {
+          "avg_ms": 0.206112,
+          "best_ms": 0.206112,
+          "best_in_gibs": 17.331,
+          "best_out_gibs": 17.331,
+          "in_gibs": 17.331,
+          "out_gibs": 17.331
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 50.4989,
+        "flush_stall_count": 1,
+        "kick_sync_ms": 50.451,
+        "kick_sync_count": 1,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 3.19681,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.68,
+      "status": "pass",
+      "throughput_in_gibs": 6.18753,
+      "throughput_out_gibs": 6.19478,
+      "compression_fold": 0.998829,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51975,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.568179,
+      "init_s": 0.00488087,
+      "flush_s": 1.85e-07,
+      "memory_estimate_total_bytes": 2419730968,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.99494,
+          "best_ms": 2.16274,
+          "best_in_gibs": 7.22464,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.3845,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.36518,
+          "best_ms": 2.60212,
+          "best_in_gibs": 54.0426,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.6276,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.811,
+          "best_ms": 2.65459,
+          "best_in_gibs": 52.9743,
+          "best_out_gibs": 0.0,
+          "in_gibs": 46.4555,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.51,
+      "status": "pass",
+      "throughput_in_gibs": 7.05051,
+      "throughput_out_gibs": 7.05471,
+      "compression_fold": 0.999405,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51772,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.498634,
+      "init_s": 0.00422667,
+      "flush_s": 2.23e-07,
+      "memory_estimate_total_bytes": 2417982176,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.17022,
+          "best_ms": 1.909,
+          "best_in_gibs": 8.18491,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.2404,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.30255,
+          "best_ms": 2.4202,
+          "best_in_gibs": 58.1046,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.9887,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.8697,
+          "best_ms": 2.40602,
+          "best_in_gibs": 58.4471,
+          "best_out_gibs": 0.0,
+          "in_gibs": 46.2048,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.49,
+      "status": "pass",
+      "throughput_in_gibs": 7.05076,
+      "throughput_out_gibs": 7.05283,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51666,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.498616,
+      "init_s": 0.00440143,
+      "flush_s": 2.06e-07,
+      "memory_estimate_total_bytes": 2417076760,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.26132,
+          "best_ms": 1.75212,
+          "best_in_gibs": 8.91777,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.0001,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.29579,
+          "best_ms": 2.31244,
+          "best_in_gibs": 60.8123,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.0279,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.5831,
+          "best_ms": 2.34368,
+          "best_in_gibs": 60.0017,
+          "best_out_gibs": 0.0,
+          "in_gibs": 47.4562,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.56,
+      "status": "pass",
+      "throughput_in_gibs": 8.23314,
+      "throughput_out_gibs": 8.23446,
+      "compression_fold": 0.99984,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51619,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.427009,
+      "init_s": 0.00439738,
+      "flush_s": 1.58e-07,
+      "memory_estimate_total_bytes": 2416665440,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.3107,
+          "best_ms": 1.60314,
+          "best_in_gibs": 9.7465,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.1586,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.26836,
+          "best_ms": 2.36547,
+          "best_in_gibs": 59.4489,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.1878,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.7649,
+          "best_ms": 2.26493,
+          "best_in_gibs": 62.088,
+          "best_out_gibs": 0.0,
+          "in_gibs": 46.6545,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.48,
+      "status": "pass",
+      "throughput_in_gibs": 8.31924,
+      "throughput_out_gibs": 8.31992,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.51591,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.42259,
+      "init_s": 0.00444308,
+      "flush_s": 2.22e-07,
+      "memory_estimate_total_bytes": 2416431640,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.30316,
+          "best_ms": 1.59364,
+          "best_in_gibs": 9.80459,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.191,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.21646,
+          "best_ms": 2.31003,
+          "best_in_gibs": 60.8758,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.493,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.3855,
+          "best_ms": 2.29129,
+          "best_in_gibs": 61.3738,
+          "best_out_gibs": 0.0,
+          "in_gibs": 48.3589,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.43,
+      "status": "pass",
+      "throughput_in_gibs": 8.50538,
+      "throughput_out_gibs": 8.84595,
+      "compression_fold": 0.999961,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65639,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.413341,
+      "init_s": 0.00396454,
+      "flush_s": 2.1e-07,
+      "memory_estimate_total_bytes": 2416311568,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.76348,
+          "best_ms": 1.6388,
+          "best_in_gibs": 9.53443,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.8276,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.5012,
+          "best_ms": 4.2932,
+          "best_in_gibs": 65.5106,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.9742,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.7316,
+          "best_ms": 4.21567,
+          "best_in_gibs": 66.7153,
+          "best_out_gibs": 0.0,
+          "in_gibs": 48.6713,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.39,
+      "status": "pass",
+      "throughput_in_gibs": 8.88555,
+      "throughput_out_gibs": 9.24114,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65631,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.395656,
+      "init_s": 0.00410589,
+      "flush_s": 1.7e-07,
+      "memory_estimate_total_bytes": 2416246832,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.50138,
+          "best_ms": 1.54166,
+          "best_in_gibs": 10.1352,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.9376,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.30632,
+          "best_ms": 4.45814,
+          "best_in_gibs": 63.0868,
+          "best_out_gibs": 0.0,
+          "in_gibs": 56.1255,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.6144,
+          "best_ms": 4.56469,
+          "best_in_gibs": 61.6143,
+          "best_out_gibs": 0.0,
+          "in_gibs": 49.2087,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__none__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.37,
+      "status": "pass",
+      "throughput_in_gibs": 9.28313,
+      "throughput_out_gibs": 9.65454,
+      "compression_fold": 0.999991,
+      "input_gib": 3.51562,
+      "compressed_gib": 3.65628,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.378711,
+      "init_s": 0.0039633,
+      "flush_s": 1.8e-07,
+      "memory_estimate_total_bytes": 2416219184,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.56535,
+          "best_ms": 1.60017,
+          "best_in_gibs": 9.76457,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.6516,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.66694,
+          "best_ms": 3.26276,
+          "best_in_gibs": 86.2,
+          "best_out_gibs": 0.0,
+          "in_gibs": 68.1264,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.48553,
+          "best_ms": 3.22027,
+          "best_in_gibs": 87.3375,
+          "best_out_gibs": 0.0,
+          "in_gibs": 55.065,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.27222,
+      "throughput_out_gibs": 1.69055,
+      "compression_fold": 2.52712,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.39116,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.822904,
+      "init_s": 0.00436029,
+      "flush_s": 1.52e-07,
+      "memory_estimate_total_bytes": 2428578328,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.11592,
+          "best_ms": 2.17774,
+          "best_in_gibs": 7.17486,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.16258,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 50.5528,
+          "best_ms": 13.9607,
+          "best_in_gibs": 10.0729,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.9348,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.00488,
+          "best_ms": 1.4337,
+          "best_in_gibs": 98.564,
+          "best_out_gibs": 0.0,
+          "in_gibs": 100.838,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.73,
+      "status": "pass",
+      "throughput_in_gibs": 4.70041,
+      "throughput_out_gibs": 1.81201,
+      "compression_fold": 2.59403,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.35528,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.747941,
+      "init_s": 0.00420856,
+      "flush_s": 2.38e-07,
+      "memory_estimate_total_bytes": 2425944800,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.28836,
+          "best_ms": 1.8067,
+          "best_in_gibs": 8.64834,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9308,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 50.1186,
+          "best_ms": 14.4193,
+          "best_in_gibs": 9.75254,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.0209,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.79298,
+          "best_ms": 1.30875,
+          "best_in_gibs": 107.922,
+          "best_out_gibs": 0.0,
+          "in_gibs": 105.245,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.66,
+      "status": "pass",
+      "throughput_in_gibs": 4.87695,
+      "throughput_out_gibs": 1.81366,
+      "compression_fold": 2.68901,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.30741,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.720865,
+      "init_s": 0.00422017,
+      "flush_s": 4.57e-07,
+      "memory_estimate_total_bytes": 2424630808,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.29656,
+          "best_ms": 1.85332,
+          "best_in_gibs": 8.4308,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9099,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 46.8669,
+          "best_ms": 13.39,
+          "best_in_gibs": 10.5023,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.7161,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.60528,
+          "best_ms": 1.20304,
+          "best_in_gibs": 117.379,
+          "best_out_gibs": 0.0,
+          "in_gibs": 109.511,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.59,
+      "status": "pass",
+      "throughput_in_gibs": 5.51838,
+      "throughput_out_gibs": 1.95427,
+      "compression_fold": 2.82375,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.24502,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.637075,
+      "init_s": 0.0042748,
+      "flush_s": 2.28e-07,
+      "memory_estimate_total_bytes": 2423998304,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.3612,
+          "best_ms": 1.61294,
+          "best_in_gibs": 9.68729,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.9459,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 45.4704,
+          "best_ms": 13.0957,
+          "best_in_gibs": 10.7383,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.0452,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.33,
+          "best_ms": 1.17616,
+          "best_in_gibs": 120.049,
+          "best_out_gibs": 0.0,
+          "in_gibs": 116.459,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.58,
+      "status": "pass",
+      "throughput_in_gibs": 5.61821,
+      "throughput_out_gibs": 1.93071,
+      "compression_fold": 2.90991,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.20816,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.625756,
+      "init_s": 0.00421114,
+      "flush_s": 2.74e-07,
+      "memory_estimate_total_bytes": 2423653912,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.36577,
+          "best_ms": 1.5517,
+          "best_in_gibs": 10.0696,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.927,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 44.2411,
+          "best_ms": 12.8303,
+          "best_in_gibs": 10.9604,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.3522,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.96687,
+          "best_ms": 1.21807,
+          "best_in_gibs": 115.909,
+          "best_out_gibs": 0.0,
+          "in_gibs": 127.112,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.58,
+      "status": "pass",
+      "throughput_in_gibs": 5.64552,
+      "throughput_out_gibs": 1.98161,
+      "compression_fold": 2.96291,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.234,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.622729,
+      "init_s": 0.00402632,
+      "flush_s": 2.59e-07,
+      "memory_estimate_total_bytes": 2423474448,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.79786,
+          "best_ms": 1.86575,
+          "best_in_gibs": 8.37464,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.6934,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 45.3682,
+          "best_ms": 24.8529,
+          "best_in_gibs": 11.3166,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.5129,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.19121,
+          "best_ms": 2.16196,
+          "best_in_gibs": 130.606,
+          "best_out_gibs": 0.0,
+          "in_gibs": 125.116,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.55,
+      "status": "pass",
+      "throughput_in_gibs": 5.8245,
+      "throughput_out_gibs": 1.94498,
+      "compression_fold": 3.11441,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.17398,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.603593,
+      "init_s": 0.00401569,
+      "flush_s": 2.69e-07,
+      "memory_estimate_total_bytes": 2423384112,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.56815,
+          "best_ms": 1.90624,
+          "best_in_gibs": 8.19674,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.6394,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 44.9099,
+          "best_ms": 24.2717,
+          "best_in_gibs": 11.5876,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.6304,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.95779,
+          "best_ms": 1.61079,
+          "best_in_gibs": 175.293,
+          "best_out_gibs": 0.0,
+          "in_gibs": 132.493,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__lz4__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.57,
+      "status": "pass",
+      "throughput_in_gibs": 5.69822,
+      "throughput_out_gibs": 1.96796,
+      "compression_fold": 3.01132,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.21417,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.616969,
+      "init_s": 0.00401059,
+      "flush_s": 2.26e-07,
+      "memory_estimate_total_bytes": 2423343664,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.6112,
+          "best_ms": 1.672,
+          "best_in_gibs": 9.34512,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.4529,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 46.7713,
+          "best_ms": 25.1946,
+          "best_in_gibs": 11.1631,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.1676,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.94595,
+          "best_ms": 1.75459,
+          "best_in_gibs": 160.924,
+          "best_out_gibs": 0.0,
+          "in_gibs": 132.89,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.97,
+      "status": "pass",
+      "throughput_in_gibs": 3.57113,
+      "throughput_out_gibs": 0.441057,
+      "compression_fold": 8.09676,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.434202,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.984456,
+      "init_s": 0.00442074,
+      "flush_s": 1.54e-07,
+      "memory_estimate_total_bytes": 2433002008,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.16036,
+          "best_ms": 2.18811,
+          "best_in_gibs": 7.14086,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.08366,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 75.7443,
+          "best_ms": 19.274,
+          "best_in_gibs": 7.2961,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.63063,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.28647,
+          "best_ms": 0.985035,
+          "best_in_gibs": 143.807,
+          "best_out_gibs": 0.0,
+          "in_gibs": 221.263,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.9,
+      "status": "pass",
+      "throughput_in_gibs": 3.8977,
+      "throughput_out_gibs": 0.498551,
+      "compression_fold": 7.81805,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.449681,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.901975,
+      "init_s": 0.00424417,
+      "flush_s": 1.6e-07,
+      "memory_estimate_total_bytes": 2427714272,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.31213,
+          "best_ms": 1.94145,
+          "best_in_gibs": 8.04813,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.8705,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 74.1059,
+          "best_ms": 19.8486,
+          "best_in_gibs": 7.08487,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.77722,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.15789,
+          "best_ms": 0.976652,
+          "best_in_gibs": 144.76,
+          "best_out_gibs": 0.0,
+          "in_gibs": 233.992,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.8,
+      "status": "pass",
+      "throughput_in_gibs": 4.04873,
+      "throughput_out_gibs": 0.485939,
+      "compression_fold": 8.33177,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.421954,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.868328,
+      "init_s": 0.00422525,
+      "flush_s": 1.6e-07,
+      "memory_estimate_total_bytes": 2425039384,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.38149,
+          "best_ms": 1.74584,
+          "best_in_gibs": 8.94982,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.6984,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 69.3,
+          "best_ms": 20.6956,
+          "best_in_gibs": 6.79494,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.24721,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.98203,
+          "best_ms": 0.945113,
+          "best_in_gibs": 149.446,
+          "best_out_gibs": 0.0,
+          "in_gibs": 254.507,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.69,
+      "status": "pass",
+      "throughput_in_gibs": 4.62962,
+      "throughput_out_gibs": 0.557202,
+      "compression_fold": 8.30868,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.423127,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.759377,
+      "init_s": 0.00435302,
+      "flush_s": 2.6e-07,
+      "memory_estimate_total_bytes": 2423743328,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.34685,
+          "best_ms": 1.62151,
+          "best_in_gibs": 9.63606,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0057,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 65.2003,
+          "best_ms": 19.3372,
+          "best_in_gibs": 7.27226,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.70291,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.9371,
+          "best_ms": 1.12231,
+          "best_in_gibs": 125.789,
+          "best_out_gibs": 0.0,
+          "in_gibs": 260.283,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.7,
+      "status": "pass",
+      "throughput_in_gibs": 4.5344,
+      "throughput_out_gibs": 0.4993,
+      "compression_fold": 9.0815,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.387119,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.775324,
+      "init_s": 0.00432281,
+      "flush_s": 2.21e-07,
+      "memory_estimate_total_bytes": 2423509528,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.34219,
+          "best_ms": 1.58019,
+          "best_in_gibs": 9.88803,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0252,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 67.6415,
+          "best_ms": 20.243,
+          "best_in_gibs": 6.94683,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.42491,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.80377,
+          "best_ms": 0.927226,
+          "best_in_gibs": 152.254,
+          "best_out_gibs": 0.0,
+          "in_gibs": 279.522,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.74,
+      "status": "pass",
+      "throughput_in_gibs": 4.35817,
+      "throughput_out_gibs": 0.497457,
+      "compression_fold": 9.11134,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.401286,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.806674,
+      "init_s": 0.00419859,
+      "flush_s": 1.9e-07,
+      "memory_estimate_total_bytes": 2423389456,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.8344,
+          "best_ms": 1.88264,
+          "best_in_gibs": 8.2995,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.5534,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 73.7171,
+          "best_ms": 39.5737,
+          "best_in_gibs": 7.107,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.08548,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.85744,
+          "best_ms": 1.05523,
+          "best_in_gibs": 267.572,
+          "best_out_gibs": 0.0,
+          "in_gibs": 282.303,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.73,
+      "status": "pass",
+      "throughput_in_gibs": 4.411,
+      "throughput_out_gibs": 0.509629,
+      "compression_fold": 9.00154,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.406181,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.797013,
+      "init_s": 0.00425604,
+      "flush_s": 1.58e-07,
+      "memory_estimate_total_bytes": 2423324720,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.5943,
+          "best_ms": 1.59234,
+          "best_in_gibs": 9.81258,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.5256,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 74.4409,
+          "best_ms": 39.6491,
+          "best_in_gibs": 7.09348,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.01659,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.81738,
+          "best_ms": 1.0811,
+          "best_in_gibs": 261.168,
+          "best_out_gibs": 0.0,
+          "in_gibs": 288.526,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__zstd__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.78,
+      "status": "pass",
+      "throughput_in_gibs": 4.38234,
+      "throughput_out_gibs": 0.485116,
+      "compression_fold": 9.39494,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.389172,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.802226,
+      "init_s": 0.00420523,
+      "flush_s": 1.51e-07,
+      "memory_estimate_total_bytes": 2423297072,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.57821,
+          "best_ms": 1.64033,
+          "best_in_gibs": 9.52551,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.5954,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 75.3535,
+          "best_ms": 43.215,
+          "best_in_gibs": 6.50816,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.93161,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.77388,
+          "best_ms": 1.32319,
+          "best_in_gibs": 426.769,
+          "best_out_gibs": 0.0,
+          "in_gibs": 295.601,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 2.69,
+      "status": "pass",
+      "throughput_in_gibs": 5.09263,
+      "throughput_out_gibs": 3.25035,
+      "compression_fold": 1.5668,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.24383,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.690336,
+      "init_s": 0.00455643,
+      "flush_s": 1.46e-07,
+      "memory_estimate_total_bytes": 2421500440,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.14498,
+          "best_ms": 2.16531,
+          "best_in_gibs": 7.21605,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.11082,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.5083,
+          "best_ms": 7.97018,
+          "best_in_gibs": 17.6439,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.617,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.51918,
+          "best_ms": 2.03847,
+          "best_in_gibs": 69.0528,
+          "best_out_gibs": 0.0,
+          "in_gibs": 66.8587,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.6,
+      "status": "pass",
+      "throughput_in_gibs": 5.79619,
+      "throughput_out_gibs": 3.49827,
+      "compression_fold": 1.65688,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.12184,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.606541,
+      "init_s": 0.00415677,
+      "flush_s": 2.79e-07,
+      "memory_estimate_total_bytes": 2418866912,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.29135,
+          "best_ms": 1.88675,
+          "best_in_gibs": 8.28145,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9231,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.4573,
+          "best_ms": 7.78108,
+          "best_in_gibs": 18.0727,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.2914,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.87269,
+          "best_ms": 1.66058,
+          "best_in_gibs": 84.7255,
+          "best_out_gibs": 0.0,
+          "in_gibs": 73.1122,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.58,
+      "status": "pass",
+      "throughput_in_gibs": 5.80205,
+      "throughput_out_gibs": 3.39384,
+      "compression_fold": 1.70959,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.05642,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.605928,
+      "init_s": 0.0046594,
+      "flush_s": 1.84e-07,
+      "memory_estimate_total_bytes": 2417519128,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.31979,
+          "best_ms": 1.85714,
+          "best_in_gibs": 8.41345,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.8512,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.7942,
+          "best_ms": 8.01285,
+          "best_in_gibs": 17.5499,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.0697,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.69514,
+          "best_ms": 1.82593,
+          "best_in_gibs": 77.0343,
+          "best_out_gibs": 0.0,
+          "in_gibs": 75.0327,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.51,
+      "status": "pass",
+      "throughput_in_gibs": 6.64014,
+      "throughput_out_gibs": 3.72308,
+      "compression_fold": 1.78351,
+      "input_gib": 3.51562,
+      "compressed_gib": 1.97119,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.52945,
+      "init_s": 0.00441309,
+      "flush_s": 2.25e-07,
+      "memory_estimate_total_bytes": 2416886624,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.34258,
+          "best_ms": 1.62287,
+          "best_in_gibs": 9.62798,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0236,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.9264,
+          "best_ms": 8.31116,
+          "best_in_gibs": 16.92,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.9841,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.27458,
+          "best_ms": 1.58319,
+          "best_in_gibs": 88.8362,
+          "best_out_gibs": 0.0,
+          "in_gibs": 80.0521,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.53,
+      "status": "pass",
+      "throughput_in_gibs": 6.59938,
+      "throughput_out_gibs": 3.79586,
+      "compression_fold": 1.73857,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.02213,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.53272,
+      "init_s": 0.0043119,
+      "flush_s": 1.59e-07,
+      "memory_estimate_total_bytes": 2416542232,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.35776,
+          "best_ms": 1.6269,
+          "best_in_gibs": 9.60413,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.9602,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.4154,
+          "best_ms": 8.19024,
+          "best_in_gibs": 17.1698,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.6747,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.36242,
+          "best_ms": 1.42341,
+          "best_in_gibs": 98.8023,
+          "best_out_gibs": 0.0,
+          "in_gibs": 78.9422,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.5,
+      "status": "pass",
+      "throughput_in_gibs": 6.58981,
+      "throughput_out_gibs": 3.94477,
+      "compression_fold": 1.73734,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.10451,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.533494,
+      "init_s": 0.00399594,
+      "flush_s": 1.68e-07,
+      "memory_estimate_total_bytes": 2416370960,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.83928,
+          "best_ms": 1.63682,
+          "best_in_gibs": 9.54594,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.5349,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.7502,
+          "best_ms": 15.6822,
+          "best_in_gibs": 17.9343,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.5569,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.65427,
+          "best_ms": 3.01331,
+          "best_in_gibs": 93.3398,
+          "best_out_gibs": 0.0,
+          "in_gibs": 78.4968,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.55,
+      "status": "pass",
+      "throughput_in_gibs": 6.83705,
+      "throughput_out_gibs": 3.9153,
+      "compression_fold": 1.81609,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.01325,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.514202,
+      "init_s": 0.00412571,
+      "flush_s": 1.44e-07,
+      "memory_estimate_total_bytes": 2416280624,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.57813,
+          "best_ms": 1.61045,
+          "best_in_gibs": 9.70223,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.5957,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.8382,
+          "best_ms": 15.9028,
+          "best_in_gibs": 17.6856,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.5051,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.32128,
+          "best_ms": 3.01049,
+          "best_in_gibs": 93.4258,
+          "best_out_gibs": 0.0,
+          "in_gibs": 82.6308,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.52,
+      "status": "pass",
+      "throughput_in_gibs": 6.75156,
+      "throughput_out_gibs": 3.86623,
+      "compression_fold": 1.81614,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.01319,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.520713,
+      "init_s": 0.00419806,
+      "flush_s": 2.31e-07,
+      "memory_estimate_total_bytes": 2416240176,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.57256,
+          "best_ms": 1.60816,
+          "best_in_gibs": 9.7161,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.6201,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 31.105,
+          "best_ms": 16.9746,
+          "best_in_gibs": 16.5689,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.7922,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.21948,
+          "best_ms": 2.52295,
+          "best_in_gibs": 111.478,
+          "best_out_gibs": 0.0,
+          "in_gibs": 83.9827,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 3.03,
+      "status": "pass",
+      "throughput_in_gibs": 3.62164,
+      "throughput_out_gibs": 0.270669,
+      "compression_fold": 13.3803,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.262747,
+      "total_chunks": 230400,
+      "chunks_per_epoch": 9216,
+      "wall_s": 0.970729,
+      "init_s": 0.00491975,
+      "flush_s": 5.01e-07,
+      "memory_estimate_total_bytes": 2421500440,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.16109,
+          "best_ms": 2.16978,
+          "best_in_gibs": 7.20119,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.08238,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 74.208,
+          "best_ms": 19.7998,
+          "best_in_gibs": 7.10233,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.7679,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.87402,
+          "best_ms": 0.961342,
+          "best_in_gibs": 146.423,
+          "best_out_gibs": 0.0,
+          "in_gibs": 268.259,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 2.82,
+      "status": "pass",
+      "throughput_in_gibs": 3.95874,
+      "throughput_out_gibs": 0.271219,
+      "compression_fold": 14.5961,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.24086,
+      "total_chunks": 115200,
+      "chunks_per_epoch": 4608,
+      "wall_s": 0.888068,
+      "init_s": 0.00426564,
+      "flush_s": 2.09e-07,
+      "memory_estimate_total_bytes": 2418866912,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.35013,
+          "best_ms": 1.7681,
+          "best_in_gibs": 8.83715,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.7755,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 72.6481,
+          "best_ms": 14.7153,
+          "best_in_gibs": 9.5564,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.91321,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.53977,
+          "best_ms": 0.912312,
+          "best_in_gibs": 154.217,
+          "best_out_gibs": 0.0,
+          "in_gibs": 326.332,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 2.7,
+      "status": "pass",
+      "throughput_in_gibs": 4.75965,
+      "throughput_out_gibs": 0.224451,
+      "compression_fold": 21.2058,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.165786,
+      "total_chunks": 57600,
+      "chunks_per_epoch": 2304,
+      "wall_s": 0.738631,
+      "init_s": 0.00421709,
+      "flush_s": 2.79e-07,
+      "memory_estimate_total_bytes": 2417519128,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.40124,
+          "best_ms": 1.76895,
+          "best_in_gibs": 8.8329,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.6504,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 51.3154,
+          "best_ms": 10.8024,
+          "best_in_gibs": 13.0179,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.78717,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.32263,
+          "best_ms": 0.862739,
+          "best_in_gibs": 163.038,
+          "best_out_gibs": 0.0,
+          "in_gibs": 379.814,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 2.58,
+      "status": "pass",
+      "throughput_in_gibs": 5.55602,
+      "throughput_out_gibs": 0.242745,
+      "compression_fold": 22.8883,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.153599,
+      "total_chunks": 28800,
+      "chunks_per_epoch": 1152,
+      "wall_s": 0.63276,
+      "init_s": 0.00431649,
+      "flush_s": 1.63e-07,
+      "memory_estimate_total_bytes": 2416886624,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.35511,
+          "best_ms": 1.63944,
+          "best_in_gibs": 9.53067,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.9712,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 47.5795,
+          "best_ms": 12.4757,
+          "best_in_gibs": 11.2719,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.5556,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.28758,
+          "best_ms": 0.890968,
+          "best_in_gibs": 157.855,
+          "best_out_gibs": 0.0,
+          "in_gibs": 390.106,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 2.46,
+      "status": "pass",
+      "throughput_in_gibs": 6.71866,
+      "throughput_out_gibs": 0.218544,
+      "compression_fold": 30.7428,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.114356,
+      "total_chunks": 14400,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.523263,
+      "init_s": 0.00409084,
+      "flush_s": 1.56e-07,
+      "memory_estimate_total_bytes": 2416542232,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.3448,
+          "best_ms": 1.60892,
+          "best_in_gibs": 9.71149,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0143,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.3011,
+          "best_ms": 8.89685,
+          "best_in_gibs": 15.8062,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.5484,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.12188,
+          "best_ms": 0.866414,
+          "best_in_gibs": 162.32,
+          "best_out_gibs": 0.0,
+          "in_gibs": 447.7,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 2.45,
+      "status": "pass",
+      "throughput_in_gibs": 6.71086,
+      "throughput_out_gibs": 0.226846,
+      "compression_fold": 30.7667,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.118838,
+      "total_chunks": 7488,
+      "chunks_per_epoch": 576,
+      "wall_s": 0.523871,
+      "init_s": 0.00406569,
+      "flush_s": 1.46e-07,
+      "memory_estimate_total_bytes": 2416370960,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.81193,
+          "best_ms": 1.61497,
+          "best_in_gibs": 9.67512,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.6392,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.1232,
+          "best_ms": 17.0716,
+          "best_in_gibs": 16.4747,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.3069,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.18944,
+          "best_ms": 0.982822,
+          "best_in_gibs": 572.351,
+          "best_out_gibs": 0.0,
+          "in_gibs": 439.148,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 2.46,
+      "status": "pass",
+      "throughput_in_gibs": 7.05895,
+      "throughput_out_gibs": 0.246936,
+      "compression_fold": 29.7296,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.122984,
+      "total_chunks": 3744,
+      "chunks_per_epoch": 288,
+      "wall_s": 0.498038,
+      "init_s": 0.00435789,
+      "flush_s": 1.48e-07,
+      "memory_estimate_total_bytes": 2416280624,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.52779,
+          "best_ms": 1.74361,
+          "best_in_gibs": 8.96128,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.8183,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.9705,
+          "best_ms": 17.1928,
+          "best_in_gibs": 16.3586,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.8421,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.13236,
+          "best_ms": 0.894485,
+          "best_in_gibs": 314.435,
+          "best_out_gibs": 0.0,
+          "in_gibs": 461.279,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "orca2_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 2.4,
+      "status": "pass",
+      "throughput_in_gibs": 7.65041,
+      "throughput_out_gibs": 0.232208,
+      "compression_fold": 34.2642,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.106708,
+      "total_chunks": 1872,
+      "chunks_per_epoch": 144,
+      "wall_s": 0.459534,
+      "init_s": 0.00400779,
+      "flush_s": 1.57e-07,
+      "memory_estimate_total_bytes": 2416240176,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.54707,
+          "best_ms": 1.6255,
+          "best_in_gibs": 9.61243,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.7323,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.4089,
+          "best_ms": 14.1304,
+          "best_in_gibs": 19.9039,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.0566,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.09094,
+          "best_ms": 0.897369,
+          "best_in_gibs": 313.42,
+          "best_out_gibs": 0.0,
+          "in_gibs": 478.788,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.6,
+      "status": "pass",
+      "throughput_in_gibs": 7.18141,
+      "throughput_out_gibs": 7.18842,
+      "compression_fold": 0.999024,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75366,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.522182,
+      "init_s": 0.00456499,
+      "flush_s": 4.36e-07,
+      "memory_estimate_total_bytes": 2419829140,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.34786,
+          "best_ms": 4.92189,
+          "best_in_gibs": 12.6984,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.6869,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.92252,
+          "best_ms": 6.15634,
+          "best_in_gibs": 60.9128,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.9897,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.4099,
+          "best_ms": 6.29123,
+          "best_in_gibs": 59.6068,
+          "best_out_gibs": 0.0,
+          "in_gibs": 46.9516,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 12.53,
+      "status": "pass",
+      "throughput_in_gibs": 8.09247,
+      "throughput_out_gibs": 8.09642,
+      "compression_fold": 0.999512,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75183,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.463394,
+      "init_s": 0.00428754,
+      "flush_s": 1.58e-07,
+      "memory_estimate_total_bytes": 2418010516,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.51347,
+          "best_ms": 4.13941,
+          "best_in_gibs": 15.0988,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.8474,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.8807,
+          "best_ms": 5.89372,
+          "best_in_gibs": 63.6271,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.2183,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.3151,
+          "best_ms": 6.20044,
+          "best_in_gibs": 60.4795,
+          "best_out_gibs": 0.0,
+          "in_gibs": 47.3452,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.51,
+      "status": "pass",
+      "throughput_in_gibs": 8.29256,
+      "throughput_out_gibs": 8.29459,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75092,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.452213,
+      "init_s": 0.00434003,
+      "flush_s": 3.03e-07,
+      "memory_estimate_total_bytes": 2417101204,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.41932,
+          "best_ms": 3.99775,
+          "best_in_gibs": 15.6338,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.1424,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.75727,
+          "best_ms": 5.66485,
+          "best_in_gibs": 66.1976,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.9041,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.4777,
+          "best_ms": 5.88304,
+          "best_in_gibs": 63.7425,
+          "best_out_gibs": 0.0,
+          "in_gibs": 46.6744,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 12.52,
+      "status": "pass",
+      "throughput_in_gibs": 8.29074,
+      "throughput_out_gibs": 8.29175,
+      "compression_fold": 0.999878,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75046,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.452312,
+      "init_s": 0.0041348,
+      "flush_s": 2.18e-07,
+      "memory_estimate_total_bytes": 2416646548,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.4606,
+          "best_ms": 3.92427,
+          "best_in_gibs": 15.9265,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0116,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.0213,
+          "best_ms": 6.11713,
+          "best_in_gibs": 61.3033,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.4578,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.1262,
+          "best_ms": 5.88046,
+          "best_in_gibs": 63.7705,
+          "best_out_gibs": 0.0,
+          "in_gibs": 48.1489,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.56,
+      "status": "pass",
+      "throughput_in_gibs": 8.22882,
+      "throughput_out_gibs": 8.22932,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75023,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.455715,
+      "init_s": 0.00408363,
+      "flush_s": 1.67e-07,
+      "memory_estimate_total_bytes": 3221768464,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.48251,
+          "best_ms": 3.92788,
+          "best_in_gibs": 15.9119,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.9431,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 13.9866,
+          "best_ms": 11.4025,
+          "best_in_gibs": 65.7751,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.6227,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 16.2829,
+          "best_ms": 11.1641,
+          "best_in_gibs": 67.1796,
+          "best_out_gibs": 0.0,
+          "in_gibs": 46.0605,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.57,
+      "status": "pass",
+      "throughput_in_gibs": 8.23599,
+      "throughput_out_gibs": 8.23624,
+      "compression_fold": 0.999969,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75011,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.455319,
+      "init_s": 0.00425499,
+      "flush_s": 1.56e-07,
+      "memory_estimate_total_bytes": 3221633296,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.37026,
+          "best_ms": 3.74901,
+          "best_in_gibs": 16.6711,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.3012,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.8908,
+          "best_ms": 11.3495,
+          "best_in_gibs": 66.082,
+          "best_out_gibs": 0.0,
+          "in_gibs": 50.3667,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 16.6326,
+          "best_ms": 11.2553,
+          "best_in_gibs": 66.6351,
+          "best_out_gibs": 0.0,
+          "in_gibs": 45.0922,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.54,
+      "status": "pass",
+      "throughput_in_gibs": 8.39103,
+      "throughput_out_gibs": 8.39116,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75006,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.446906,
+      "init_s": 0.00412253,
+      "flush_s": 1.48e-07,
+      "memory_estimate_total_bytes": 3221565712,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.34257,
+          "best_ms": 3.67125,
+          "best_in_gibs": 17.0242,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.3924,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.1441,
+          "best_ms": 11.2631,
+          "best_in_gibs": 66.5892,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.0256,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 16.2592,
+          "best_ms": 11.408,
+          "best_in_gibs": 65.7433,
+          "best_out_gibs": 0.0,
+          "in_gibs": 46.1277,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__none__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.53,
+      "status": "pass",
+      "throughput_in_gibs": 8.75811,
+      "throughput_out_gibs": 8.7582,
+      "compression_fold": 0.99999,
+      "input_gib": 3.75,
+      "compressed_gib": 3.75004,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.428175,
+      "init_s": 0.00444295,
+      "flush_s": 2.06e-07,
+      "memory_estimate_total_bytes": 3221540112,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.33322,
+          "best_ms": 3.86857,
+          "best_in_gibs": 16.1558,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.4235,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.9388,
+          "best_ms": 8.31462,
+          "best_in_gibs": 90.2026,
+          "best_out_gibs": 0.0,
+          "in_gibs": 62.8203,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.6879,
+          "best_ms": 7.9774,
+          "best_in_gibs": 94.0156,
+          "best_out_gibs": 0.0,
+          "in_gibs": 51.0624,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.7,
+      "status": "pass",
+      "throughput_in_gibs": 5.54882,
+      "throughput_out_gibs": 1.4951,
+      "compression_fold": 3.71134,
+      "input_gib": 3.75,
+      "compressed_gib": 1.01042,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.675819,
+      "init_s": 0.00450382,
+      "flush_s": 1.64e-07,
+      "memory_estimate_total_bytes": 2428676500,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.46294,
+          "best_ms": 4.82812,
+          "best_in_gibs": 12.945,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.4407,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 38.4171,
+          "best_ms": 26.2007,
+          "best_in_gibs": 14.3126,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.9447,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.04571,
+          "best_ms": 2.31613,
+          "best_in_gibs": 162.699,
+          "best_out_gibs": 0.0,
+          "in_gibs": 133.062,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 12.56,
+      "status": "pass",
+      "throughput_in_gibs": 6.71653,
+      "throughput_out_gibs": 1.5196,
+      "compression_fold": 4.41995,
+      "input_gib": 3.75,
+      "compressed_gib": 0.848426,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.558324,
+      "init_s": 0.00422158,
+      "flush_s": 2.99e-07,
+      "memory_estimate_total_bytes": 2425973140,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.4991,
+          "best_ms": 3.92729,
+          "best_in_gibs": 15.9143,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.8917,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 31.9927,
+          "best_ms": 22.0218,
+          "best_in_gibs": 17.0286,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.7449,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.07421,
+          "best_ms": 1.7246,
+          "best_in_gibs": 218.397,
+          "best_out_gibs": 0.0,
+          "in_gibs": 175.026,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.57,
+      "status": "pass",
+      "throughput_in_gibs": 7.08496,
+      "throughput_out_gibs": 1.51595,
+      "compression_fold": 4.67362,
+      "input_gib": 3.75,
+      "compressed_gib": 0.802376,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.52929,
+      "init_s": 0.00439989,
+      "flush_s": 3.14e-07,
+      "memory_estimate_total_bytes": 2424655252,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.53393,
+          "best_ms": 4.04822,
+          "best_in_gibs": 15.4389,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.7849,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.2949,
+          "best_ms": 19.6278,
+          "best_in_gibs": 19.1056,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.9332,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.89086,
+          "best_ms": 1.74935,
+          "best_in_gibs": 215.259,
+          "best_out_gibs": 0.0,
+          "in_gibs": 186.086,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 12.5,
+      "status": "pass",
+      "throughput_in_gibs": 7.63809,
+      "throughput_out_gibs": 1.4664,
+      "compression_fold": 5.20875,
+      "input_gib": 3.75,
+      "compressed_gib": 0.719942,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.490961,
+      "init_s": 0.00408448,
+      "flush_s": 3.23e-07,
+      "memory_estimate_total_bytes": 2423979412,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.41466,
+          "best_ms": 3.93318,
+          "best_in_gibs": 15.8904,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.1574,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.4564,
+          "best_ms": 16.9046,
+          "best_in_gibs": 22.1832,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.9049,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.61177,
+          "best_ms": 1.42615,
+          "best_in_gibs": 264.011,
+          "best_out_gibs": 0.0,
+          "in_gibs": 205.946,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.54,
+      "status": "pass",
+      "throughput_in_gibs": 7.70927,
+      "throughput_out_gibs": 1.46333,
+      "compression_fold": 5.26832,
+      "input_gib": 3.75,
+      "compressed_gib": 0.711801,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.486427,
+      "init_s": 0.00433366,
+      "flush_s": 2.2e-07,
+      "memory_estimate_total_bytes": 3231389968,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.45504,
+          "best_ms": 3.79728,
+          "best_in_gibs": 16.4592,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0291,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.959,
+          "best_ms": 31.76,
+          "best_in_gibs": 23.6146,
+          "best_out_gibs": 0.0,
+          "in_gibs": 22.7556,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.61387,
+          "best_ms": 2.36789,
+          "best_in_gibs": 317.999,
+          "best_out_gibs": 0.0,
+          "in_gibs": 208.36,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.56,
+      "status": "pass",
+      "throughput_in_gibs": 7.68447,
+      "throughput_out_gibs": 1.41938,
+      "compression_fold": 5.41397,
+      "input_gib": 3.75,
+      "compressed_gib": 0.692652,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.487997,
+      "init_s": 0.00436,
+      "flush_s": 1.96e-07,
+      "memory_estimate_total_bytes": 3231181072,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.28335,
+          "best_ms": 3.68348,
+          "best_in_gibs": 16.9676,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.5914,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 35.7228,
+          "best_ms": 34.8073,
+          "best_in_gibs": 21.5472,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.995,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.40941,
+          "best_ms": 2.30837,
+          "best_in_gibs": 326.189,
+          "best_out_gibs": 0.0,
+          "in_gibs": 220.849,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.55,
+      "status": "pass",
+      "throughput_in_gibs": 7.47095,
+      "throughput_out_gibs": 1.40632,
+      "compression_fold": 5.31241,
+      "input_gib": 3.75,
+      "compressed_gib": 0.705894,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.501944,
+      "init_s": 0.00411512,
+      "flush_s": 3.06e-07,
+      "memory_estimate_total_bytes": 3231076624,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.39764,
+          "best_ms": 3.83863,
+          "best_in_gibs": 16.2818,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.2122,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 37.0601,
+          "best_ms": 35.8589,
+          "best_in_gibs": 20.9153,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.2374,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.53091,
+          "best_ms": 2.37978,
+          "best_in_gibs": 316.396,
+          "best_out_gibs": 0.0,
+          "in_gibs": 213.246,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__lz4__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.53,
+      "status": "pass",
+      "throughput_in_gibs": 7.48808,
+      "throughput_out_gibs": 1.36221,
+      "compression_fold": 5.49701,
+      "input_gib": 3.75,
+      "compressed_gib": 0.682188,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.500796,
+      "init_s": 0.00423639,
+      "flush_s": 1.98e-07,
+      "memory_estimate_total_bytes": 3231036688,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.40553,
+          "best_ms": 3.88082,
+          "best_in_gibs": 16.1048,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.1867,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.7618,
+          "best_ms": 34.8934,
+          "best_in_gibs": 21.494,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.4016,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.40316,
+          "best_ms": 2.27297,
+          "best_in_gibs": 331.261,
+          "best_out_gibs": 0.0,
+          "in_gibs": 221.25,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.86,
+      "status": "pass",
+      "throughput_in_gibs": 4.43331,
+      "throughput_out_gibs": 0.48022,
+      "compression_fold": 9.23183,
+      "input_gib": 3.75,
+      "compressed_gib": 0.406203,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.845869,
+      "init_s": 0.00446918,
+      "flush_s": 1.85e-07,
+      "memory_estimate_total_bytes": 2433100180,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.36756,
+          "best_ms": 4.50538,
+          "best_in_gibs": 13.8723,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.644,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 65.3962,
+          "best_ms": 45.428,
+          "best_in_gibs": 8.25482,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.19182,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.10979,
+          "best_ms": 1.30287,
+          "best_in_gibs": 289.934,
+          "best_out_gibs": 0.0,
+          "in_gibs": 255.778,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 12.7,
+      "status": "pass",
+      "throughput_in_gibs": 5.3599,
+      "throughput_out_gibs": 0.498121,
+      "compression_fold": 10.7602,
+      "input_gib": 3.75,
+      "compressed_gib": 0.348505,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.699639,
+      "init_s": 0.00422451,
+      "flush_s": 1.55e-07,
+      "memory_estimate_total_bytes": 2427742612,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.53264,
+          "best_ms": 3.88973,
+          "best_in_gibs": 16.0679,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.7889,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 53.099,
+          "best_ms": 36.9846,
+          "best_in_gibs": 10.1393,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.089,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.88731,
+          "best_ms": 1.19934,
+          "best_in_gibs": 314.352,
+          "best_out_gibs": 0.0,
+          "in_gibs": 285.376,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.6,
+      "status": "pass",
+      "throughput_in_gibs": 6.02108,
+      "throughput_out_gibs": 0.489216,
+      "compression_fold": 12.3076,
+      "input_gib": 3.75,
+      "compressed_gib": 0.30469,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.622812,
+      "init_s": 0.00450395,
+      "flush_s": 2.11e-07,
+      "memory_estimate_total_bytes": 2425063828,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.4604,
+          "best_ms": 4.01222,
+          "best_in_gibs": 15.5774,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0122,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.5186,
+          "best_ms": 30.3797,
+          "best_in_gibs": 12.3438,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.31,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.6045,
+          "best_ms": 1.14615,
+          "best_in_gibs": 328.622,
+          "best_out_gibs": 0.0,
+          "in_gibs": 335.35,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 12.56,
+      "status": "pass",
+      "throughput_in_gibs": 6.44666,
+      "throughput_out_gibs": 0.460368,
+      "compression_fold": 14.0033,
+      "input_gib": 3.75,
+      "compressed_gib": 0.267795,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.581697,
+      "init_s": 0.00411901,
+      "flush_s": 4e-07,
+      "memory_estimate_total_bytes": 2423724436,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.37231,
+          "best_ms": 3.83525,
+          "best_in_gibs": 16.2962,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.2945,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 38.8358,
+          "best_ms": 27.0902,
+          "best_in_gibs": 13.8426,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.7943,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.47892,
+          "best_ms": 1.01542,
+          "best_in_gibs": 370.746,
+          "best_out_gibs": 0.0,
+          "in_gibs": 363.648,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.54,
+      "status": "pass",
+      "throughput_in_gibs": 6.9256,
+      "throughput_out_gibs": 0.344723,
+      "compression_fold": 20.0903,
+      "input_gib": 3.75,
+      "compressed_gib": 0.186657,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.541469,
+      "init_s": 0.00421457,
+      "flush_s": 1.62e-07,
+      "memory_estimate_total_bytes": 3231205648,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.52949,
+          "best_ms": 3.93585,
+          "best_in_gibs": 15.8797,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.7985,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 45.2443,
+          "best_ms": 43.976,
+          "best_in_gibs": 17.0547,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.5767,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.50854,
+          "best_ms": 1.16925,
+          "best_in_gibs": 643.941,
+          "best_out_gibs": 0.0,
+          "in_gibs": 499.113,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.52,
+      "status": "pass",
+      "throughput_in_gibs": 7.02222,
+      "throughput_out_gibs": 0.309974,
+      "compression_fold": 22.6542,
+      "input_gib": 3.75,
+      "compressed_gib": 0.165532,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.534019,
+      "init_s": 0.00416327,
+      "flush_s": 2.03e-07,
+      "memory_estimate_total_bytes": 3231070480,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.36848,
+          "best_ms": 3.79898,
+          "best_in_gibs": 16.4518,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.307,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 45.9212,
+          "best_ms": 43.7254,
+          "best_in_gibs": 17.1525,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.3323,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.39518,
+          "best_ms": 1.06328,
+          "best_in_gibs": 708.122,
+          "best_out_gibs": 0.0,
+          "in_gibs": 539.666,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.52,
+      "status": "pass",
+      "throughput_in_gibs": 7.13075,
+      "throughput_out_gibs": 0.288793,
+      "compression_fold": 24.6916,
+      "input_gib": 3.75,
+      "compressed_gib": 0.151874,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.525892,
+      "init_s": 0.00430527,
+      "flush_s": 1.92e-07,
+      "memory_estimate_total_bytes": 3231002896,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.4131,
+          "best_ms": 3.76963,
+          "best_in_gibs": 16.5799,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.1624,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.8001,
+          "best_ms": 41.6295,
+          "best_in_gibs": 18.0161,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.1233,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.45118,
+          "best_ms": 1.11653,
+          "best_in_gibs": 674.349,
+          "best_out_gibs": 0.0,
+          "in_gibs": 518.84,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__zstd__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.53,
+      "status": "pass",
+      "throughput_in_gibs": 7.20584,
+      "throughput_out_gibs": 0.2663,
+      "compression_fold": 27.0591,
+      "input_gib": 3.75,
+      "compressed_gib": 0.138586,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.520412,
+      "init_s": 0.00418251,
+      "flush_s": 1.59e-07,
+      "memory_estimate_total_bytes": 3230977296,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.42786,
+          "best_ms": 3.92474,
+          "best_in_gibs": 15.9246,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.1152,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 42.6154,
+          "best_ms": 39.5284,
+          "best_in_gibs": 18.9737,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.5993,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.31439,
+          "best_ms": 1.08562,
+          "best_in_gibs": 693.546,
+          "best_out_gibs": 0.0,
+          "in_gibs": 572.835,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 12.65,
+      "status": "pass",
+      "throughput_in_gibs": 6.04703,
+      "throughput_out_gibs": 3.08905,
+      "compression_fold": 1.95757,
+      "input_gib": 3.75,
+      "compressed_gib": 1.91564,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 0.620139,
+      "init_s": 0.00480058,
+      "flush_s": 3.09e-07,
+      "memory_estimate_total_bytes": 2421598612,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.33954,
+          "best_ms": 4.51431,
+          "best_in_gibs": 13.8449,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.7051,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.8015,
+          "best_ms": 18.1997,
+          "best_in_gibs": 20.6047,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.6002,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.57848,
+          "best_ms": 3.37867,
+          "best_in_gibs": 111.099,
+          "best_out_gibs": 0.0,
+          "in_gibs": 81.5139,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 12.59,
+      "status": "pass",
+      "throughput_in_gibs": 7.04033,
+      "throughput_out_gibs": 3.16014,
+      "compression_fold": 2.22786,
+      "input_gib": 3.75,
+      "compressed_gib": 1.68323,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.532646,
+      "init_s": 0.0042786,
+      "flush_s": 1.68e-07,
+      "memory_estimate_total_bytes": 2418895252,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.50472,
+          "best_ms": 3.97733,
+          "best_in_gibs": 15.7141,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.8743,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.9244,
+          "best_ms": 17.226,
+          "best_in_gibs": 21.7694,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.6645,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.42165,
+          "best_ms": 2.79932,
+          "best_in_gibs": 134.027,
+          "best_out_gibs": 0.0,
+          "in_gibs": 98.8585,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.59,
+      "status": "pass",
+      "throughput_in_gibs": 7.00053,
+      "throughput_out_gibs": 3.31656,
+      "compression_fold": 2.11078,
+      "input_gib": 3.75,
+      "compressed_gib": 1.7766,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.535674,
+      "init_s": 0.00452893,
+      "flush_s": 1.55e-07,
+      "memory_estimate_total_bytes": 2417543572,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.40689,
+          "best_ms": 3.82681,
+          "best_in_gibs": 16.3322,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.1823,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.7103,
+          "best_ms": 18.7235,
+          "best_in_gibs": 20.0283,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.3327,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.50409,
+          "best_ms": 3.1554,
+          "best_in_gibs": 118.873,
+          "best_out_gibs": 0.0,
+          "in_gibs": 97.354,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 12.54,
+      "status": "pass",
+      "throughput_in_gibs": 7.07279,
+      "throughput_out_gibs": 3.2639,
+      "compression_fold": 2.16698,
+      "input_gib": 3.75,
+      "compressed_gib": 1.73052,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.530201,
+      "init_s": 0.00449248,
+      "flush_s": 2.07e-07,
+      "memory_estimate_total_bytes": 2416867732,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.394,
+          "best_ms": 3.80937,
+          "best_in_gibs": 16.4069,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.2239,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.3611,
+          "best_ms": 18.6897,
+          "best_in_gibs": 20.0645,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.5794,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.39843,
+          "best_ms": 3.10944,
+          "best_in_gibs": 120.615,
+          "best_out_gibs": 0.0,
+          "in_gibs": 99.2474,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.58,
+      "status": "pass",
+      "throughput_in_gibs": 7.06553,
+      "throughput_out_gibs": 3.25969,
+      "compression_fold": 2.16755,
+      "input_gib": 3.75,
+      "compressed_gib": 1.73006,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.530746,
+      "init_s": 0.00426317,
+      "flush_s": 1.6e-07,
+      "memory_estimate_total_bytes": 3221915920,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.43732,
+          "best_ms": 3.86461,
+          "best_in_gibs": 16.1724,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0851,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 37.8608,
+          "best_ms": 36.0415,
+          "best_in_gibs": 20.8093,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.8094,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.95592,
+          "best_ms": 5.28099,
+          "best_in_gibs": 142.028,
+          "best_out_gibs": 0.0,
+          "in_gibs": 94.2751,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.58,
+      "status": "pass",
+      "throughput_in_gibs": 7.24066,
+      "throughput_out_gibs": 3.10471,
+      "compression_fold": 2.33215,
+      "input_gib": 3.75,
+      "compressed_gib": 1.60796,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.517908,
+      "init_s": 0.00413369,
+      "flush_s": 1.54e-07,
+      "memory_estimate_total_bytes": 3221707024,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.38765,
+          "best_ms": 3.85431,
+          "best_in_gibs": 16.2156,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.2445,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.249,
+          "best_ms": 34.1287,
+          "best_in_gibs": 21.9756,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.6902,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.63147,
+          "best_ms": 4.89532,
+          "best_in_gibs": 153.212,
+          "best_out_gibs": 0.0,
+          "in_gibs": 98.2803,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.58,
+      "status": "pass",
+      "throughput_in_gibs": 6.87638,
+      "throughput_out_gibs": 3.34107,
+      "compression_fold": 2.05814,
+      "input_gib": 3.75,
+      "compressed_gib": 1.82204,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.545345,
+      "init_s": 0.00426761,
+      "flush_s": 1.97e-07,
+      "memory_estimate_total_bytes": 3221602576,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.34636,
+          "best_ms": 3.90509,
+          "best_in_gibs": 16.0047,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.3799,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 41.6782,
+          "best_ms": 38.8891,
+          "best_in_gibs": 19.2856,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.995,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.30162,
+          "best_ms": 5.5687,
+          "best_in_gibs": 134.683,
+          "best_out_gibs": 0.0,
+          "in_gibs": 90.3452,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.59,
+      "status": "pass",
+      "throughput_in_gibs": 6.7829,
+      "throughput_out_gibs": 3.29556,
+      "compression_fold": 2.05819,
+      "input_gib": 3.75,
+      "compressed_gib": 1.82199,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.552861,
+      "init_s": 0.00397041,
+      "flush_s": 1.79e-07,
+      "memory_estimate_total_bytes": 3221562640,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.39775,
+          "best_ms": 3.93363,
+          "best_in_gibs": 15.8886,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.2118,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 42.367,
+          "best_ms": 40.0159,
+          "best_in_gibs": 18.7426,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.7025,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.50199,
+          "best_ms": 5.70888,
+          "best_in_gibs": 131.376,
+          "best_out_gibs": 0.0,
+          "in_gibs": 88.2156,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 13.03,
+      "status": "pass",
+      "throughput_in_gibs": 3.60119,
+      "throughput_out_gibs": 0.281617,
+      "compression_fold": 12.7875,
+      "input_gib": 3.75,
+      "compressed_gib": 0.293254,
+      "total_chunks": 245760,
+      "chunks_per_epoch": 12288,
+      "wall_s": 1.04132,
+      "init_s": 0.00436199,
+      "flush_s": 1.55e-07,
+      "memory_estimate_total_bytes": 2421598612,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.30886,
+          "best_ms": 4.54102,
+          "best_in_gibs": 13.7634,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.7728,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 94.0244,
+          "best_ms": 65.5101,
+          "best_in_gibs": 5.72431,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.69761,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.8851,
+          "best_ms": 1.2569,
+          "best_in_gibs": 298.645,
+          "best_out_gibs": 0.0,
+          "in_gibs": 284.461,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 12.84,
+      "status": "pass",
+      "throughput_in_gibs": 4.35037,
+      "throughput_out_gibs": 0.237928,
+      "compression_fold": 18.2844,
+      "input_gib": 3.75,
+      "compressed_gib": 0.205093,
+      "total_chunks": 122880,
+      "chunks_per_epoch": 6144,
+      "wall_s": 0.861996,
+      "init_s": 0.00431016,
+      "flush_s": 1.58e-07,
+      "memory_estimate_total_bytes": 2418895252,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.65697,
+          "best_ms": 3.99277,
+          "best_in_gibs": 15.6533,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.4207,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 75.4942,
+          "best_ms": 52.4993,
+          "best_in_gibs": 7.14296,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.0961,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.55084,
+          "best_ms": 1.16256,
+          "best_in_gibs": 322.722,
+          "best_out_gibs": 0.0,
+          "in_gibs": 345.604,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 12.75,
+      "status": "pass",
+      "throughput_in_gibs": 4.93775,
+      "throughput_out_gibs": 0.237266,
+      "compression_fold": 20.811,
+      "input_gib": 3.75,
+      "compressed_gib": 0.180193,
+      "total_chunks": 61440,
+      "chunks_per_epoch": 3072,
+      "wall_s": 0.759456,
+      "init_s": 0.00420889,
+      "flush_s": 1.55e-07,
+      "memory_estimate_total_bytes": 2417543572,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.45216,
+          "best_ms": 3.78852,
+          "best_in_gibs": 16.4972,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0381,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 63.4688,
+          "best_ms": 44.0624,
+          "best_in_gibs": 8.51065,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.44059,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.34305,
+          "best_ms": 1.03363,
+          "best_in_gibs": 362.887,
+          "best_out_gibs": 0.0,
+          "in_gibs": 398.976,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 12.71,
+      "status": "pass",
+      "throughput_in_gibs": 5.40264,
+      "throughput_out_gibs": 0.217224,
+      "compression_fold": 24.8713,
+      "input_gib": 3.75,
+      "compressed_gib": 0.150776,
+      "total_chunks": 30720,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.694105,
+      "init_s": 0.00428643,
+      "flush_s": 1.55e-07,
+      "memory_estimate_total_bytes": 2416867732,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.36327,
+          "best_ms": 3.84886,
+          "best_in_gibs": 16.2386,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.3241,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 55.2414,
+          "best_ms": 38.0926,
+          "best_in_gibs": 9.84444,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.6977,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.23667,
+          "best_ms": 1.04494,
+          "best_in_gibs": 538.376,
+          "best_out_gibs": 0.0,
+          "in_gibs": 433.244,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 12.73,
+      "status": "pass",
+      "throughput_in_gibs": 5.33621,
+      "throughput_out_gibs": 0.213902,
+      "compression_fold": 24.947,
+      "input_gib": 3.75,
+      "compressed_gib": 0.150319,
+      "total_chunks": 15360,
+      "chunks_per_epoch": 1536,
+      "wall_s": 0.702746,
+      "init_s": 0.00414746,
+      "flush_s": 1.68e-07,
+      "memory_estimate_total_bytes": 3221915920,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.62953,
+          "best_ms": 3.92925,
+          "best_in_gibs": 15.9064,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.5003,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 76.4051,
+          "best_ms": 74.7875,
+          "best_in_gibs": 10.0284,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.8161,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.44372,
+          "best_ms": 1.13574,
+          "best_in_gibs": 660.403,
+          "best_out_gibs": 0.0,
+          "in_gibs": 519.523,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 12.64,
+      "status": "pass",
+      "throughput_in_gibs": 5.75815,
+      "throughput_out_gibs": 0.167056,
+      "compression_fold": 34.4684,
+      "input_gib": 3.75,
+      "compressed_gib": 0.108795,
+      "total_chunks": 7680,
+      "chunks_per_epoch": 768,
+      "wall_s": 0.651251,
+      "init_s": 0.00396043,
+      "flush_s": 3.09e-07,
+      "memory_estimate_total_bytes": 3221707024,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.42887,
+          "best_ms": 3.78966,
+          "best_in_gibs": 16.4922,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.112,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 68.6332,
+          "best_ms": 66.5464,
+          "best_in_gibs": 11.2703,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9277,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.35025,
+          "best_ms": 1.0895,
+          "best_in_gibs": 688.41,
+          "best_out_gibs": 0.0,
+          "in_gibs": 555.468,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 12.72,
+      "status": "pass",
+      "throughput_in_gibs": 5.20654,
+      "throughput_out_gibs": 0.201907,
+      "compression_fold": 25.7868,
+      "input_gib": 3.75,
+      "compressed_gib": 0.145423,
+      "total_chunks": 3840,
+      "chunks_per_epoch": 384,
+      "wall_s": 0.720248,
+      "init_s": 0.00421654,
+      "flush_s": 2.61e-07,
+      "memory_estimate_total_bytes": 3221602576,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.49491,
+          "best_ms": 3.70688,
+          "best_in_gibs": 16.8605,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.9046,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 81.7494,
+          "best_ms": 79.0294,
+          "best_in_gibs": 9.49014,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.17438,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.37367,
+          "best_ms": 1.11424,
+          "best_in_gibs": 673.114,
+          "best_out_gibs": 0.0,
+          "in_gibs": 545.992,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "256cube_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 12.73,
+      "status": "pass",
+      "throughput_in_gibs": 5.19126,
+      "throughput_out_gibs": 0.201249,
+      "compression_fold": 25.7953,
+      "input_gib": 3.75,
+      "compressed_gib": 0.145376,
+      "total_chunks": 1920,
+      "chunks_per_epoch": 192,
+      "wall_s": 0.722368,
+      "init_s": 0.00411755,
+      "flush_s": 2.39e-07,
+      "memory_estimate_total_bytes": 3221562640,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.46965,
+          "best_ms": 3.89559,
+          "best_in_gibs": 16.0438,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.9832,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 82.5423,
+          "best_ms": 80.1315,
+          "best_in_gibs": 9.35962,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.08625,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.39607,
+          "best_ms": 1.03078,
+          "best_in_gibs": 727.612,
+          "best_out_gibs": 0.0,
+          "in_gibs": 537.229,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 30.64,
+      "status": "pass",
+      "throughput_in_gibs": 6.22294,
+      "throughput_out_gibs": 6.22902,
+      "compression_fold": 0.999024,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93255,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.470788,
+      "init_s": 0.00431345,
+      "flush_s": 2.43e-07,
+      "memory_estimate_total_bytes": 2520234348,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.90242,
+          "best_ms": 1.50063,
+          "best_in_gibs": 5.20616,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.73243,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.2871,
+          "best_ms": 9.03537,
+          "best_in_gibs": 64.8493,
+          "best_out_gibs": 0.0,
+          "in_gibs": 51.9119,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.6321,
+          "best_ms": 9.27739,
+          "best_in_gibs": 63.1576,
+          "best_out_gibs": 0.0,
+          "in_gibs": 42.9823,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 30.62,
+      "status": "pass",
+      "throughput_in_gibs": 6.37545,
+      "throughput_out_gibs": 6.37857,
+      "compression_fold": 0.999512,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93112,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.459526,
+      "init_s": 0.00439726,
+      "flush_s": 1.58e-07,
+      "memory_estimate_total_bytes": 2518544748,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.82218,
+          "best_ms": 1.50935,
+          "best_in_gibs": 5.17607,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.86656,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.2799,
+          "best_ms": 8.89031,
+          "best_in_gibs": 65.9074,
+          "best_out_gibs": 0.0,
+          "in_gibs": 51.9451,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.3821,
+          "best_ms": 9.0283,
+          "best_in_gibs": 64.9001,
+          "best_out_gibs": 0.0,
+          "in_gibs": 43.7852,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 30.66,
+      "status": "pass",
+      "throughput_in_gibs": 6.34357,
+      "throughput_out_gibs": 6.34512,
+      "compression_fold": 0.999756,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.9304,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.461836,
+      "init_s": 0.00424768,
+      "flush_s": 2.2e-07,
+      "memory_estimate_total_bytes": 2517699948,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.90948,
+          "best_ms": 1.5483,
+          "best_in_gibs": 5.04585,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.7208,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.1489,
+          "best_ms": 8.99156,
+          "best_in_gibs": 65.1652,
+          "best_out_gibs": 0.0,
+          "in_gibs": 52.5554,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.3234,
+          "best_ms": 9.05905,
+          "best_in_gibs": 64.6798,
+          "best_out_gibs": 0.0,
+          "in_gibs": 43.9781,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 30.58,
+      "status": "pass",
+      "throughput_in_gibs": 7.90116,
+      "throughput_out_gibs": 7.90213,
+      "compression_fold": 0.999878,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.93005,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.370792,
+      "init_s": 0.00414672,
+      "flush_s": 1.58e-07,
+      "memory_estimate_total_bytes": 2517277548,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.20498,
+          "best_ms": 1.40864,
+          "best_in_gibs": 5.54613,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.6611,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.1238,
+          "best_ms": 8.89253,
+          "best_in_gibs": 65.891,
+          "best_out_gibs": 0.0,
+          "in_gibs": 52.6741,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.1074,
+          "best_ms": 8.69131,
+          "best_in_gibs": 67.4165,
+          "best_out_gibs": 0.0,
+          "in_gibs": 44.7028,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 30.54,
+      "status": "pass",
+      "throughput_in_gibs": 8.04677,
+      "throughput_out_gibs": 8.04727,
+      "compression_fold": 0.999939,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92987,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.364082,
+      "init_s": 0.00404511,
+      "flush_s": 1.87e-07,
+      "memory_estimate_total_bytes": 2517066348,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.15285,
+          "best_ms": 1.34774,
+          "best_in_gibs": 5.79674,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.8326,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.908,
+          "best_ms": 8.69278,
+          "best_in_gibs": 67.4051,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.7162,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.7486,
+          "best_ms": 8.70253,
+          "best_in_gibs": 67.3296,
+          "best_out_gibs": 0.0,
+          "in_gibs": 45.9611,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 30.55,
+      "status": "pass",
+      "throughput_in_gibs": 8.25087,
+      "throughput_out_gibs": 8.25114,
+      "compression_fold": 0.999967,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92978,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.355076,
+      "init_s": 0.00413335,
+      "flush_s": 2.58e-07,
+      "memory_estimate_total_bytes": 2516965868,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.91877,
+          "best_ms": 1.247,
+          "best_in_gibs": 6.26502,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.6589,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.1643,
+          "best_ms": 8.71415,
+          "best_in_gibs": 67.2398,
+          "best_out_gibs": 0.0,
+          "in_gibs": 52.4833,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.1003,
+          "best_ms": 8.66599,
+          "best_in_gibs": 67.6134,
+          "best_out_gibs": 0.0,
+          "in_gibs": 44.7269,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 30.55,
+      "status": "pass",
+      "throughput_in_gibs": 8.3437,
+      "throughput_out_gibs": 8.34383,
+      "compression_fold": 0.999985,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.92973,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.351126,
+      "init_s": 0.00405751,
+      "flush_s": 2.67e-07,
+      "memory_estimate_total_bytes": 2516907948,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.84452,
+          "best_ms": 1.29975,
+          "best_in_gibs": 6.01077,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.942,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.0454,
+          "best_ms": 8.75916,
+          "best_in_gibs": 66.8943,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.0482,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.167,
+          "best_ms": 8.9021,
+          "best_in_gibs": 65.8201,
+          "best_out_gibs": 0.0,
+          "in_gibs": 44.5004,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__none__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 30.67,
+      "status": "pass",
+      "throughput_in_gibs": 7.45548,
+      "throughput_out_gibs": 8.94665,
+      "compression_fold": 0.999992,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.51565,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.392958,
+      "init_s": 0.0040621,
+      "flush_s": 2.26e-07,
+      "memory_estimate_total_bytes": 5033490348,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.22137,
+          "best_ms": 1.6738,
+          "best_in_gibs": 9.33502,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.1635,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 21.3278,
+          "best_ms": 12.5807,
+          "best_in_gibs": 93.1486,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.9459,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 29.4107,
+          "best_ms": 12.536,
+          "best_in_gibs": 93.4811,
+          "best_out_gibs": 0.0,
+          "in_gibs": 39.8452,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 30.88,
+      "status": "pass",
+      "throughput_in_gibs": 3.94262,
+      "throughput_out_gibs": 1.71125,
+      "compression_fold": 2.30394,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.2716,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.743082,
+      "init_s": 0.00446273,
+      "flush_s": 2.64e-07,
+      "memory_estimate_total_bytes": 2529450348,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.12536,
+          "best_ms": 1.49292,
+          "best_in_gibs": 5.23305,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.37819,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 70.1555,
+          "best_ms": 67.9568,
+          "best_in_gibs": 8.62221,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.35198,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.77882,
+          "best_ms": 4.55218,
+          "best_in_gibs": 129.344,
+          "best_out_gibs": 0.0,
+          "in_gibs": 86.8585,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 30.87,
+      "status": "pass",
+      "throughput_in_gibs": 4.19751,
+      "throughput_out_gibs": 1.74112,
+      "compression_fold": 2.41081,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.21523,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.697958,
+      "init_s": 0.00438543,
+      "flush_s": 1.62e-07,
+      "memory_estimate_total_bytes": 2526839148,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.94045,
+          "best_ms": 1.52747,
+          "best_in_gibs": 5.11467,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.67012,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 64.8666,
+          "best_ms": 63.3376,
+          "best_in_gibs": 9.25102,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.03296,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.08661,
+          "best_ms": 4.12812,
+          "best_in_gibs": 142.562,
+          "best_out_gibs": 0.0,
+          "in_gibs": 96.6897,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 30.81,
+      "status": "pass",
+      "throughput_in_gibs": 4.3358,
+      "throughput_out_gibs": 1.71382,
+      "compression_fold": 2.52991,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.15802,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.675697,
+      "init_s": 0.00426323,
+      "flush_s": 1.47e-07,
+      "memory_estimate_total_bytes": 2525563628,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.03247,
+          "best_ms": 1.54086,
+          "best_in_gibs": 5.07021,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.52261,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 60.4068,
+          "best_ms": 58.8251,
+          "best_in_gibs": 9.96068,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.69986,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.84688,
+          "best_ms": 3.84894,
+          "best_in_gibs": 152.868,
+          "best_out_gibs": 0.0,
+          "in_gibs": 100.631,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 30.69,
+      "status": "pass",
+      "throughput_in_gibs": 5.19295,
+      "throughput_out_gibs": 1.95099,
+      "compression_fold": 2.6617,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.10068,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.564166,
+      "init_s": 0.00445497,
+      "flush_s": 4.38e-07,
+      "memory_estimate_total_bytes": 2524916972,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.26424,
+          "best_ms": 1.32264,
+          "best_in_gibs": 5.90674,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.4713,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 56.6898,
+          "best_ms": 55.5321,
+          "best_in_gibs": 10.5513,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.3359,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.64605,
+          "best_ms": 3.72839,
+          "best_in_gibs": 157.792,
+          "best_out_gibs": 0.0,
+          "in_gibs": 104.199,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 30.68,
+      "status": "pass",
+      "throughput_in_gibs": 5.38982,
+      "throughput_out_gibs": 1.94572,
+      "compression_fold": 2.7701,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.05761,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.543559,
+      "init_s": 0.00428461,
+      "flush_s": 3.38e-07,
+      "memory_estimate_total_bytes": 2524585452,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.20936,
+          "best_ms": 1.34306,
+          "best_in_gibs": 5.81695,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.6469,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 53.8731,
+          "best_ms": 52.7676,
+          "best_in_gibs": 11.1041,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.8763,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.05877,
+          "best_ms": 3.36126,
+          "best_in_gibs": 175.015,
+          "best_out_gibs": 0.0,
+          "in_gibs": 116.287,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 30.69,
+      "status": "pass",
+      "throughput_in_gibs": 5.62304,
+      "throughput_out_gibs": 1.88337,
+      "compression_fold": 2.98562,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.981266,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.521015,
+      "init_s": 0.00409866,
+      "flush_s": 2.63e-07,
+      "memory_estimate_total_bytes": 2524433004,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.84729,
+          "best_ms": 1.29197,
+          "best_in_gibs": 6.04698,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.9313,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 53.4048,
+          "best_ms": 51.2616,
+          "best_in_gibs": 11.4303,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9716,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.76654,
+          "best_ms": 3.19613,
+          "best_in_gibs": 184.053,
+          "best_out_gibs": 0.0,
+          "in_gibs": 123.414,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 30.63,
+      "status": "pass",
+      "throughput_in_gibs": 5.70656,
+      "throughput_out_gibs": 1.84738,
+      "compression_fold": 3.089,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.948425,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.51339,
+      "init_s": 0.00414101,
+      "flush_s": 2.19e-07,
+      "memory_estimate_total_bytes": 2524340908,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.84767,
+          "best_ms": 1.27788,
+          "best_in_gibs": 6.11366,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.9298,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 52.0555,
+          "best_ms": 49.6384,
+          "best_in_gibs": 11.8041,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.256,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.56634,
+          "best_ms": 3.00608,
+          "best_in_gibs": 195.685,
+          "best_out_gibs": 0.0,
+          "in_gibs": 128.822,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__lz4__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 30.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.97111,
+      "throughput_out_gibs": 1.93118,
+      "compression_fold": 3.08896,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.13813,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.589343,
+      "init_s": 0.00430371,
+      "flush_s": 2.83e-07,
+      "memory_estimate_total_bytes": 5048330284,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.28375,
+          "best_ms": 1.7259,
+          "best_in_gibs": 9.05324,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.9573,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 103.584,
+          "best_ms": 98.691,
+          "best_in_gibs": 11.8742,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.3133,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.5571,
+          "best_ms": 5.76352,
+          "best_in_gibs": 204.126,
+          "best_out_gibs": 0.0,
+          "in_gibs": 101.797,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 31.06,
+      "status": "pass",
+      "throughput_in_gibs": 3.34342,
+      "throughput_out_gibs": 0.472067,
+      "compression_fold": 7.0825,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.413651,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.876256,
+      "init_s": 0.00427426,
+      "flush_s": 2.86e-07,
+      "memory_estimate_total_bytes": 2534058348,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.15279,
+          "best_ms": 1.44923,
+          "best_in_gibs": 5.39079,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.3364,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 100.505,
+          "best_ms": 98.5678,
+          "best_in_gibs": 5.94451,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.82994,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.83824,
+          "best_ms": 2.06646,
+          "best_in_gibs": 285.624,
+          "best_out_gibs": 0.0,
+          "in_gibs": 207.956,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 30.96,
+      "status": "pass",
+      "throughput_in_gibs": 3.59009,
+      "throughput_out_gibs": 0.542618,
+      "compression_fold": 6.61623,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.442803,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.816049,
+      "init_s": 0.00409923,
+      "flush_s": 1.56e-07,
+      "memory_estimate_total_bytes": 2528682348,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.96253,
+          "best_ms": 1.52802,
+          "best_in_gibs": 5.11283,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.63431,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 91.5144,
+          "best_ms": 90.0788,
+          "best_in_gibs": 6.50472,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.40268,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.90654,
+          "best_ms": 1.93837,
+          "best_in_gibs": 303.907,
+          "best_out_gibs": 0.0,
+          "in_gibs": 202.675,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 30.89,
+      "status": "pass",
+      "throughput_in_gibs": 3.82566,
+      "throughput_out_gibs": 0.509634,
+      "compression_fold": 7.50668,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.390277,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.765799,
+      "init_s": 0.00429263,
+      "flush_s": 1.72e-07,
+      "memory_estimate_total_bytes": 2525994348,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.92944,
+          "best_ms": 1.49762,
+          "best_in_gibs": 5.21662,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.68807,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 82.7896,
+          "best_ms": 81.2551,
+          "best_in_gibs": 7.21108,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.07743,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.49758,
+          "best_ms": 1.76665,
+          "best_in_gibs": 333.124,
+          "best_out_gibs": 0.0,
+          "in_gibs": 235.633,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 30.8,
+      "status": "pass",
+      "throughput_in_gibs": 4.45806,
+      "throughput_out_gibs": 0.59027,
+      "compression_fold": 7.55257,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.387906,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.657167,
+      "init_s": 0.00426795,
+      "flush_s": 3.13e-07,
+      "memory_estimate_total_bytes": 2524650348,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.22684,
+          "best_ms": 1.35876,
+          "best_in_gibs": 5.74974,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.5905,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 78.8385,
+          "best_ms": 77.5211,
+          "best_in_gibs": 7.55842,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.43212,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.42398,
+          "best_ms": 1.62386,
+          "best_in_gibs": 362.239,
+          "best_out_gibs": 0.0,
+          "in_gibs": 242.669,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 30.78,
+      "status": "pass",
+      "throughput_in_gibs": 4.40088,
+      "throughput_out_gibs": 0.521637,
+      "compression_fold": 8.43667,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.347256,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.665704,
+      "init_s": 0.0044238,
+      "flush_s": 1.84e-07,
+      "memory_estimate_total_bytes": 2524439148,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.18672,
+          "best_ms": 1.36727,
+          "best_in_gibs": 5.71393,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.7207,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 81.3278,
+          "best_ms": 79.4807,
+          "best_in_gibs": 7.37207,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.20464,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.14228,
+          "best_ms": 1.51102,
+          "best_in_gibs": 389.291,
+          "best_out_gibs": 0.0,
+          "in_gibs": 274.58,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 30.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.40276,
+      "throughput_out_gibs": 0.557492,
+      "compression_fold": 7.89744,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.370967,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.665421,
+      "init_s": 0.00400307,
+      "flush_s": 1.96e-07,
+      "memory_estimate_total_bytes": 2524338668,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.90461,
+          "best_ms": 1.28255,
+          "best_in_gibs": 6.09138,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.7121,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 84.055,
+          "best_ms": 80.6682,
+          "best_in_gibs": 7.26355,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.97088,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.32818,
+          "best_ms": 1.60425,
+          "best_in_gibs": 366.667,
+          "best_out_gibs": 0.0,
+          "in_gibs": 252.655,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 30.83,
+      "status": "pass",
+      "throughput_in_gibs": 4.29772,
+      "throughput_out_gibs": 0.521951,
+      "compression_fold": 8.23396,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.355806,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.681684,
+      "init_s": 0.00411448,
+      "flush_s": 1.56e-07,
+      "memory_estimate_total_bytes": 2524280748,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.97092,
+          "best_ms": 1.27492,
+          "best_in_gibs": 6.12782,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.4664,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 86.6845,
+          "best_ms": 82.1899,
+          "best_in_gibs": 7.12907,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.75942,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.338,
+          "best_ms": 1.62044,
+          "best_in_gibs": 363.004,
+          "best_out_gibs": 0.0,
+          "in_gibs": 251.594,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__zstd__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 30.93,
+      "status": "pass",
+      "throughput_in_gibs": 3.88705,
+      "throughput_out_gibs": 0.563939,
+      "compression_fold": 8.27121,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.425044,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.753705,
+      "init_s": 0.00429526,
+      "flush_s": 3.22e-07,
+      "memory_estimate_total_bytes": 5048235948,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.24303,
+          "best_ms": 2.00362,
+          "best_in_gibs": 7.79839,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0912,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 166.314,
+          "best_ms": 161.636,
+          "best_in_gibs": 7.25011,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.04617,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.24454,
+          "best_ms": 2.54068,
+          "best_in_gibs": 463.047,
+          "best_out_gibs": 0.0,
+          "in_gibs": 277.169,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 30.73,
+      "status": "pass",
+      "throughput_in_gibs": 5.11547,
+      "throughput_out_gibs": 3.34346,
+      "compression_fold": 1.52999,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.91484,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.572712,
+      "init_s": 0.00425904,
+      "flush_s": 1.6e-07,
+      "memory_estimate_total_bytes": 2522077548,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.03159,
+          "best_ms": 1.6861,
+          "best_in_gibs": 4.63348,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.524,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 34.3522,
+          "best_ms": 28.2747,
+          "best_in_gibs": 20.723,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.0568,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.56078,
+          "best_ms": 6.33358,
+          "best_in_gibs": 92.6032,
+          "best_out_gibs": 0.0,
+          "in_gibs": 61.3454,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 30.76,
+      "status": "pass",
+      "throughput_in_gibs": 5.30642,
+      "throughput_out_gibs": 3.29848,
+      "compression_fold": 1.60875,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.8211,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.552102,
+      "init_s": 0.00448151,
+      "flush_s": 2.23e-07,
+      "memory_estimate_total_bytes": 2519466348,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.93624,
+          "best_ms": 1.49321,
+          "best_in_gibs": 5.232,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.67697,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 33.0674,
+          "best_ms": 29.2239,
+          "best_in_gibs": 20.05,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.7195,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.71817,
+          "best_ms": 6.08924,
+          "best_in_gibs": 96.2721,
+          "best_out_gibs": 0.0,
+          "in_gibs": 67.2416,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 30.74,
+      "status": "pass",
+      "throughput_in_gibs": 5.31456,
+      "throughput_out_gibs": 3.23633,
+      "compression_fold": 1.64216,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.78405,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.551257,
+      "init_s": 0.00422975,
+      "flush_s": 1.47e-07,
+      "memory_estimate_total_bytes": 2518164844,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.93775,
+          "best_ms": 1.54897,
+          "best_in_gibs": 5.04367,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.67451,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 33.6957,
+          "best_ms": 30.7681,
+          "best_in_gibs": 19.0437,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.3891,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.6684,
+          "best_ms": 5.68295,
+          "best_in_gibs": 103.13,
+          "best_out_gibs": 0.0,
+          "in_gibs": 67.6113,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 30.59,
+      "status": "pass",
+      "throughput_in_gibs": 6.43373,
+      "throughput_out_gibs": 3.54676,
+      "compression_fold": 1.81397,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.61507,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.455364,
+      "init_s": 0.00435228,
+      "flush_s": 1.52e-07,
+      "memory_estimate_total_bytes": 2517509996,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.24533,
+          "best_ms": 1.36162,
+          "best_in_gibs": 5.73766,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.5313,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.9618,
+          "best_ms": 31.0335,
+          "best_in_gibs": 18.8808,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.7763,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.74181,
+          "best_ms": 5.22999,
+          "best_in_gibs": 112.048,
+          "best_out_gibs": 0.0,
+          "in_gibs": 75.6942,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 30.59,
+      "status": "pass",
+      "throughput_in_gibs": 6.46743,
+      "throughput_out_gibs": 3.56456,
+      "compression_fold": 1.81437,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.61471,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.452991,
+      "init_s": 0.00439992,
+      "flush_s": 2.05e-07,
+      "memory_estimate_total_bytes": 2517186668,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.24036,
+          "best_ms": 1.33209,
+          "best_in_gibs": 5.86484,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.5472,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.9874,
+          "best_ms": 30.9166,
+          "best_in_gibs": 18.9522,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.7625,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.57532,
+          "best_ms": 5.02696,
+          "best_in_gibs": 116.567,
+          "best_out_gibs": 0.0,
+          "in_gibs": 77.3533,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 30.63,
+      "status": "pass",
+      "throughput_in_gibs": 6.46256,
+      "throughput_out_gibs": 3.7476,
+      "compression_fold": 1.72445,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.69891,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.453332,
+      "init_s": 0.00412042,
+      "flush_s": 3.93e-07,
+      "memory_estimate_total_bytes": 2517026028,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.94524,
+          "best_ms": 1.31353,
+          "best_in_gibs": 5.94769,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.5606,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 35.6754,
+          "best_ms": 33.4926,
+          "best_in_gibs": 17.4945,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.4241,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.95624,
+          "best_ms": 5.43838,
+          "best_in_gibs": 107.745,
+          "best_out_gibs": 0.0,
+          "in_gibs": 73.6474,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 30.61,
+      "status": "pass",
+      "throughput_in_gibs": 6.49591,
+      "throughput_out_gibs": 3.76673,
+      "compression_fold": 1.72455,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.69881,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.451005,
+      "init_s": 0.00411456,
+      "flush_s": 2.81e-07,
+      "memory_estimate_total_bytes": 2516942124,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.87391,
+          "best_ms": 1.28222,
+          "best_in_gibs": 6.09294,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.8286,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 36.1145,
+          "best_ms": 33.3868,
+          "best_in_gibs": 17.55,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.2244,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.80699,
+          "best_ms": 5.1067,
+          "best_in_gibs": 114.741,
+          "best_out_gibs": 0.0,
+          "in_gibs": 75.0544,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 30.75,
+      "status": "pass",
+      "throughput_in_gibs": 5.65583,
+      "throughput_out_gibs": 3.93596,
+      "compression_fold": 1.72436,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.03881,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.517994,
+      "init_s": 0.00410252,
+      "flush_s": 2.14e-07,
+      "memory_estimate_total_bytes": 5033524524,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.24319,
+          "best_ms": 1.72785,
+          "best_in_gibs": 9.043,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0907,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 73.3679,
+          "best_ms": 67.1289,
+          "best_in_gibs": 17.4571,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.9726,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 18.6805,
+          "best_ms": 10.0662,
+          "best_in_gibs": 116.418,
+          "best_out_gibs": 0.0,
+          "in_gibs": 62.7333,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 31.0,
+      "status": "pass",
+      "throughput_in_gibs": 3.41419,
+      "throughput_out_gibs": 0.308455,
+      "compression_fold": 11.0687,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.264683,
+      "total_chunks": 192000,
+      "chunks_per_epoch": 38400,
+      "wall_s": 0.858092,
+      "init_s": 0.00452774,
+      "flush_s": 2.39e-07,
+      "memory_estimate_total_bytes": 2522077548,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.01878,
+          "best_ms": 1.54271,
+          "best_in_gibs": 5.06414,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.54426,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 98.9154,
+          "best_ms": 94.9725,
+          "best_in_gibs": 6.16955,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.92362,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.17623,
+          "best_ms": 1.60331,
+          "best_in_gibs": 365.812,
+          "best_out_gibs": 0.0,
+          "in_gibs": 269.507,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 30.82,
+      "status": "pass",
+      "throughput_in_gibs": 4.09549,
+      "throughput_out_gibs": 0.311095,
+      "compression_fold": 13.1648,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.22254,
+      "total_chunks": 96000,
+      "chunks_per_epoch": 19200,
+      "wall_s": 0.715345,
+      "init_s": 0.00407978,
+      "flush_s": 1.56e-07,
+      "memory_estimate_total_bytes": 2519466348,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.97515,
+          "best_ms": 1.52309,
+          "best_in_gibs": 5.12939,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.61397,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 72.243,
+          "best_ms": 69.1868,
+          "best_in_gibs": 8.46892,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.11065,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.89217,
+          "best_ms": 1.3688,
+          "best_in_gibs": 428.276,
+          "best_out_gibs": 0.0,
+          "in_gibs": 309.816,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 30.77,
+      "status": "pass",
+      "throughput_in_gibs": 4.78543,
+      "throughput_out_gibs": 0.24623,
+      "compression_fold": 19.4348,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.150744,
+      "total_chunks": 48000,
+      "chunks_per_epoch": 9600,
+      "wall_s": 0.61221,
+      "init_s": 0.00418615,
+      "flush_s": 1.73e-07,
+      "memory_estimate_total_bytes": 2518164844,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.03998,
+          "best_ms": 1.56173,
+          "best_in_gibs": 5.00248,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.51077,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 51.9034,
+          "best_ms": 48.8035,
+          "best_in_gibs": 12.0061,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.289,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.53844,
+          "best_ms": 1.23787,
+          "best_in_gibs": 473.459,
+          "best_out_gibs": 0.0,
+          "in_gibs": 380.959,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 30.62,
+      "status": "pass",
+      "throughput_in_gibs": 6.1849,
+      "throughput_out_gibs": 0.27834,
+      "compression_fold": 22.2207,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.131845,
+      "total_chunks": 24000,
+      "chunks_per_epoch": 4800,
+      "wall_s": 0.473684,
+      "init_s": 0.00434844,
+      "flush_s": 1.82e-07,
+      "memory_estimate_total_bytes": 2517509996,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.19524,
+          "best_ms": 1.4177,
+          "best_in_gibs": 5.51067,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.6929,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.4983,
+          "best_ms": 39.7995,
+          "best_in_gibs": 14.7222,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.4704,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.39454,
+          "best_ms": 1.10264,
+          "best_in_gibs": 531.461,
+          "best_out_gibs": 0.0,
+          "in_gibs": 420.218,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 30.53,
+      "status": "pass",
+      "throughput_in_gibs": 7.12031,
+      "throughput_out_gibs": 0.215405,
+      "compression_fold": 33.0554,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.0886296,
+      "total_chunks": 12000,
+      "chunks_per_epoch": 2400,
+      "wall_s": 0.411455,
+      "init_s": 0.00407082,
+      "flush_s": 2.31e-07,
+      "memory_estimate_total_bytes": 2517186668,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.24977,
+          "best_ms": 1.35928,
+          "best_in_gibs": 5.74751,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.5172,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 30.8231,
+          "best_ms": 28.7237,
+          "best_in_gibs": 20.3991,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.0097,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.196,
+          "best_ms": 0.971002,
+          "best_in_gibs": 603.475,
+          "best_out_gibs": 0.0,
+          "in_gibs": 489.948,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 30.56,
+      "status": "pass",
+      "throughput_in_gibs": 6.73432,
+      "throughput_out_gibs": 0.281181,
+      "compression_fold": 23.9501,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.122325,
+      "total_chunks": 6000,
+      "chunks_per_epoch": 1200,
+      "wall_s": 0.435039,
+      "init_s": 0.00404642,
+      "flush_s": 1.6e-07,
+      "memory_estimate_total_bytes": 2517026028,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.85,
+          "best_ms": 1.40045,
+          "best_in_gibs": 5.57858,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.9207,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 39.6437,
+          "best_ms": 36.477,
+          "best_in_gibs": 16.0632,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.7801,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.29448,
+          "best_ms": 1.00523,
+          "best_in_gibs": 582.91,
+          "best_out_gibs": 0.0,
+          "in_gibs": 452.657,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 30.63,
+      "status": "pass",
+      "throughput_in_gibs": 6.57505,
+      "throughput_out_gibs": 0.274317,
+      "compression_fold": 23.9688,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.122229,
+      "total_chunks": 3000,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.445577,
+      "init_s": 0.00406516,
+      "flush_s": 1.46e-07,
+      "memory_estimate_total_bytes": 2516942124,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.96347,
+          "best_ms": 1.28875,
+          "best_in_gibs": 6.06207,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.4936,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 40.4693,
+          "best_ms": 36.3969,
+          "best_in_gibs": 16.0986,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.4786,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.34862,
+          "best_ms": 1.08425,
+          "best_in_gibs": 540.42,
+          "best_out_gibs": 0.0,
+          "in_gibs": 434.479,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "medfmt_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 30.61,
+      "status": "pass",
+      "throughput_in_gibs": 6.12034,
+      "throughput_out_gibs": 0.304579,
+      "compression_fold": 24.1133,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.145796,
+      "total_chunks": 1800,
+      "chunks_per_epoch": 600,
+      "wall_s": 0.47868,
+      "init_s": 0.00403162,
+      "flush_s": 1.92e-07,
+      "memory_estimate_total_bytes": 5033524524,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.22199,
+          "best_ms": 1.72604,
+          "best_in_gibs": 9.0525,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.1615,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 77.3087,
+          "best_ms": 76.2931,
+          "best_in_gibs": 15.3602,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.1584,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.05136,
+          "best_ms": 1.57306,
+          "best_in_gibs": 744.975,
+          "best_out_gibs": 0.0,
+          "in_gibs": 571.272,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 1.8,
+      "status": "pass",
+      "throughput_in_gibs": 0.0187087,
+      "throughput_out_gibs": 0.018727,
+      "compression_fold": 0.999024,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312805,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.67035,
+      "init_s": 0.00397496,
+      "flush_s": 2.51e-07,
+      "memory_estimate_total_bytes": 2154448064,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.807227,
+          "best_ms": 0.695191,
+          "best_in_gibs": 0.0219491,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0189027,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 1.68354,
+          "best_ms": 1.68354,
+          "best_in_gibs": 18.5621,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.5621,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.95102,
+          "best_ms": 1.95102,
+          "best_in_gibs": 16.0173,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.0173,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.92,
+      "status": "pass",
+      "throughput_in_gibs": 0.0369656,
+      "throughput_out_gibs": 0.0369836,
+      "compression_fold": 0.999511,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312653,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.845382,
+      "init_s": 0.00413318,
+      "flush_s": 1.51e-07,
+      "memory_estimate_total_bytes": 2151101632,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.80829,
+          "best_ms": 0.701097,
+          "best_in_gibs": 0.0435283,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0377557,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 1.75251,
+          "best_ms": 1.75251,
+          "best_in_gibs": 17.8315,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.8315,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.02988,
+          "best_ms": 2.02988,
+          "best_in_gibs": 15.395,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.395,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.52,
+      "status": "pass",
+      "throughput_in_gibs": 0.0716134,
+      "throughput_out_gibs": 0.0716309,
+      "compression_fold": 0.999755,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312576,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.436371,
+      "init_s": 0.00418141,
+      "flush_s": 1.59e-07,
+      "memory_estimate_total_bytes": 2149428416,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.816681,
+          "best_ms": 0.707326,
+          "best_in_gibs": 0.08629,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0747356,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 1.66386,
+          "best_ms": 1.66386,
+          "best_in_gibs": 18.7817,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.7817,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.83526,
+          "best_ms": 1.83526,
+          "best_in_gibs": 17.0276,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.0276,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.33,
+      "status": "pass",
+      "throughput_in_gibs": 0.133205,
+      "throughput_out_gibs": 0.133222,
+      "compression_fold": 0.999877,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312538,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.2346,
+      "init_s": 0.00404934,
+      "flush_s": 2.32e-07,
+      "memory_estimate_total_bytes": 2148591808,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.843422,
+          "best_ms": 0.717216,
+          "best_in_gibs": 0.1702,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.144732,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 2.02314,
+          "best_ms": 2.02314,
+          "best_in_gibs": 15.4463,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.4463,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.90636,
+          "best_ms": 1.90636,
+          "best_in_gibs": 16.3925,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.3925,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.21,
+      "status": "pass",
+      "throughput_in_gibs": 0.249092,
+      "throughput_out_gibs": 0.249107,
+      "compression_fold": 0.999938,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312519,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.125456,
+      "init_s": 0.00397067,
+      "flush_s": 2.41e-07,
+      "memory_estimate_total_bytes": 2148173504,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.840962,
+          "best_ms": 0.705574,
+          "best_in_gibs": 0.346017,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.290311,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 1.7349,
+          "best_ms": 1.7349,
+          "best_in_gibs": 18.0125,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.0125,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.07043,
+          "best_ms": 2.07043,
+          "best_in_gibs": 15.0935,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.0935,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.15,
+      "status": "pass",
+      "throughput_in_gibs": 0.430279,
+      "throughput_out_gibs": 0.430292,
+      "compression_fold": 0.999969,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.031251,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0726273,
+      "init_s": 0.00417288,
+      "flush_s": 9.5e-08,
+      "memory_estimate_total_bytes": 2147964352,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.854193,
+          "best_ms": 0.727113,
+          "best_in_gibs": 0.671534,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.571629,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 1.83047,
+          "best_ms": 1.83047,
+          "best_in_gibs": 17.0721,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.0721,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.94182,
+          "best_ms": 1.94182,
+          "best_in_gibs": 16.0932,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.0932,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.13,
+      "status": "pass",
+      "throughput_in_gibs": 0.662424,
+      "throughput_out_gibs": 0.662434,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0471752,
+      "init_s": 0.004095,
+      "flush_s": 2.5e-07,
+      "memory_estimate_total_bytes": 2147859776,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.90849,
+          "best_ms": 0.859568,
+          "best_in_gibs": 1.13611,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.07493,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 1.97255,
+          "best_ms": 1.97255,
+          "best_in_gibs": 15.8424,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.8424,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.29911,
+          "best_ms": 2.29911,
+          "best_in_gibs": 13.5922,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.5922,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__none__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.12,
+      "status": "pass",
+      "throughput_in_gibs": 0.654341,
+      "throughput_out_gibs": 0.654351,
+      "compression_fold": 0.999984,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0312505,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.047758,
+      "init_s": 0.00399651,
+      "flush_s": 9.7e-08,
+      "memory_estimate_total_bytes": 2147859776,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.914386,
+          "best_ms": 0.847799,
+          "best_in_gibs": 1.15188,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.068,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 1.93947,
+          "best_ms": 1.93947,
+          "best_in_gibs": 16.1127,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.1127,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.11317,
+          "best_ms": 2.11317,
+          "best_in_gibs": 14.7882,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.7882,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 1.76,
+      "status": "pass",
+      "throughput_in_gibs": 0.018631,
+      "throughput_out_gibs": 0.0068661,
+      "compression_fold": 2.71348,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0115166,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.67731,
+      "init_s": 0.00402422,
+      "flush_s": 2.63e-07,
+      "memory_estimate_total_bytes": 2162312384,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.807953,
+          "best_ms": 0.695495,
+          "best_in_gibs": 0.0219395,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0188857,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.58291,
+          "best_ms": 6.58291,
+          "best_in_gibs": 4.74714,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.74714,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.24898,
+          "best_ms": 1.24898,
+          "best_in_gibs": 25.1425,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25.1425,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.94,
+      "status": "pass",
+      "throughput_in_gibs": 0.036729,
+      "throughput_out_gibs": 0.0134035,
+      "compression_fold": 2.74025,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0114041,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.850825,
+      "init_s": 0.00422572,
+      "flush_s": 2.89e-07,
+      "memory_estimate_total_bytes": 2158179520,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.80952,
+          "best_ms": 0.692942,
+          "best_in_gibs": 0.0440406,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0376984,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.41277,
+          "best_ms": 5.41277,
+          "best_in_gibs": 5.77339,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.77339,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.15836,
+          "best_ms": 1.15836,
+          "best_in_gibs": 27.0964,
+          "best_out_gibs": 0.0,
+          "in_gibs": 27.0964,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.53,
+      "status": "pass",
+      "throughput_in_gibs": 0.0704325,
+      "throughput_out_gibs": 0.0255761,
+      "compression_fold": 2.75384,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0113478,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.443687,
+      "init_s": 0.00425408,
+      "flush_s": 1.54e-07,
+      "memory_estimate_total_bytes": 2156137664,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.824985,
+          "best_ms": 0.712323,
+          "best_in_gibs": 0.0856847,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0739833,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.25597,
+          "best_ms": 5.25597,
+          "best_in_gibs": 5.94562,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.94562,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.05561,
+          "best_ms": 1.05561,
+          "best_in_gibs": 29.7303,
+          "best_out_gibs": 0.0,
+          "in_gibs": 29.7303,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.32,
+      "status": "pass",
+      "throughput_in_gibs": 0.134979,
+      "throughput_out_gibs": 0.0488934,
+      "compression_fold": 2.76069,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0113197,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.231517,
+      "init_s": 0.00421191,
+      "flush_s": 8.6e-08,
+      "memory_estimate_total_bytes": 2155104448,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.820215,
+          "best_ms": 0.71404,
+          "best_in_gibs": 0.170957,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.148827,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.82364,
+          "best_ms": 4.82364,
+          "best_in_gibs": 6.47851,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.47851,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.00275,
+          "best_ms": 1.00275,
+          "best_in_gibs": 31.2936,
+          "best_out_gibs": 0.0,
+          "in_gibs": 31.2936,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.21,
+      "status": "pass",
+      "throughput_in_gibs": 0.236459,
+      "throughput_out_gibs": 0.0855459,
+      "compression_fold": 2.76412,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0113056,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.132158,
+      "init_s": 0.00391403,
+      "flush_s": 2.01e-07,
+      "memory_estimate_total_bytes": 2154587840,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.873555,
+          "best_ms": 0.789731,
+          "best_in_gibs": 0.309144,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.279479,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.91149,
+          "best_ms": 5.91149,
+          "best_in_gibs": 5.28632,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.28632,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.25359,
+          "best_ms": 1.25359,
+          "best_in_gibs": 25.0289,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25.0289,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.15,
+      "status": "pass",
+      "throughput_in_gibs": 0.404669,
+      "throughput_out_gibs": 0.14631,
+      "compression_fold": 2.76584,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0112986,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0772235,
+      "init_s": 0.00408965,
+      "flush_s": 2.07e-07,
+      "memory_estimate_total_bytes": 2154329536,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.856904,
+          "best_ms": 0.741057,
+          "best_in_gibs": 0.658898,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.569821,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.70616,
+          "best_ms": 6.70616,
+          "best_in_gibs": 4.6599,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.6599,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.10264,
+          "best_ms": 1.10264,
+          "best_in_gibs": 28.4552,
+          "best_out_gibs": 0.0,
+          "in_gibs": 28.4552,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.12,
+      "status": "pass",
+      "throughput_in_gibs": 0.649924,
+      "throughput_out_gibs": 0.234909,
+      "compression_fold": 2.7667,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.011295,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0480825,
+      "init_s": 0.0039856,
+      "flush_s": 8.8e-08,
+      "memory_estimate_total_bytes": 2154200384,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.905014,
+          "best_ms": 0.860954,
+          "best_in_gibs": 1.13428,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.07906,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.15647,
+          "best_ms": 4.15647,
+          "best_in_gibs": 7.51839,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.51839,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.25332,
+          "best_ms": 1.25332,
+          "best_in_gibs": 25.0341,
+          "best_out_gibs": 0.0,
+          "in_gibs": 25.0341,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__lz4__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.13,
+      "status": "pass",
+      "throughput_in_gibs": 0.643907,
+      "throughput_out_gibs": 0.232734,
+      "compression_fold": 2.7667,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.011295,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0485319,
+      "init_s": 0.00406535,
+      "flush_s": 8.8e-08,
+      "memory_estimate_total_bytes": 2154200384,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.912593,
+          "best_ms": 0.852608,
+          "best_in_gibs": 1.14538,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.0701,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.4205,
+          "best_ms": 4.4205,
+          "best_in_gibs": 7.06933,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.06933,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.05974,
+          "best_ms": 1.05974,
+          "best_in_gibs": 29.6071,
+          "best_out_gibs": 0.0,
+          "in_gibs": 29.6071,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 1.79,
+      "status": "pass",
+      "throughput_in_gibs": 0.0184863,
+      "throughput_out_gibs": 0.00164171,
+      "compression_fold": 11.2604,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00277521,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.69044,
+      "init_s": 0.00415356,
+      "flush_s": 4.05e-07,
+      "memory_estimate_total_bytes": 2166244544,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.814235,
+          "best_ms": 0.69418,
+          "best_in_gibs": 0.021981,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.01874,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.65609,
+          "best_ms": 7.65609,
+          "best_in_gibs": 4.08172,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.08172,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.803499,
+          "best_ms": 0.803499,
+          "best_in_gibs": 39.1772,
+          "best_out_gibs": 0.0,
+          "in_gibs": 39.1772,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.94,
+      "status": "pass",
+      "throughput_in_gibs": 0.0366196,
+      "throughput_out_gibs": 0.00314031,
+      "compression_fold": 11.6611,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00267984,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.853367,
+      "init_s": 0.00415553,
+      "flush_s": 2.04e-07,
+      "memory_estimate_total_bytes": 2159752384,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.809487,
+          "best_ms": 0.698015,
+          "best_in_gibs": 0.0437205,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0376999,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.29576,
+          "best_ms": 8.29576,
+          "best_in_gibs": 3.76698,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.76698,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.924217,
+          "best_ms": 0.924217,
+          "best_in_gibs": 33.994,
+          "best_out_gibs": 0.0,
+          "in_gibs": 33.994,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.53,
+      "status": "pass",
+      "throughput_in_gibs": 0.0697407,
+      "throughput_out_gibs": 0.0058561,
+      "compression_fold": 11.9091,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00262405,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.448089,
+      "init_s": 0.0042929,
+      "flush_s": 2e-07,
+      "memory_estimate_total_bytes": 2156506304,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.819934,
+          "best_ms": 0.711399,
+          "best_in_gibs": 0.085796,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0744391,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.8454,
+          "best_ms": 12.8454,
+          "best_in_gibs": 2.43277,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.43277,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.958455,
+          "best_ms": 0.958455,
+          "best_in_gibs": 32.7478,
+          "best_out_gibs": 0.0,
+          "in_gibs": 32.7478,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.31,
+      "status": "pass",
+      "throughput_in_gibs": 0.132007,
+      "throughput_out_gibs": 0.0109778,
+      "compression_fold": 12.0249,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00259878,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.236729,
+      "init_s": 0.00423437,
+      "flush_s": 2.35e-07,
+      "memory_estimate_total_bytes": 2154883264,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.833535,
+          "best_ms": 0.725158,
+          "best_in_gibs": 0.168336,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.146449,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.05161,
+          "best_ms": 8.05161,
+          "best_in_gibs": 3.88121,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.88121,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.942024,
+          "best_ms": 0.942024,
+          "best_in_gibs": 33.3028,
+          "best_out_gibs": 0.0,
+          "in_gibs": 33.3028,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.23,
+      "status": "pass",
+      "throughput_in_gibs": 0.238859,
+      "throughput_out_gibs": 0.0197671,
+      "compression_fold": 12.0836,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00258614,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.130831,
+      "init_s": 0.00426377,
+      "flush_s": 2.11e-07,
+      "memory_estimate_total_bytes": 2154464960,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.837239,
+          "best_ms": 0.731527,
+          "best_in_gibs": 0.333741,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.291602,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.3495,
+          "best_ms": 8.3495,
+          "best_in_gibs": 3.74274,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.74274,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.891502,
+          "best_ms": 0.891502,
+          "best_in_gibs": 35.1901,
+          "best_out_gibs": 0.0,
+          "in_gibs": 35.1901,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.19,
+      "status": "pass",
+      "throughput_in_gibs": 0.377912,
+      "throughput_out_gibs": 0.0312047,
+      "compression_fold": 12.1107,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00258036,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0826913,
+      "init_s": 0.00403385,
+      "flush_s": 9.3e-08,
+      "memory_estimate_total_bytes": 2154255808,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.889175,
+          "best_ms": 0.760034,
+          "best_in_gibs": 0.642447,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.549139,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.2706,
+          "best_ms": 11.2706,
+          "best_in_gibs": 2.77271,
+          "best_out_gibs": 0.0,
+          "in_gibs": 2.77271,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.05875,
+          "best_ms": 1.05875,
+          "best_in_gibs": 29.6311,
+          "best_out_gibs": 0.0,
+          "in_gibs": 29.6311,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.12,
+      "status": "pass",
+      "throughput_in_gibs": 0.614222,
+      "throughput_out_gibs": 0.0506569,
+      "compression_fold": 12.1251,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00257729,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0508774,
+      "init_s": 0.00410249,
+      "flush_s": 1.42e-07,
+      "memory_estimate_total_bytes": 2154151232,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.890456,
+          "best_ms": 0.847142,
+          "best_in_gibs": 1.15277,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.0967,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.40201,
+          "best_ms": 7.40201,
+          "best_in_gibs": 4.22182,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.22182,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.977357,
+          "best_ms": 0.977357,
+          "best_in_gibs": 32.0989,
+          "best_out_gibs": 0.0,
+          "in_gibs": 32.0989,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__zstd__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.13,
+      "status": "pass",
+      "throughput_in_gibs": 0.597521,
+      "throughput_out_gibs": 0.0492795,
+      "compression_fold": 12.1251,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00257729,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0522994,
+      "init_s": 0.00429824,
+      "flush_s": 2.29e-07,
+      "memory_estimate_total_bytes": 2154151232,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.892797,
+          "best_ms": 0.774598,
+          "best_in_gibs": 1.26073,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.09382,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.71753,
+          "best_ms": 7.71753,
+          "best_in_gibs": 4.04923,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.04923,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.999203,
+          "best_ms": 0.999203,
+          "best_in_gibs": 31.3971,
+          "best_out_gibs": 0.0,
+          "in_gibs": 31.3971,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 1.77,
+      "status": "pass",
+      "throughput_in_gibs": 0.0185582,
+      "throughput_out_gibs": 0.0124054,
+      "compression_fold": 1.49598,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0208893,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.68389,
+      "init_s": 0.00416034,
+      "flush_s": 3.8e-07,
+      "memory_estimate_total_bytes": 2156020928,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.811475,
+          "best_ms": 0.697286,
+          "best_in_gibs": 0.0218831,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0188038,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.45254,
+          "best_ms": 5.45254,
+          "best_in_gibs": 5.73127,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.73127,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.52029,
+          "best_ms": 1.52029,
+          "best_in_gibs": 20.5754,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.5754,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.93,
+      "status": "pass",
+      "throughput_in_gibs": 0.0367068,
+      "throughput_out_gibs": 0.0245929,
+      "compression_fold": 1.49257,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.020937,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.851341,
+      "init_s": 0.00406267,
+      "flush_s": 2.69e-07,
+      "memory_estimate_total_bytes": 2151888064,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.810877,
+          "best_ms": 0.690175,
+          "best_in_gibs": 0.0442172,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0376353,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.11065,
+          "best_ms": 5.11065,
+          "best_in_gibs": 6.11469,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.11469,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.28001,
+          "best_ms": 1.28001,
+          "best_in_gibs": 24.4257,
+          "best_out_gibs": 0.0,
+          "in_gibs": 24.4257,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.51,
+      "status": "pass",
+      "throughput_in_gibs": 0.0710452,
+      "throughput_out_gibs": 0.0476533,
+      "compression_fold": 1.49088,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209608,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.439861,
+      "init_s": 0.0041936,
+      "flush_s": 2.22e-07,
+      "memory_estimate_total_bytes": 2149821632,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.817602,
+          "best_ms": 0.704558,
+          "best_in_gibs": 0.086629,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0746515,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.49441,
+          "best_ms": 5.49441,
+          "best_in_gibs": 5.6876,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.6876,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.25431,
+          "best_ms": 1.25431,
+          "best_in_gibs": 24.9201,
+          "best_out_gibs": 0.0,
+          "in_gibs": 24.9201,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.32,
+      "status": "pass",
+      "throughput_in_gibs": 0.131536,
+      "throughput_out_gibs": 0.0882772,
+      "compression_fold": 1.49003,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209727,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.237578,
+      "init_s": 0.00404476,
+      "flush_s": 9.3e-08,
+      "memory_estimate_total_bytes": 2148788416,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.847732,
+          "best_ms": 0.712752,
+          "best_in_gibs": 0.171266,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.143996,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.12482,
+          "best_ms": 5.12482,
+          "best_in_gibs": 6.09777,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.09777,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.37803,
+          "best_ms": 1.37803,
+          "best_in_gibs": 22.6801,
+          "best_out_gibs": 0.0,
+          "in_gibs": 22.6801,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.21,
+      "status": "pass",
+      "throughput_in_gibs": 0.24362,
+      "throughput_out_gibs": 0.16347,
+      "compression_fold": 1.4903,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209689,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.128273,
+      "init_s": 0.00398049,
+      "flush_s": 1.62e-07,
+      "memory_estimate_total_bytes": 2148271808,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.842073,
+          "best_ms": 0.715594,
+          "best_in_gibs": 0.341172,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.289928,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.09252,
+          "best_ms": 5.09252,
+          "best_in_gibs": 6.13645,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.13645,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.56244,
+          "best_ms": 1.56244,
+          "best_in_gibs": 20.0032,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.0032,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.16,
+      "status": "pass",
+      "throughput_in_gibs": 0.405964,
+      "throughput_out_gibs": 0.272379,
+      "compression_fold": 1.49044,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.020967,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0769773,
+      "init_s": 0.00405336,
+      "flush_s": 9.3e-08,
+      "memory_estimate_total_bytes": 2148013504,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.860006,
+          "best_ms": 0.821171,
+          "best_in_gibs": 0.594616,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.567765,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.48111,
+          "best_ms": 6.48111,
+          "best_in_gibs": 4.82171,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.82171,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.40354,
+          "best_ms": 1.40354,
+          "best_in_gibs": 22.2678,
+          "best_out_gibs": 0.0,
+          "in_gibs": 22.2678,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.18,
+      "status": "pass",
+      "throughput_in_gibs": 0.633779,
+      "throughput_out_gibs": 0.425211,
+      "compression_fold": 1.4905,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209661,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0493074,
+      "init_s": 0.00405119,
+      "flush_s": 4.73e-07,
+      "memory_estimate_total_bytes": 2147884352,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.912558,
+          "best_ms": 0.746928,
+          "best_in_gibs": 1.30744,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.07014,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 4.19532,
+          "best_ms": 4.19532,
+          "best_in_gibs": 7.44877,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.44877,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.76334,
+          "best_ms": 1.76334,
+          "best_in_gibs": 17.7242,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.7242,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-lz4__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.15,
+      "status": "pass",
+      "throughput_in_gibs": 0.627178,
+      "throughput_out_gibs": 0.420783,
+      "compression_fold": 1.4905,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.0209661,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0498264,
+      "init_s": 0.00396065,
+      "flush_s": 9.7e-08,
+      "memory_estimate_total_bytes": 2147884352,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.906409,
+          "best_ms": 0.861829,
+          "best_in_gibs": 1.13313,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.0774,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 5.11643,
+          "best_ms": 5.11643,
+          "best_in_gibs": 6.10778,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.10778,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 1.52402,
+          "best_ms": 1.52402,
+          "best_in_gibs": 20.5075,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.5075,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__16K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 16384,
+      "chunk_bytes_label": "16K",
+      "sink": "discard",
+      "elapsed_s": 1.78,
+      "status": "pass",
+      "throughput_in_gibs": 0.0185633,
+      "throughput_out_gibs": 0.00060957,
+      "compression_fold": 30.4531,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102617,
+      "total_chunks": 2048,
+      "chunks_per_epoch": 1,
+      "wall_s": 1.68343,
+      "init_s": 0.00397962,
+      "flush_s": 1.82e-07,
+      "memory_estimate_total_bytes": 2156020928,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.811475,
+          "best_ms": 0.691101,
+          "best_in_gibs": 0.022079,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0188038,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 6.34351,
+          "best_ms": 6.34351,
+          "best_in_gibs": 4.9263,
+          "best_out_gibs": 0.0,
+          "in_gibs": 4.9263,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.883946,
+          "best_ms": 0.883946,
+          "best_in_gibs": 35.3874,
+          "best_out_gibs": 0.0,
+          "in_gibs": 35.3874,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__32K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 32768,
+      "chunk_bytes_label": "32K",
+      "sink": "discard",
+      "elapsed_s": 0.94,
+      "status": "pass",
+      "throughput_in_gibs": 0.0365514,
+      "throughput_out_gibs": 0.00129953,
+      "compression_fold": 28.1267,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00111105,
+      "total_chunks": 1024,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.854961,
+      "init_s": 0.00414814,
+      "flush_s": 1.78e-07,
+      "memory_estimate_total_bytes": 2151888064,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.811255,
+          "best_ms": 0.698691,
+          "best_in_gibs": 0.0436782,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0376178,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.72262,
+          "best_ms": 8.72262,
+          "best_in_gibs": 3.58264,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.58264,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.814161,
+          "best_ms": 0.814161,
+          "best_in_gibs": 38.4018,
+          "best_out_gibs": 0.0,
+          "in_gibs": 38.4018,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 0.54,
+      "status": "pass",
+      "throughput_in_gibs": 0.0696713,
+      "throughput_out_gibs": 0.00229526,
+      "compression_fold": 30.3544,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.00102951,
+      "total_chunks": 512,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.448535,
+      "init_s": 0.00452162,
+      "flush_s": 1.53e-07,
+      "memory_estimate_total_bytes": 2149821632,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.823507,
+          "best_ms": 0.704099,
+          "best_in_gibs": 0.0866855,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.0741161,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.2438,
+          "best_ms": 10.2438,
+          "best_in_gibs": 3.05062,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.05062,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.903853,
+          "best_ms": 0.903853,
+          "best_in_gibs": 34.5826,
+          "best_out_gibs": 0.0,
+          "in_gibs": 34.5826,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__128K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 131072,
+      "chunk_bytes_label": "128K",
+      "sink": "discard",
+      "elapsed_s": 0.31,
+      "status": "pass",
+      "throughput_in_gibs": 0.128197,
+      "throughput_out_gibs": 0.00405022,
+      "compression_fold": 31.6518,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000987306,
+      "total_chunks": 256,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.243766,
+      "init_s": 0.00396107,
+      "flush_s": 1.92e-07,
+      "memory_estimate_total_bytes": 2148788416,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.826468,
+          "best_ms": 0.70947,
+          "best_in_gibs": 0.172058,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.147701,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 17.5414,
+          "best_ms": 17.5414,
+          "best_in_gibs": 1.7815,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.7815,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.853117,
+          "best_ms": 0.853117,
+          "best_in_gibs": 36.6349,
+          "best_out_gibs": 0.0,
+          "in_gibs": 36.6349,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 0.23,
+      "status": "pass",
+      "throughput_in_gibs": 0.22386,
+      "throughput_out_gibs": 0.00704526,
+      "compression_fold": 31.7745,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000983492,
+      "total_chunks": 128,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.139596,
+      "init_s": 0.00412228,
+      "flush_s": 2.08e-07,
+      "memory_estimate_total_bytes": 2148271808,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.852333,
+          "best_ms": 0.714953,
+          "best_in_gibs": 0.341478,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.286438,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.6298,
+          "best_ms": 15.6298,
+          "best_in_gibs": 1.99939,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.99939,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.886534,
+          "best_ms": 0.886534,
+          "best_in_gibs": 35.2539,
+          "best_out_gibs": 0.0,
+          "in_gibs": 35.2539,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__512K",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 524288,
+      "chunk_bytes_label": "512K",
+      "sink": "discard",
+      "elapsed_s": 0.15,
+      "status": "pass",
+      "throughput_in_gibs": 0.388272,
+      "throughput_out_gibs": 0.0121959,
+      "compression_fold": 31.8363,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000981584,
+      "total_chunks": 64,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0804849,
+      "init_s": 0.00394422,
+      "flush_s": 9e-08,
+      "memory_estimate_total_bytes": 2148013504,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.865757,
+          "best_ms": 0.765095,
+          "best_in_gibs": 0.638197,
+          "best_out_gibs": 0.0,
+          "in_gibs": 0.563993,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 10.1823,
+          "best_ms": 10.1823,
+          "best_in_gibs": 3.06904,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.06904,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.907616,
+          "best_ms": 0.907616,
+          "best_in_gibs": 34.4351,
+          "best_out_gibs": 0.0,
+          "in_gibs": 34.4351,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 0.12,
+      "status": "pass",
+      "throughput_in_gibs": 0.609584,
+      "throughput_out_gibs": 0.0191288,
+      "compression_fold": 31.8673,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000980631,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.0512645,
+      "init_s": 0.00396439,
+      "flush_s": 4.08e-07,
+      "memory_estimate_total_bytes": 2147884352,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.898516,
+          "best_ms": 0.855692,
+          "best_in_gibs": 1.14125,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.08686,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.85214,
+          "best_ms": 7.85214,
+          "best_in_gibs": 3.97981,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.97981,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.83995,
+          "best_ms": 0.83995,
+          "best_in_gibs": 37.2091,
+          "best_out_gibs": 0.0,
+          "in_gibs": 37.2091,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "smallepoch_single__blosc-zstd__xor__cpu__u16__2M",
+      "scenario": "smallepoch_single",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 2097152,
+      "chunk_bytes_label": "2M",
+      "sink": "discard",
+      "elapsed_s": 0.14,
+      "status": "pass",
+      "throughput_in_gibs": 0.59254,
+      "throughput_out_gibs": 0.018594,
+      "compression_fold": 31.8673,
+      "input_gib": 0.03125,
+      "compressed_gib": 0.000980631,
+      "total_chunks": 32,
+      "chunks_per_epoch": 1,
+      "wall_s": 0.052739,
+      "init_s": 0.00434405,
+      "flush_s": 1.47e-07,
+      "memory_estimate_total_bytes": 2147884352,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 0.918865,
+          "best_ms": 0.795761,
+          "best_in_gibs": 1.22721,
+          "best_out_gibs": 0.0,
+          "in_gibs": 1.06279,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 7.8453,
+          "best_ms": 7.8453,
+          "best_in_gibs": 3.98328,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.98328,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 0.874738,
+          "best_ms": 0.874738,
+          "best_in_gibs": 35.7293,
+          "best_out_gibs": 0.0,
+          "in_gibs": 35.7293,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.19,
+      "status": "pass",
+      "throughput_in_gibs": 11.2787,
+      "throughput_out_gibs": 15.0917,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.70414,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.311704,
+      "init_s": 0.496803,
+      "flush_s": 1.75e-07,
+      "memory_estimate_total_bytes": 4095948470,
+      "memory_estimate_pinned_bytes": 1480623280,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.754891,
+          "best_ms": 0.244349,
+          "best_in_gibs": 63.9454,
+          "best_out_gibs": 63.9454,
+          "in_gibs": 62.095,
+          "out_gibs": 62.095
+        },
+        "h2d": {
+          "avg_ms": 2.08976,
+          "best_ms": 0.630784,
+          "best_in_gibs": 24.7708,
+          "best_out_gibs": 24.7708,
+          "in_gibs": 22.5332,
+          "out_gibs": 22.5332
+        },
+        "scatter": {
+          "avg_ms": 0.116496,
+          "best_ms": 0.039424,
+          "best_in_gibs": 396.332,
+          "best_out_gibs": 396.332,
+          "in_gibs": 343.695,
+          "out_gibs": 343.695
+        },
+        "lod_gather": {
+          "avg_ms": 0.590524,
+          "best_ms": 0.558016,
+          "best_in_gibs": 252.009,
+          "best_out_gibs": 252.009,
+          "in_gibs": 238.136,
+          "out_gibs": 238.136
+        },
+        "lod_reduce": {
+          "avg_ms": 1.83885,
+          "best_ms": 1.79046,
+          "best_in_gibs": 78.5411,
+          "best_out_gibs": 104.764,
+          "in_gibs": 76.4745,
+          "out_gibs": 102.008
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.578258,
+          "best_ms": 0.564416,
+          "best_in_gibs": 332.337,
+          "best_out_gibs": 333.283,
+          "in_gibs": 324.382,
+          "out_gibs": 325.305
+        },
+        "aggregate": {
+          "avg_ms": 2.85393,
+          "best_ms": 0.724736,
+          "best_in_gibs": 259.557,
+          "best_out_gibs": 259.557,
+          "in_gibs": 183.091,
+          "out_gibs": 183.091
+        },
+        "d2h": {
+          "avg_ms": 25.8793,
+          "best_ms": 8.07757,
+          "best_in_gibs": 23.288,
+          "best_out_gibs": 23.288,
+          "in_gibs": 20.191,
+          "out_gibs": 20.191
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 116.917,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 240.813,
+        "kick_sync_count": 9,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.7821,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 7.59,
+      "status": "pass",
+      "throughput_in_gibs": 1.48047,
+      "throughput_out_gibs": 1.98096,
+      "compression_fold": 0.999707,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.70414,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 2.37467,
+      "init_s": 3.15727,
+      "flush_s": 1.72e-07,
+      "memory_estimate_total_bytes": 3828229468,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.08079,
+          "best_ms": 1.0745,
+          "best_in_gibs": 14.5417,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.4867,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.5869,
+          "best_ms": 15.7303,
+          "best_in_gibs": 8.93975,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.47807,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.7556,
+          "best_ms": 14.9365,
+          "best_in_gibs": 12.5582,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.9054,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 26.4703,
+          "best_ms": 25.0223,
+          "best_in_gibs": 7.5177,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.10647,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.30907,
+          "best_ms": 3.23323,
+          "best_in_gibs": 58.1803,
+          "best_out_gibs": 0.0,
+          "in_gibs": 56.1312,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.9282,
+          "best_ms": 7.83564,
+          "best_in_gibs": 24.007,
+          "best_out_gibs": 0.0,
+          "in_gibs": 35.0028,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.87,
+      "status": "pass",
+      "throughput_in_gibs": 3.38467,
+      "throughput_out_gibs": 0.627482,
+      "compression_fold": 7.21547,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.651761,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 1.03869,
+      "init_s": 0.511313,
+      "flush_s": 1.77e-07,
+      "memory_estimate_total_bytes": 6986463913,
+      "memory_estimate_pinned_bytes": 1480869040,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.905661,
+          "best_ms": 0.250265,
+          "best_in_gibs": 62.4338,
+          "best_out_gibs": 62.4338,
+          "in_gibs": 51.7578,
+          "out_gibs": 51.7578
+        },
+        "h2d": {
+          "avg_ms": 1.919,
+          "best_ms": 0.629984,
+          "best_in_gibs": 24.8022,
+          "best_out_gibs": 24.8022,
+          "in_gibs": 24.5383,
+          "out_gibs": 24.5383
+        },
+        "scatter": {
+          "avg_ms": 0.0968128,
+          "best_ms": 0.041088,
+          "best_in_gibs": 380.281,
+          "best_out_gibs": 380.281,
+          "in_gibs": 355.067,
+          "out_gibs": 355.067
+        },
+        "lod_gather": {
+          "avg_ms": 4.77727,
+          "best_ms": 0.577728,
+          "best_in_gibs": 243.41,
+          "best_out_gibs": 243.41,
+          "in_gibs": 29.4363,
+          "out_gibs": 29.4363
+        },
+        "lod_reduce": {
+          "avg_ms": 4.79218,
+          "best_ms": 1.78547,
+          "best_in_gibs": 78.7607,
+          "best_out_gibs": 105.057,
+          "in_gibs": 29.3447,
+          "out_gibs": 39.1422
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.46721,
+          "best_ms": 0.559008,
+          "best_in_gibs": 335.552,
+          "best_out_gibs": 336.507,
+          "in_gibs": 41.9896,
+          "out_gibs": 42.1091
+        },
+        "compress": {
+          "avg_ms": 103.877,
+          "best_ms": 35.5468,
+          "best_in_gibs": 5.29191,
+          "best_out_gibs": 0.741441,
+          "in_gibs": 5.03027,
+          "out_gibs": 0.695677
+        },
+        "aggregate": {
+          "avg_ms": 0.355975,
+          "best_ms": 0.064864,
+          "best_in_gibs": 406.324,
+          "best_out_gibs": 406.324,
+          "in_gibs": 203.005,
+          "out_gibs": 203.005
+        },
+        "d2h": {
+          "avg_ms": 3.74422,
+          "best_ms": 1.16259,
+          "best_in_gibs": 22.6699,
+          "best_out_gibs": 22.6699,
+          "in_gibs": 19.3003,
+          "out_gibs": 19.3003
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 213.569,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 949.902,
+        "kick_sync_count": 9,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 100.233,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 7.93,
+      "status": "pass",
+      "throughput_in_gibs": 1.25668,
+      "throughput_out_gibs": 0.185234,
+      "compression_fold": 9.07517,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.5182,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 2.79755,
+      "init_s": 3.13142,
+      "flush_s": 1.53e-07,
+      "memory_estimate_total_bytes": 3836241692,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.24706,
+          "best_ms": 1.13169,
+          "best_in_gibs": 13.8068,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.0371,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.3857,
+          "best_ms": 15.7409,
+          "best_in_gibs": 8.93371,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.58219,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.62,
+          "best_ms": 14.6365,
+          "best_in_gibs": 12.8156,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.0087,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 25.8197,
+          "best_ms": 24.4183,
+          "best_in_gibs": 7.70366,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.28555,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 64.5766,
+          "best_ms": 24.9827,
+          "best_in_gibs": 7.52963,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.09161,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.85319,
+          "best_ms": 5.6168,
+          "best_in_gibs": 33.6401,
+          "best_out_gibs": 0.0,
+          "in_gibs": 76.5828,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 7.66,
+      "status": "pass",
+      "throughput_in_gibs": 1.40612,
+      "throughput_out_gibs": 0.992384,
+      "compression_fold": 1.89537,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.48119,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 2.50023,
+      "init_s": 3.125,
+      "flush_s": 1.9e-07,
+      "memory_estimate_total_bytes": 3828705084,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.2996,
+          "best_ms": 1.13822,
+          "best_in_gibs": 13.7276,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9022,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.6596,
+          "best_ms": 15.7781,
+          "best_in_gibs": 8.91267,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.44109,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.9023,
+          "best_ms": 14.7086,
+          "best_in_gibs": 12.7528,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.7955,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 26.004,
+          "best_ms": 24.6984,
+          "best_in_gibs": 7.6163,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.23389,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 25.828,
+          "best_ms": 9.74914,
+          "best_in_gibs": 19.2951,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.2311,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 10.5253,
+          "best_ms": 6.58401,
+          "best_in_gibs": 28.5806,
+          "best_out_gibs": 0.0,
+          "in_gibs": 49.6584,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 7.82,
+      "status": "pass",
+      "throughput_in_gibs": 1.31412,
+      "throughput_out_gibs": 0.0788214,
+      "compression_fold": 22.3019,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.210868,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 2.67526,
+      "init_s": 3.1452,
+      "flush_s": 1.95e-07,
+      "memory_estimate_total_bytes": 3828705084,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.24469,
+          "best_ms": 1.11858,
+          "best_in_gibs": 13.9686,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.0432,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.8185,
+          "best_ms": 15.7524,
+          "best_in_gibs": 8.92723,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.36131,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.6429,
+          "best_ms": 14.7961,
+          "best_in_gibs": 12.6774,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.9911,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 25.8231,
+          "best_ms": 24.5394,
+          "best_in_gibs": 7.66563,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.28457,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 49.7334,
+          "best_ms": 14.1402,
+          "best_in_gibs": 13.3032,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.5066,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.47213,
+          "best_ms": 6.11694,
+          "best_in_gibs": 92.2821,
+          "best_out_gibs": 0.0,
+          "in_gibs": 80.7573,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.14,
+      "status": "pass",
+      "throughput_in_gibs": 11.2552,
+      "throughput_out_gibs": 15.2036,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.74892,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.312354,
+      "init_s": 0.500469,
+      "flush_s": 2.38e-07,
+      "memory_estimate_total_bytes": 4119786566,
+      "memory_estimate_pinned_bytes": 1492206224,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.760602,
+          "best_ms": 0.254158,
+          "best_in_gibs": 61.4775,
+          "best_out_gibs": 61.4775,
+          "in_gibs": 61.6288,
+          "out_gibs": 61.6288
+        },
+        "h2d": {
+          "avg_ms": 2.13114,
+          "best_ms": 0.63536,
+          "best_in_gibs": 24.5924,
+          "best_out_gibs": 24.5924,
+          "in_gibs": 22.0957,
+          "out_gibs": 22.0957
+        },
+        "scatter": {
+          "avg_ms": 0.118594,
+          "best_ms": 0.039552,
+          "best_in_gibs": 395.05,
+          "best_out_gibs": 395.05,
+          "in_gibs": 342.555,
+          "out_gibs": 342.555
+        },
+        "lod_gather": {
+          "avg_ms": 0.586066,
+          "best_ms": 0.564512,
+          "best_in_gibs": 249.109,
+          "best_out_gibs": 249.109,
+          "in_gibs": 239.947,
+          "out_gibs": 239.947
+        },
+        "lod_reduce": {
+          "avg_ms": 1.83505,
+          "best_ms": 1.78928,
+          "best_in_gibs": 78.5931,
+          "best_out_gibs": 104.961,
+          "in_gibs": 76.6328,
+          "out_gibs": 102.343
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.585294,
+          "best_ms": 0.566624,
+          "best_in_gibs": 331.446,
+          "best_out_gibs": 335.216,
+          "in_gibs": 320.873,
+          "out_gibs": 324.523
+        },
+        "aggregate": {
+          "avg_ms": 3.33822,
+          "best_ms": 0.7928,
+          "best_in_gibs": 239.583,
+          "best_out_gibs": 239.583,
+          "in_gibs": 158.053,
+          "out_gibs": 158.053
+        },
+        "d2h": {
+          "avg_ms": 25.8911,
+          "best_ms": 7.85805,
+          "best_in_gibs": 24.1716,
+          "best_out_gibs": 24.1716,
+          "in_gibs": 20.3783,
+          "out_gibs": 20.3783
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 113.79,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 243.459,
+        "kick_sync_count": 9,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.7821,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 7.61,
+      "status": "pass",
+      "throughput_in_gibs": 1.49993,
+      "throughput_out_gibs": 2.02611,
+      "compression_fold": 0.999919,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.74892,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.34386,
+      "init_s": 3.13998,
+      "flush_s": 1.63e-07,
+      "memory_estimate_total_bytes": 3851751540,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.31924,
+          "best_ms": 1.14506,
+          "best_in_gibs": 13.6456,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.8526,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.6252,
+          "best_ms": 15.7966,
+          "best_in_gibs": 8.90221,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.45857,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.7488,
+          "best_ms": 14.0116,
+          "best_in_gibs": 13.4035,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.7336,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 25.4286,
+          "best_ms": 24.0312,
+          "best_in_gibs": 7.90394,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.46959,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.3384,
+          "best_ms": 3.33509,
+          "best_in_gibs": 56.9524,
+          "best_out_gibs": 0.0,
+          "in_gibs": 56.4995,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.1814,
+          "best_ms": 6.91399,
+          "best_in_gibs": 27.472,
+          "best_out_gibs": 0.0,
+          "in_gibs": 37.2046,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 4.34,
+      "status": "pass",
+      "throughput_in_gibs": 2.32898,
+      "throughput_out_gibs": 0.416973,
+      "compression_fold": 7.54422,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.629427,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.50952,
+      "init_s": 0.498445,
+      "flush_s": 2.48e-07,
+      "memory_estimate_total_bytes": 7031373149,
+      "memory_estimate_pinned_bytes": 1492345488,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.881778,
+          "best_ms": 0.287071,
+          "best_in_gibs": 54.429,
+          "best_out_gibs": 54.429,
+          "in_gibs": 53.1597,
+          "out_gibs": 53.1597
+        },
+        "h2d": {
+          "avg_ms": 1.91258,
+          "best_ms": 0.629664,
+          "best_in_gibs": 24.8148,
+          "best_out_gibs": 24.8148,
+          "in_gibs": 24.6207,
+          "out_gibs": 24.6207
+        },
+        "scatter": {
+          "avg_ms": 0.098312,
+          "best_ms": 0.040864,
+          "best_in_gibs": 382.366,
+          "best_out_gibs": 382.366,
+          "in_gibs": 357.599,
+          "out_gibs": 357.599
+        },
+        "lod_gather": {
+          "avg_ms": 6.43466,
+          "best_ms": 0.581344,
+          "best_in_gibs": 241.896,
+          "best_out_gibs": 241.896,
+          "in_gibs": 21.8543,
+          "out_gibs": 21.8543
+        },
+        "lod_reduce": {
+          "avg_ms": 6.26827,
+          "best_ms": 1.78781,
+          "best_in_gibs": 78.6578,
+          "best_out_gibs": 105.048,
+          "in_gibs": 22.4344,
+          "out_gibs": 29.9613
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.72821,
+          "best_ms": 0.560256,
+          "best_in_gibs": 335.213,
+          "best_out_gibs": 339.026,
+          "in_gibs": 32.786,
+          "out_gibs": 33.1589
+        },
+        "compress": {
+          "avg_ms": 156.359,
+          "best_ms": 32.1812,
+          "best_in_gibs": 5.90226,
+          "best_out_gibs": 0.781102,
+          "in_gibs": 3.37437,
+          "out_gibs": 0.447007
+        },
+        "aggregate": {
+          "avg_ms": 0.334695,
+          "best_ms": 0.052288,
+          "best_in_gibs": 480.737,
+          "best_out_gibs": 480.737,
+          "in_gibs": 208.828,
+          "out_gibs": 208.828
+        },
+        "d2h": {
+          "avg_ms": 3.74814,
+          "best_ms": 1.10291,
+          "best_in_gibs": 22.7913,
+          "best_out_gibs": 22.7913,
+          "in_gibs": 18.6475,
+          "out_gibs": 18.6475
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 305.936,
+        "flush_stall_count": 9,
+        "kick_sync_ms": 1423.88,
+        "kick_sync_count": 9,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 166.632,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 7.84,
+      "status": "pass",
+      "throughput_in_gibs": 1.29595,
+      "throughput_out_gibs": 0.17388,
+      "compression_fold": 10.0669,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.471698,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.71277,
+      "init_s": 3.13837,
+      "flush_s": 1.56e-07,
+      "memory_estimate_total_bytes": 3858925684,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.11346,
+          "best_ms": 1.06986,
+          "best_in_gibs": 14.6047,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.3955,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.3184,
+          "best_ms": 15.4946,
+          "best_in_gibs": 9.07574,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.61756,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.7499,
+          "best_ms": 13.9183,
+          "best_in_gibs": 13.4934,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.7327,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 24.9619,
+          "best_ms": 23.3652,
+          "best_in_gibs": 8.12923,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.60926,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 63.2122,
+          "best_ms": 24.7966,
+          "best_in_gibs": 7.65997,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.34672,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.8801,
+          "best_ms": 5.17495,
+          "best_in_gibs": 110.543,
+          "best_out_gibs": 0.0,
+          "in_gibs": 90.0798,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 7.63,
+      "status": "pass",
+      "throughput_in_gibs": 1.43871,
+      "throughput_out_gibs": 1.01641,
+      "compression_fold": 1.91189,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.48368,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.44359,
+      "init_s": 3.14487,
+      "flush_s": 1.97e-07,
+      "memory_estimate_total_bytes": 3851895380,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.09482,
+          "best_ms": 1.08432,
+          "best_in_gibs": 14.41,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.4474,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.5645,
+          "best_ms": 15.7705,
+          "best_in_gibs": 8.91694,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.48955,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.9796,
+          "best_ms": 14.0825,
+          "best_in_gibs": 13.3361,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.5374,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 25.5238,
+          "best_ms": 24.0937,
+          "best_in_gibs": 7.88345,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.44173,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 27.2755,
+          "best_ms": 10.2007,
+          "best_in_gibs": 18.6204,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.3439,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.56309,
+          "best_ms": 5.8629,
+          "best_in_gibs": 32.4024,
+          "best_out_gibs": 0.0,
+          "in_gibs": 55.177,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 7.61,
+      "status": "pass",
+      "throughput_in_gibs": 1.41416,
+      "throughput_out_gibs": 0.0596179,
+      "compression_fold": 32.039,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.148211,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.48602,
+      "init_s": 3.11056,
+      "flush_s": 1.53e-07,
+      "memory_estimate_total_bytes": 3851895380,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.41735,
+          "best_ms": 1.17595,
+          "best_in_gibs": 13.2872,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.6116,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.7402,
+          "best_ms": 15.7451,
+          "best_in_gibs": 8.93136,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.40045,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.9081,
+          "best_ms": 14.0895,
+          "best_in_gibs": 13.3294,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.5975,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 25.2894,
+          "best_ms": 24.1904,
+          "best_in_gibs": 7.85193,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.51071,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 32.2411,
+          "best_ms": 11.345,
+          "best_in_gibs": 16.7423,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.3647,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.41178,
+          "best_ms": 5.04785,
+          "best_in_gibs": 37.6342,
+          "best_out_gibs": 0.0,
+          "in_gibs": 97.5026,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.34,
+      "status": "pass",
+      "throughput_in_gibs": 10.2675,
+      "throughput_out_gibs": 14.9052,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 5.10361,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 0.342404,
+      "init_s": 0.661938,
+      "flush_s": 2.24e-07,
+      "memory_estimate_total_bytes": 6399019334,
+      "memory_estimate_pinned_bytes": 1954572592,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.883604,
+          "best_ms": 0.254143,
+          "best_in_gibs": 61.4811,
+          "best_out_gibs": 61.4811,
+          "in_gibs": 63.1545,
+          "out_gibs": 63.1545
+        },
+        "h2d": {
+          "avg_ms": 2.51588,
+          "best_ms": 1.24854,
+          "best_in_gibs": 25.0292,
+          "best_out_gibs": 25.0292,
+          "in_gibs": 22.3987,
+          "out_gibs": 22.3987
+        },
+        "scatter": {
+          "avg_ms": 0.171872,
+          "best_ms": 0.079552,
+          "best_in_gibs": 392.825,
+          "best_out_gibs": 392.825,
+          "in_gibs": 337.668,
+          "out_gibs": 337.668
+        },
+        "lod_gather": {
+          "avg_ms": 1.11792,
+          "best_ms": 1.03104,
+          "best_in_gibs": 272.783,
+          "best_out_gibs": 272.783,
+          "in_gibs": 251.583,
+          "out_gibs": 251.583
+        },
+        "lod_reduce": {
+          "avg_ms": 3.61792,
+          "best_ms": 3.50358,
+          "best_in_gibs": 80.2749,
+          "best_out_gibs": 107.173,
+          "in_gibs": 77.7381,
+          "out_gibs": 103.786
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.17335,
+          "best_ms": 1.12346,
+          "best_in_gibs": 334.226,
+          "best_out_gibs": 349.438,
+          "in_gibs": 320.013,
+          "out_gibs": 334.578
+        },
+        "aggregate": {
+          "avg_ms": 4.77971,
+          "best_ms": 1.9928,
+          "best_in_gibs": 196.998,
+          "best_out_gibs": 196.998,
+          "in_gibs": 152.535,
+          "out_gibs": 152.535
+        },
+        "d2h": {
+          "avg_ms": 34.9438,
+          "best_ms": 16.2732,
+          "best_in_gibs": 24.1241,
+          "best_out_gibs": 24.1241,
+          "in_gibs": 20.8642,
+          "out_gibs": 20.8642
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 121.895,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 267.248,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 21.19,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__none__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 10.44,
+      "status": "pass",
+      "throughput_in_gibs": 1.57387,
+      "throughput_out_gibs": 2.28478,
+      "compression_fold": 0.999982,
+      "input_gib": 3.51562,
+      "compressed_gib": 5.10361,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.23374,
+      "init_s": 6.04569,
+      "flush_s": 1.95e-07,
+      "memory_estimate_total_bytes": 6130886392,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.46427,
+          "best_ms": 1.06539,
+          "best_in_gibs": 14.6659,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.2125,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 32.0912,
+          "best_ms": 30.4592,
+          "best_in_gibs": 9.23365,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.76408,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.3054,
+          "best_ms": 23.1024,
+          "best_in_gibs": 16.2532,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.4488,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 44.2238,
+          "best_ms": 42.7746,
+          "best_in_gibs": 9.17783,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.87708,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.9537,
+          "best_ms": 5.99202,
+          "best_in_gibs": 65.5168,
+          "best_out_gibs": 0.0,
+          "in_gibs": 56.2831,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 18.1045,
+          "best_ms": 8.72248,
+          "best_in_gibs": 45.0076,
+          "best_out_gibs": 0.0,
+          "in_gibs": 40.2704,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 4.38,
+      "status": "pass",
+      "throughput_in_gibs": 2.8747,
+      "throughput_out_gibs": 0.527668,
+      "compression_fold": 7.90859,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.645313,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.22295,
+      "init_s": 0.677872,
+      "flush_s": 2.82e-07,
+      "memory_estimate_total_bytes": 10149002461,
+      "memory_estimate_pinned_bytes": 1954695472,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.21166,
+          "best_ms": 0.262753,
+          "best_in_gibs": 59.4665,
+          "best_out_gibs": 59.4665,
+          "in_gibs": 46.0555,
+          "out_gibs": 46.0555
+        },
+        "h2d": {
+          "avg_ms": 2.27393,
+          "best_ms": 1.24608,
+          "best_in_gibs": 25.0786,
+          "best_out_gibs": 25.0786,
+          "in_gibs": 24.7819,
+          "out_gibs": 24.7819
+        },
+        "scatter": {
+          "avg_ms": 0.181872,
+          "best_ms": 0.174816,
+          "best_in_gibs": 357.519,
+          "best_out_gibs": 357.519,
+          "in_gibs": 343.648,
+          "out_gibs": 343.648
+        },
+        "lod_gather": {
+          "avg_ms": 4.99643,
+          "best_ms": 1.03504,
+          "best_in_gibs": 271.729,
+          "best_out_gibs": 271.729,
+          "in_gibs": 56.2902,
+          "out_gibs": 56.2902
+        },
+        "lod_reduce": {
+          "avg_ms": 5.78466,
+          "best_ms": 3.50442,
+          "best_in_gibs": 80.2559,
+          "best_out_gibs": 107.147,
+          "in_gibs": 48.6199,
+          "out_gibs": 64.911
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.91392,
+          "best_ms": 1.1216,
+          "best_in_gibs": 334.779,
+          "best_out_gibs": 350.016,
+          "in_gibs": 95.9367,
+          "out_gibs": 100.303
+        },
+        "compress": {
+          "avg_ms": 155.911,
+          "best_ms": 63.0058,
+          "best_in_gibs": 6.23082,
+          "best_out_gibs": 0.791021,
+          "in_gibs": 4.67621,
+          "out_gibs": 0.591197
+        },
+        "aggregate": {
+          "avg_ms": 0.598779,
+          "best_ms": 0.246272,
+          "best_in_gibs": 202.374,
+          "best_out_gibs": 202.374,
+          "in_gibs": 153.937,
+          "out_gibs": 153.937
+        },
+        "d2h": {
+          "avg_ms": 4.99733,
+          "best_ms": 2.18038,
+          "best_in_gibs": 22.8579,
+          "best_out_gibs": 22.8579,
+          "in_gibs": 18.4447,
+          "out_gibs": 18.4447
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 372.936,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 1121.33,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 156.961,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 10.86,
+      "status": "pass",
+      "throughput_in_gibs": 1.30839,
+      "throughput_out_gibs": 0.180017,
+      "compression_fold": 10.5509,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.483703,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.68698,
+      "init_s": 6.08546,
+      "flush_s": 4.25e-07,
+      "memory_estimate_total_bytes": 6140765944,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.67815,
+          "best_ms": 1.11279,
+          "best_in_gibs": 14.0412,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.82777,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 31.3463,
+          "best_ms": 29.2323,
+          "best_in_gibs": 9.62121,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.97235,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.4159,
+          "best_ms": 22.8717,
+          "best_in_gibs": 16.4171,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.3788,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 44.2079,
+          "best_ms": 42.7092,
+          "best_in_gibs": 9.19189,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.88028,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 88.9066,
+          "best_ms": 48.4522,
+          "best_in_gibs": 8.10238,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.20045,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.33519,
+          "best_ms": 4.64972,
+          "best_in_gibs": 84.7603,
+          "best_out_gibs": 0.0,
+          "in_gibs": 137.187,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 10.55,
+      "status": "pass",
+      "throughput_in_gibs": 1.47797,
+      "throughput_out_gibs": 1.11601,
+      "compression_fold": 1.92249,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.65464,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.37869,
+      "init_s": 6.05193,
+      "flush_s": 1.9e-07,
+      "memory_estimate_total_bytes": 6130956600,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.62158,
+          "best_ms": 1.10073,
+          "best_in_gibs": 14.1951,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.92667,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 31.7079,
+          "best_ms": 30.5225,
+          "best_in_gibs": 9.2145,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.87003,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.6795,
+          "best_ms": 23.0012,
+          "best_in_gibs": 16.3247,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.2146,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 43.7658,
+          "best_ms": 41.649,
+          "best_in_gibs": 9.42588,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.96998,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 39.2023,
+          "best_ms": 20.8795,
+          "best_in_gibs": 18.8021,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.5977,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.0224,
+          "best_ms": 6.89604,
+          "best_in_gibs": 56.9314,
+          "best_out_gibs": 0.0,
+          "in_gibs": 66.1469,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 10.5,
+      "status": "pass",
+      "throughput_in_gibs": 1.48719,
+      "throughput_out_gibs": 0.0702189,
+      "compression_fold": 30.7453,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.165993,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.36394,
+      "init_s": 6.05771,
+      "flush_s": 1.53e-07,
+      "memory_estimate_total_bytes": 6130956600,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.70459,
+          "best_ms": 1.11685,
+          "best_in_gibs": 13.9902,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.78222,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 31.5523,
+          "best_ms": 30.0633,
+          "best_in_gibs": 9.35526,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.91376,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.2201,
+          "best_ms": 22.9284,
+          "best_in_gibs": 16.3766,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.5032,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 44.1434,
+          "best_ms": 42.0762,
+          "best_in_gibs": 9.33016,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.89325,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.2389,
+          "best_ms": 22.806,
+          "best_in_gibs": 17.2138,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.8615,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.58158,
+          "best_ms": 4.03108,
+          "best_in_gibs": 97.3935,
+          "best_out_gibs": 0.0,
+          "in_gibs": 159.137,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.38,
+      "status": "pass",
+      "throughput_in_gibs": 12.5231,
+      "throughput_out_gibs": 14.3244,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28938,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.299446,
+      "init_s": 0.570751,
+      "flush_s": 2.06e-07,
+      "memory_estimate_total_bytes": 4642862630,
+      "memory_estimate_pinned_bytes": 1650140688,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.28952,
+          "best_ms": 1.13725,
+          "best_in_gibs": 54.9572,
+          "best_out_gibs": 54.9572,
+          "in_gibs": 48.4678,
+          "out_gibs": 48.4678
+        },
+        "h2d": {
+          "avg_ms": 2.79212,
+          "best_ms": 2.48733,
+          "best_in_gibs": 25.1274,
+          "best_out_gibs": 25.1274,
+          "in_gibs": 22.3844,
+          "out_gibs": 22.3844
+        },
+        "scatter": {
+          "avg_ms": 0.217344,
+          "best_ms": 0.217344,
+          "best_in_gibs": 287.563,
+          "best_out_gibs": 287.563,
+          "in_gibs": 287.563,
+          "out_gibs": 287.563
+        },
+        "lod_gather": {
+          "avg_ms": 2.55279,
+          "best_ms": 2.45107,
+          "best_in_gibs": 76.4971,
+          "best_out_gibs": 76.4971,
+          "in_gibs": 73.4492,
+          "out_gibs": 73.4492
+        },
+        "lod_reduce": {
+          "avg_ms": 2.02025,
+          "best_ms": 1.92013,
+          "best_in_gibs": 97.6497,
+          "best_out_gibs": 111.668,
+          "in_gibs": 92.8104,
+          "out_gibs": 106.134
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.31419,
+          "best_ms": 1.26653,
+          "best_in_gibs": 169.295,
+          "best_out_gibs": 169.295,
+          "in_gibs": 163.154,
+          "out_gibs": 163.154
+        },
+        "aggregate": {
+          "avg_ms": 3.61299,
+          "best_ms": 1.62934,
+          "best_in_gibs": 263.194,
+          "best_out_gibs": 263.194,
+          "in_gibs": 169.56,
+          "out_gibs": 169.56
+        },
+        "d2h": {
+          "avg_ms": 29.7655,
+          "best_ms": 17.6907,
+          "best_in_gibs": 24.2406,
+          "best_out_gibs": 24.2406,
+          "in_gibs": 20.5815,
+          "out_gibs": 20.5815
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 56.6983,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 221.859,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 8.87966,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 18.05,
+      "status": "pass",
+      "throughput_in_gibs": 1.70015,
+      "throughput_out_gibs": 1.94469,
+      "compression_fold": 0.999756,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28938,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 2.20569,
+      "init_s": 3.67108,
+      "flush_s": 4.27e-07,
+      "memory_estimate_total_bytes": 4375169668,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.72271,
+          "best_ms": 3.834,
+          "best_in_gibs": 16.3015,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9214,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 25.1016,
+          "best_ms": 23.4746,
+          "best_in_gibs": 7.98737,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.46963,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 12.3109,
+          "best_ms": 11.7548,
+          "best_in_gibs": 18.2407,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.4168,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 27.9077,
+          "best_ms": 26.176,
+          "best_in_gibs": 8.19133,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.68306,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 11.2887,
+          "best_ms": 7.24002,
+          "best_in_gibs": 59.2309,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.2681,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 15.9709,
+          "best_ms": 10.0847,
+          "best_in_gibs": 42.5233,
+          "best_out_gibs": 0.0,
+          "in_gibs": 38.3585,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.57,
+      "status": "pass",
+      "throughput_in_gibs": 6.20443,
+      "throughput_out_gibs": 0.785364,
+      "compression_fold": 9.03416,
+      "input_gib": 3.75,
+      "compressed_gib": 0.474679,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 0.604407,
+      "init_s": 0.550098,
+      "flush_s": 1.56e-07,
+      "memory_estimate_total_bytes": 7840731503,
+      "memory_estimate_pinned_bytes": 1650402832,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.996953,
+          "best_ms": 0.956889,
+          "best_in_gibs": 65.3158,
+          "best_out_gibs": 65.3158,
+          "in_gibs": 62.691,
+          "out_gibs": 62.691
+        },
+        "h2d": {
+          "avg_ms": 2.52709,
+          "best_ms": 2.48768,
+          "best_in_gibs": 25.1238,
+          "best_out_gibs": 25.1238,
+          "in_gibs": 24.732,
+          "out_gibs": 24.732
+        },
+        "scatter": {
+          "avg_ms": 0.197008,
+          "best_ms": 0.176832,
+          "best_in_gibs": 353.443,
+          "best_out_gibs": 353.443,
+          "in_gibs": 317.246,
+          "out_gibs": 317.246
+        },
+        "lod_gather": {
+          "avg_ms": 5.59374,
+          "best_ms": 2.39245,
+          "best_in_gibs": 78.3716,
+          "best_out_gibs": 78.3716,
+          "in_gibs": 33.5196,
+          "out_gibs": 33.5196
+        },
+        "lod_reduce": {
+          "avg_ms": 3.38912,
+          "best_ms": 1.91699,
+          "best_in_gibs": 97.8095,
+          "best_out_gibs": 111.85,
+          "in_gibs": 55.324,
+          "out_gibs": 63.266
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.21596,
+          "best_ms": 1.2649,
+          "best_in_gibs": 169.513,
+          "best_out_gibs": 169.513,
+          "in_gibs": 50.8582,
+          "out_gibs": 50.8582
+        },
+        "compress": {
+          "avg_ms": 68.7969,
+          "best_ms": 38.0804,
+          "best_in_gibs": 11.2612,
+          "best_out_gibs": 1.24377,
+          "in_gibs": 8.90474,
+          "out_gibs": 0.9835
+        },
+        "aggregate": {
+          "avg_ms": 0.281797,
+          "best_ms": 0.168608,
+          "best_in_gibs": 280.907,
+          "best_out_gibs": 280.907,
+          "in_gibs": 240.108,
+          "out_gibs": 240.108
+        },
+        "d2h": {
+          "avg_ms": 3.54064,
+          "best_ms": 2.04275,
+          "best_in_gibs": 23.186,
+          "best_out_gibs": 23.186,
+          "in_gibs": 19.11,
+          "out_gibs": 19.11
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 108.438,
+        "flush_stall_count": 7,
+        "kick_sync_ms": 501.309,
+        "kick_sync_count": 7,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 54.919,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 18.2,
+      "status": "pass",
+      "throughput_in_gibs": 1.59274,
+      "throughput_out_gibs": 0.151909,
+      "compression_fold": 11.9899,
+      "input_gib": 3.75,
+      "compressed_gib": 0.357661,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 2.35444,
+      "init_s": 3.69053,
+      "flush_s": 3.41e-07,
+      "memory_estimate_total_bytes": 4384291556,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.67858,
+          "best_ms": 3.78145,
+          "best_in_gibs": 16.5281,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.0063,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 23.7197,
+          "best_ms": 22.5314,
+          "best_in_gibs": 8.32171,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.90483,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 12.2276,
+          "best_ms": 11.6882,
+          "best_in_gibs": 18.3448,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.5355,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 27.3206,
+          "best_ms": 26.1399,
+          "best_in_gibs": 8.20266,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.84817,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 50.7132,
+          "best_ms": 34.7634,
+          "best_in_gibs": 12.3358,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.0801,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.11908,
+          "best_ms": 4.50309,
+          "best_in_gibs": 143.476,
+          "best_out_gibs": 0.0,
+          "in_gibs": 120.201,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 18.07,
+      "status": "pass",
+      "throughput_in_gibs": 1.65407,
+      "throughput_out_gibs": 0.865237,
+      "compression_fold": 2.18613,
+      "input_gib": 3.75,
+      "compressed_gib": 1.9616,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 2.26713,
+      "init_s": 3.68849,
+      "flush_s": 1.91e-07,
+      "memory_estimate_total_bytes": 4375698740,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.74599,
+          "best_ms": 3.9317,
+          "best_in_gibs": 15.8964,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.8771,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.4575,
+          "best_ms": 22.7467,
+          "best_in_gibs": 8.24295,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.66635,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 12.2681,
+          "best_ms": 11.546,
+          "best_in_gibs": 18.5706,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.4775,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 27.5542,
+          "best_ms": 25.7805,
+          "best_in_gibs": 8.31701,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.78163,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 30.6246,
+          "best_ms": 20.7643,
+          "best_in_gibs": 20.6524,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.0041,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.26413,
+          "best_ms": 6.88477,
+          "best_in_gibs": 62.3038,
+          "best_out_gibs": 0.0,
+          "in_gibs": 66.1453,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 18.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.48191,
+      "throughput_out_gibs": 0.0854594,
+      "compression_fold": 19.8298,
+      "input_gib": 3.75,
+      "compressed_gib": 0.216256,
+      "total_chunks": 70260,
+      "chunks_per_epoch": 3513,
+      "wall_s": 2.53052,
+      "init_s": 3.66323,
+      "flush_s": 3.65e-07,
+      "memory_estimate_total_bytes": 4375698740,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.64743,
+          "best_ms": 3.77401,
+          "best_in_gibs": 16.5606,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.067,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 24.2795,
+          "best_ms": 22.8979,
+          "best_in_gibs": 8.18851,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.72255,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 12.2048,
+          "best_ms": 11.7252,
+          "best_in_gibs": 18.2868,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.5682,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 26.9917,
+          "best_ms": 25.8144,
+          "best_in_gibs": 8.3061,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.94378,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 76.2231,
+          "best_ms": 52.1072,
+          "best_in_gibs": 8.22982,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.03717,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.67745,
+          "best_ms": 4.16127,
+          "best_in_gibs": 154.621,
+          "best_out_gibs": 0.0,
+          "in_gibs": 131.007,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.64,
+      "status": "pass",
+      "throughput_in_gibs": 11.2504,
+      "throughput_out_gibs": 12.8553,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28493,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.33332,
+      "init_s": 0.707548,
+      "flush_s": 2.53e-07,
+      "memory_estimate_total_bytes": 7022383958,
+      "memory_estimate_pinned_bytes": 2108798800,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.20603,
+          "best_ms": 1.14766,
+          "best_in_gibs": 54.4585,
+          "best_out_gibs": 54.4585,
+          "in_gibs": 51.8231,
+          "out_gibs": 51.8231
+        },
+        "h2d": {
+          "avg_ms": 2.74405,
+          "best_ms": 2.49146,
+          "best_in_gibs": 25.0857,
+          "best_out_gibs": 25.0857,
+          "in_gibs": 22.7766,
+          "out_gibs": 22.7766
+        },
+        "lod_gather": {
+          "avg_ms": 4.88212,
+          "best_ms": 4.65606,
+          "best_in_gibs": 80.5401,
+          "best_out_gibs": 80.5401,
+          "in_gibs": 76.8108,
+          "out_gibs": 76.8108
+        },
+        "lod_reduce": {
+          "avg_ms": 3.90277,
+          "best_ms": 3.80349,
+          "best_in_gibs": 98.5937,
+          "best_out_gibs": 112.651,
+          "in_gibs": 96.0856,
+          "out_gibs": 109.785
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.41267,
+          "best_ms": 2.37011,
+          "best_in_gibs": 180.779,
+          "best_out_gibs": 180.779,
+          "in_gibs": 177.591,
+          "out_gibs": 177.591
+        },
+        "aggregate": {
+          "avg_ms": 5.49822,
+          "best_ms": 4.97683,
+          "best_in_gibs": 172.185,
+          "best_out_gibs": 172.185,
+          "in_gibs": 155.857,
+          "out_gibs": 155.857
+        },
+        "d2h": {
+          "avg_ms": 40.3726,
+          "best_ms": 35.2902,
+          "best_in_gibs": 24.2825,
+          "best_out_gibs": 24.2825,
+          "in_gibs": 21.2256,
+          "out_gibs": 21.2256
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 56.231,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 247.816,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 13.5839,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 21.31,
+      "status": "pass",
+      "throughput_in_gibs": 1.77152,
+      "throughput_out_gibs": 2.02422,
+      "compression_fold": 0.999939,
+      "input_gib": 3.75,
+      "compressed_gib": 4.28493,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 2.11683,
+      "init_s": 6.90957,
+      "flush_s": 1.67e-07,
+      "memory_estimate_total_bytes": 6754329328,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.48937,
+          "best_ms": 3.28359,
+          "best_in_gibs": 19.0341,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.63113,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 49.12,
+          "best_ms": 45.6443,
+          "best_in_gibs": 8.21571,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.63436,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 19.9701,
+          "best_ms": 19.0582,
+          "best_in_gibs": 22.482,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.4554,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 49.2649,
+          "best_ms": 47.1841,
+          "best_in_gibs": 9.08075,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.6972,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 16.0522,
+          "best_ms": 12.7805,
+          "best_in_gibs": 67.0503,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.3841,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 21.2301,
+          "best_ms": 15.135,
+          "best_in_gibs": 56.6194,
+          "best_out_gibs": 0.0,
+          "in_gibs": 40.364,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.74,
+      "status": "pass",
+      "throughput_in_gibs": 7.52719,
+      "throughput_out_gibs": 0.591803,
+      "compression_fold": 14.5326,
+      "input_gib": 3.75,
+      "compressed_gib": 0.294832,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.498194,
+      "init_s": 0.728169,
+      "flush_s": 1.98e-07,
+      "memory_estimate_total_bytes": 11052011181,
+      "memory_estimate_pinned_bytes": 2108979024,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.950211,
+          "best_ms": 0.894606,
+          "best_in_gibs": 69.8632,
+          "best_out_gibs": 69.8632,
+          "in_gibs": 65.7748,
+          "out_gibs": 65.7748
+        },
+        "h2d": {
+          "avg_ms": 2.50789,
+          "best_ms": 2.48838,
+          "best_in_gibs": 25.1167,
+          "best_out_gibs": 25.1167,
+          "in_gibs": 24.9214,
+          "out_gibs": 24.9214
+        },
+        "scatter": {
+          "avg_ms": 0.183312,
+          "best_ms": 0.175744,
+          "best_in_gibs": 355.631,
+          "best_out_gibs": 355.631,
+          "in_gibs": 340.949,
+          "out_gibs": 340.949
+        },
+        "lod_gather": {
+          "avg_ms": 5.3534,
+          "best_ms": 4.76595,
+          "best_in_gibs": 78.6831,
+          "best_out_gibs": 78.6831,
+          "in_gibs": 70.0489,
+          "out_gibs": 70.0489
+        },
+        "lod_reduce": {
+          "avg_ms": 4.05711,
+          "best_ms": 3.79706,
+          "best_in_gibs": 98.7607,
+          "best_out_gibs": 112.842,
+          "in_gibs": 92.4303,
+          "out_gibs": 105.609
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.67615,
+          "best_ms": 2.36282,
+          "best_in_gibs": 181.337,
+          "best_out_gibs": 181.337,
+          "in_gibs": 160.106,
+          "out_gibs": 160.106
+        },
+        "compress": {
+          "avg_ms": 69.4414,
+          "best_ms": 52.1124,
+          "best_in_gibs": 16.4439,
+          "best_out_gibs": 1.13052,
+          "in_gibs": 12.3404,
+          "out_gibs": 0.848401
+        },
+        "aggregate": {
+          "avg_ms": 0.527808,
+          "best_ms": 0.22528,
+          "best_in_gibs": 261.515,
+          "best_out_gibs": 261.515,
+          "in_gibs": 111.62,
+          "out_gibs": 111.62
+        },
+        "d2h": {
+          "avg_ms": 3.08233,
+          "best_ms": 2.61859,
+          "best_in_gibs": 22.4984,
+          "best_out_gibs": 22.4984,
+          "in_gibs": 19.1135,
+          "out_gibs": 19.1135
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 88.3443,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 370.11,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 53.7095,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 21.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.68195,
+      "throughput_out_gibs": 0.097499,
+      "compression_fold": 19.7106,
+      "input_gib": 3.75,
+      "compressed_gib": 0.217379,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 2.22955,
+      "init_s": 6.85846,
+      "flush_s": 1.73e-07,
+      "memory_estimate_total_bytes": 6765116144,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.92405,
+          "best_ms": 3.55133,
+          "best_in_gibs": 17.599,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.0265,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 47.3382,
+          "best_ms": 44.9631,
+          "best_in_gibs": 8.34017,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.92172,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 20.1238,
+          "best_ms": 19.3306,
+          "best_in_gibs": 22.1652,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.2915,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 48.8861,
+          "best_ms": 46.7893,
+          "best_in_gibs": 9.15737,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.76459,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 52.7595,
+          "best_ms": 50.5564,
+          "best_in_gibs": 16.95,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.2423,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.95806,
+          "best_ms": 3.4263,
+          "best_in_gibs": 251.082,
+          "best_out_gibs": 0.0,
+          "in_gibs": 217.35,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 21.27,
+      "status": "pass",
+      "throughput_in_gibs": 1.69452,
+      "throughput_out_gibs": 0.860352,
+      "compression_fold": 2.25038,
+      "input_gib": 3.75,
+      "compressed_gib": 1.90397,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 2.21302,
+      "init_s": 6.84721,
+      "flush_s": 2.46e-07,
+      "memory_estimate_total_bytes": 6754516560,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.78156,
+          "best_ms": 3.31686,
+          "best_in_gibs": 18.8431,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.21617,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 48.7339,
+          "best_ms": 44.4649,
+          "best_in_gibs": 8.43362,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.69484,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 19.836,
+          "best_ms": 19.1261,
+          "best_in_gibs": 22.4022,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.6005,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 48.8835,
+          "best_ms": 46.0384,
+          "best_in_gibs": 9.30672,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.76506,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 41.9926,
+          "best_ms": 39.7897,
+          "best_in_gibs": 21.5366,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.4068,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.0527,
+          "best_ms": 7.88826,
+          "best_in_gibs": 108.642,
+          "best_out_gibs": 0.0,
+          "in_gibs": 77.5374,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 21.31,
+      "status": "pass",
+      "throughput_in_gibs": 1.57271,
+      "throughput_out_gibs": 0.075488,
+      "compression_fold": 23.8043,
+      "input_gib": 3.75,
+      "compressed_gib": 0.179995,
+      "total_chunks": 17550,
+      "chunks_per_epoch": 1755,
+      "wall_s": 2.38443,
+      "init_s": 6.76688,
+      "flush_s": 2.58e-07,
+      "memory_estimate_total_bytes": 6754516560,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.50744,
+          "best_ms": 3.28703,
+          "best_in_gibs": 19.0141,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.60439,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 47.4124,
+          "best_ms": 45.1212,
+          "best_in_gibs": 8.31094,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.90932,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 19.6376,
+          "best_ms": 18.9491,
+          "best_in_gibs": 22.6114,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.8187,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 48.7531,
+          "best_ms": 46.9689,
+          "best_in_gibs": 9.12235,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.7885,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 91.418,
+          "best_ms": 89.0527,
+          "best_in_gibs": 9.62277,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.37379,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 4.04998,
+          "best_ms": 3.48452,
+          "best_in_gibs": 245.943,
+          "best_out_gibs": 0.0,
+          "in_gibs": 211.604,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.56,
+      "status": "pass",
+      "throughput_in_gibs": 11.1304,
+      "throughput_out_gibs": 12.7828,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 4.30671,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.336915,
+      "init_s": 0.742892,
+      "flush_s": 2.48e-07,
+      "memory_estimate_total_bytes": 7052973254,
+      "memory_estimate_pinned_bytes": 2118151888,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.972362,
+          "best_ms": 0.910304,
+          "best_in_gibs": 68.6584,
+          "best_out_gibs": 68.6584,
+          "in_gibs": 64.2765,
+          "out_gibs": 64.2765
+        },
+        "h2d": {
+          "avg_ms": 2.73181,
+          "best_ms": 2.48899,
+          "best_in_gibs": 25.1106,
+          "best_out_gibs": 25.1106,
+          "in_gibs": 22.8786,
+          "out_gibs": 22.8786
+        },
+        "lod_gather": {
+          "avg_ms": 4.92414,
+          "best_ms": 4.71616,
+          "best_in_gibs": 79.5138,
+          "best_out_gibs": 79.5138,
+          "in_gibs": 76.1554,
+          "out_gibs": 76.1554
+        },
+        "lod_reduce": {
+          "avg_ms": 3.91238,
+          "best_ms": 3.81466,
+          "best_in_gibs": 98.3051,
+          "best_out_gibs": 112.897,
+          "in_gibs": 95.8496,
+          "out_gibs": 110.077
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 2.65773,
+          "best_ms": 2.6487,
+          "best_in_gibs": 162.594,
+          "best_out_gibs": 162.594,
+          "in_gibs": 162.042,
+          "out_gibs": 162.042
+        },
+        "aggregate": {
+          "avg_ms": 6.59544,
+          "best_ms": 5.9287,
+          "best_in_gibs": 145.281,
+          "best_out_gibs": 145.281,
+          "in_gibs": 130.594,
+          "out_gibs": 130.594
+        },
+        "d2h": {
+          "avg_ms": 39.7309,
+          "best_ms": 35.3478,
+          "best_in_gibs": 24.3672,
+          "best_out_gibs": 24.3672,
+          "in_gibs": 21.679,
+          "out_gibs": 21.679
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 57.7471,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 251.534,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 14.0076,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__none__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 21.22,
+      "status": "pass",
+      "throughput_in_gibs": 1.76617,
+      "throughput_out_gibs": 2.02837,
+      "compression_fold": 0.999985,
+      "input_gib": 3.75,
+      "compressed_gib": 4.30671,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.12324,
+      "init_s": 6.85134,
+      "flush_s": 3.04e-07,
+      "memory_estimate_total_bytes": 6785031088,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.59805,
+          "best_ms": 3.37907,
+          "best_in_gibs": 18.4962,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.4725,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 48.4834,
+          "best_ms": 45.0067,
+          "best_in_gibs": 8.3321,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.73461,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 20.0961,
+          "best_ms": 19.3788,
+          "best_in_gibs": 22.2235,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.4302,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 49.2127,
+          "best_ms": 47.1038,
+          "best_in_gibs": 9.14286,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.75108,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.9724,
+          "best_ms": 12.9253,
+          "best_in_gibs": 66.6391,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.926,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 20.8895,
+          "best_ms": 15.0962,
+          "best_in_gibs": 57.056,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41.2327,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 14.02,
+      "status": "pass",
+      "throughput_in_gibs": 5.47321,
+      "throughput_out_gibs": 0.608682,
+      "compression_fold": 10.3266,
+      "input_gib": 3.75,
+      "compressed_gib": 0.417042,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.685155,
+      "init_s": 0.745082,
+      "flush_s": 3.05e-07,
+      "memory_estimate_total_bytes": 11099560117,
+      "memory_estimate_pinned_bytes": 2118274768,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.12025,
+          "best_ms": 1.05229,
+          "best_in_gibs": 59.3944,
+          "best_out_gibs": 59.3944,
+          "in_gibs": 55.7913,
+          "out_gibs": 55.7913
+        },
+        "h2d": {
+          "avg_ms": 2.51701,
+          "best_ms": 2.48826,
+          "best_in_gibs": 25.118,
+          "best_out_gibs": 25.118,
+          "in_gibs": 24.8311,
+          "out_gibs": 24.8311
+        },
+        "scatter": {
+          "avg_ms": 0.183696,
+          "best_ms": 0.171616,
+          "best_in_gibs": 364.185,
+          "best_out_gibs": 364.185,
+          "in_gibs": 340.236,
+          "out_gibs": 340.236
+        },
+        "lod_gather": {
+          "avg_ms": 9.01554,
+          "best_ms": 4.76531,
+          "best_in_gibs": 78.6937,
+          "best_out_gibs": 78.6937,
+          "in_gibs": 41.5948,
+          "out_gibs": 41.5948
+        },
+        "lod_reduce": {
+          "avg_ms": 6.18546,
+          "best_ms": 3.81213,
+          "best_in_gibs": 98.3703,
+          "best_out_gibs": 112.972,
+          "in_gibs": 60.6261,
+          "out_gibs": 69.6252
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 5.38429,
+          "best_ms": 2.65226,
+          "best_in_gibs": 162.377,
+          "best_out_gibs": 162.377,
+          "in_gibs": 79.9852,
+          "out_gibs": 79.9852
+        },
+        "compress": {
+          "avg_ms": 106.322,
+          "best_ms": 82.6541,
+          "best_in_gibs": 10.4209,
+          "best_out_gibs": 1.00897,
+          "in_gibs": 8.1011,
+          "out_gibs": 0.784362
+        },
+        "aggregate": {
+          "avg_ms": 0.649485,
+          "best_ms": 0.363232,
+          "best_in_gibs": 229.592,
+          "best_out_gibs": 229.592,
+          "in_gibs": 128.402,
+          "out_gibs": 128.402
+        },
+        "d2h": {
+          "avg_ms": 4.39874,
+          "best_ms": 3.70973,
+          "best_in_gibs": 22.4801,
+          "best_out_gibs": 22.4801,
+          "in_gibs": 18.9589,
+          "out_gibs": 18.9589
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 165.527,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 558.195,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 84.1113,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 21.12,
+      "status": "pass",
+      "throughput_in_gibs": 1.70388,
+      "throughput_out_gibs": 0.0794899,
+      "compression_fold": 24.6169,
+      "input_gib": 3.75,
+      "compressed_gib": 0.174946,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.20086,
+      "init_s": 6.78764,
+      "flush_s": 2.82e-07,
+      "memory_estimate_total_bytes": 6795869104,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.50755,
+          "best_ms": 3.28132,
+          "best_in_gibs": 19.0472,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.60423,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 48.3598,
+          "best_ms": 44.8995,
+          "best_in_gibs": 8.35199,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.75437,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 20.0584,
+          "best_ms": 19.2555,
+          "best_in_gibs": 22.3658,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.4705,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 49.4834,
+          "best_ms": 47.1605,
+          "best_in_gibs": 9.13189,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.7032,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 50.5295,
+          "best_ms": 47.9697,
+          "best_in_gibs": 17.9557,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.046,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.72539,
+          "best_ms": 3.40314,
+          "best_in_gibs": 254.086,
+          "best_out_gibs": 0.0,
+          "in_gibs": 232.108,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 21.28,
+      "status": "pass",
+      "throughput_in_gibs": 1.69602,
+      "throughput_out_gibs": 0.898749,
+      "compression_fold": 2.1672,
+      "input_gib": 3.75,
+      "compressed_gib": 1.98719,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.21106,
+      "init_s": 6.85397,
+      "flush_s": 2.54e-07,
+      "memory_estimate_total_bytes": 6785094352,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.71126,
+          "best_ms": 3.30921,
+          "best_in_gibs": 18.8867,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.31271,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 47.6532,
+          "best_ms": 45.1162,
+          "best_in_gibs": 8.31188,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.86936,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 19.8733,
+          "best_ms": 19.206,
+          "best_in_gibs": 22.4234,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.6705,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 48.9246,
+          "best_ms": 45.4773,
+          "best_in_gibs": 9.46988,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.80261,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 44.8831,
+          "best_ms": 42.5001,
+          "best_in_gibs": 20.2665,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.1905,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.0002,
+          "best_ms": 8.01169,
+          "best_in_gibs": 107.512,
+          "best_out_gibs": 0.0,
+          "in_gibs": 78.3029,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 21.35,
+      "status": "pass",
+      "throughput_in_gibs": 1.56803,
+      "throughput_out_gibs": 0.0708744,
+      "compression_fold": 25.4082,
+      "input_gib": 3.75,
+      "compressed_gib": 0.169498,
+      "total_chunks": 4410,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.39153,
+      "init_s": 6.80391,
+      "flush_s": 2.27e-07,
+      "memory_estimate_total_bytes": 6785094352,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 6.51525,
+          "best_ms": 3.30052,
+          "best_in_gibs": 18.9364,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.59288,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 47.0146,
+          "best_ms": 44.9181,
+          "best_in_gibs": 8.34853,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.97624,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 19.5348,
+          "best_ms": 19.2215,
+          "best_in_gibs": 22.4053,
+          "best_out_gibs": 0.0,
+          "in_gibs": 22.046,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 48.7718,
+          "best_ms": 46.9143,
+          "best_in_gibs": 9.17981,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.83019,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 93.5135,
+          "best_ms": 91.7132,
+          "best_in_gibs": 9.39154,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.21074,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.77708,
+          "best_ms": 3.29644,
+          "best_in_gibs": 261.297,
+          "best_out_gibs": 0.0,
+          "in_gibs": 228.047,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__gpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 31.78,
+      "status": "pass",
+      "throughput_in_gibs": 10.0905,
+      "throughput_out_gibs": 13.4649,
+      "compression_fold": 0.99974,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.9094,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 0.290341,
+      "init_s": 0.897981,
+      "flush_s": 4.67e-07,
+      "memory_estimate_total_bytes": 10756661886,
+      "memory_estimate_pinned_bytes": 1947511536,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.939212,
+          "best_ms": 0.141117,
+          "best_in_gibs": 55.3619,
+          "best_out_gibs": 55.3619,
+          "in_gibs": 61.1628,
+          "out_gibs": 61.1628
+        },
+        "h2d": {
+          "avg_ms": 2.53661,
+          "best_ms": 0.372576,
+          "best_in_gibs": 20.9689,
+          "best_out_gibs": 20.9689,
+          "in_gibs": 22.6278,
+          "out_gibs": 22.6278
+        },
+        "scatter": {
+          "avg_ms": 0.026496,
+          "best_ms": 0.026496,
+          "best_in_gibs": 294.856,
+          "best_out_gibs": 294.856,
+          "in_gibs": 294.856,
+          "out_gibs": 294.856
+        },
+        "lod_gather": {
+          "avg_ms": 4.14841,
+          "best_ms": 3.99645,
+          "best_in_gibs": 146.615,
+          "best_out_gibs": 146.615,
+          "in_gibs": 141.244,
+          "out_gibs": 141.244
+        },
+        "lod_reduce": {
+          "avg_ms": 7.40289,
+          "best_ms": 7.27434,
+          "best_in_gibs": 80.5486,
+          "best_out_gibs": 107.4,
+          "in_gibs": 79.1499,
+          "out_gibs": 105.535
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.58792,
+          "best_ms": 4.49005,
+          "best_in_gibs": 173.999,
+          "best_out_gibs": 174.091,
+          "in_gibs": 170.287,
+          "out_gibs": 170.377
+        },
+        "aggregate": {
+          "avg_ms": 4.54752,
+          "best_ms": 3.86138,
+          "best_in_gibs": 202.435,
+          "best_out_gibs": 202.435,
+          "in_gibs": 171.891,
+          "out_gibs": 171.891
+        },
+        "d2h": {
+          "avg_ms": 38.7557,
+          "best_ms": 32.3799,
+          "best_in_gibs": 24.1408,
+          "best_out_gibs": 24.1408,
+          "in_gibs": 20.1693,
+          "out_gibs": 20.1693
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 59.0144,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 217.495,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 17.7411,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 50.78,
+      "status": "pass",
+      "throughput_in_gibs": 1.51611,
+      "throughput_out_gibs": 2.02311,
+      "compression_fold": 0.99974,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.9094,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.93238,
+      "init_s": 18.3104,
+      "flush_s": 2.3e-07,
+      "memory_estimate_total_bytes": 10488930956,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.32095,
+          "best_ms": 0.410838,
+          "best_in_gibs": 19.016,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.90364,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 63.5648,
+          "best_ms": 60.8178,
+          "best_in_gibs": 9.63431,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.21796,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 47.7381,
+          "best_ms": 45.844,
+          "best_in_gibs": 17.0418,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.3656,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 87.2042,
+          "best_ms": 83.5626,
+          "best_in_gibs": 9.35439,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.96376,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.4391,
+          "best_ms": 11.6946,
+          "best_in_gibs": 66.8408,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.1363,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 22.1752,
+          "best_ms": 16.574,
+          "best_in_gibs": 47.1629,
+          "best_out_gibs": 0.0,
+          "in_gibs": 35.25,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__gpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 32.92,
+      "status": "pass",
+      "throughput_in_gibs": 2.09932,
+      "throughput_out_gibs": 0.473873,
+      "compression_fold": 5.91009,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.661308,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.39554,
+      "init_s": 0.887641,
+      "flush_s": 1.74e-07,
+      "memory_estimate_total_bytes": 14493684023,
+      "memory_estimate_pinned_bytes": 1947839216,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.34156,
+          "best_ms": 0.199056,
+          "best_in_gibs": 39.2477,
+          "best_out_gibs": 39.2477,
+          "in_gibs": 42.8194,
+          "out_gibs": 42.8194
+        },
+        "h2d": {
+          "avg_ms": 2.33478,
+          "best_ms": 0.320288,
+          "best_in_gibs": 24.3921,
+          "best_out_gibs": 24.3921,
+          "in_gibs": 24.5839,
+          "out_gibs": 24.5839
+        },
+        "scatter": {
+          "avg_ms": 0.123136,
+          "best_ms": 0.05968,
+          "best_in_gibs": 392.72,
+          "best_out_gibs": 392.72,
+          "in_gibs": 253.784,
+          "out_gibs": 253.784
+        },
+        "lod_gather": {
+          "avg_ms": 22.214,
+          "best_ms": 3.9711,
+          "best_in_gibs": 147.55,
+          "best_out_gibs": 147.55,
+          "in_gibs": 26.377,
+          "out_gibs": 26.377
+        },
+        "lod_reduce": {
+          "avg_ms": 21.8828,
+          "best_ms": 7.25485,
+          "best_in_gibs": 80.765,
+          "best_out_gibs": 107.688,
+          "in_gibs": 26.7762,
+          "out_gibs": 35.7022
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 24.0062,
+          "best_ms": 4.48368,
+          "best_in_gibs": 174.246,
+          "best_out_gibs": 174.338,
+          "in_gibs": 32.5442,
+          "out_gibs": 32.5615
+        },
+        "compress": {
+          "avg_ms": 251.68,
+          "best_ms": 236.652,
+          "best_in_gibs": 3.30306,
+          "best_out_gibs": 0.55141,
+          "in_gibs": 3.10584,
+          "out_gibs": 0.524707
+        },
+        "aggregate": {
+          "avg_ms": 0.582074,
+          "best_ms": 0.499104,
+          "best_in_gibs": 261.365,
+          "best_out_gibs": 261.365,
+          "in_gibs": 226.875,
+          "out_gibs": 226.875
+        },
+        "d2h": {
+          "avg_ms": 7.17951,
+          "best_ms": 5.7968,
+          "best_in_gibs": 22.8634,
+          "best_out_gibs": 22.8634,
+          "in_gibs": 18.3938,
+          "out_gibs": 18.3938
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 489.554,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 1291.15,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 240.978,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 51.08,
+      "status": "pass",
+      "throughput_in_gibs": 1.24238,
+      "throughput_out_gibs": 0.220439,
+      "compression_fold": 7.51867,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.519824,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 2.35813,
+      "init_s": 18.2828,
+      "flush_s": 2.11e-07,
+      "memory_estimate_total_bytes": 10500024940,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.40182,
+          "best_ms": 0.423698,
+          "best_in_gibs": 18.4388,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.83719,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 66.8773,
+          "best_ms": 62.1505,
+          "best_in_gibs": 9.42772,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.76138,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 48.0804,
+          "best_ms": 46.6033,
+          "best_in_gibs": 16.7641,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.2491,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 87.9398,
+          "best_ms": 83.4926,
+          "best_in_gibs": 9.36223,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.88877,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 107.215,
+          "best_ms": 103.646,
+          "best_in_gibs": 7.54177,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.29078,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.55459,
+          "best_ms": 7.19722,
+          "best_in_gibs": 109.087,
+          "best_out_gibs": 0.0,
+          "in_gibs": 91.7783,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 50.88,
+      "status": "pass",
+      "throughput_in_gibs": 1.41531,
+      "throughput_out_gibs": 1.13122,
+      "compression_fold": 1.6691,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.34161,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 2.06999,
+      "init_s": 18.273,
+      "flush_s": 1.94e-07,
+      "memory_estimate_total_bytes": 10489594620,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.37649,
+          "best_ms": 0.415823,
+          "best_in_gibs": 18.788,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.85786,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 65.1188,
+          "best_ms": 60.3168,
+          "best_in_gibs": 9.71433,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.99798,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 47.4258,
+          "best_ms": 46.4082,
+          "best_in_gibs": 16.8346,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.4734,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 89.0029,
+          "best_ms": 86.5211,
+          "best_in_gibs": 9.03452,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.7826,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 44.1061,
+          "best_ms": 40.6287,
+          "best_in_gibs": 19.2395,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.7226,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 16.2645,
+          "best_ms": 12.4134,
+          "best_in_gibs": 62.9875,
+          "best_out_gibs": 0.0,
+          "in_gibs": 48.0735,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 50.87,
+      "status": "pass",
+      "throughput_in_gibs": 1.36971,
+      "throughput_out_gibs": 0.0961428,
+      "compression_fold": 19.0059,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.205641,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 2.13891,
+      "init_s": 18.2871,
+      "flush_s": 2.06e-07,
+      "memory_estimate_total_bytes": 10489594620,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.32944,
+          "best_ms": 0.419256,
+          "best_in_gibs": 18.6342,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.8966,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 63.8088,
+          "best_ms": 61.196,
+          "best_in_gibs": 9.57478,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.18271,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 47.3008,
+          "best_ms": 45.5476,
+          "best_in_gibs": 17.1527,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.5169,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 87.8863,
+          "best_ms": 83.2861,
+          "best_in_gibs": 9.38545,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.89419,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 69.8801,
+          "best_ms": 65.839,
+          "best_in_gibs": 11.8726,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.186,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.62274,
+          "best_ms": 6.69156,
+          "best_in_gibs": 116.847,
+          "best_out_gibs": 0.0,
+          "in_gibs": 102.573,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__gpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 31.82,
+      "status": "pass",
+      "throughput_in_gibs": 10.0929,
+      "throughput_out_gibs": 13.4875,
+      "compression_fold": 0.999935,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.91505,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 0.290273,
+      "init_s": 0.889319,
+      "flush_s": 1.87e-07,
+      "memory_estimate_total_bytes": 10761252486,
+      "memory_estimate_pinned_bytes": 1949936656,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.941247,
+          "best_ms": 0.139108,
+          "best_in_gibs": 56.1614,
+          "best_out_gibs": 56.1614,
+          "in_gibs": 61.0306,
+          "out_gibs": 61.0306
+        },
+        "h2d": {
+          "avg_ms": 2.51153,
+          "best_ms": 0.369472,
+          "best_in_gibs": 21.145,
+          "best_out_gibs": 21.145,
+          "in_gibs": 22.8538,
+          "out_gibs": 22.8538
+        },
+        "scatter": {
+          "avg_ms": 0.021152,
+          "best_ms": 0.021152,
+          "best_in_gibs": 369.35,
+          "best_out_gibs": 369.35,
+          "in_gibs": 369.35,
+          "out_gibs": 369.35
+        },
+        "lod_gather": {
+          "avg_ms": 4.14388,
+          "best_ms": 3.97958,
+          "best_in_gibs": 147.236,
+          "best_out_gibs": 147.236,
+          "in_gibs": 141.398,
+          "out_gibs": 141.398
+        },
+        "lod_reduce": {
+          "avg_ms": 7.40042,
+          "best_ms": 7.26797,
+          "best_in_gibs": 80.6192,
+          "best_out_gibs": 107.5,
+          "in_gibs": 79.1762,
+          "out_gibs": 105.576
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.5865,
+          "best_ms": 4.50205,
+          "best_in_gibs": 173.544,
+          "best_out_gibs": 173.912,
+          "in_gibs": 170.349,
+          "out_gibs": 170.71
+        },
+        "aggregate": {
+          "avg_ms": 4.91704,
+          "best_ms": 4.49882,
+          "best_in_gibs": 174.037,
+          "best_out_gibs": 174.037,
+          "in_gibs": 159.234,
+          "out_gibs": 159.234
+        },
+        "d2h": {
+          "avg_ms": 38.9251,
+          "best_ms": 32.9214,
+          "best_in_gibs": 23.7826,
+          "best_out_gibs": 23.7826,
+          "in_gibs": 20.1145,
+          "out_gibs": 20.1145
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 60.1482,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 219.216,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 17.5627,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 50.67,
+      "status": "pass",
+      "throughput_in_gibs": 1.51369,
+      "throughput_out_gibs": 2.02281,
+      "compression_fold": 0.999935,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.91505,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.93545,
+      "init_s": 18.2409,
+      "flush_s": 2.29e-07,
+      "memory_estimate_total_bytes": 10493194388,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.4737,
+          "best_ms": 0.445261,
+          "best_in_gibs": 17.5459,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.77919,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 64.7111,
+          "best_ms": 61.9177,
+          "best_in_gibs": 9.46316,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.05467,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 46.8512,
+          "best_ms": 45.4223,
+          "best_in_gibs": 17.2009,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.6763,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 86.9131,
+          "best_ms": 83.4139,
+          "best_in_gibs": 9.38643,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.00852,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.3614,
+          "best_ms": 11.5695,
+          "best_in_gibs": 67.6743,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.5183,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 21.9415,
+          "best_ms": 15.6511,
+          "best_in_gibs": 50.0258,
+          "best_out_gibs": 0.0,
+          "in_gibs": 35.6839,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__gpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 32.88,
+      "status": "pass",
+      "throughput_in_gibs": 2.1234,
+      "throughput_out_gibs": 0.431813,
+      "compression_fold": 6.57091,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.595777,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.37971,
+      "init_s": 0.866601,
+      "flush_s": 3.21e-07,
+      "memory_estimate_total_bytes": 14502823673,
+      "memory_estimate_pinned_bytes": 1950116880,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.34181,
+          "best_ms": 0.197103,
+          "best_in_gibs": 39.6366,
+          "best_out_gibs": 39.6366,
+          "in_gibs": 42.8116,
+          "out_gibs": 42.8116
+        },
+        "h2d": {
+          "avg_ms": 2.32936,
+          "best_ms": 0.321152,
+          "best_in_gibs": 24.3265,
+          "best_out_gibs": 24.3265,
+          "in_gibs": 24.6411,
+          "out_gibs": 24.6411
+        },
+        "scatter": {
+          "avg_ms": 0.119019,
+          "best_ms": 0.060448,
+          "best_in_gibs": 387.73,
+          "best_out_gibs": 387.73,
+          "in_gibs": 262.564,
+          "out_gibs": 262.564
+        },
+        "lod_gather": {
+          "avg_ms": 23.3654,
+          "best_ms": 3.95946,
+          "best_in_gibs": 147.984,
+          "best_out_gibs": 147.984,
+          "in_gibs": 25.0772,
+          "out_gibs": 25.0772
+        },
+        "lod_reduce": {
+          "avg_ms": 23.3131,
+          "best_ms": 7.25267,
+          "best_in_gibs": 80.7892,
+          "best_out_gibs": 107.726,
+          "in_gibs": 25.1334,
+          "out_gibs": 33.5134
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 21.0083,
+          "best_ms": 4.46128,
+          "best_in_gibs": 175.13,
+          "best_out_gibs": 175.501,
+          "in_gibs": 37.1903,
+          "out_gibs": 37.2691
+        },
+        "compress": {
+          "avg_ms": 248.791,
+          "best_ms": 231.659,
+          "best_in_gibs": 3.3798,
+          "best_out_gibs": 0.514071,
+          "in_gibs": 3.14706,
+          "out_gibs": 0.478733
+        },
+        "aggregate": {
+          "avg_ms": 0.813203,
+          "best_ms": 0.519072,
+          "best_in_gibs": 229.485,
+          "best_out_gibs": 229.485,
+          "in_gibs": 146.463,
+          "out_gibs": 146.463
+        },
+        "d2h": {
+          "avg_ms": 6.4057,
+          "best_ms": 5.18278,
+          "best_in_gibs": 22.9836,
+          "best_out_gibs": 22.9836,
+          "in_gibs": 18.5935,
+          "out_gibs": 18.5935
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 484.436,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 1277.55,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 240.902,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 51.07,
+      "status": "pass",
+      "throughput_in_gibs": 1.25944,
+      "throughput_out_gibs": 0.197379,
+      "compression_fold": 8.52638,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.459139,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 2.32618,
+      "init_s": 18.2695,
+      "flush_s": 1.51e-07,
+      "memory_estimate_total_bytes": 10503056532,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.64767,
+          "best_ms": 0.452976,
+          "best_in_gibs": 17.247,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.64281,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 63.7844,
+          "best_ms": 59.0437,
+          "best_in_gibs": 9.92379,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.18622,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 48.2514,
+          "best_ms": 44.0465,
+          "best_in_gibs": 17.7381,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.1924,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 87.0477,
+          "best_ms": 82.9598,
+          "best_in_gibs": 9.43781,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.9946,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 103.39,
+          "best_ms": 101.243,
+          "best_in_gibs": 7.73347,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.57284,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.52822,
+          "best_ms": 6.8165,
+          "best_in_gibs": 115.312,
+          "best_out_gibs": 0.0,
+          "in_gibs": 104.41,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 50.74,
+      "status": "pass",
+      "throughput_in_gibs": 1.44461,
+      "throughput_out_gibs": 1.04873,
+      "compression_fold": 1.84067,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.12684,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 2.02801,
+      "init_s": 18.2544,
+      "flush_s": 1.64e-07,
+      "memory_estimate_total_bytes": 10493393156,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.18564,
+          "best_ms": 0.396667,
+          "best_in_gibs": 19.6954,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.01776,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 64.1243,
+          "best_ms": 59.7093,
+          "best_in_gibs": 9.81317,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.13753,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 47.4746,
+          "best_ms": 45.1561,
+          "best_in_gibs": 17.3023,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.4573,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 88.0129,
+          "best_ms": 83.1155,
+          "best_in_gibs": 9.42013,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.89595,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 43.3488,
+          "best_ms": 41.0358,
+          "best_in_gibs": 19.0799,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.0618,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 14.265,
+          "best_ms": 10.7107,
+          "best_in_gibs": 73.1073,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.8914,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 50.85,
+      "status": "pass",
+      "throughput_in_gibs": 1.46843,
+      "throughput_out_gibs": 0.0614924,
+      "compression_fold": 31.9095,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.122684,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.99512,
+      "init_s": 18.4136,
+      "flush_s": 1.87e-07,
+      "memory_estimate_total_bytes": 10493393156,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.56049,
+          "best_ms": 0.424604,
+          "best_in_gibs": 18.3995,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.71046,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 65.8955,
+          "best_ms": 60.173,
+          "best_in_gibs": 9.73755,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.89192,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 46.7663,
+          "best_ms": 44.9824,
+          "best_in_gibs": 17.3691,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.7066,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 85.6785,
+          "best_ms": 83.1361,
+          "best_in_gibs": 9.4178,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.13834,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 40.8816,
+          "best_ms": 38.3608,
+          "best_in_gibs": 20.4104,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.1519,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.13043,
+          "best_ms": 5.84107,
+          "best_in_gibs": 134.056,
+          "best_out_gibs": 0.0,
+          "in_gibs": 127.728,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__gpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 32.1,
+      "status": "pass",
+      "throughput_in_gibs": 10.0778,
+      "throughput_out_gibs": 13.5549,
+      "compression_fold": 0.999984,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.94049,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 0.290707,
+      "init_s": 0.876615,
+      "flush_s": 1.66e-07,
+      "memory_estimate_total_bytes": 10781707342,
+      "memory_estimate_pinned_bytes": 1960864752,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.0211,
+          "best_ms": 0.150878,
+          "best_in_gibs": 51.7802,
+          "best_out_gibs": 51.7802,
+          "in_gibs": 56.2577,
+          "out_gibs": 56.2577
+        },
+        "h2d": {
+          "avg_ms": 2.51152,
+          "best_ms": 0.373088,
+          "best_in_gibs": 20.9401,
+          "best_out_gibs": 20.9401,
+          "in_gibs": 22.8538,
+          "out_gibs": 22.8538
+        },
+        "scatter": {
+          "avg_ms": 0.041328,
+          "best_ms": 0.021344,
+          "best_in_gibs": 366.028,
+          "best_out_gibs": 366.028,
+          "in_gibs": 378.073,
+          "out_gibs": 378.073
+        },
+        "lod_gather": {
+          "avg_ms": 4.13896,
+          "best_ms": 3.95997,
+          "best_in_gibs": 147.965,
+          "best_out_gibs": 147.965,
+          "in_gibs": 141.566,
+          "out_gibs": 141.566
+        },
+        "lod_reduce": {
+          "avg_ms": 7.39343,
+          "best_ms": 7.25824,
+          "best_in_gibs": 80.7272,
+          "best_out_gibs": 107.666,
+          "in_gibs": 79.2511,
+          "out_gibs": 105.697
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 4.60521,
+          "best_ms": 4.50995,
+          "best_in_gibs": 173.275,
+          "best_out_gibs": 174.744,
+          "in_gibs": 169.691,
+          "out_gibs": 171.129
+        },
+        "aggregate": {
+          "avg_ms": 5.2068,
+          "best_ms": 4.8207,
+          "best_in_gibs": 163.479,
+          "best_out_gibs": 163.479,
+          "in_gibs": 151.357,
+          "out_gibs": 151.357
+        },
+        "d2h": {
+          "avg_ms": 39.155,
+          "best_ms": 33.0927,
+          "best_in_gibs": 23.8145,
+          "best_out_gibs": 23.8145,
+          "in_gibs": 20.1273,
+          "out_gibs": 20.1273
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 60.7713,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 220.504,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 17.5566,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__none__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 50.65,
+      "status": "pass",
+      "throughput_in_gibs": 1.49881,
+      "throughput_out_gibs": 2.01593,
+      "compression_fold": 0.999984,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.94049,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.95468,
+      "init_s": 18.1724,
+      "flush_s": 1.85e-07,
+      "memory_estimate_total_bytes": 10513567516,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.75073,
+          "best_ms": 0.47676,
+          "best_in_gibs": 16.3867,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.56458,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 66.0038,
+          "best_ms": 61.197,
+          "best_in_gibs": 9.57461,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.87733,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 46.3685,
+          "best_ms": 44.6011,
+          "best_in_gibs": 17.5212,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.8533,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 86.8813,
+          "best_ms": 83.3656,
+          "best_in_gibs": 9.45337,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.07084,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.4801,
+          "best_ms": 11.4748,
+          "best_in_gibs": 68.6798,
+          "best_out_gibs": 0.0,
+          "in_gibs": 54.4253,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 20.6133,
+          "best_ms": 14.6966,
+          "best_in_gibs": 53.6236,
+          "best_out_gibs": 0.0,
+          "in_gibs": 38.2318,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__gpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 32.74,
+      "status": "pass",
+      "throughput_in_gibs": 2.532,
+      "throughput_out_gibs": 0.517803,
+      "compression_fold": 6.5769,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.599132,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.15706,
+      "init_s": 0.875225,
+      "flush_s": 1.55e-07,
+      "memory_estimate_total_bytes": 14543106497,
+      "memory_estimate_pinned_bytes": 1960995824,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.961851,
+          "best_ms": 0.133459,
+          "best_in_gibs": 58.5386,
+          "best_out_gibs": 58.5386,
+          "in_gibs": 59.7232,
+          "out_gibs": 59.7232
+        },
+        "h2d": {
+          "avg_ms": 2.32709,
+          "best_ms": 0.321952,
+          "best_in_gibs": 24.266,
+          "best_out_gibs": 24.266,
+          "in_gibs": 24.6651,
+          "out_gibs": 24.6651
+        },
+        "scatter": {
+          "avg_ms": 0.108,
+          "best_ms": 0.058304,
+          "best_in_gibs": 401.988,
+          "best_out_gibs": 401.988,
+          "in_gibs": 289.352,
+          "out_gibs": 289.352
+        },
+        "lod_gather": {
+          "avg_ms": 11.0357,
+          "best_ms": 3.99434,
+          "best_in_gibs": 146.692,
+          "best_out_gibs": 146.692,
+          "in_gibs": 53.0949,
+          "out_gibs": 53.0949
+        },
+        "lod_reduce": {
+          "avg_ms": 11.9218,
+          "best_ms": 7.25203,
+          "best_in_gibs": 80.7963,
+          "best_out_gibs": 107.758,
+          "in_gibs": 49.1483,
+          "out_gibs": 65.549
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 9.89676,
+          "best_ms": 4.49251,
+          "best_in_gibs": 173.948,
+          "best_out_gibs": 175.422,
+          "in_gibs": 78.9616,
+          "out_gibs": 79.6307
+        },
+        "compress": {
+          "avg_ms": 204.101,
+          "best_ms": 188.347,
+          "best_in_gibs": 4.18422,
+          "best_out_gibs": 0.638029,
+          "in_gibs": 3.86126,
+          "out_gibs": 0.587032
+        },
+        "aggregate": {
+          "avg_ms": 0.87641,
+          "best_ms": 0.57936,
+          "best_in_gibs": 207.802,
+          "best_out_gibs": 207.802,
+          "in_gibs": 136.709,
+          "out_gibs": 136.709
+        },
+        "d2h": {
+          "avg_ms": 6.47413,
+          "best_ms": 5.27344,
+          "best_in_gibs": 22.7639,
+          "best_out_gibs": 22.7639,
+          "in_gibs": 18.5065,
+          "out_gibs": 18.5065
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 394.302,
+        "flush_stall_count": 5,
+        "kick_sync_ms": 1055.45,
+        "kick_sync_count": 5,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 195.197,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 50.99,
+      "status": "pass",
+      "throughput_in_gibs": 1.26999,
+      "throughput_out_gibs": 0.200554,
+      "compression_fold": 8.5171,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.462649,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 2.30686,
+      "init_s": 18.2455,
+      "flush_s": 1.55e-07,
+      "memory_estimate_total_bytes": 10523483932,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.19352,
+          "best_ms": 0.409264,
+          "best_in_gibs": 19.0891,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.01101,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 66.3075,
+          "best_ms": 63.8596,
+          "best_in_gibs": 9.17541,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.83668,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 45.8815,
+          "best_ms": 43.3999,
+          "best_in_gibs": 18.0061,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.0322,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 87.4066,
+          "best_ms": 82.5387,
+          "best_in_gibs": 9.54808,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.01632,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 106.327,
+          "best_ms": 103.718,
+          "best_in_gibs": 7.59833,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.41191,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.81549,
+          "best_ms": 5.76732,
+          "best_in_gibs": 137.181,
+          "best_out_gibs": 0.0,
+          "in_gibs": 116.083,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 50.86,
+      "status": "pass",
+      "throughput_in_gibs": 1.43523,
+      "throughput_out_gibs": 1.09015,
+      "compression_fold": 1.77075,
+      "input_gib": 2.92969,
+      "compressed_gib": 2.22529,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 2.04127,
+      "init_s": 18.3207,
+      "flush_s": 2.7e-07,
+      "memory_estimate_total_bytes": 10513645964,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.36458,
+          "best_ms": 0.403219,
+          "best_in_gibs": 19.3753,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.86763,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 64.4448,
+          "best_ms": 59.494,
+          "best_in_gibs": 9.84868,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.09209,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 46.5979,
+          "best_ms": 44.8673,
+          "best_in_gibs": 17.4172,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.7704,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 85.2394,
+          "best_ms": 82.4845,
+          "best_in_gibs": 9.55435,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.24555,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 46.9903,
+          "best_ms": 44.4418,
+          "best_in_gibs": 17.733,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.7713,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.6822,
+          "best_ms": 10.4152,
+          "best_in_gibs": 75.6697,
+          "best_out_gibs": 0.0,
+          "in_gibs": 57.6015,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 50.93,
+      "status": "pass",
+      "throughput_in_gibs": 1.44604,
+      "throughput_out_gibs": 0.0826219,
+      "compression_fold": 23.5401,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.167392,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 2.026,
+      "init_s": 18.4076,
+      "flush_s": 2.78e-07,
+      "memory_estimate_total_bytes": 10513645964,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.3597,
+          "best_ms": 0.410446,
+          "best_in_gibs": 19.0342,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.87164,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 62.9571,
+          "best_ms": 60.3417,
+          "best_in_gibs": 9.71033,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.30693,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 45.8,
+          "best_ms": 44.0565,
+          "best_in_gibs": 17.7378,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.0625,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 86.6134,
+          "best_ms": 84.2767,
+          "best_in_gibs": 9.35117,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.09889,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 53.539,
+          "best_ms": 50.1755,
+          "best_in_gibs": 15.7066,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.7199,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 5.53917,
+          "best_ms": 5.06897,
+          "best_in_gibs": 155.478,
+          "best_out_gibs": 0.0,
+          "in_gibs": 142.281,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.15,
+      "status": "pass",
+      "throughput_in_gibs": 12.2393,
+      "throughput_out_gibs": 14.0891,
+      "compression_fold": 1.16205,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04695,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.28724,
+      "init_s": 0.493391,
+      "flush_s": 2.29e-07,
+      "memory_estimate_total_bytes": 4043079090,
+      "memory_estimate_pinned_bytes": 1352141360,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.749558,
+          "best_ms": 0.254666,
+          "best_in_gibs": 61.3549,
+          "best_out_gibs": 61.3549,
+          "in_gibs": 62.5369,
+          "out_gibs": 62.5369
+        },
+        "h2d": {
+          "avg_ms": 2.07977,
+          "best_ms": 0.631168,
+          "best_in_gibs": 24.7557,
+          "best_out_gibs": 24.7557,
+          "in_gibs": 22.6415,
+          "out_gibs": 22.6415
+        },
+        "scatter": {
+          "avg_ms": 0.113948,
+          "best_ms": 0.039552,
+          "best_in_gibs": 395.05,
+          "best_out_gibs": 395.05,
+          "in_gibs": 346.842,
+          "out_gibs": 346.842
+        },
+        "lod_gather": {
+          "avg_ms": 0.586023,
+          "best_ms": 0.560224,
+          "best_in_gibs": 251.016,
+          "best_out_gibs": 251.016,
+          "in_gibs": 239.965,
+          "out_gibs": 239.965
+        },
+        "lod_reduce": {
+          "avg_ms": 1.84309,
+          "best_ms": 1.78944,
+          "best_in_gibs": 78.586,
+          "best_out_gibs": 104.824,
+          "in_gibs": 76.2984,
+          "out_gibs": 101.773
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.213365,
+          "best_ms": 0.139392,
+          "best_in_gibs": 336.829,
+          "best_out_gibs": 336.829,
+          "in_gibs": 220.051,
+          "out_gibs": 220.051
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.530823,
+          "best_ms": 0.441728,
+          "best_in_gibs": 424.642,
+          "best_out_gibs": 425.851,
+          "in_gibs": 353.369,
+          "out_gibs": 354.375
+        },
+        "aggregate": {
+          "avg_ms": 2.35289,
+          "best_ms": 0.172736,
+          "best_in_gibs": 274.901,
+          "best_out_gibs": 274.901,
+          "in_gibs": 171.949,
+          "out_gibs": 171.949
+        },
+        "d2h": {
+          "avg_ms": 20.7283,
+          "best_ms": 2.05334,
+          "best_in_gibs": 23.1259,
+          "best_out_gibs": 23.1259,
+          "in_gibs": 19.5181,
+          "out_gibs": 19.5181
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 89.1743,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 215.479,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 12.5484,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 7.65,
+      "status": "pass",
+      "throughput_in_gibs": 1.45573,
+      "throughput_out_gibs": 1.67574,
+      "compression_fold": 1.16205,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.04695,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 2.41502,
+      "init_s": 3.16234,
+      "flush_s": 2.26e-07,
+      "memory_estimate_total_bytes": 3750085948,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.27311,
+          "best_ms": 1.11595,
+          "best_in_gibs": 14.0015,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9698,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.4821,
+          "best_ms": 15.5852,
+          "best_in_gibs": 9.023,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.53197,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.8724,
+          "best_ms": 14.9319,
+          "best_in_gibs": 12.5621,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.8178,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 7.56882,
+          "best_ms": 5.39475,
+          "best_in_gibs": 8.70314,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.20325,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.6231,
+          "best_ms": 15.2603,
+          "best_in_gibs": 12.3268,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.12132,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.74061,
+          "best_ms": 3.17051,
+          "best_in_gibs": 59.3313,
+          "best_out_gibs": 0.0,
+          "in_gibs": 55.9557,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.88599,
+          "best_ms": 2.4624,
+          "best_in_gibs": 57.1089,
+          "best_out_gibs": 0.0,
+          "in_gibs": 40.9243,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 3.95,
+      "status": "pass",
+      "throughput_in_gibs": 3.6124,
+      "throughput_out_gibs": 0.613738,
+      "compression_fold": 7.87341,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.597296,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 0.973211,
+      "init_s": 0.526,
+      "flush_s": 3.14e-07,
+      "memory_estimate_total_bytes": 6933578149,
+      "memory_estimate_pinned_bytes": 1352370736,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.757343,
+          "best_ms": 0.240434,
+          "best_in_gibs": 64.9866,
+          "best_out_gibs": 64.9866,
+          "in_gibs": 61.894,
+          "out_gibs": 61.894
+        },
+        "h2d": {
+          "avg_ms": 1.91576,
+          "best_ms": 0.62896,
+          "best_in_gibs": 24.8426,
+          "best_out_gibs": 24.8426,
+          "in_gibs": 24.5798,
+          "out_gibs": 24.5798
+        },
+        "scatter": {
+          "avg_ms": 0.0959744,
+          "best_ms": 0.04112,
+          "best_in_gibs": 379.985,
+          "best_out_gibs": 379.985,
+          "in_gibs": 358.168,
+          "out_gibs": 358.168
+        },
+        "lod_gather": {
+          "avg_ms": 4.82163,
+          "best_ms": 0.588768,
+          "best_in_gibs": 238.846,
+          "best_out_gibs": 238.846,
+          "in_gibs": 29.1655,
+          "out_gibs": 29.1655
+        },
+        "lod_reduce": {
+          "avg_ms": 5.02122,
+          "best_ms": 1.78515,
+          "best_in_gibs": 78.7748,
+          "best_out_gibs": 105.076,
+          "in_gibs": 28.0061,
+          "out_gibs": 37.3567
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.31959,
+          "best_ms": 0.148448,
+          "best_in_gibs": 316.281,
+          "best_out_gibs": 316.281,
+          "in_gibs": 35.5801,
+          "out_gibs": 35.5801
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.9783,
+          "best_ms": 0.43984,
+          "best_in_gibs": 426.465,
+          "best_out_gibs": 427.679,
+          "in_gibs": 47.1499,
+          "out_gibs": 47.2841
+        },
+        "compress": {
+          "avg_ms": 86.8739,
+          "best_ms": 31.5803,
+          "best_in_gibs": 5.95658,
+          "best_out_gibs": 0.656441,
+          "in_gibs": 5.62985,
+          "out_gibs": 0.686189
+        },
+        "aggregate": {
+          "avg_ms": 0.218355,
+          "best_ms": 0.025728,
+          "best_in_gibs": 221.709,
+          "best_out_gibs": 221.709,
+          "in_gibs": 273.004,
+          "out_gibs": 273.004
+        },
+        "d2h": {
+          "avg_ms": 3.16395,
+          "best_ms": 0.35312,
+          "best_in_gibs": 16.1535,
+          "best_out_gibs": 16.1535,
+          "in_gibs": 18.841,
+          "out_gibs": 18.841
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 228.406,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 883.643,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 79.8875,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 7.99,
+      "status": "pass",
+      "throughput_in_gibs": 1.23832,
+      "throughput_out_gibs": 0.170199,
+      "compression_fold": 9.73251,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.483201,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 2.83904,
+      "init_s": 3.11911,
+      "flush_s": 3.16e-07,
+      "memory_estimate_total_bytes": 3757532924,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.16015,
+          "best_ms": 1.09465,
+          "best_in_gibs": 14.274,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.2676,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.4012,
+          "best_ms": 15.5855,
+          "best_in_gibs": 9.02284,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.57408,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.534,
+          "best_ms": 14.6305,
+          "best_in_gibs": 12.8209,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.0752,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 7.4926,
+          "best_ms": 5.44933,
+          "best_in_gibs": 8.61598,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.26635,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.3002,
+          "best_ms": 15.364,
+          "best_in_gibs": 12.2436,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.26645,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 60.3657,
+          "best_ms": 24.5813,
+          "best_in_gibs": 7.65257,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.10207,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.53678,
+          "best_ms": 0.955877,
+          "best_in_gibs": 147.763,
+          "best_out_gibs": 0.0,
+          "in_gibs": 114.895,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 7.65,
+      "status": "pass",
+      "throughput_in_gibs": 1.40056,
+      "throughput_out_gibs": 0.875819,
+      "compression_fold": 2.13913,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.19845,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 2.51016,
+      "init_s": 3.11722,
+      "flush_s": 3.53e-07,
+      "memory_estimate_total_bytes": 3750536988,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.08564,
+          "best_ms": 1.07253,
+          "best_in_gibs": 14.5684,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.4731,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.6896,
+          "best_ms": 15.6851,
+          "best_in_gibs": 8.96554,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.42589,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.7082,
+          "best_ms": 14.851,
+          "best_in_gibs": 12.6306,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.9413,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 7.61824,
+          "best_ms": 5.47299,
+          "best_in_gibs": 8.57873,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.16301,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.2246,
+          "best_ms": 15.2944,
+          "best_in_gibs": 12.2993,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.30105,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.0071,
+          "best_ms": 9.57233,
+          "best_in_gibs": 19.6515,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.3726,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.64296,
+          "best_ms": 1.56287,
+          "best_in_gibs": 90.0007,
+          "best_out_gibs": 0.0,
+          "in_gibs": 60.919,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 7.96,
+      "status": "pass",
+      "throughput_in_gibs": 1.24632,
+      "throughput_out_gibs": 0.0768819,
+      "compression_fold": 21.6848,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.216869,
+      "total_chunks": 77050,
+      "chunks_per_epoch": 3082,
+      "wall_s": 2.82081,
+      "init_s": 3.14247,
+      "flush_s": 1.46e-07,
+      "memory_estimate_total_bytes": 3750536988,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.08958,
+          "best_ms": 1.08078,
+          "best_in_gibs": 14.4572,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.4621,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.483,
+          "best_ms": 15.4924,
+          "best_in_gibs": 9.07705,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.53154,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.6115,
+          "best_ms": 14.6755,
+          "best_in_gibs": 12.7816,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.0153,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 7.56142,
+          "best_ms": 5.36143,
+          "best_in_gibs": 8.75724,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.20932,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.4352,
+          "best_ms": 15.3951,
+          "best_in_gibs": 12.2188,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.2052,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 58.8143,
+          "best_ms": 14.1783,
+          "best_in_gibs": 13.2674,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.31578,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.10824,
+          "best_ms": 0.981322,
+          "best_in_gibs": 143.337,
+          "best_out_gibs": 0.0,
+          "in_gibs": 130.197,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 3.18,
+      "status": "pass",
+      "throughput_in_gibs": 12.387,
+      "throughput_out_gibs": 14.2892,
+      "compression_fold": 1.17089,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.0555,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 0.283816,
+      "init_s": 0.472708,
+      "flush_s": 1.58e-07,
+      "memory_estimate_total_bytes": 4059449790,
+      "memory_estimate_pinned_bytes": 1355882512,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.757723,
+          "best_ms": 0.25211,
+          "best_in_gibs": 61.9769,
+          "best_out_gibs": 61.9769,
+          "in_gibs": 61.863,
+          "out_gibs": 61.863
+        },
+        "h2d": {
+          "avg_ms": 2.12204,
+          "best_ms": 0.63168,
+          "best_in_gibs": 24.7356,
+          "best_out_gibs": 24.7356,
+          "in_gibs": 22.1905,
+          "out_gibs": 22.1905
+        },
+        "scatter": {
+          "avg_ms": 0.115826,
+          "best_ms": 0.0392,
+          "best_in_gibs": 398.597,
+          "best_out_gibs": 398.597,
+          "in_gibs": 346.886,
+          "out_gibs": 346.886
+        },
+        "lod_gather": {
+          "avg_ms": 0.592284,
+          "best_ms": 0.56528,
+          "best_in_gibs": 248.771,
+          "best_out_gibs": 248.771,
+          "in_gibs": 237.428,
+          "out_gibs": 237.428
+        },
+        "lod_reduce": {
+          "avg_ms": 1.84356,
+          "best_ms": 1.78864,
+          "best_in_gibs": 78.6212,
+          "best_out_gibs": 104.999,
+          "in_gibs": 76.2789,
+          "out_gibs": 101.871
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.212391,
+          "best_ms": 0.141344,
+          "best_in_gibs": 333.797,
+          "best_out_gibs": 333.797,
+          "in_gibs": 222.138,
+          "out_gibs": 222.138
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.536007,
+          "best_ms": 0.447968,
+          "best_in_gibs": 419.238,
+          "best_out_gibs": 424.007,
+          "in_gibs": 350.378,
+          "out_gibs": 354.364
+        },
+        "aggregate": {
+          "avg_ms": 2.74893,
+          "best_ms": 0.367328,
+          "best_in_gibs": 134.257,
+          "best_out_gibs": 134.257,
+          "in_gibs": 147.518,
+          "out_gibs": 147.518
+        },
+        "d2h": {
+          "avg_ms": 20.421,
+          "best_ms": 2.02074,
+          "best_in_gibs": 24.4052,
+          "best_out_gibs": 24.4052,
+          "in_gibs": 19.8579,
+          "out_gibs": 19.8579
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 82.9403,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 214.677,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 11.7328,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 7.57,
+      "status": "pass",
+      "throughput_in_gibs": 1.49101,
+      "throughput_out_gibs": 1.71998,
+      "compression_fold": 1.17089,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.0555,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.35788,
+      "init_s": 3.14849,
+      "flush_s": 1.98e-07,
+      "memory_estimate_total_bytes": 3766066260,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.18741,
+          "best_ms": 1.09871,
+          "best_in_gibs": 14.2212,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.1943,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.4829,
+          "best_ms": 15.739,
+          "best_in_gibs": 8.93479,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.53155,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 15.0291,
+          "best_ms": 14.1217,
+          "best_in_gibs": 13.2991,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.4961,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.70957,
+          "best_ms": 4.63226,
+          "best_in_gibs": 10.1851,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.03178,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.4322,
+          "best_ms": 15.2289,
+          "best_in_gibs": 12.4724,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.29619,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 8.9558,
+          "best_ms": 3.0541,
+          "best_in_gibs": 62.1922,
+          "best_out_gibs": 0.0,
+          "in_gibs": 55.1428,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 9.67839,
+          "best_ms": 2.47227,
+          "best_in_gibs": 56.8808,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41.8993,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 4.24,
+      "status": "pass",
+      "throughput_in_gibs": 2.75927,
+      "throughput_out_gibs": 0.443481,
+      "compression_fold": 8.40381,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.565046,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 1.27411,
+      "init_s": 0.484142,
+      "flush_s": 1.84e-07,
+      "memory_estimate_total_bytes": 6971028181,
+      "memory_estimate_pinned_bytes": 1356013584,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.722921,
+          "best_ms": 0.234099,
+          "best_in_gibs": 66.7453,
+          "best_out_gibs": 66.7453,
+          "in_gibs": 64.8411,
+          "out_gibs": 64.8411
+        },
+        "h2d": {
+          "avg_ms": 1.90806,
+          "best_ms": 0.630752,
+          "best_in_gibs": 24.772,
+          "best_out_gibs": 24.772,
+          "in_gibs": 24.6791,
+          "out_gibs": 24.6791
+        },
+        "scatter": {
+          "avg_ms": 0.099792,
+          "best_ms": 0.040544,
+          "best_in_gibs": 385.384,
+          "best_out_gibs": 385.384,
+          "in_gibs": 352.295,
+          "out_gibs": 352.295
+        },
+        "lod_gather": {
+          "avg_ms": 5.18674,
+          "best_ms": 0.576288,
+          "best_in_gibs": 244.019,
+          "best_out_gibs": 244.019,
+          "in_gibs": 27.1124,
+          "out_gibs": 27.1124
+        },
+        "lod_reduce": {
+          "avg_ms": 5.09511,
+          "best_ms": 1.7815,
+          "best_in_gibs": 78.9361,
+          "best_out_gibs": 105.419,
+          "in_gibs": 27.6,
+          "out_gibs": 36.8599
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.26498,
+          "best_ms": 0.152832,
+          "best_in_gibs": 308.706,
+          "best_out_gibs": 308.706,
+          "in_gibs": 37.297,
+          "out_gibs": 37.297
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.47755,
+          "best_ms": 0.443168,
+          "best_in_gibs": 423.779,
+          "best_out_gibs": 428.599,
+          "in_gibs": 54.0051,
+          "out_gibs": 54.6194
+        },
+        "compress": {
+          "avg_ms": 117.021,
+          "best_ms": 29.7621,
+          "best_in_gibs": 6.38198,
+          "best_out_gibs": 0.67183,
+          "in_gibs": 4.22017,
+          "out_gibs": 0.482579
+        },
+        "aggregate": {
+          "avg_ms": 0.377792,
+          "best_ms": 0.045536,
+          "best_in_gibs": 439.105,
+          "best_out_gibs": 439.105,
+          "in_gibs": 149.479,
+          "out_gibs": 149.479
+        },
+        "d2h": {
+          "avg_ms": 3.05978,
+          "best_ms": 0.25776,
+          "best_in_gibs": 20.2626,
+          "best_out_gibs": 20.2626,
+          "in_gibs": 18.4562,
+          "out_gibs": 18.4562
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 283.587,
+        "flush_stall_count": 10,
+        "kick_sync_ms": 1187.19,
+        "kick_sync_count": 10,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 119.125,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 7.9,
+      "status": "pass",
+      "throughput_in_gibs": 1.27335,
+      "throughput_out_gibs": 0.155698,
+      "compression_fold": 11.0464,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.429871,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.76093,
+      "init_s": 3.12265,
+      "flush_s": 1.91e-07,
+      "memory_estimate_total_bytes": 3772707924,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.07056,
+          "best_ms": 1.07915,
+          "best_in_gibs": 14.4789,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.5156,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.3928,
+          "best_ms": 15.3985,
+          "best_in_gibs": 9.13241,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.57849,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.7306,
+          "best_ms": 13.9785,
+          "best_in_gibs": 13.4353,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.7493,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.72607,
+          "best_ms": 4.56303,
+          "best_in_gibs": 10.3397,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.01452,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.2881,
+          "best_ms": 15.3328,
+          "best_in_gibs": 12.3879,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.36219,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 58.1687,
+          "best_ms": 24.0083,
+          "best_in_gibs": 7.91148,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.48993,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.32119,
+          "best_ms": 0.998523,
+          "best_in_gibs": 141.383,
+          "best_out_gibs": 0.0,
+          "in_gibs": 122.577,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 7.71,
+      "status": "pass",
+      "throughput_in_gibs": 1.40966,
+      "throughput_out_gibs": 0.858764,
+      "compression_fold": 2.21716,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.14172,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.49395,
+      "init_s": 3.1712,
+      "flush_s": 1.58e-07,
+      "memory_estimate_total_bytes": 3766210100,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.21997,
+          "best_ms": 1.11758,
+          "best_in_gibs": 13.9811,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.1079,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.4964,
+          "best_ms": 15.7283,
+          "best_in_gibs": 8.94089,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.52457,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.9337,
+          "best_ms": 14.0891,
+          "best_in_gibs": 13.3299,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.5759,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.99729,
+          "best_ms": 4.6122,
+          "best_in_gibs": 10.2294,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.74264,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.7155,
+          "best_ms": 15.3194,
+          "best_in_gibs": 12.3988,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.16903,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 24.3453,
+          "best_ms": 9.75282,
+          "best_in_gibs": 19.4755,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.2851,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.21281,
+          "best_ms": 1.41312,
+          "best_in_gibs": 99.5219,
+          "best_out_gibs": 0.0,
+          "in_gibs": 65.2764,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 7.81,
+      "status": "pass",
+      "throughput_in_gibs": 1.34542,
+      "throughput_out_gibs": 0.058583,
+      "compression_fold": 31.0201,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.153079,
+      "total_chunks": 19450,
+      "chunks_per_epoch": 778,
+      "wall_s": 2.61303,
+      "init_s": 3.1728,
+      "flush_s": 1.55e-07,
+      "memory_estimate_total_bytes": 3766210100,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.09795,
+          "best_ms": 1.08585,
+          "best_in_gibs": 14.3897,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.4387,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 16.69,
+          "best_ms": 15.602,
+          "best_in_gibs": 9.01326,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.42573,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 14.8357,
+          "best_ms": 13.9304,
+          "best_in_gibs": 13.4816,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.659,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 6.71899,
+          "best_ms": 4.62129,
+          "best_in_gibs": 10.2093,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.02192,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.12,
+          "best_ms": 15.1999,
+          "best_in_gibs": 12.4962,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.44041,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 42.8475,
+          "best_ms": 11.8553,
+          "best_in_gibs": 16.0216,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.5257,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.86489,
+          "best_ms": 0.960414,
+          "best_in_gibs": 146.433,
+          "best_out_gibs": 0.0,
+          "in_gibs": 141.559,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 3.41,
+      "status": "pass",
+      "throughput_in_gibs": 11.2462,
+      "throughput_out_gibs": 13.8019,
+      "compression_fold": 1.18287,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31453,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 0.312605,
+      "init_s": 0.655482,
+      "flush_s": 1.9e-07,
+      "memory_estimate_total_bytes": 6311720330,
+      "memory_estimate_pinned_bytes": 1715493104,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.904893,
+          "best_ms": 0.260854,
+          "best_in_gibs": 59.8994,
+          "best_out_gibs": 59.8994,
+          "in_gibs": 61.6687,
+          "out_gibs": 61.6687
+        },
+        "h2d": {
+          "avg_ms": 2.5099,
+          "best_ms": 1.24832,
+          "best_in_gibs": 25.0336,
+          "best_out_gibs": 25.0336,
+          "in_gibs": 22.4521,
+          "out_gibs": 22.4521
+        },
+        "lod_gather": {
+          "avg_ms": 1.1283,
+          "best_ms": 1.02912,
+          "best_in_gibs": 273.292,
+          "best_out_gibs": 273.292,
+          "in_gibs": 249.268,
+          "out_gibs": 249.268
+        },
+        "lod_reduce": {
+          "avg_ms": 3.65818,
+          "best_ms": 3.50618,
+          "best_in_gibs": 80.2156,
+          "best_out_gibs": 107.093,
+          "in_gibs": 76.8826,
+          "out_gibs": 102.644
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.643877,
+          "best_ms": 0.323232,
+          "best_in_gibs": 291.55,
+          "best_out_gibs": 291.55,
+          "in_gibs": 146.361,
+          "out_gibs": 146.361
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.15068,
+          "best_ms": 0.862176,
+          "best_in_gibs": 435.512,
+          "best_out_gibs": 455.334,
+          "in_gibs": 326.319,
+          "out_gibs": 341.171
+        },
+        "aggregate": {
+          "avg_ms": 4.0775,
+          "best_ms": 1.34422,
+          "best_in_gibs": 82.8196,
+          "best_out_gibs": 82.8196,
+          "in_gibs": 132.264,
+          "out_gibs": 132.264
+        },
+        "d2h": {
+          "avg_ms": 26.442,
+          "best_ms": 4.58147,
+          "best_in_gibs": 24.2996,
+          "best_out_gibs": 24.2996,
+          "in_gibs": 20.3958,
+          "out_gibs": 20.3958
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 72.6332,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 237.176,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 9.1786,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__none__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 10.5,
+      "status": "pass",
+      "throughput_in_gibs": 1.56415,
+      "throughput_out_gibs": 1.9196,
+      "compression_fold": 1.18287,
+      "input_gib": 3.51562,
+      "compressed_gib": 4.31453,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.24762,
+      "init_s": 6.0815,
+      "flush_s": 2.06e-07,
+      "memory_estimate_total_bytes": 5992986424,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.68423,
+          "best_ms": 1.11044,
+          "best_in_gibs": 14.071,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.81726,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 31.7635,
+          "best_ms": 30.6246,
+          "best_in_gibs": 9.18378,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.85451,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.5126,
+          "best_ms": 22.951,
+          "best_in_gibs": 16.3604,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.3182,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 9.66343,
+          "best_ms": 4.27998,
+          "best_in_gibs": 22.0184,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.75205,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 35.6532,
+          "best_ms": 28.7832,
+          "best_in_gibs": 13.6391,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.011,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 12.1274,
+          "best_ms": 5.43893,
+          "best_in_gibs": 72.1793,
+          "best_out_gibs": 0.0,
+          "in_gibs": 56.6495,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.1613,
+          "best_ms": 4.18924,
+          "best_in_gibs": 26.5748,
+          "best_out_gibs": 0.0,
+          "in_gibs": 44.346,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__gpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 4.26,
+      "status": "pass",
+      "throughput_in_gibs": 3.27435,
+      "throughput_out_gibs": 0.538007,
+      "compression_fold": 8.83495,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.577651,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 1.07369,
+      "init_s": 0.657481,
+      "flush_s": 1.67e-07,
+      "memory_estimate_total_bytes": 10061695265,
+      "memory_estimate_pinned_bytes": 1715607792,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.884476,
+          "best_ms": 0.241519,
+          "best_in_gibs": 64.6947,
+          "best_out_gibs": 64.6947,
+          "in_gibs": 63.0922,
+          "out_gibs": 63.0922
+        },
+        "h2d": {
+          "avg_ms": 2.27828,
+          "best_ms": 1.248,
+          "best_in_gibs": 25.0401,
+          "best_out_gibs": 25.0401,
+          "in_gibs": 24.7347,
+          "out_gibs": 24.7347
+        },
+        "scatter": {
+          "avg_ms": 0.182624,
+          "best_ms": 0.174752,
+          "best_in_gibs": 357.65,
+          "best_out_gibs": 357.65,
+          "in_gibs": 342.233,
+          "out_gibs": 342.233
+        },
+        "lod_gather": {
+          "avg_ms": 3.99403,
+          "best_ms": 1.03286,
+          "best_in_gibs": 272.301,
+          "best_out_gibs": 272.301,
+          "in_gibs": 70.4177,
+          "out_gibs": 70.4177
+        },
+        "lod_reduce": {
+          "avg_ms": 5.38666,
+          "best_ms": 3.50509,
+          "best_in_gibs": 80.2405,
+          "best_out_gibs": 107.127,
+          "in_gibs": 52.2124,
+          "out_gibs": 69.7071
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.52099,
+          "best_ms": 0.323424,
+          "best_in_gibs": 291.377,
+          "best_out_gibs": 291.377,
+          "in_gibs": 61.9584,
+          "out_gibs": 61.9584
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.05659,
+          "best_ms": 0.865024,
+          "best_in_gibs": 434.078,
+          "best_out_gibs": 453.835,
+          "in_gibs": 122.846,
+          "out_gibs": 128.437
+        },
+        "compress": {
+          "avg_ms": 117.903,
+          "best_ms": 62.369,
+          "best_in_gibs": 6.29444,
+          "best_out_gibs": 0.659537,
+          "in_gibs": 5.82691,
+          "out_gibs": 0.61234
+        },
+        "aggregate": {
+          "avg_ms": 0.500864,
+          "best_ms": 0.12128,
+          "best_in_gibs": 75.1562,
+          "best_out_gibs": 75.1562,
+          "in_gibs": 144.145,
+          "out_gibs": 144.145
+        },
+        "d2h": {
+          "avg_ms": 3.82067,
+          "best_ms": 0.46336,
+          "best_in_gibs": 19.6714,
+          "best_out_gibs": 19.6714,
+          "in_gibs": 18.8964,
+          "out_gibs": 18.8964
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 371.39,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 974.098,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 117.371,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 10.82,
+      "status": "pass",
+      "throughput_in_gibs": 1.30276,
+      "throughput_out_gibs": 0.161673,
+      "compression_fold": 11.6975,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.436291,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.6986,
+      "init_s": 6.0448,
+      "flush_s": 1.62e-07,
+      "memory_estimate_total_bytes": 6001932088,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.57844,
+          "best_ms": 1.10686,
+          "best_in_gibs": 14.1165,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.0034,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 31.6279,
+          "best_ms": 29.2028,
+          "best_in_gibs": 9.63094,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.89247,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.6003,
+          "best_ms": 23.0616,
+          "best_in_gibs": 16.282,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.2636,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 9.80135,
+          "best_ms": 4.56999,
+          "best_in_gibs": 20.6211,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.61483,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 36.4879,
+          "best_ms": 28.5905,
+          "best_in_gibs": 13.7311,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.7591,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 76.6493,
+          "best_ms": 41.3058,
+          "best_in_gibs": 9.50419,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.96305,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.16962,
+          "best_ms": 1.17077,
+          "best_in_gibs": 241.166,
+          "best_out_gibs": 0.0,
+          "in_gibs": 170.813,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 10.57,
+      "status": "pass",
+      "throughput_in_gibs": 1.48297,
+      "throughput_out_gibs": 0.9208,
+      "compression_fold": 2.33795,
+      "input_gib": 3.51562,
+      "compressed_gib": 2.18291,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.37066,
+      "init_s": 6.09857,
+      "flush_s": 5.17e-07,
+      "memory_estimate_total_bytes": 5993056632,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.61127,
+          "best_ms": 1.10075,
+          "best_in_gibs": 14.1948,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.94491,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 31.4658,
+          "best_ms": 30.6854,
+          "best_in_gibs": 9.1656,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.93829,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.7765,
+          "best_ms": 23.0035,
+          "best_in_gibs": 16.3231,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.155,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 9.67936,
+          "best_ms": 4.58325,
+          "best_in_gibs": 20.5615,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.73601,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 36.5578,
+          "best_ms": 29.673,
+          "best_in_gibs": 13.2301,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.7386,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 31.5449,
+          "best_ms": 15.9056,
+          "best_in_gibs": 24.6818,
+          "best_out_gibs": 0.0,
+          "in_gibs": 21.7788,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.16871,
+          "best_ms": 2.52265,
+          "best_in_gibs": 111.493,
+          "best_out_gibs": 0.0,
+          "in_gibs": 75.2329,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "orca2_multiscale_dim0__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "orca2_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 10.58,
+      "status": "pass",
+      "throughput_in_gibs": 1.43452,
+      "throughput_out_gibs": 0.0652915,
+      "compression_fold": 31.8945,
+      "input_gib": 3.51562,
+      "compressed_gib": 0.160012,
+      "total_chunks": 5226,
+      "chunks_per_epoch": 402,
+      "wall_s": 2.45074,
+      "init_s": 6.04157,
+      "flush_s": 2.48e-07,
+      "memory_estimate_total_bytes": 5993056632,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 5.7936,
+          "best_ms": 1.12645,
+          "best_in_gibs": 13.871,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.63193,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 31.4291,
+          "best_ms": 30.5364,
+          "best_in_gibs": 9.21031,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.94871,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 24.6307,
+          "best_ms": 22.9095,
+          "best_in_gibs": 16.3901,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.2447,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 9.74366,
+          "best_ms": 4.67119,
+          "best_in_gibs": 20.1744,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.67175,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 36.2893,
+          "best_ms": 29.2687,
+          "best_in_gibs": 13.4129,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.818,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 45.2985,
+          "best_ms": 18.5112,
+          "best_in_gibs": 21.2076,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.1663,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.49151,
+          "best_ms": 0.909632,
+          "best_in_gibs": 309.199,
+          "best_out_gibs": 0.0,
+          "in_gibs": 216.464,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.27,
+      "status": "pass",
+      "throughput_in_gibs": 13.5284,
+      "throughput_out_gibs": 14.4336,
+      "compression_fold": 1.07092,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00092,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.277194,
+      "init_s": 0.496991,
+      "flush_s": 4.83e-07,
+      "memory_estimate_total_bytes": 3405564234,
+      "memory_estimate_pinned_bytes": 1357516528,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.757089,
+          "best_ms": 0.477138,
+          "best_in_gibs": 65.4947,
+          "best_out_gibs": 65.4947,
+          "in_gibs": 61.9148,
+          "out_gibs": 61.9148
+        },
+        "h2d": {
+          "avg_ms": 2.07315,
+          "best_ms": 1.24621,
+          "best_in_gibs": 25.0761,
+          "best_out_gibs": 25.0761,
+          "in_gibs": 22.6105,
+          "out_gibs": 22.6105
+        },
+        "scatter": {
+          "avg_ms": 0.104948,
+          "best_ms": 0.075296,
+          "best_in_gibs": 415.029,
+          "best_out_gibs": 415.029,
+          "in_gibs": 372.208,
+          "out_gibs": 372.208
+        },
+        "lod_gather": {
+          "avg_ms": 1.24672,
+          "best_ms": 1.21677,
+          "best_in_gibs": 77.0484,
+          "best_out_gibs": 77.0484,
+          "in_gibs": 75.1971,
+          "out_gibs": 75.1971
+        },
+        "lod_reduce": {
+          "avg_ms": 1.0178,
+          "best_ms": 0.969216,
+          "best_in_gibs": 96.7277,
+          "best_out_gibs": 110.519,
+          "in_gibs": 92.1104,
+          "out_gibs": 105.243
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.043524,
+          "best_ms": 0.027584,
+          "best_in_gibs": 484.582,
+          "best_out_gibs": 484.582,
+          "in_gibs": 307.111,
+          "out_gibs": 307.111
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.599712,
+          "best_ms": 0.528544,
+          "best_in_gibs": 202.664,
+          "best_out_gibs": 202.664,
+          "in_gibs": 178.614,
+          "out_gibs": 178.614
+        },
+        "aggregate": {
+          "avg_ms": 3.08986,
+          "best_ms": 2.78893,
+          "best_in_gibs": 181.797,
+          "best_out_gibs": 181.797,
+          "in_gibs": 161.817,
+          "out_gibs": 161.817
+        },
+        "d2h": {
+          "avg_ms": 24.7966,
+          "best_ms": 20.7793,
+          "best_in_gibs": 24.4002,
+          "best_out_gibs": 24.4002,
+          "in_gibs": 20.1638,
+          "out_gibs": 20.1638
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 58.1473,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 205.032,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 9.41887,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 16.44,
+      "status": "pass",
+      "throughput_in_gibs": 1.63269,
+      "throughput_out_gibs": 1.74193,
+      "compression_fold": 1.07092,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00092,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 2.29682,
+      "init_s": 2.03657,
+      "flush_s": 3.97e-07,
+      "memory_estimate_total_bytes": 3130612396,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.82241,
+          "best_ms": 2.15967,
+          "best_in_gibs": 14.4698,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.2632,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.7353,
+          "best_ms": 11.9533,
+          "best_in_gibs": 7.843,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.36146,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.03214,
+          "best_ms": 6.70145,
+          "best_in_gibs": 15.9841,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.2324,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.49819,
+          "best_ms": 0.000168,
+          "best_in_gibs": 79563.7,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.82103,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.1594,
+          "best_ms": 10.2388,
+          "best_in_gibs": 10.4619,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.13991,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.60679,
+          "best_ms": 8.25479,
+          "best_in_gibs": 64.8816,
+          "best_out_gibs": 0.0,
+          "in_gibs": 55.7505,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 12.0972,
+          "best_ms": 9.14822,
+          "best_in_gibs": 53.9616,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41.3313,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 13.46,
+      "status": "pass",
+      "throughput_in_gibs": 6.49677,
+      "throughput_out_gibs": 0.727501,
+      "compression_fold": 10.2035,
+      "input_gib": 3.75,
+      "compressed_gib": 0.419921,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 0.57721,
+      "init_s": 0.454511,
+      "flush_s": 5.05e-07,
+      "memory_estimate_total_bytes": 6184085315,
+      "memory_estimate_pinned_bytes": 1357721328,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.769256,
+          "best_ms": 0.484666,
+          "best_in_gibs": 64.4774,
+          "best_out_gibs": 64.4774,
+          "in_gibs": 60.9355,
+          "out_gibs": 60.9355
+        },
+        "h2d": {
+          "avg_ms": 1.89118,
+          "best_ms": 1.24605,
+          "best_in_gibs": 25.0793,
+          "best_out_gibs": 25.0793,
+          "in_gibs": 24.7861,
+          "out_gibs": 24.7861
+        },
+        "scatter": {
+          "avg_ms": 0.12776,
+          "best_ms": 0.08608,
+          "best_in_gibs": 363.034,
+          "best_out_gibs": 363.034,
+          "in_gibs": 366.899,
+          "out_gibs": 366.899
+        },
+        "lod_gather": {
+          "avg_ms": 2.96058,
+          "best_ms": 1.20819,
+          "best_in_gibs": 77.5953,
+          "best_out_gibs": 77.5953,
+          "in_gibs": 31.6661,
+          "out_gibs": 31.6661
+        },
+        "lod_reduce": {
+          "avg_ms": 1.96546,
+          "best_ms": 0.96704,
+          "best_in_gibs": 96.9453,
+          "best_out_gibs": 110.768,
+          "in_gibs": 47.6988,
+          "out_gibs": 54.4996
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.291228,
+          "best_ms": 0.02656,
+          "best_in_gibs": 503.264,
+          "best_out_gibs": 503.264,
+          "in_gibs": 45.8977,
+          "out_gibs": 45.8977
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.82393,
+          "best_ms": 0.532288,
+          "best_in_gibs": 201.238,
+          "best_out_gibs": 201.238,
+          "in_gibs": 58.7286,
+          "out_gibs": 58.7286
+        },
+        "compress": {
+          "avg_ms": 59.3982,
+          "best_ms": 40.6496,
+          "best_in_gibs": 13.1756,
+          "best_out_gibs": 1.28199,
+          "in_gibs": 9.01683,
+          "out_gibs": 0.881642
+        },
+        "aggregate": {
+          "avg_ms": 0.229876,
+          "best_ms": 0.179776,
+          "best_in_gibs": 291.397,
+          "best_out_gibs": 291.397,
+          "in_gibs": 227.81,
+          "out_gibs": 227.81
+        },
+        "d2h": {
+          "avg_ms": 2.91288,
+          "best_ms": 2.24106,
+          "best_in_gibs": 23.5766,
+          "best_out_gibs": 23.5766,
+          "in_gibs": 17.9781,
+          "out_gibs": 17.9781
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 88.7085,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 485.607,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 41.3413,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 16.61,
+      "status": "pass",
+      "throughput_in_gibs": 1.48812,
+      "throughput_out_gibs": 0.121195,
+      "compression_fold": 14.0294,
+      "input_gib": 3.75,
+      "compressed_gib": 0.305407,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 2.51996,
+      "init_s": 2.02209,
+      "flush_s": 4.53e-07,
+      "memory_estimate_total_bytes": 3137940108,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.94994,
+          "best_ms": 2.23207,
+          "best_in_gibs": 14.0005,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.8673,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.6089,
+          "best_ms": 12.0238,
+          "best_in_gibs": 7.79705,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.43525,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.9349,
+          "best_ms": 6.59811,
+          "best_in_gibs": 16.2344,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.446,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.53581,
+          "best_ms": 0.00017,
+          "best_in_gibs": 78627.6,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.78038,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.1693,
+          "best_ms": 10.2517,
+          "best_in_gibs": 10.4487,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.13383,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 44.9083,
+          "best_ms": 41.5157,
+          "best_in_gibs": 12.9007,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.9262,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.56628,
+          "best_ms": 2.71404,
+          "best_in_gibs": 182.688,
+          "best_out_gibs": 0.0,
+          "in_gibs": 140.817,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 16.56,
+      "status": "pass",
+      "throughput_in_gibs": 1.55763,
+      "throughput_out_gibs": 0.78887,
+      "compression_fold": 2.25603,
+      "input_gib": 3.75,
+      "compressed_gib": 1.89921,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 2.4075,
+      "init_s": 2.09263,
+      "flush_s": 4.38e-07,
+      "memory_estimate_total_bytes": 3131039516,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.82333,
+          "best_ms": 2.15173,
+          "best_in_gibs": 14.5232,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.2602,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.654,
+          "best_ms": 11.9758,
+          "best_in_gibs": 7.82826,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.40874,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.90356,
+          "best_ms": 6.6899,
+          "best_in_gibs": 16.0117,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.5162,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.55396,
+          "best_ms": 0.000161,
+          "best_in_gibs": 83023,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.76107,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.2818,
+          "best_ms": 10.4031,
+          "best_in_gibs": 10.2967,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.06492,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 28.3134,
+          "best_ms": 26.587,
+          "best_in_gibs": 20.1446,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.9162,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.01372,
+          "best_ms": 5.3673,
+          "best_in_gibs": 91.9976,
+          "best_out_gibs": 0.0,
+          "in_gibs": 71.3064,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 16.92,
+      "status": "pass",
+      "throughput_in_gibs": 1.37503,
+      "throughput_out_gibs": 0.0725624,
+      "compression_fold": 21.6514,
+      "input_gib": 3.75,
+      "compressed_gib": 0.197893,
+      "total_chunks": 70200,
+      "chunks_per_epoch": 1755,
+      "wall_s": 2.72721,
+      "init_s": 2.08984,
+      "flush_s": 3.63e-07,
+      "memory_estimate_total_bytes": 3131039516,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.91175,
+          "best_ms": 2.17227,
+          "best_in_gibs": 14.3858,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.9831,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.5129,
+          "best_ms": 11.8197,
+          "best_in_gibs": 7.93165,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.49227,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.0323,
+          "best_ms": 6.62436,
+          "best_in_gibs": 16.1701,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.2321,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.48908,
+          "best_ms": 0.000173,
+          "best_in_gibs": 77264.2,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.83101,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.1058,
+          "best_ms": 10.2724,
+          "best_in_gibs": 10.4276,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.17321,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 71.5809,
+          "best_ms": 63.6234,
+          "best_in_gibs": 8.41803,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.48221,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.34992,
+          "best_ms": 2.65546,
+          "best_in_gibs": 190.363,
+          "best_out_gibs": 0.0,
+          "in_gibs": 149.294,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.19,
+      "status": "pass",
+      "throughput_in_gibs": 13.5327,
+      "throughput_out_gibs": 14.4455,
+      "compression_fold": 1.07587,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00293,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.277106,
+      "init_s": 0.466533,
+      "flush_s": 3.62e-07,
+      "memory_estimate_total_bytes": 3416039934,
+      "memory_estimate_pinned_bytes": 1358496880,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.759384,
+          "best_ms": 0.489649,
+          "best_in_gibs": 63.8212,
+          "best_out_gibs": 63.8212,
+          "in_gibs": 61.7277,
+          "out_gibs": 61.7277
+        },
+        "h2d": {
+          "avg_ms": 2.03569,
+          "best_ms": 1.24522,
+          "best_in_gibs": 25.096,
+          "best_out_gibs": 25.096,
+          "in_gibs": 23.0265,
+          "out_gibs": 23.0265
+        },
+        "scatter": {
+          "avg_ms": 0.119014,
+          "best_ms": 0.075168,
+          "best_in_gibs": 415.735,
+          "best_out_gibs": 415.735,
+          "in_gibs": 367.603,
+          "out_gibs": 367.603
+        },
+        "lod_gather": {
+          "avg_ms": 1.24459,
+          "best_ms": 1.1745,
+          "best_in_gibs": 79.8215,
+          "best_out_gibs": 79.8215,
+          "in_gibs": 75.3261,
+          "out_gibs": 75.3261
+        },
+        "lod_reduce": {
+          "avg_ms": 1.02249,
+          "best_ms": 0.973184,
+          "best_in_gibs": 96.3333,
+          "best_out_gibs": 110.633,
+          "in_gibs": 91.6878,
+          "out_gibs": 105.298
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.044792,
+          "best_ms": 0.029344,
+          "best_in_gibs": 474.237,
+          "best_out_gibs": 474.237,
+          "in_gibs": 310.681,
+          "out_gibs": 310.681
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.627968,
+          "best_ms": 0.56144,
+          "best_in_gibs": 191.768,
+          "best_out_gibs": 191.768,
+          "in_gibs": 171.451,
+          "out_gibs": 171.451
+        },
+        "aggregate": {
+          "avg_ms": 3.41068,
+          "best_ms": 3.03699,
+          "best_in_gibs": 167.129,
+          "best_out_gibs": 167.129,
+          "in_gibs": 146.697,
+          "out_gibs": 146.697
+        },
+        "d2h": {
+          "avg_ms": 24.8343,
+          "best_ms": 20.9435,
+          "best_in_gibs": 24.2352,
+          "best_out_gibs": 24.2352,
+          "in_gibs": 20.147,
+          "out_gibs": 20.147
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 60.4915,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 207.289,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 10.6099,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 16.5,
+      "status": "pass",
+      "throughput_in_gibs": 1.61278,
+      "throughput_out_gibs": 1.72156,
+      "compression_fold": 1.07587,
+      "input_gib": 3.75,
+      "compressed_gib": 4.00293,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.32517,
+      "init_s": 2.04516,
+      "flush_s": 3.86e-07,
+      "memory_estimate_total_bytes": 3140548996,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.95195,
+          "best_ms": 2.28011,
+          "best_in_gibs": 13.7054,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.8612,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.6239,
+          "best_ms": 12.0556,
+          "best_in_gibs": 7.77648,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.42637,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.03582,
+          "best_ms": 6.72875,
+          "best_in_gibs": 16.0009,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.3026,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.5623,
+          "best_ms": 0.000171,
+          "best_in_gibs": 81380.2,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.90647,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.513,
+          "best_ms": 10.5094,
+          "best_in_gibs": 10.2447,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.96759,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.56453,
+          "best_ms": 8.07515,
+          "best_in_gibs": 66.665,
+          "best_out_gibs": 0.0,
+          "in_gibs": 56.284,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.9919,
+          "best_ms": 9.24208,
+          "best_in_gibs": 54.6815,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41.7229,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 13.72,
+      "status": "pass",
+      "throughput_in_gibs": 5.23182,
+      "throughput_out_gibs": 0.590171,
+      "compression_fold": 10.1808,
+      "input_gib": 3.75,
+      "compressed_gib": 0.423015,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 0.716768,
+      "init_s": 0.457157,
+      "flush_s": 3.92e-07,
+      "memory_estimate_total_bytes": 6204964225,
+      "memory_estimate_pinned_bytes": 1358611568,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.75837,
+          "best_ms": 0.479365,
+          "best_in_gibs": 65.1904,
+          "best_out_gibs": 65.1904,
+          "in_gibs": 61.8102,
+          "out_gibs": 61.8102
+        },
+        "h2d": {
+          "avg_ms": 1.8892,
+          "best_ms": 1.24621,
+          "best_in_gibs": 25.0761,
+          "best_out_gibs": 25.0761,
+          "in_gibs": 24.8121,
+          "out_gibs": 24.8121
+        },
+        "scatter": {
+          "avg_ms": 0.109824,
+          "best_ms": 0.078336,
+          "best_in_gibs": 398.923,
+          "best_out_gibs": 398.923,
+          "in_gibs": 379.395,
+          "out_gibs": 379.395
+        },
+        "lod_gather": {
+          "avg_ms": 3.02646,
+          "best_ms": 1.2057,
+          "best_in_gibs": 77.7559,
+          "best_out_gibs": 77.7559,
+          "in_gibs": 30.9768,
+          "out_gibs": 30.9768
+        },
+        "lod_reduce": {
+          "avg_ms": 1.89986,
+          "best_ms": 0.971104,
+          "best_in_gibs": 96.5396,
+          "best_out_gibs": 110.87,
+          "in_gibs": 49.3457,
+          "out_gibs": 56.6705
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.236992,
+          "best_ms": 0.028224,
+          "best_in_gibs": 493.056,
+          "best_out_gibs": 493.056,
+          "in_gibs": 58.7193,
+          "out_gibs": 58.7193
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.65004,
+          "best_ms": 0.560992,
+          "best_in_gibs": 191.921,
+          "best_out_gibs": 191.921,
+          "in_gibs": 65.2504,
+          "out_gibs": 65.2504
+        },
+        "compress": {
+          "avg_ms": 76.898,
+          "best_ms": 58.765,
+          "best_in_gibs": 9.16073,
+          "best_out_gibs": 0.888189,
+          "in_gibs": 7.00058,
+          "out_gibs": 0.687227
+        },
+        "aggregate": {
+          "avg_ms": 0.361332,
+          "best_ms": 0.233888,
+          "best_in_gibs": 223.419,
+          "best_out_gibs": 223.419,
+          "in_gibs": 146.254,
+          "out_gibs": 146.254
+        },
+        "d2h": {
+          "avg_ms": 2.90529,
+          "best_ms": 2.23734,
+          "best_in_gibs": 24.0021,
+          "best_out_gibs": 24.0021,
+          "in_gibs": 18.1897,
+          "out_gibs": 18.1897
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 112.971,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 628.071,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 59.368,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 16.58,
+      "status": "pass",
+      "throughput_in_gibs": 1.51504,
+      "throughput_out_gibs": 0.0999661,
+      "compression_fold": 17.4052,
+      "input_gib": 3.75,
+      "compressed_gib": 0.247434,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.47518,
+      "init_s": 2.06222,
+      "flush_s": 2.38e-07,
+      "memory_estimate_total_bytes": 3147066756,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.89657,
+          "best_ms": 2.24188,
+          "best_in_gibs": 13.9392,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.0298,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.6653,
+          "best_ms": 11.9975,
+          "best_in_gibs": 7.81415,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.40211,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.00316,
+          "best_ms": 6.6892,
+          "best_in_gibs": 16.0955,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.3739,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.54735,
+          "best_ms": 7.2e-05,
+          "best_in_gibs": 193278,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.92294,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.3193,
+          "best_ms": 10.4092,
+          "best_in_gibs": 10.3434,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.08347,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 38.2484,
+          "best_ms": 35.703,
+          "best_in_gibs": 15.078,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.0746,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.39456,
+          "best_ms": 2.76529,
+          "best_in_gibs": 183.47,
+          "best_out_gibs": 0.0,
+          "in_gibs": 147.97,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 16.54,
+      "status": "pass",
+      "throughput_in_gibs": 1.52457,
+      "throughput_out_gibs": 0.78259,
+      "compression_fold": 2.23729,
+      "input_gib": 3.75,
+      "compressed_gib": 1.92494,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.4597,
+      "init_s": 2.02301,
+      "flush_s": 4.22e-07,
+      "memory_estimate_total_bytes": 3140674388,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 4.07259,
+          "best_ms": 2.19701,
+          "best_in_gibs": 14.2239,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.5099,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.692,
+          "best_ms": 11.995,
+          "best_in_gibs": 7.81574,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.38652,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 7.01157,
+          "best_ms": 6.74521,
+          "best_in_gibs": 15.9618,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.3555,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.57202,
+          "best_ms": 0.000173,
+          "best_in_gibs": 80439.4,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.89584,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.5037,
+          "best_ms": 10.3467,
+          "best_in_gibs": 10.4058,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.97308,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 29.1301,
+          "best_ms": 28.3723,
+          "best_in_gibs": 18.9738,
+          "best_out_gibs": 0.0,
+          "in_gibs": 18.4802,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.15609,
+          "best_ms": 5.39808,
+          "best_in_gibs": 91.4567,
+          "best_out_gibs": 0.0,
+          "in_gibs": 69.9232,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 16.83,
+      "status": "pass",
+      "throughput_in_gibs": 1.3842,
+      "throughput_out_gibs": 0.0690369,
+      "compression_fold": 23.0264,
+      "input_gib": 3.75,
+      "compressed_gib": 0.187031,
+      "total_chunks": 17640,
+      "chunks_per_epoch": 441,
+      "wall_s": 2.70914,
+      "init_s": 2.04803,
+      "flush_s": 3.95e-07,
+      "memory_estimate_total_bytes": 3140674388,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.84958,
+          "best_ms": 2.18256,
+          "best_in_gibs": 14.3181,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.1767,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.5935,
+          "best_ms": 11.8333,
+          "best_in_gibs": 7.92256,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.44429,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.95757,
+          "best_ms": 6.48837,
+          "best_in_gibs": 16.5937,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.4746,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 3.51762,
+          "best_ms": 5.1e-05,
+          "best_in_gibs": 272863,
+          "best_out_gibs": 0.0,
+          "in_gibs": 3.95609,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 13.4582,
+          "best_ms": 10.1567,
+          "best_in_gibs": 10.6005,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.00003,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 68.6291,
+          "best_ms": 59.0114,
+          "best_in_gibs": 9.12248,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.84405,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.2574,
+          "best_ms": 2.47977,
+          "best_in_gibs": 203.813,
+          "best_out_gibs": 0.0,
+          "in_gibs": 153.612,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.17,
+      "status": "pass",
+      "throughput_in_gibs": 13.4829,
+      "throughput_out_gibs": 14.4312,
+      "compression_fold": 1.08027,
+      "input_gib": 3.75,
+      "compressed_gib": 4.01375,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 0.27813,
+      "init_s": 0.447116,
+      "flush_s": 4.86e-07,
+      "memory_estimate_total_bytes": 3426279886,
+      "memory_estimate_pinned_bytes": 1363171184,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.754889,
+          "best_ms": 0.468947,
+          "best_in_gibs": 66.6387,
+          "best_out_gibs": 66.6387,
+          "in_gibs": 62.0952,
+          "out_gibs": 62.0952
+        },
+        "h2d": {
+          "avg_ms": 2.06593,
+          "best_ms": 1.2456,
+          "best_in_gibs": 25.0883,
+          "best_out_gibs": 25.0883,
+          "in_gibs": 22.6896,
+          "out_gibs": 22.6896
+        },
+        "scatter": {
+          "avg_ms": 0.0992747,
+          "best_ms": 0.076,
+          "best_in_gibs": 411.184,
+          "best_out_gibs": 411.184,
+          "in_gibs": 367.247,
+          "out_gibs": 367.247
+        },
+        "lod_gather": {
+          "avg_ms": 1.25032,
+          "best_ms": 1.19098,
+          "best_in_gibs": 78.7169,
+          "best_out_gibs": 78.7169,
+          "in_gibs": 74.9806,
+          "out_gibs": 74.9806
+        },
+        "lod_reduce": {
+          "avg_ms": 1.01376,
+          "best_ms": 0.964416,
+          "best_in_gibs": 97.2091,
+          "best_out_gibs": 112.398,
+          "in_gibs": 92.4775,
+          "out_gibs": 106.927
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.047268,
+          "best_ms": 0.0296,
+          "best_in_gibs": 494.88,
+          "best_out_gibs": 494.88,
+          "in_gibs": 309.902,
+          "out_gibs": 309.902
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 0.643524,
+          "best_ms": 0.56576,
+          "best_in_gibs": 191.598,
+          "best_out_gibs": 191.598,
+          "in_gibs": 168.445,
+          "out_gibs": 168.445
+        },
+        "aggregate": {
+          "avg_ms": 4.81026,
+          "best_ms": 3.3679,
+          "best_in_gibs": 151.36,
+          "best_out_gibs": 151.36,
+          "in_gibs": 104.3,
+          "out_gibs": 104.3
+        },
+        "d2h": {
+          "avg_ms": 24.8135,
+          "best_ms": 21.0994,
+          "best_in_gibs": 24.1602,
+          "best_out_gibs": 24.1602,
+          "in_gibs": 20.2192,
+          "out_gibs": 20.2192
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 57.6534,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 208.815,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 9.22048,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__none__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 16.42,
+      "status": "pass",
+      "throughput_in_gibs": 1.63565,
+      "throughput_out_gibs": 1.7507,
+      "compression_fold": 1.08027,
+      "input_gib": 3.75,
+      "compressed_gib": 4.01375,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 2.29266,
+      "init_s": 2.00958,
+      "flush_s": 4.18e-07,
+      "memory_estimate_total_bytes": 3150283404,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.82528,
+          "best_ms": 2.19773,
+          "best_in_gibs": 14.2192,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.254,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.883,
+          "best_ms": 12.064,
+          "best_in_gibs": 7.77108,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.27701,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.10014,
+          "best_ms": 5.86992,
+          "best_in_gibs": 18.4668,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.7698,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.84882,
+          "best_ms": 6.2e-05,
+          "best_in_gibs": 236265,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.14193,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.4648,
+          "best_ms": 10.6805,
+          "best_in_gibs": 10.1492,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.49397,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 9.68769,
+          "best_ms": 8.09649,
+          "best_in_gibs": 66.9416,
+          "best_out_gibs": 0.0,
+          "in_gibs": 55.9465,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 11.7771,
+          "best_ms": 9.25644,
+          "best_in_gibs": 53.4889,
+          "best_out_gibs": 0.0,
+          "in_gibs": 42.6004,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__gpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 13.62,
+      "status": "pass",
+      "throughput_in_gibs": 4.99776,
+      "throughput_out_gibs": 0.561442,
+      "compression_fold": 10.2925,
+      "input_gib": 3.75,
+      "compressed_gib": 0.421271,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 0.750337,
+      "init_s": 0.464886,
+      "flush_s": 3.84e-07,
+      "memory_estimate_total_bytes": 6229363473,
+      "memory_estimate_pinned_bytes": 1363244912,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.758635,
+          "best_ms": 0.485098,
+          "best_in_gibs": 64.42,
+          "best_out_gibs": 64.42,
+          "in_gibs": 61.7886,
+          "out_gibs": 61.7886
+        },
+        "h2d": {
+          "avg_ms": 1.89185,
+          "best_ms": 1.24592,
+          "best_in_gibs": 25.0819,
+          "best_out_gibs": 25.0819,
+          "in_gibs": 24.7773,
+          "out_gibs": 24.7773
+        },
+        "scatter": {
+          "avg_ms": 0.128368,
+          "best_ms": 0.085408,
+          "best_in_gibs": 365.891,
+          "best_out_gibs": 365.891,
+          "in_gibs": 365.161,
+          "out_gibs": 365.161
+        },
+        "lod_gather": {
+          "avg_ms": 1.87864,
+          "best_ms": 1.19862,
+          "best_in_gibs": 78.2147,
+          "best_out_gibs": 78.2147,
+          "in_gibs": 49.9032,
+          "out_gibs": 49.9032
+        },
+        "lod_reduce": {
+          "avg_ms": 1.33746,
+          "best_ms": 0.964096,
+          "best_in_gibs": 97.2414,
+          "best_out_gibs": 112.435,
+          "in_gibs": 70.0958,
+          "out_gibs": 81.0482
+        },
+        "lod_append_fold": {
+          "avg_ms": 0.13176,
+          "best_ms": 0.02864,
+          "best_in_gibs": 511.468,
+          "best_out_gibs": 511.468,
+          "in_gibs": 111.175,
+          "out_gibs": 111.175
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 1.06887,
+          "best_ms": 0.562336,
+          "best_in_gibs": 192.765,
+          "best_out_gibs": 192.765,
+          "in_gibs": 101.414,
+          "out_gibs": 101.414
+        },
+        "compress": {
+          "avg_ms": 81.0524,
+          "best_ms": 63.9992,
+          "best_in_gibs": 8.46873,
+          "best_out_gibs": 0.824699,
+          "in_gibs": 6.68694,
+          "out_gibs": 0.649563
+        },
+        "aggregate": {
+          "avg_ms": 0.423112,
+          "best_ms": 0.269056,
+          "best_in_gibs": 196.083,
+          "best_out_gibs": 196.083,
+          "in_gibs": 124.432,
+          "out_gibs": 124.432
+        },
+        "d2h": {
+          "avg_ms": 2.83132,
+          "best_ms": 2.22099,
+          "best_in_gibs": 23.7642,
+          "best_out_gibs": 23.7642,
+          "in_gibs": 18.5951,
+          "out_gibs": 18.5951
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 138.104,
+        "flush_stall_count": 8,
+        "kick_sync_ms": 662.307,
+        "kick_sync_count": 8,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 65.2728,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 16.47,
+      "status": "pass",
+      "throughput_in_gibs": 1.53471,
+      "throughput_out_gibs": 0.0883161,
+      "compression_fold": 20.0927,
+      "input_gib": 3.75,
+      "compressed_gib": 0.215797,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 2.44346,
+      "init_s": 1.996,
+      "flush_s": 3.72e-07,
+      "memory_estimate_total_bytes": 3156832908,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.87533,
+          "best_ms": 2.1956,
+          "best_in_gibs": 14.233,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.0957,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.6025,
+          "best_ms": 12.027,
+          "best_in_gibs": 7.79493,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.43901,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.116,
+          "best_ms": 5.89823,
+          "best_in_gibs": 18.3781,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.7238,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.90626,
+          "best_ms": 0.00017,
+          "best_in_gibs": 86167.3,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.0403,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.4856,
+          "best_ms": 10.6436,
+          "best_in_gibs": 10.1844,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.48317,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 37.4181,
+          "best_ms": 33.2955,
+          "best_in_gibs": 16.2783,
+          "best_out_gibs": 0.0,
+          "in_gibs": 14.4848,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.85174,
+          "best_ms": 2.69212,
+          "best_in_gibs": 190.095,
+          "best_out_gibs": 0.0,
+          "in_gibs": 176.618,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 16.5,
+      "status": "pass",
+      "throughput_in_gibs": 1.54851,
+      "throughput_out_gibs": 0.848063,
+      "compression_fold": 2.11124,
+      "input_gib": 3.75,
+      "compressed_gib": 2.05374,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 2.42169,
+      "init_s": 1.98316,
+      "flush_s": 4.01e-07,
+      "memory_estimate_total_bytes": 3150325052,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.82541,
+          "best_ms": 2.16774,
+          "best_in_gibs": 14.416,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.2536,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.7239,
+          "best_ms": 12.0366,
+          "best_in_gibs": 7.78873,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.36802,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.16452,
+          "best_ms": 5.83785,
+          "best_in_gibs": 18.5682,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.5842,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.85848,
+          "best_ms": 0.000162,
+          "best_in_gibs": 90422.4,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.12455,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.4419,
+          "best_ms": 10.6371,
+          "best_in_gibs": 10.1906,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.50581,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 31.1872,
+          "best_ms": 29.0762,
+          "best_in_gibs": 18.6404,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.3787,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 6.8813,
+          "best_ms": 5.46041,
+          "best_in_gibs": 90.6769,
+          "best_out_gibs": 0.0,
+          "in_gibs": 72.9113,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "256cube_multiscale_dim0__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "256cube_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 16.88,
+      "status": "pass",
+      "throughput_in_gibs": 1.32893,
+      "throughput_out_gibs": 0.0715294,
+      "compression_fold": 21.4817,
+      "input_gib": 3.75,
+      "compressed_gib": 0.201844,
+      "total_chunks": 4440,
+      "chunks_per_epoch": 111,
+      "wall_s": 2.82183,
+      "init_s": 2.01012,
+      "flush_s": 3.8e-07,
+      "memory_estimate_total_bytes": 3150325052,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 3.81829,
+          "best_ms": 2.19047,
+          "best_in_gibs": 14.2663,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.2764,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 12.4914,
+          "best_ms": 11.9509,
+          "best_in_gibs": 7.84457,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.50519,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 6.20174,
+          "best_ms": 5.7537,
+          "best_in_gibs": 18.8398,
+          "best_out_gibs": 0.0,
+          "in_gibs": 17.4787,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.89419,
+          "best_ms": 0.000167,
+          "best_in_gibs": 87715.2,
+          "best_out_gibs": 0.0,
+          "in_gibs": 5.06133,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 14.6006,
+          "best_ms": 10.3198,
+          "best_in_gibs": 10.5039,
+          "best_out_gibs": 0.0,
+          "in_gibs": 7.42425,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 85.4312,
+          "best_ms": 77.7953,
+          "best_in_gibs": 6.9669,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.34419,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.79353,
+          "best_ms": 2.52265,
+          "best_in_gibs": 196.275,
+          "best_out_gibs": 0.0,
+          "in_gibs": 179.602,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__gpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 31.91,
+      "status": "pass",
+      "throughput_in_gibs": 10.1195,
+      "throughput_out_gibs": 11.9371,
+      "compression_fold": 1.13093,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.45589,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 0.289509,
+      "init_s": 0.964459,
+      "flush_s": 1.69e-07,
+      "memory_estimate_total_bytes": 11071256222,
+      "memory_estimate_pinned_bytes": 1947511536,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 0.98222,
+          "best_ms": 0.138801,
+          "best_in_gibs": 56.2856,
+          "best_out_gibs": 56.2856,
+          "in_gibs": 58.4847,
+          "out_gibs": 58.4847
+        },
+        "h2d": {
+          "avg_ms": 2.44118,
+          "best_ms": 0.363072,
+          "best_in_gibs": 21.5178,
+          "best_out_gibs": 21.5178,
+          "in_gibs": 23.5124,
+          "out_gibs": 23.5124
+        },
+        "scatter": {
+          "avg_ms": 0.024672,
+          "best_ms": 0.024672,
+          "best_in_gibs": 316.655,
+          "best_out_gibs": 316.655,
+          "in_gibs": 316.655,
+          "out_gibs": 316.655
+        },
+        "lod_gather": {
+          "avg_ms": 4.11187,
+          "best_ms": 3.94531,
+          "best_in_gibs": 148.515,
+          "best_out_gibs": 148.515,
+          "in_gibs": 142.499,
+          "out_gibs": 142.499
+        },
+        "lod_reduce": {
+          "avg_ms": 7.38447,
+          "best_ms": 7.27619,
+          "best_in_gibs": 80.528,
+          "best_out_gibs": 107.373,
+          "in_gibs": 79.3472,
+          "out_gibs": 105.798
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.05104,
+          "best_ms": 0.712224,
+          "best_in_gibs": 274.248,
+          "best_out_gibs": 274.248,
+          "in_gibs": 185.841,
+          "out_gibs": 185.841
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.91987,
+          "best_ms": 3.47053,
+          "best_in_gibs": 225.114,
+          "best_out_gibs": 225.233,
+          "in_gibs": 199.308,
+          "out_gibs": 199.414
+        },
+        "aggregate": {
+          "avg_ms": 3.52371,
+          "best_ms": 0.737856,
+          "best_in_gibs": 265.282,
+          "best_out_gibs": 265.282,
+          "in_gibs": 163.418,
+          "out_gibs": 163.418
+        },
+        "d2h": {
+          "avg_ms": 28.6299,
+          "best_ms": 8.28032,
+          "best_in_gibs": 23.6392,
+          "best_out_gibs": 23.6392,
+          "in_gibs": 20.1131,
+          "out_gibs": 20.1131
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 60.8448,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 217.911,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 17.8285,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 50.99,
+      "status": "pass",
+      "throughput_in_gibs": 1.47709,
+      "throughput_out_gibs": 1.7424,
+      "compression_fold": 1.13093,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.45589,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.98341,
+      "init_s": 18.3887,
+      "flush_s": 1.59e-07,
+      "memory_estimate_total_bytes": 10698660492,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.51684,
+          "best_ms": 0.451977,
+          "best_in_gibs": 17.2852,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.74485,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 65.461,
+          "best_ms": 63.2474,
+          "best_in_gibs": 9.26421,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.95094,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 48.3538,
+          "best_ms": 46.0228,
+          "best_in_gibs": 16.9756,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.1572,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 17.9811,
+          "best_ms": 8.95987,
+          "best_in_gibs": 21.8001,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.8628,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 73.4054,
+          "best_ms": 61.0241,
+          "best_in_gibs": 12.8093,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.6488,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 15.0988,
+          "best_ms": 11.2627,
+          "best_in_gibs": 69.4039,
+          "best_out_gibs": 0.0,
+          "in_gibs": 51.7709,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.9815,
+          "best_ms": 7.83242,
+          "best_in_gibs": 24.991,
+          "best_out_gibs": 0.0,
+          "in_gibs": 41.1857,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__gpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 32.91,
+      "status": "pass",
+      "throughput_in_gibs": 2.2842,
+      "throughput_out_gibs": 0.453394,
+      "compression_fold": 6.72102,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.581517,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 1.28259,
+      "init_s": 0.944632,
+      "flush_s": 1.58e-07,
+      "memory_estimate_total_bytes": 14808278359,
+      "memory_estimate_pinned_bytes": 1947839216,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.00185,
+          "best_ms": 0.133427,
+          "best_in_gibs": 58.5526,
+          "best_out_gibs": 58.5526,
+          "in_gibs": 57.339,
+          "out_gibs": 57.339
+        },
+        "h2d": {
+          "avg_ms": 2.34028,
+          "best_ms": 0.32096,
+          "best_in_gibs": 24.341,
+          "best_out_gibs": 24.341,
+          "in_gibs": 24.5261,
+          "out_gibs": 24.5261
+        },
+        "scatter": {
+          "avg_ms": 0.12416,
+          "best_ms": 0.060544,
+          "best_in_gibs": 387.115,
+          "best_out_gibs": 387.115,
+          "in_gibs": 251.691,
+          "out_gibs": 251.691
+        },
+        "lod_gather": {
+          "avg_ms": 23.011,
+          "best_ms": 3.95974,
+          "best_in_gibs": 147.974,
+          "best_out_gibs": 147.974,
+          "in_gibs": 25.4634,
+          "out_gibs": 25.4634
+        },
+        "lod_reduce": {
+          "avg_ms": 23.2806,
+          "best_ms": 7.2544,
+          "best_in_gibs": 80.7699,
+          "best_out_gibs": 107.695,
+          "in_gibs": 25.1685,
+          "out_gibs": 33.5586
+        },
+        "lod_append_fold": {
+          "avg_ms": 5.49004,
+          "best_ms": 0.710944,
+          "best_in_gibs": 274.742,
+          "best_out_gibs": 274.742,
+          "in_gibs": 35.5782,
+          "out_gibs": 35.5782
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.1393,
+          "best_ms": 3.47942,
+          "best_in_gibs": 224.538,
+          "best_out_gibs": 224.657,
+          "in_gibs": 38.7929,
+          "out_gibs": 38.8135
+        },
+        "compress": {
+          "avg_ms": 190.553,
+          "best_ms": 49.7288,
+          "best_in_gibs": 15.7188,
+          "best_out_gibs": 0.661948,
+          "in_gibs": 4.10216,
+          "out_gibs": 0.507857
+        },
+        "aggregate": {
+          "avg_ms": 0.381781,
+          "best_ms": 0.095584,
+          "best_in_gibs": 344.387,
+          "best_out_gibs": 344.387,
+          "in_gibs": 253.479,
+          "out_gibs": 253.479
+        },
+        "d2h": {
+          "avg_ms": 5.17951,
+          "best_ms": 1.46758,
+          "best_in_gibs": 22.43,
+          "best_out_gibs": 22.43,
+          "in_gibs": 18.6839,
+          "out_gibs": 18.6839
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 480.531,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 1177.84,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 208.308,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 51.15,
+      "status": "pass",
+      "throughput_in_gibs": 1.21916,
+      "throughput_out_gibs": 0.189533,
+      "compression_fold": 8.5813,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.455454,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 2.40303,
+      "init_s": 18.3037,
+      "flush_s": 2.18e-07,
+      "memory_estimate_total_bytes": 10709754476,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.4511,
+          "best_ms": 0.499558,
+          "best_in_gibs": 15.6388,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.79733,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 64.7561,
+          "best_ms": 61.8259,
+          "best_in_gibs": 9.47721,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.04837,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 47.9871,
+          "best_ms": 45.8006,
+          "best_in_gibs": 17.0579,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.2807,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 17.9055,
+          "best_ms": 8.65097,
+          "best_in_gibs": 22.5785,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9087,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 74.469,
+          "best_ms": 61.3203,
+          "best_in_gibs": 12.7475,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.4967,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 96.0678,
+          "best_ms": 90.638,
+          "best_in_gibs": 8.62416,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.13672,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.61403,
+          "best_ms": 1.6743,
+          "best_in_gibs": 351.497,
+          "best_out_gibs": 0.0,
+          "in_gibs": 160.035,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-lz4__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 51.05,
+      "status": "pass",
+      "throughput_in_gibs": 1.38517,
+      "throughput_out_gibs": 0.939286,
+      "compression_fold": 1.96734,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.98663,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 2.11504,
+      "init_s": 18.4041,
+      "flush_s": 1.62e-07,
+      "memory_estimate_total_bytes": 10699324156,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.88149,
+          "best_ms": 0.492464,
+          "best_in_gibs": 15.8641,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.46793,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 64.427,
+          "best_ms": 62.1339,
+          "best_in_gibs": 9.43024,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.0946,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 48.0154,
+          "best_ms": 46.0114,
+          "best_in_gibs": 16.9798,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.2711,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 17.9961,
+          "best_ms": 8.76464,
+          "best_in_gibs": 22.2857,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.8538,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 72.9771,
+          "best_ms": 60.0568,
+          "best_in_gibs": 13.0156,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.7113,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 39.1424,
+          "best_ms": 34.0768,
+          "best_in_gibs": 22.9387,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.9701,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 8.8981,
+          "best_ms": 5.56861,
+          "best_in_gibs": 105.247,
+          "best_out_gibs": 0.0,
+          "in_gibs": 64.731,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-zstd__xor__cpu__u16__64K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 65536,
+      "chunk_bytes_label": "64K",
+      "sink": "discard",
+      "elapsed_s": 51.22,
+      "status": "pass",
+      "throughput_in_gibs": 1.27944,
+      "throughput_out_gibs": 0.0858101,
+      "compression_fold": 19.891,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.19649,
+      "total_chunks": 64035,
+      "chunks_per_epoch": 12807,
+      "wall_s": 2.28983,
+      "init_s": 18.4814,
+      "flush_s": 1.48e-07,
+      "memory_estimate_total_bytes": 10699324156,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.4885,
+          "best_ms": 0.480898,
+          "best_in_gibs": 16.2456,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.76737,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 64.741,
+          "best_ms": 63.0986,
+          "best_in_gibs": 9.28606,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.05048,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 48.1966,
+          "best_ms": 46.2757,
+          "best_in_gibs": 16.8828,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.2099,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 18.3375,
+          "best_ms": 8.95061,
+          "best_in_gibs": 21.8226,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.6517,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 74.2649,
+          "best_ms": 61.249,
+          "best_in_gibs": 12.7623,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.5255,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 77.22,
+          "best_ms": 59.2713,
+          "best_in_gibs": 13.1881,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.1227,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.73545,
+          "best_ms": 1.1988,
+          "best_in_gibs": 488.891,
+          "best_out_gibs": 0.0,
+          "in_gibs": 210.563,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__gpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 31.99,
+      "status": "pass",
+      "throughput_in_gibs": 10.0474,
+      "throughput_out_gibs": 11.8542,
+      "compression_fold": 1.13258,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.45652,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 0.291586,
+      "init_s": 0.937053,
+      "flush_s": 2.49e-07,
+      "memory_estimate_total_bytes": 11075911330,
+      "memory_estimate_pinned_bytes": 1949936656,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.05416,
+          "best_ms": 0.155678,
+          "best_in_gibs": 50.1837,
+          "best_out_gibs": 50.1837,
+          "in_gibs": 54.4937,
+          "out_gibs": 54.4937
+        },
+        "h2d": {
+          "avg_ms": 2.56312,
+          "best_ms": 0.368768,
+          "best_in_gibs": 21.1854,
+          "best_out_gibs": 21.1854,
+          "in_gibs": 22.3937,
+          "out_gibs": 22.3937
+        },
+        "scatter": {
+          "avg_ms": 0.022144,
+          "best_ms": 0.022144,
+          "best_in_gibs": 352.804,
+          "best_out_gibs": 352.804,
+          "in_gibs": 352.804,
+          "out_gibs": 352.804
+        },
+        "lod_gather": {
+          "avg_ms": 4.11676,
+          "best_ms": 3.93792,
+          "best_in_gibs": 148.794,
+          "best_out_gibs": 148.794,
+          "in_gibs": 142.33,
+          "out_gibs": 142.33
+        },
+        "lod_reduce": {
+          "avg_ms": 7.37181,
+          "best_ms": 7.26454,
+          "best_in_gibs": 80.6572,
+          "best_out_gibs": 107.55,
+          "in_gibs": 79.4836,
+          "out_gibs": 105.985
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.03718,
+          "best_ms": 0.711136,
+          "best_in_gibs": 274.724,
+          "best_out_gibs": 274.724,
+          "in_gibs": 188.362,
+          "out_gibs": 188.362
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.93162,
+          "best_ms": 3.48794,
+          "best_in_gibs": 224.002,
+          "best_out_gibs": 224.476,
+          "in_gibs": 198.723,
+          "out_gibs": 199.144
+        },
+        "aggregate": {
+          "avg_ms": 3.71701,
+          "best_ms": 0.782304,
+          "best_in_gibs": 251.848,
+          "best_out_gibs": 251.848,
+          "in_gibs": 154.977,
+          "out_gibs": 154.977
+        },
+        "d2h": {
+          "avg_ms": 27.9139,
+          "best_ms": 8.0207,
+          "best_in_gibs": 24.5641,
+          "best_out_gibs": 24.5641,
+          "in_gibs": 20.6367,
+          "out_gibs": 20.6367
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 58.8527,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 222.64,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 17.4768,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 51.02,
+      "status": "pass",
+      "throughput_in_gibs": 1.49824,
+      "throughput_out_gibs": 1.76766,
+      "compression_fold": 1.13258,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.45652,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.95542,
+      "init_s": 18.4384,
+      "flush_s": 1.86e-07,
+      "memory_estimate_total_bytes": 10702966932,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.44745,
+          "best_ms": 0.430991,
+          "best_in_gibs": 18.1268,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.80026,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 63.1484,
+          "best_ms": 60.0261,
+          "best_in_gibs": 9.76138,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.27875,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 46.7342,
+          "best_ms": 45.5889,
+          "best_in_gibs": 17.138,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.718,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 17.7692,
+          "best_ms": 7.77885,
+          "best_in_gibs": 25.115,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.9946,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 74.1845,
+          "best_ms": 60.1661,
+          "best_in_gibs": 13.0133,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.5542,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.7659,
+          "best_ms": 11.9185,
+          "best_in_gibs": 65.6927,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.025,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.71,
+          "best_ms": 7.0152,
+          "best_in_gibs": 28.0849,
+          "best_out_gibs": 0.0,
+          "in_gibs": 42.0168,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__gpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 33.16,
+      "status": "pass",
+      "throughput_in_gibs": 2.13672,
+      "throughput_out_gibs": 0.378269,
+      "compression_fold": 7.54807,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.518649,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 1.37111,
+      "init_s": 0.952152,
+      "flush_s": 2.69e-07,
+      "memory_estimate_total_bytes": 14817482517,
+      "memory_estimate_pinned_bytes": 1950116880,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.05257,
+          "best_ms": 0.144101,
+          "best_in_gibs": 54.2154,
+          "best_out_gibs": 54.2154,
+          "in_gibs": 54.5756,
+          "out_gibs": 54.5756
+        },
+        "h2d": {
+          "avg_ms": 2.3407,
+          "best_ms": 0.320864,
+          "best_in_gibs": 24.3483,
+          "best_out_gibs": 24.3483,
+          "in_gibs": 24.5217,
+          "out_gibs": 24.5217
+        },
+        "scatter": {
+          "avg_ms": 0.12528,
+          "best_ms": 0.060544,
+          "best_in_gibs": 387.115,
+          "best_out_gibs": 387.115,
+          "in_gibs": 249.441,
+          "out_gibs": 249.441
+        },
+        "lod_gather": {
+          "avg_ms": 22.5463,
+          "best_ms": 3.95693,
+          "best_in_gibs": 148.079,
+          "best_out_gibs": 148.079,
+          "in_gibs": 25.9882,
+          "out_gibs": 25.9882
+        },
+        "lod_reduce": {
+          "avg_ms": 23.1185,
+          "best_ms": 7.25686,
+          "best_in_gibs": 80.7425,
+          "best_out_gibs": 107.664,
+          "in_gibs": 25.345,
+          "out_gibs": 33.7957
+        },
+        "lod_append_fold": {
+          "avg_ms": 5.44016,
+          "best_ms": 0.711008,
+          "best_in_gibs": 274.773,
+          "best_out_gibs": 274.773,
+          "in_gibs": 35.9118,
+          "out_gibs": 35.9118
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 20.6696,
+          "best_ms": 3.48118,
+          "best_in_gibs": 224.436,
+          "best_out_gibs": 224.912,
+          "in_gibs": 37.7997,
+          "out_gibs": 37.8798
+        },
+        "compress": {
+          "avg_ms": 205.364,
+          "best_ms": 46.512,
+          "best_in_gibs": 16.8335,
+          "best_out_gibs": 0.660505,
+          "in_gibs": 3.81254,
+          "out_gibs": 0.420739
+        },
+        "aggregate": {
+          "avg_ms": 0.43792,
+          "best_ms": 0.11712,
+          "best_in_gibs": 262.307,
+          "best_out_gibs": 262.307,
+          "in_gibs": 197.307,
+          "out_gibs": 197.307
+        },
+        "d2h": {
+          "avg_ms": 4.5461,
+          "best_ms": 1.33552,
+          "best_in_gibs": 23.0033,
+          "best_out_gibs": 23.0033,
+          "in_gibs": 19.0064,
+          "out_gibs": 19.0064
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 518.861,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 1267.11,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 223.238,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 51.08,
+      "status": "pass",
+      "throughput_in_gibs": 1.2426,
+      "throughput_out_gibs": 0.168361,
+      "compression_fold": 9.86225,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.396947,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 2.35771,
+      "init_s": 18.2714,
+      "flush_s": 1.51e-07,
+      "memory_estimate_total_bytes": 10712829076,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.39194,
+          "best_ms": 0.472642,
+          "best_in_gibs": 16.5294,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.84524,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 65.1143,
+          "best_ms": 61.2158,
+          "best_in_gibs": 9.57168,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.9986,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 47.0537,
+          "best_ms": 45.4309,
+          "best_in_gibs": 17.1976,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.6045,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 16.9194,
+          "best_ms": 7.78619,
+          "best_in_gibs": 25.0913,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.5469,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 73.4095,
+          "best_ms": 61.0105,
+          "best_in_gibs": 12.8332,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.6656,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 92.4793,
+          "best_ms": 85.2609,
+          "best_in_gibs": 9.18309,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.46632,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.18973,
+          "best_ms": 1.4892,
+          "best_in_gibs": 394.996,
+          "best_out_gibs": 0.0,
+          "in_gibs": 181.301,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-lz4__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 51.0,
+      "status": "pass",
+      "throughput_in_gibs": 1.40808,
+      "throughput_out_gibs": 0.86241,
+      "compression_fold": 2.18174,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.79435,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 2.08062,
+      "init_s": 18.3458,
+      "flush_s": 1.53e-07,
+      "memory_estimate_total_bytes": 10703165700,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.6377,
+          "best_ms": 0.434392,
+          "best_in_gibs": 17.9849,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.65048,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 64.2028,
+          "best_ms": 62.7323,
+          "best_in_gibs": 9.34028,
+          "best_out_gibs": 0.0,
+          "in_gibs": 9.12635,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 48.1177,
+          "best_ms": 45.7365,
+          "best_in_gibs": 17.0827,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.2373,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 17.1007,
+          "best_ms": 7.98631,
+          "best_in_gibs": 24.4626,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.4244,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 74.6326,
+          "best_ms": 62.8613,
+          "best_in_gibs": 12.4553,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.4908,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 38.3089,
+          "best_ms": 34.0999,
+          "best_in_gibs": 22.9607,
+          "best_out_gibs": 0.0,
+          "in_gibs": 20.438,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.99342,
+          "best_ms": 5.01868,
+          "best_in_gibs": 116.759,
+          "best_out_gibs": 0.0,
+          "in_gibs": 72.0707,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-zstd__xor__cpu__u16__256K",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 262144,
+      "chunk_bytes_label": "256K",
+      "sink": "discard",
+      "elapsed_s": 51.06,
+      "status": "pass",
+      "throughput_in_gibs": 1.35578,
+      "throughput_out_gibs": 0.0563908,
+      "compression_fold": 32.1268,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.121855,
+      "total_chunks": 16035,
+      "chunks_per_epoch": 3207,
+      "wall_s": 2.16089,
+      "init_s": 18.3612,
+      "flush_s": 1.53e-07,
+      "memory_estimate_total_bytes": 10703165700,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.76254,
+          "best_ms": 0.498743,
+          "best_in_gibs": 15.6644,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.55573,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 65.7876,
+          "best_ms": 61.6595,
+          "best_in_gibs": 9.50279,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.9065,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 48.9469,
+          "best_ms": 46.9047,
+          "best_in_gibs": 16.6572,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.9623,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 17.5901,
+          "best_ms": 8.22654,
+          "best_in_gibs": 23.7482,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.1066,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 74.9072,
+          "best_ms": 58.6484,
+          "best_in_gibs": 13.3501,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.4524,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 51.9197,
+          "best_ms": 37.9087,
+          "best_in_gibs": 20.6538,
+          "best_out_gibs": 0.0,
+          "in_gibs": 15.0802,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.29724,
+          "best_ms": 0.996195,
+          "best_in_gibs": 588.214,
+          "best_out_gibs": 0.0,
+          "in_gibs": 250.776,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__gpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 31.93,
+      "status": "pass",
+      "throughput_in_gibs": 9.97196,
+      "throughput_out_gibs": 11.7904,
+      "compression_fold": 1.13756,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.46392,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 0.293793,
+      "init_s": 0.913746,
+      "flush_s": 2.55e-07,
+      "memory_estimate_total_bytes": 11096624230,
+      "memory_estimate_pinned_bytes": 1960864752,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.09491,
+          "best_ms": 0.147001,
+          "best_in_gibs": 53.1459,
+          "best_out_gibs": 53.1459,
+          "in_gibs": 52.4653,
+          "out_gibs": 52.4653
+        },
+        "h2d": {
+          "avg_ms": 2.54492,
+          "best_ms": 0.36928,
+          "best_in_gibs": 21.156,
+          "best_out_gibs": 21.156,
+          "in_gibs": 22.5539,
+          "out_gibs": 22.5539
+        },
+        "scatter": {
+          "avg_ms": 0.04192,
+          "best_ms": 0.023168,
+          "best_in_gibs": 337.211,
+          "best_out_gibs": 337.211,
+          "in_gibs": 372.734,
+          "out_gibs": 372.734
+        },
+        "lod_gather": {
+          "avg_ms": 4.11621,
+          "best_ms": 3.97517,
+          "best_in_gibs": 147.399,
+          "best_out_gibs": 147.399,
+          "in_gibs": 142.349,
+          "out_gibs": 142.349
+        },
+        "lod_reduce": {
+          "avg_ms": 7.38014,
+          "best_ms": 7.26288,
+          "best_in_gibs": 80.6756,
+          "best_out_gibs": 107.597,
+          "in_gibs": 79.3938,
+          "out_gibs": 105.887
+        },
+        "lod_append_fold": {
+          "avg_ms": 1.0416,
+          "best_ms": 0.710336,
+          "best_in_gibs": 275.259,
+          "best_out_gibs": 275.259,
+          "in_gibs": 187.717,
+          "out_gibs": 187.717
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 3.95292,
+          "best_ms": 3.50115,
+          "best_in_gibs": 223.202,
+          "best_out_gibs": 225.093,
+          "in_gibs": 197.693,
+          "out_gibs": 199.368
+        },
+        "aggregate": {
+          "avg_ms": 4.15501,
+          "best_ms": 1.47894,
+          "best_in_gibs": 136.684,
+          "best_out_gibs": 136.684,
+          "in_gibs": 138.943,
+          "out_gibs": 138.943
+        },
+        "d2h": {
+          "avg_ms": 28.113,
+          "best_ms": 8.23206,
+          "best_in_gibs": 24.5562,
+          "best_out_gibs": 24.5562,
+          "in_gibs": 20.5354,
+          "out_gibs": 20.5354
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 60.0719,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 223.786,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 17.125,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__none__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "none",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 50.94,
+      "status": "pass",
+      "throughput_in_gibs": 1.48979,
+      "throughput_out_gibs": 1.76146,
+      "compression_fold": 1.13756,
+      "input_gib": 2.92969,
+      "compressed_gib": 3.46392,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 1.96651,
+      "init_s": 18.3524,
+      "flush_s": 1.5e-07,
+      "memory_estimate_total_bytes": 10723512092,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.542,
+          "best_ms": 0.449852,
+          "best_in_gibs": 17.3668,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.72499,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 66.158,
+          "best_ms": 63.2669,
+          "best_in_gibs": 9.26136,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.85664,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 46.4764,
+          "best_ms": 44.2783,
+          "best_in_gibs": 17.6489,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.8142,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 16.4445,
+          "best_ms": 7.38445,
+          "best_in_gibs": 26.4781,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.8901,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 73.5406,
+          "best_ms": 59.7257,
+          "best_in_gibs": 13.1951,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.7163,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 14.6025,
+          "best_ms": 11.577,
+          "best_in_gibs": 68.0736,
+          "best_out_gibs": 0.0,
+          "in_gibs": 53.9694,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 13.463,
+          "best_ms": 5.99224,
+          "best_in_gibs": 33.735,
+          "best_out_gibs": 0.0,
+          "in_gibs": 42.8812,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__gpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "gpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 32.55,
+      "status": "pass",
+      "throughput_in_gibs": 3.03634,
+      "throughput_out_gibs": 0.514632,
+      "compression_fold": 7.93551,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.496556,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 0.964876,
+      "init_s": 0.932011,
+      "flush_s": 2e-07,
+      "memory_estimate_total_bytes": 14858023385,
+      "memory_estimate_pinned_bytes": 1960995824,
+      "stages": {
+        "memcpy": {
+          "avg_ms": 1.00508,
+          "best_ms": 0.140482,
+          "best_in_gibs": 55.6121,
+          "best_out_gibs": 55.6121,
+          "in_gibs": 57.1544,
+          "out_gibs": 57.1544
+        },
+        "h2d": {
+          "avg_ms": 2.33155,
+          "best_ms": 0.321728,
+          "best_in_gibs": 24.2829,
+          "best_out_gibs": 24.2829,
+          "in_gibs": 24.6179,
+          "out_gibs": 24.6179
+        },
+        "scatter": {
+          "avg_ms": 0.10592,
+          "best_ms": 0.058496,
+          "best_in_gibs": 400.668,
+          "best_out_gibs": 400.668,
+          "in_gibs": 295.034,
+          "out_gibs": 295.034
+        },
+        "lod_gather": {
+          "avg_ms": 9.48382,
+          "best_ms": 3.94131,
+          "best_in_gibs": 148.666,
+          "best_out_gibs": 148.666,
+          "in_gibs": 61.7829,
+          "out_gibs": 61.7829
+        },
+        "lod_reduce": {
+          "avg_ms": 11.1497,
+          "best_ms": 7.25251,
+          "best_in_gibs": 80.791,
+          "best_out_gibs": 107.751,
+          "in_gibs": 52.5517,
+          "out_gibs": 70.0881
+        },
+        "lod_append_fold": {
+          "avg_ms": 2.38643,
+          "best_ms": 0.710368,
+          "best_in_gibs": 275.246,
+          "best_out_gibs": 275.246,
+          "in_gibs": 81.9326,
+          "out_gibs": 81.9326
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 7.36653,
+          "best_ms": 3.49962,
+          "best_in_gibs": 223.3,
+          "best_out_gibs": 225.192,
+          "in_gibs": 106.083,
+          "out_gibs": 106.982
+        },
+        "compress": {
+          "avg_ms": 137.742,
+          "best_ms": 69.2474,
+          "best_in_gibs": 11.3807,
+          "best_out_gibs": 0.529576,
+          "in_gibs": 5.72148,
+          "out_gibs": 0.600764
+        },
+        "aggregate": {
+          "avg_ms": 0.680619,
+          "best_ms": 0.320896,
+          "best_in_gibs": 114.279,
+          "best_out_gibs": 114.279,
+          "in_gibs": 121.581,
+          "out_gibs": 121.581
+        },
+        "d2h": {
+          "avg_ms": 4.35299,
+          "best_ms": 1.54256,
+          "best_in_gibs": 23.7733,
+          "best_out_gibs": 23.7733,
+          "in_gibs": 19.01,
+          "out_gibs": 19.01
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 365.403,
+        "flush_stall_count": 6,
+        "kick_sync_ms": 862.535,
+        "kick_sync_count": 6,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 141.581,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 51.2,
+      "status": "pass",
+      "throughput_in_gibs": 1.22854,
+      "throughput_out_gibs": 0.167979,
+      "compression_fold": 9.83686,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.400578,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 2.38469,
+      "init_s": 18.3187,
+      "flush_s": 3e-07,
+      "memory_estimate_total_bytes": 10733428508,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.36865,
+          "best_ms": 0.441034,
+          "best_in_gibs": 17.7141,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.86429,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 66.3865,
+          "best_ms": 62.8865,
+          "best_in_gibs": 9.31739,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.82616,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 46.8242,
+          "best_ms": 43.7524,
+          "best_in_gibs": 17.8611,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.6893,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 15.891,
+          "best_ms": 6.99999,
+          "best_in_gibs": 27.9323,
+          "best_out_gibs": 0.0,
+          "in_gibs": 12.3042,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 74.0491,
+          "best_ms": 60.8717,
+          "best_in_gibs": 12.9467,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.6427,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 97.137,
+          "best_ms": 87.7941,
+          "best_in_gibs": 8.97653,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.11314,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 3.01751,
+          "best_ms": 1.51621,
+          "best_in_gibs": 387.958,
+          "best_out_gibs": 0.0,
+          "in_gibs": 192.068,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-lz4__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-lz4",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 51.02,
+      "status": "pass",
+      "throughput_in_gibs": 1.39682,
+      "throughput_out_gibs": 0.895931,
+      "compression_fold": 2.09694,
+      "input_gib": 2.92969,
+      "compressed_gib": 1.87913,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 2.0974,
+      "init_s": 18.3882,
+      "flush_s": 3.59e-07,
+      "memory_estimate_total_bytes": 10723590540,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.52659,
+          "best_ms": 0.465084,
+          "best_in_gibs": 16.798,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.73714,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 67.673,
+          "best_ms": 63.0265,
+          "best_in_gibs": 9.29669,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.65836,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 46.0254,
+          "best_ms": 44.6414,
+          "best_in_gibs": 17.5054,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.979,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 16.4734,
+          "best_ms": 7.14059,
+          "best_in_gibs": 27.3823,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.8692,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 73.9168,
+          "best_ms": 59.623,
+          "best_in_gibs": 13.2178,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.6618,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 41.4379,
+          "best_ms": 36.842,
+          "best_in_gibs": 21.391,
+          "best_out_gibs": 0.0,
+          "in_gibs": 19.0185,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 7.99456,
+          "best_ms": 4.9022,
+          "best_in_gibs": 41.2402,
+          "best_out_gibs": 0.0,
+          "in_gibs": 72.2148,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    },
+    {
+      "id": "medfmt_multiscale_dim0__blosc-zstd__xor__cpu__u16__1M",
+      "scenario": "medfmt_multiscale_dim0",
+      "codec": "blosc-zstd",
+      "fill": "xor",
+      "backend": "cpu",
+      "dtype": "u16",
+      "chunk_bytes": 1048576,
+      "chunk_bytes_label": "1M",
+      "sink": "discard",
+      "elapsed_s": 51.14,
+      "status": "pass",
+      "throughput_in_gibs": 1.34054,
+      "throughput_out_gibs": 0.071884,
+      "compression_fold": 25.0825,
+      "input_gib": 2.92969,
+      "compressed_gib": 0.157099,
+      "total_chunks": 4035,
+      "chunks_per_epoch": 807,
+      "wall_s": 2.18545,
+      "init_s": 18.4501,
+      "flush_s": 1.8e-07,
+      "memory_estimate_total_bytes": 10723590540,
+      "memory_estimate_pinned_bytes": 0,
+      "stages": {
+        "scatter": {
+          "avg_ms": 8.62204,
+          "best_ms": 0.458339,
+          "best_in_gibs": 17.0452,
+          "best_out_gibs": 0.0,
+          "in_gibs": 6.66256,
+          "out_gibs": 0.0
+        },
+        "lod_gather": {
+          "avg_ms": 66.1298,
+          "best_ms": 63.0622,
+          "best_in_gibs": 9.29142,
+          "best_out_gibs": 0.0,
+          "in_gibs": 8.86041,
+          "out_gibs": 0.0
+        },
+        "lod_reduce": {
+          "avg_ms": 46.521,
+          "best_ms": 44.7467,
+          "best_in_gibs": 17.4642,
+          "best_out_gibs": 0.0,
+          "in_gibs": 16.7981,
+          "out_gibs": 0.0
+        },
+        "lod_append_fold": {
+          "avg_ms": 16.4194,
+          "best_ms": 6.9841,
+          "best_in_gibs": 27.9959,
+          "best_out_gibs": 0.0,
+          "in_gibs": 11.9082,
+          "out_gibs": 0.0
+        },
+        "lod_morton_chunk": {
+          "avg_ms": 75.3722,
+          "best_ms": 62.0871,
+          "best_in_gibs": 12.6932,
+          "best_out_gibs": 0.0,
+          "in_gibs": 10.4559,
+          "out_gibs": 0.0
+        },
+        "compress": {
+          "avg_ms": 60.5196,
+          "best_ms": 44.3029,
+          "best_in_gibs": 17.7886,
+          "best_out_gibs": 0.0,
+          "in_gibs": 13.022,
+          "out_gibs": 0.0
+        },
+        "aggregate": {
+          "avg_ms": 2.32714,
+          "best_ms": 1.01504,
+          "best_in_gibs": 577.267,
+          "best_out_gibs": 0.0,
+          "in_gibs": 248.084,
+          "out_gibs": 0.0
+        }
+      },
+      "stalls": {
+        "flush_stall_ms": 0.0,
+        "flush_stall_count": 0,
+        "kick_sync_ms": 0.0,
+        "kick_sync_count": 0,
+        "io_fence_ms": 0.0,
+        "io_fence_count": 0,
+        "backpressure_ms": 0.0,
+        "backpressure_count": 0,
+        "max_append_ms": 0.0,
+        "peak_pending_mib": 0.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
A benchmark sweep on an L40 at 46fa2e8, 364 runs. Measured 2026-07-01 and kept
out of the repo until now.
