### PR TITLE
Benchmark report: trends and machine grouping

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'bench/results/*.json'
+      - 'bench/machines.toml'
       - 'scripts/sweep/**'
   workflow_dispatch:
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
 
       - name: Generate report
-        run: uv run scripts/sweep/report.py --results-dir bench/results/ -o _site/index.html
+        run: uv run scripts/sweep/report.py --results-dir bench/results/ -o _site
 
       - uses: actions/upload-pages-artifact@v3
 

--- a/bench/machines.toml
+++ b/bench/machines.toml
@@ -1,0 +1,64 @@
+# Which sweep files belong to the same machine, and what to call it.
+#
+# A sweep is named after its results file, `<name>-<commit>-<date>.json`, which
+# sweep.py writes using --machine (or the hostname when that is not given). That
+# is not enough on its own: one box can boot two systems, and a cluster hands out
+# a different node every allocation. This file says which of those names are the
+# same machine.
+#
+# Each entry matches on the sweep name or on the hostname recorded inside the
+# file. Both accept shell-style wildcards and ignore case, and the first entry
+# that matches wins. A sweep matching nothing keeps its own name and the report
+# points it out, so a new machine gets described here on purpose rather than
+# quietly appearing as a stranger.
+#
+# `specs` is free-form: put whatever decides whether two runs are comparable.
+# Storage and network usually matter as much as the GPU.
+
+[[machine]]
+name = "livescreen"
+description = "RTX PRO 6000 workstation, two systems on one box"
+names = ["LiveScreen-1", "livescreen-kubuntu"]
+[machine.specs]
+gpu = "RTX PRO 6000 Blackwell Workstation Edition"
+
+[[machine]]
+name = "reef-l40"
+description = "CoreWeave L40 node, whichever one the scheduler hands out"
+names = ["reef-l40"]
+hosts = ["cw-us-e4a2-l40-*"]
+[machine.specs]
+gpu = "L40"
+storage = "shared /mnt/main0"
+
+[[machine]]
+name = "reef-h100"
+description = "CoreWeave H100 node, whichever one the scheduler hands out"
+names = ["reef-h100"]
+hosts = ["cw-us-e4a1-h100-*"]
+[machine.specs]
+gpu = "H100"
+storage = "shared /mnt/main0"
+
+[[machine]]
+name = "reef-h200"
+description = "CoreWeave H200 node, whichever one the scheduler hands out"
+names = ["reef-h200"]
+hosts = ["cw-us-e4a1-h200-*"]
+[machine.specs]
+gpu = "H200"
+storage = "shared /mnt/main0"
+
+[[machine]]
+name = "auk"
+description = "Laptop"
+names = ["auk"]
+[machine.specs]
+gpu = "GeForce RTX 5070 Laptop GPU"
+
+[[machine]]
+name = "oreb"
+description = "Desktop"
+names = ["oreb"]
+[machine.specs]
+gpu = "GeForce RTX 5080"

--- a/bench/machines.toml
+++ b/bench/machines.toml
@@ -12,15 +12,14 @@
 # points it out, so a new machine gets described here on purpose rather than
 # quietly appearing as a stranger.
 #
-# `specs` is free-form: put whatever decides whether two runs are comparable.
-# Storage and network usually matter as much as the GPU.
+# `specs` is free-form and only worth filling in for what the sweep file does
+# not already record. The GPU is in there; the disk and the network are not,
+# and they decide as much about whether two runs compare.
 
 [[machine]]
 name = "livescreen"
-description = "RTX PRO 6000 workstation, two systems on one box"
+description = "Workstation running two systems"
 names = ["LiveScreen-1", "livescreen-kubuntu"]
-[machine.specs]
-gpu = "RTX PRO 6000 Blackwell Workstation Edition"
 
 [[machine]]
 name = "reef-l40"
@@ -28,7 +27,6 @@ description = "CoreWeave L40 node, whichever one the scheduler hands out"
 names = ["reef-l40"]
 hosts = ["cw-us-e4a2-l40-*"]
 [machine.specs]
-gpu = "L40"
 storage = "shared /mnt/main0"
 
 [[machine]]
@@ -37,7 +35,6 @@ description = "CoreWeave H100 node, whichever one the scheduler hands out"
 names = ["reef-h100"]
 hosts = ["cw-us-e4a1-h100-*"]
 [machine.specs]
-gpu = "H100"
 storage = "shared /mnt/main0"
 
 [[machine]]
@@ -46,19 +43,14 @@ description = "CoreWeave H200 node, whichever one the scheduler hands out"
 names = ["reef-h200"]
 hosts = ["cw-us-e4a1-h200-*"]
 [machine.specs]
-gpu = "H200"
 storage = "shared /mnt/main0"
 
+# A machine that always reports the same name needs nothing but the name; the
+# GPU already comes from the sweep file.
 [[machine]]
 name = "auk"
-description = "Laptop"
 names = ["auk"]
-[machine.specs]
-gpu = "GeForce RTX 5070 Laptop GPU"
 
 [[machine]]
 name = "oreb"
-description = "Desktop"
 names = ["oreb"]
-[machine.specs]
-gpu = "GeForce RTX 5080"

--- a/bench/machines.toml
+++ b/bench/machines.toml
@@ -1,29 +1,27 @@
-# Which sweep files belong to the same machine, and what to call it.
+# This file identifies the different names that may be used for one machine.
 #
-# A sweep is named after its results file, `<name>-<commit>-<date>.json`, which
-# sweep.py writes using --machine (or the hostname when that is not given). That
-# is not enough on its own: one box can boot two systems, and a cluster hands out
-# a different node every allocation. This file says which of those names are the
-# same machine.
+# A sweep's name is the first part of its results file name. sweep.py takes it
+# from --machine, or uses the hostname when you do not pass one. One name is not
+# always one machine: a computer can boot two systems, and a cluster gives out a
+# different node each time you ask for one.
 #
-# Each entry matches on the sweep name or on the hostname recorded inside the
-# file. Both accept shell-style wildcards and ignore case, and the first entry
-# that matches wins. A sweep matching nothing keeps its own name and the report
-# points it out, so a new machine gets described here on purpose rather than
-# quietly appearing as a stranger.
+# An entry matches a sweep by its name, or by the hostname stored in the file.
+# Both accept wildcards and ignore case, and the first matching entry wins. A
+# sweep that matches nothing keeps its own name, and the report marks it as not
+# described here.
 #
-# `specs` is free-form and only worth filling in for what the sweep file does
-# not already record. The GPU is in there; the disk and the network are not,
-# and they decide as much about whether two runs compare.
+# Fill in specs only where the sweep file does not already record something. It
+# records the GPU. It does not record the disk or the network, which matter just
+# as much when you compare two runs.
 
 [[machine]]
 name = "livescreen"
-description = "Workstation running two systems"
+description = "Workstation with two operating systems installed"
 names = ["LiveScreen-1", "livescreen-kubuntu"]
 
 [[machine]]
 name = "reef-l40"
-description = "CoreWeave L40 node, whichever one the scheduler hands out"
+description = "One of the CoreWeave L40 nodes"
 names = ["reef-l40"]
 hosts = ["cw-us-e4a2-l40-*"]
 [machine.specs]
@@ -31,7 +29,7 @@ storage = "shared /mnt/main0"
 
 [[machine]]
 name = "reef-h100"
-description = "CoreWeave H100 node, whichever one the scheduler hands out"
+description = "One of the CoreWeave H100 nodes"
 names = ["reef-h100"]
 hosts = ["cw-us-e4a1-h100-*"]
 [machine.specs]
@@ -39,14 +37,13 @@ storage = "shared /mnt/main0"
 
 [[machine]]
 name = "reef-h200"
-description = "CoreWeave H200 node, whichever one the scheduler hands out"
+description = "One of the CoreWeave H200 nodes"
 names = ["reef-h200"]
 hosts = ["cw-us-e4a1-h200-*"]
 [machine.specs]
 storage = "shared /mnt/main0"
 
-# A machine that always reports the same name needs nothing but the name; the
-# GPU already comes from the sweep file.
+# A machine that always reports the same name needs only that name.
 [[machine]]
 name = "auk"
 names = ["auk"]

--- a/bench/machines.toml
+++ b/bench/machines.toml
@@ -11,8 +11,7 @@
 # described here.
 #
 # Fill in specs only where the sweep file does not already record something. It
-# records the GPU. It does not record the disk or the network, which matter just
-# as much when you compare two runs.
+# records the GPU. It does not record the disk or the network.
 
 [[machine]]
 name = "livescreen"

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -46,17 +46,18 @@ hostname inside the file, both with wildcards:
 ```toml
 [[machine]]
 name = "livescreen"
-description = "RTX PRO 6000 workstation, two systems on one box"
+description = "Workstation running two systems"
 names = ["LiveScreen-1", "livescreen-kubuntu"]
 [machine.specs]
-gpu = "RTX PRO 6000 Blackwell Workstation Edition"
 storage = "local nvme"
 ```
 
-`specs` is free-form — put whatever decides whether two runs are comparable,
-since storage and network usually matter as much as the GPU. It is shown on the
-machine card. A sweep matching no entry keeps its own name and the page says it
-is undescribed, so a new machine gets an entry deliberately.
+A machine whose name never changes needs nothing but the name. `specs` is
+free-form and only worth filling in for what the sweep file does not already
+record — the GPU is in there, the disk and the network are not, and they decide
+as much about whether two runs compare. Both the description and the specs show
+on the machine card. A sweep matching no entry keeps its own name and the page
+says it is undescribed, so a new machine gets an entry deliberately.
 
 Grouping is a view, not a fact baked into the data: untick **Group** on the
 overview to split a machine back into the sweep names underneath and check that

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -65,7 +65,7 @@ its members really do agree. Where a comparison crosses two members — last
 sweep on one system, previous on the other — the page says so rather than
 quietly presenting it as one machine changing.
 
-Colours are assigned per machine in order of first appearance, so adding a
+Colors are assigned per machine in order of first appearance, so adding a
 machine never repaints the ones already on screen. The palette holds eight;
 machines past that stay in the tables and drop out of the chart, which the page
 says out loud.

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -1,91 +1,64 @@
-# Benchmark sweeps and the site they feed
+# Benchmark sweeps and reports
 
-`sweep.py` runs the bench binaries and writes one JSON file per sweep to
-`bench/results/`. `report.py` turns every one of those files into a two-page
-static site, which CI publishes to GitHub Pages on each push to `main`
-(`.github/workflows/pages.yml`).
+`sweep.py` runs the benchmarks and writes one JSON file per sweep to
+`bench/results/`, named `<machine>-<commit>-<date>.json`. `report.py` reads those
+files and writes a site with two pages. CI publishes it to GitHub Pages on every
+push to `main` (`.github/workflows/pages.yml`).
+
+- `index.html` shows how each machine's numbers change from one sweep to the next.
+- `explore.html` shows a single sweep in detail, down to per-stage timing.
+
+Clicking a point on a trend chart, or a commit on a machine card, opens that
+sweep in `explore.html`.
 
 ## Generating the site
 
 ```sh
 uv run scripts/sweep/report.py --results-dir bench/results/ -o _site
-python3 -m http.server -d _site      # or just open _site/index.html
+python3 -m http.server -d _site      # or open _site/index.html
 ```
 
-`machines.toml` is picked up from beside the results (or one level up); point at
-another with `--machines`.
+The data is embedded in the pages when they are written, so they need no server
+and load nothing. Run the command again after you add or change a results file.
 
-Both pages embed their data at generation time, so they work straight off the
-filesystem and there is nothing to fetch at load. Re-run the command after
-adding or editing a results file.
+`report.py` looks for `bench/machines.toml` next to the results directory, then
+one level up. Use `--machines` to point somewhere else.
 
-| Page | Question it answers |
-|---|---|
-| `index.html` | Is this getting faster or slower, on which machine, and what moved last? |
-| `explore.html` | Inside one sweep: every codec, chunk size, and per-stage timing. |
+## Machine names
 
-The overview links into the explorer (`explore.html?file=<results file name>`);
-clicking a point on the trend chart or a commit on a machine card lands on that
-sweep.
-
-## Which sweeps are the same machine
-
-Every sweep names itself after its file, `<name>-<commit>-<yyyymmdd>.json`, which
-`sweep.py` writes from `--machine` (or `CHUCKY_MACHINE`), falling back to the
-hostname. Pass `--machine` where the hostname is not stable:
+Pass `--machine` when a machine's hostname changes between runs, or set
+`CHUCKY_MACHINE`:
 
 ```sh
 uv run scripts/sweep/sweep.py --all --machine reef-l40
 ```
 
-That name alone is not enough to say what is the same machine — one box can boot
-two systems, and a cluster hands out a different node every allocation. So
-**`bench/machines.toml`** holds the grouping, matching on the sweep name or the
-hostname inside the file, both with wildcards:
+`bench/machines.toml` says which names belong to the same machine and describes
+each one. The comment at the top of that file explains the fields.
 
-```toml
-[[machine]]
-name = "livescreen"
-description = "Workstation running two systems"
-names = ["LiveScreen-1", "livescreen-kubuntu"]
-[machine.specs]
-storage = "local nvme"
-```
+The overview groups machines that way. A **Group** checkbox turns the grouping
+off, so you can check that the names under one machine really do agree. When a
+comparison uses two of those names, the last sweep from one and the sweep before
+it from another, the page says so.
 
-A machine whose name never changes needs nothing but the name. `specs` is
-free-form and only worth filling in for what the sweep file does not already
-record — the GPU is in there, the disk and the network are not, and they decide
-as much about whether two runs compare. Both the description and the specs show
-on the machine card. A sweep matching no entry keeps its own name and the page
-says it is undescribed, so a new machine gets an entry deliberately.
-
-Grouping is a view, not a fact baked into the data: untick **Group** on the
-overview to split a machine back into the sweep names underneath and check that
-its members really do agree. Where a comparison crosses two members — last
-sweep on one system, previous on the other — the page says so rather than
-quietly presenting it as one machine changing.
-
-Colors are assigned per machine in order of first appearance, so adding a
-machine never repaints the ones already on screen. The palette holds eight;
-machines past that stay in the tables and drop out of the chart, which the page
-says out loud.
+A machine keeps its color as other machines are added. Eight colors are
+available; machines past that appear in the tables but not in the chart, and the
+page names them.
 
 ## What the numbers mean
 
-- A plotted point is the **best** passing run of that sweep for the selected
-  scenario, codec, backend, and sink. Data type, chunk size, and fill are
-  searched rather than averaged — hover a point for the winning configuration
-  and how many runs it beat.
-- Runs that did not pass are excluded and counted on the machine card instead.
-- A missing point means that sweep ran nothing matching the filter, not zero.
-- Changes are per machine, latest sweep against its previous sweep with
-  matching runs, matched on the exact run id. Anything under ±2% is labelled
-  "no real change".
+- A point is the best passing run in that sweep for the scenario, codec,
+  backend, and sink you picked. Data type, chunk size, and fill are searched
+  instead of averaged. Hover a point to see which run won and how many it beat.
+- Runs that did not pass are left out, and counted on the machine card instead.
+- A gap means the sweep ran nothing matching the filter. It does not mean zero.
+- A change compares a machine's latest sweep against its previous one, matching
+  runs by id. Changes under 2% are shown as no real change.
 
 ## Schema changes
 
-`models.py` owns the results schema, its version, and the migrations.
-`retired_metrics` reports the metrics a file carries whose meaning changed
-later; the overview drops those from comparisons rather than converting them.
-Bump `CURRENT_VERSION` when a metric is renamed, removed, or changes meaning —
-adding one does not need a bump.
+`models.py` holds the results schema, its version, and the migrations.
+`retired_metrics` lists the metrics in a file whose meaning changed later, and
+the overview leaves those out of comparisons instead of converting them. Bump
+`CURRENT_VERSION` when a metric is renamed, removed, or changes meaning. Adding
+one does not need a bump.

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -12,6 +12,9 @@ uv run scripts/sweep/report.py --results-dir bench/results/ -o _site
 python3 -m http.server -d _site      # or just open _site/index.html
 ```
 
+`machines.toml` is picked up from beside the results (or one level up); point at
+another with `--machines`.
+
 Both pages embed their data at generation time, so they work straight off the
 filesystem and there is nothing to fetch at load. Re-run the command after
 adding or editing a results file.
@@ -25,15 +28,41 @@ The overview links into the explorer (`explore.html?file=<results file name>`);
 clicking a point on the trend chart or a commit on a machine card lands on that
 sweep.
 
-## One sweep is one machine at one commit
+## Which sweeps are the same machine
 
-The overview groups sweeps by **machine name taken from the file name**, which
-`sweep.py` writes as `<machine>-<commit>-<yyyymmdd>.json`. The name is the one a
-person chose, so it stays stable when a cluster hands out a different hostname
-for every allocation — `reef-l40` covers whichever `cw-us-e4a2-l40-*` node ran
-it. The hostname and GPU from the file's `machine` block are shown on the
-machine card. If a file name does not follow the pattern, the hostname is used
-instead.
+Every sweep names itself after its file, `<name>-<commit>-<yyyymmdd>.json`, which
+`sweep.py` writes from `--machine` (or `CHUCKY_MACHINE`), falling back to the
+hostname. Pass `--machine` where the hostname is not stable:
+
+```sh
+uv run scripts/sweep/sweep.py --all --machine reef-l40
+```
+
+That name alone is not enough to say what is the same machine — one box can boot
+two systems, and a cluster hands out a different node every allocation. So
+**`bench/machines.toml`** holds the grouping, matching on the sweep name or the
+hostname inside the file, both with wildcards:
+
+```toml
+[[machine]]
+name = "livescreen"
+description = "RTX PRO 6000 workstation, two systems on one box"
+names = ["LiveScreen-1", "livescreen-kubuntu"]
+[machine.specs]
+gpu = "RTX PRO 6000 Blackwell Workstation Edition"
+storage = "local nvme"
+```
+
+`specs` is free-form — put whatever decides whether two runs are comparable,
+since storage and network usually matter as much as the GPU. It is shown on the
+machine card. A sweep matching no entry keeps its own name and the page says it
+is undescribed, so a new machine gets an entry deliberately.
+
+Grouping is a view, not a fact baked into the data: untick **Group** on the
+overview to split a machine back into the sweep names underneath and check that
+its members really do agree. Where a comparison crosses two members — last
+sweep on one system, previous on the other — the page says so rather than
+quietly presenting it as one machine changing.
 
 Colours are assigned per machine in order of first appearance, so adding a
 machine never repaints the ones already on screen. The palette holds eight;

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -1,0 +1,61 @@
+# Benchmark sweeps and the site they feed
+
+`sweep.py` runs the bench binaries and writes one JSON file per sweep to
+`bench/results/`. `report.py` turns every one of those files into a two-page
+static site, which CI publishes to GitHub Pages on each push to `main`
+(`.github/workflows/pages.yml`).
+
+## Generating the site
+
+```sh
+uv run scripts/sweep/report.py --results-dir bench/results/ -o _site
+python3 -m http.server -d _site      # or just open _site/index.html
+```
+
+Both pages embed their data at generation time, so they work straight off the
+filesystem and there is nothing to fetch at load. Re-run the command after
+adding or editing a results file.
+
+| Page | Question it answers |
+|---|---|
+| `index.html` | Is this getting faster or slower, on which machine, and what moved last? |
+| `explore.html` | Inside one sweep: every codec, chunk size, and per-stage timing. |
+
+The overview links into the explorer (`explore.html?file=<results file name>`);
+clicking a point on the trend chart or a commit on a machine card lands on that
+sweep.
+
+## One sweep is one machine at one commit
+
+The overview groups sweeps by **machine name taken from the file name**, which
+`sweep.py` writes as `<machine>-<commit>-<yyyymmdd>.json`. The name is the one a
+person chose, so it stays stable when a cluster hands out a different hostname
+for every allocation — `reef-l40` covers whichever `cw-us-e4a2-l40-*` node ran
+it. The hostname and GPU from the file's `machine` block are shown on the
+machine card. If a file name does not follow the pattern, the hostname is used
+instead.
+
+Colours are assigned per machine in order of first appearance, so adding a
+machine never repaints the ones already on screen. The palette holds eight;
+machines past that stay in the tables and drop out of the chart, which the page
+says out loud.
+
+## What the numbers mean
+
+- A plotted point is the **best** passing run of that sweep for the selected
+  scenario, codec, backend, and sink. Data type, chunk size, and fill are
+  searched rather than averaged — hover a point for the winning configuration
+  and how many runs it beat.
+- Runs that did not pass are excluded and counted on the machine card instead.
+- A missing point means that sweep ran nothing matching the filter, not zero.
+- Changes are per machine, latest sweep against its previous sweep with
+  matching runs, matched on the exact run id. Anything under ±2% is labelled
+  "no real change".
+
+## Schema changes
+
+`models.py` owns the results schema, its version, and the migrations.
+`retired_metrics` reports the metrics a file carries whose meaning changed
+later; the overview drops those from comparisons rather than converting them.
+Bump `CURRENT_VERSION` when a metric is renamed, removed, or changes meaning —
+adding one does not need a bump.

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -335,12 +335,17 @@ function buildMachines(grouped) {
     const machine = seen.get(name);
     machine.last = sweep.day;
     machine.sweeps.push(sweep);
+    if (sweep.registered && !machine.registered) {
+      machine.registered = true;
+      machine.description = sweep.description || "";
+      machine.specs = sweep.specs || {};
+    }
     for (const [key, value] of [["gpus", sweep.gpu], ["hosts", sweep.host], ["members", sweep.member]]) {
       if (value && !machine[key].includes(value)) machine[key].push(value);
     }
   }
 
-  // Colour follows the machine, assigned in order of first appearance so an
+  // Color follows the machine, assigned in order of first appearance so an
   // added machine never repaints the ones already on screen. Past the palette's
   // eight slots the extra machines stay in the tables but leave the chart.
   const machines = [...seen.values()];
@@ -399,7 +404,7 @@ function pickDefaults() {
     const here = new Set();
     for (const r of s.runs) {
       if (r.status !== "pass" || metricValue(r, state.metric) == null) continue;
-      here.add([r.scenario, r.codec, r.backend, r.sink].join(" "));
+      here.add([r.scenario, r.codec, r.backend, r.sink].join("|"));
     }
     for (const combo of here) counts.set(combo, (counts.get(combo) || 0) + 1);
   }
@@ -408,7 +413,7 @@ function pickDefaults() {
     if (count > bestCount) { best = combo; bestCount = count; }
   }
   const [scenario, codec, backend, sink] = best
-    ? best.split(" ")
+    ? best.split("|")
     : [ALL_SCENARIOS[0], ALL_CODECS[0], ALL_BACKENDS[0], ALL_SINKS[0]];
   state.scenario = scenario; state.codec = codec; state.backend = backend; state.sink = sink;
 }
@@ -661,8 +666,18 @@ sinkSel.addEventListener("change", () => { state.sink = sinkSel.value; render();
 
 const themeToggle = document.getElementById("theme-toggle");
 
+// Reading storage throws in some file:// and private-browsing contexts, and this
+// runs before the page is drawn, so a theme preference must never be fatal.
+function storedTheme() {
+  try {
+    return localStorage.getItem("bench-theme");
+  } catch {
+    return null;
+  }
+}
+
 function currentTheme() {
-  const stored = localStorage.getItem("bench-theme");
+  const stored = storedTheme();
   if (stored === "light" || stored === "dark") return stored;
   return matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
@@ -674,7 +689,11 @@ function applyTheme(theme) {
 
 themeToggle.addEventListener("click", () => {
   const next = currentTheme() === "dark" ? "light" : "dark";
-  localStorage.setItem("bench-theme", next);
+  try {
+    localStorage.setItem("bench-theme", next);
+  } catch {
+    // The choice still applies to this page; it just will not be remembered.
+  }
   applyTheme(next);
   render();
 });
@@ -959,7 +978,7 @@ function renderTrend() {
 
   const hidden = machineOrder.filter(m => !m.plotted);
   const noteParts = [];
-  if (hidden.length) noteParts.push(`${hidden.length} machine(s) beyond the eight-colour palette are in the tables only: ${hidden.map(m => m.name).join(", ")}.`);
+  if (hidden.length) noteParts.push(`${hidden.length} machine(s) beyond the eight-color palette are in the tables only: ${hidden.map(m => m.name).join(", ")}.`);
   if (meta.note) noteParts.push(`Reading this metric: ${meta.note}.`);
   document.getElementById("trend-note").textContent = noteParts.join(" ");
 }

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -740,7 +740,8 @@ function renderTiles() {
     const sub = el("div", "tile-sub", machine.description || machine.gpus[0] || "");
     if (machine.hosts.length > 1) sub.title = machine.hosts.join(", ");
     tile.appendChild(sub);
-    tile.appendChild(el("div", "tile-specs", [...specs, hosts].filter(Boolean).join(" · ")));
+    const gpu = machine.description && machine.gpus.length === 1 ? machine.gpus[0] : "";
+    tile.appendChild(el("div", "tile-specs", [gpu, ...specs, hosts].filter(Boolean).join(" · ")));
     if (machine.gpus.length > 1) {
       tile.appendChild(el("div", "tile-warn", `${machine.gpus.length} GPU models here: ${machine.gpus.join(", ")}`));
     }

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -129,6 +129,12 @@ h2 { font-size: 1.02em; margin: 0; }
   background: var(--plane); border: 1px solid var(--border); border-radius: 6px;
 }
 .filters .match-count { margin-left: auto; font-size: 0.8em; color: var(--text-secondary); }
+.filters .check {
+  display: flex; align-items: center; gap: 5px; cursor: pointer;
+  font-size: 0.88em; font-weight: 400; text-transform: none; letter-spacing: 0;
+  color: var(--text-primary); padding: 5px 8px;
+  background: var(--plane); border: 1px solid var(--border); border-radius: 6px;
+}
 
 /* Machine tiles */
 .tiles { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: var(--gap); margin-bottom: var(--gap); }
@@ -138,7 +144,9 @@ h2 { font-size: 1.02em; margin: 0; }
 }
 .tile-head { display: flex; align-items: center; gap: 7px; font-weight: 600; font-size: 0.92em; }
 .tile-key { width: 10px; height: 10px; border-radius: 2px; flex: none; }
-.tile-sub { color: var(--text-muted); font-size: 0.74em; margin-top: 2px; min-height: 2.2em; }
+.tile-sub { color: var(--text-secondary); font-size: 0.78em; margin-top: 3px; }
+.tile-specs { color: var(--text-muted); font-size: 0.72em; margin-top: 2px; min-height: 2.1em; }
+.tile-warn { color: var(--critical); font-size: 0.72em; margin-top: 3px; }
 .tile-value { font-size: 1.9em; font-weight: 650; line-height: 1.1; margin-top: 8px; }
 .tile-value .unit { font-size: 0.45em; font-weight: 500; color: var(--text-secondary); margin-left: 3px; }
 .tile-blank { font-size: 0.85em; color: var(--text-muted); margin-top: 12px; }
@@ -236,6 +244,10 @@ code { font-size: 0.92em; color: var(--text-secondary); }
       <label for="sink-sel">Sink</label>
       <select id="sink-sel"></select>
     </div>
+    <div>
+      <label for="group-toggle">Machines</label>
+      <label class="check"><input type="checkbox" id="group-toggle" checked> Group</label>
+    </div>
     <span class="match-count" id="match-count"></span>
   </section>
 
@@ -301,27 +313,45 @@ const SCENARIO_GROUPS = [
 const sweeps = DATA.sweeps.slice();
 sweeps.forEach(s => { s.dateObj = new Date(s.day + "T00:00:00"); });
 
-const machineOrder = (() => {
+/**
+ * One entry per machine. Grouped, that is what bench/machines.toml calls the
+ * same machine; split, it is each sweep name on its own — the way to check that
+ * two systems on one box, or two nodes from one cluster pool, really do match.
+ */
+function buildMachines(grouped) {
   const seen = new Map();
-  for (const s of sweeps) {
-    if (!seen.has(s.machine)) seen.set(s.machine, {name: s.machine, first: s.day, last: s.day, gpu: s.gpu, hosts: [], sweeps: []});
-    const m = seen.get(s.machine);
-    m.last = s.day;
-    m.gpu = m.gpu || s.gpu;
-    if (s.host && !m.hosts.includes(s.host)) m.hosts.push(s.host);
-    m.sweeps.push(s);
+  for (const sweep of sweeps) {
+    const name = grouped ? sweep.machine : sweep.member;
+    if (!seen.has(name)) {
+      seen.set(name, {
+        name,
+        description: sweep.description || "",
+        specs: sweep.specs || {},
+        registered: sweep.registered,
+        first: sweep.day, last: sweep.day,
+        gpus: [], hosts: [], members: [], sweeps: [],
+      });
+    }
+    const machine = seen.get(name);
+    machine.last = sweep.day;
+    machine.sweeps.push(sweep);
+    for (const [key, value] of [["gpus", sweep.gpu], ["hosts", sweep.host], ["members", sweep.member]]) {
+      if (value && !machine[key].includes(value)) machine[key].push(value);
+    }
   }
-  return [...seen.values()];
-})();
 
-// Colour follows the machine, assigned in order of first appearance so an added
-// machine never repaints the ones already on screen. Past the palette's eight
-// slots the extra machines stay in the tables but leave the chart.
-machineOrder.forEach((m, i) => {
-  m.color = i < MAX_SERIES ? SERIES_VARS[i] : "var(--series-none)";
-  m.plotted = i < MAX_SERIES;
-});
-const machineByName = new Map(machineOrder.map(m => [m.name, m]));
+  // Colour follows the machine, assigned in order of first appearance so an
+  // added machine never repaints the ones already on screen. Past the palette's
+  // eight slots the extra machines stay in the tables but leave the chart.
+  const machines = [...seen.values()];
+  machines.forEach((machine, i) => {
+    machine.color = i < MAX_SERIES ? SERIES_VARS[i] : "var(--series-none)";
+    machine.plotted = i < MAX_SERIES;
+  });
+  return machines;
+}
+
+let machineOrder = [];
 
 function metricValue(run, key) {
   const parts = key.split(".");
@@ -357,7 +387,8 @@ const ALL_SINKS = distinct("sink").sort();
 // Selection
 // =========================================================================
 
-const state = {metric: METRICS[0].key, scenario: null, codec: null, backend: null, sink: null};
+const state = {metric: METRICS[0].key, scenario: null, codec: null, backend: null, sink: null,
+               grouped: true};
 
 function metricMeta(key) { return METRICS.find(m => m.key === key) || METRICS[0]; }
 
@@ -607,12 +638,16 @@ fillSelect(backendSel, ALL_BACKENDS);
 fillSelect(sinkSel, ALL_SINKS);
 
 function syncControls() {
+  groupToggle.checked = state.grouped;
   metricSel.value = state.metric;
   scenarioSel.value = state.scenario;
   codecSel.value = state.codec;
   backendSel.value = state.backend;
   sinkSel.value = state.sink;
 }
+
+const groupToggle = document.getElementById("group-toggle");
+groupToggle.addEventListener("change", () => { state.grouped = groupToggle.checked; render(); });
 
 metricSel.addEventListener("change", () => { state.metric = metricSel.value; render(); });
 scenarioSel.addEventListener("change", () => { state.scenario = scenarioSel.value; render(); });
@@ -697,10 +732,18 @@ function renderTiles() {
     head.appendChild(el("span", null, machine.name));
     tile.appendChild(head);
 
+    const specs = Object.entries(machine.specs).map(([key, value]) => `${key}: ${value}`);
+    const onlyHost = machine.hosts.length === 1 ? machine.hosts[0] : "";
     const hosts = machine.hosts.length > 1
       ? `${machine.hosts.length} hosts`
-      : (machine.hosts[0] || "");
-    tile.appendChild(el("div", "tile-sub", [machine.gpu, hosts].filter(Boolean).join(" · ")));
+      : (onlyHost === machine.name || machine.members.includes(onlyHost) ? "" : onlyHost);
+    const sub = el("div", "tile-sub", machine.description || machine.gpus[0] || "");
+    if (machine.hosts.length > 1) sub.title = machine.hosts.join(", ");
+    tile.appendChild(sub);
+    tile.appendChild(el("div", "tile-specs", [...specs, hosts].filter(Boolean).join(" · ")));
+    if (machine.gpus.length > 1) {
+      tile.appendChild(el("div", "tile-warn", `${machine.gpus.length} GPU models here: ${machine.gpus.join(", ")}`));
+    }
 
     if (latest) {
       const value = el("div", "tile-value");
@@ -719,6 +762,10 @@ function renderTiles() {
       delta.appendChild(document.createTextNode(
         cls === "flat" ? ` vs ${previous.sweep.commit} — no real change`
                        : ` ${CHANGE_WORD[cls]} than ${previous.sweep.commit}`));
+      if (previous.sweep.member !== latest.sweep.member) {
+        delta.appendChild(el("div", "tile-warn",
+          `compares ${previous.sweep.member} against ${latest.sweep.member}`));
+      }
     } else if (latest) {
       delta.appendChild(document.createTextNode("first sweep with this configuration"));
     }
@@ -733,13 +780,23 @@ function renderTiles() {
     link.href = explorerLink(latestSweep);
     link.title = `Open ${latestSweep.filename} in the sweep explorer`;
     foot.appendChild(link);
-    foot.appendChild(document.createTextNode(` on ${fmtDay(latestSweep.day)}`));
+    foot.appendChild(document.createTextNode(
+      machine.members.length > 1
+        ? ` on ${fmtDay(latestSweep.day)}, ${latestSweep.member}`
+        : ` on ${fmtDay(latestSweep.day)}`));
     const fails = failureCount(latestSweep);
     if (fails) {
       foot.appendChild(document.createTextNode(" · "));
       foot.appendChild(el("span", "fails", `${fails} run${fails === 1 ? "" : "s"} did not pass`));
     }
     tile.appendChild(foot);
+
+    if (machine.members.length > 1) {
+      tile.appendChild(el("div", "tile-foot", `covers ${machine.members.join(", ")}`));
+    }
+    if (!machine.registered) {
+      tile.appendChild(el("div", "tile-foot tile-warn", "not in machines.toml"));
+    }
     host.appendChild(tile);
   }
 }
@@ -881,8 +938,10 @@ function renderTrend() {
       showTooltip(event, node => {
         node.appendChild(el("div", "tt-head", d3.timeFormat("%Y-%m-%d")(nearest)));
         for (const {machine, point} of rows) {
-          tooltipRow(node, machine.color, `${machine.name} · ${point.sweep.commit}`,
-            `${fmt(point.value)} ${meta.unit}`);
+          const who = machine.members.length > 1
+            ? `${machine.name} (${point.sweep.member}) · ${point.sweep.commit}`
+            : `${machine.name} · ${point.sweep.commit}`;
+          tooltipRow(node, machine.color, who, `${fmt(point.value)} ${meta.unit}`);
           node.appendChild(el("div", "tt-head", `  ${configLabel(point.run)} — best of ${point.count} run${point.count === 1 ? "" : "s"}`));
         }
         node.appendChild(el("div", "tt-head", "click to open the nearest sweep in the explorer"));
@@ -1085,6 +1144,15 @@ function renderMovers() {
       `Showing ${shown.length} of ${all.length} shared configurations, taking turns between machines; ` +
       `${realCount} moved by ${REAL_CHANGE_PCT}% or more. The rest are in the sweep explorer.`));
   }
+
+  const crossing = [...new Set(shown
+    .filter(row => row.previousSweep.member !== row.latestSweep.member)
+    .map(row => `${row.previousSweep.member} → ${row.latestSweep.member}`))];
+  if (crossing.length) {
+    host.appendChild(el("p", "note",
+      `Some rows compare across the systems grouped into one machine (${crossing.join(", ")}). ` +
+      "Untick Group to keep them apart."));
+  }
 }
 
 // =========================================================================
@@ -1147,10 +1215,15 @@ function renderLede() {
     `${sweeps.length} sweeps · ${machineOrder.length} machines · ${span}`;
 
   const versions = [...new Set(sweeps.map(s => s.migrated_from ?? s.version))].sort();
+  const strangers = [...new Set(sweeps.filter(s => !s.registered).map(s => s.member))];
   const notes = [
+    "Machines are grouped by bench/machines.toml, which is where a box running two systems, or a pool of cluster nodes, is declared to be one machine. Untick Group to see the sweep names underneath.",
     "Each plotted value is the best run of a sweep for the chosen scenario and configuration; the remaining dimensions (data type, chunk size, fill) are searched, not averaged.",
     "Only passing runs count. A missing point means that sweep ran nothing matching the filter.",
   ];
+  if (strangers.length) {
+    notes.push(`Not described in bench/machines.toml: ${strangers.join(", ")}. Add an entry there to name and group them.`);
+  }
   if (versions.length > 1) {
     notes.push(`Sweeps here were written at result-schema versions ${versions.join(", ")}; a metric whose meaning changed between them is dropped from comparisons rather than converted.`);
   }
@@ -1172,6 +1245,8 @@ function renderMatchCount() {
 }
 
 function render() {
+  machineOrder = buildMachines(state.grouped);
+  renderLede();
   renderMatchCount();
   renderTiles();
   renderTrend();
@@ -1182,7 +1257,6 @@ function render() {
 
 pickDefaults();
 syncControls();
-renderLede();
 render();
 
 let resizeTimer = null;

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -1,0 +1,1195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Benchmarks over time</title>
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<style>
+:root {
+  color-scheme: light;
+  --surface-1: #fcfcfb;
+  --plane: #f9f9f7;
+  --text-primary: #0b0b0b;
+  --text-secondary: #52514e;
+  --text-muted: #898781;
+  --grid: #e1e0d9;
+  --axis: #c3c2b7;
+  --border: rgba(11,11,11,0.10);
+  --good: #0ca30c;
+  --good-text: #006300;
+  --critical: #d03b3b;
+  --series-1: #2a78d6;
+  --series-2: #eb6834;
+  --series-3: #1baf7a;
+  --series-4: #eda100;
+  --series-5: #e87ba4;
+  --series-6: #008300;
+  --series-7: #4a3aa7;
+  --series-8: #e34948;
+  --series-none: #898781;
+  --radius: 8px;
+  --gap: 16px;
+}
+@media (prefers-color-scheme: dark) {
+  :root:where(:not([data-theme="light"])) {
+    color-scheme: dark;
+    --surface-1: #1a1a19;
+    --plane: #0d0d0d;
+    --text-primary: #ffffff;
+    --text-secondary: #c3c2b7;
+    --text-muted: #898781;
+    --grid: #2c2c2a;
+    --axis: #383835;
+    --border: rgba(255,255,255,0.10);
+    --good-text: #0ca30c;
+    --series-1: #3987e5;
+    --series-2: #d95926;
+    --series-3: #199e70;
+    --series-4: #c98500;
+    --series-5: #d55181;
+    --series-6: #008300;
+    --series-7: #9085e9;
+    --series-8: #e66767;
+  }
+}
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --surface-1: #1a1a19;
+  --plane: #0d0d0d;
+  --text-primary: #ffffff;
+  --text-secondary: #c3c2b7;
+  --text-muted: #898781;
+  --grid: #2c2c2a;
+  --axis: #383835;
+  --border: rgba(255,255,255,0.10);
+  --good-text: #0ca30c;
+  --series-1: #3987e5;
+  --series-2: #d95926;
+  --series-3: #199e70;
+  --series-4: #c98500;
+  --series-5: #d55181;
+  --series-6: #008300;
+  --series-7: #9085e9;
+  --series-8: #e66767;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--plane);
+  color: var(--text-primary);
+  font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+a { color: var(--series-1); }
+
+.site-head {
+  display: flex; align-items: center; gap: var(--gap);
+  padding: 12px 24px; border-bottom: 1px solid var(--border);
+  background: var(--surface-1); flex-wrap: wrap;
+}
+.brand { font-weight: 650; }
+.site-head nav { display: flex; gap: 4px; margin-right: auto; }
+.site-head nav a {
+  padding: 4px 10px; border-radius: var(--radius); text-decoration: none;
+  color: var(--text-secondary); font-size: 0.9em;
+}
+.site-head nav a[aria-current="page"] { background: var(--plane); color: var(--text-primary); font-weight: 600; }
+.theme-toggle {
+  font: inherit; font-size: 0.85em; padding: 4px 10px; cursor: pointer;
+  background: var(--surface-1); color: var(--text-secondary);
+  border: 1px solid var(--border); border-radius: var(--radius);
+}
+
+main { max-width: 1180px; margin: 0 auto; padding: 24px; }
+.lede { color: var(--text-secondary); font-size: 0.9em; margin: 0 0 var(--gap); }
+h1 { font-size: 1.35em; margin: 0 0 4px; }
+h2 { font-size: 1.02em; margin: 0; }
+.card {
+  background: var(--surface-1); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: var(--gap); margin-bottom: var(--gap);
+}
+.card-sub { color: var(--text-secondary); font-size: 0.82em; margin: 2px 0 12px; }
+.note { color: var(--text-muted); font-size: 0.78em; margin: 8px 0 0; }
+.empty { color: var(--text-secondary); font-size: 0.9em; padding: 24px 0; text-align: center; }
+.link-button {
+  font: inherit; font-size: inherit; padding: 2px 6px; cursor: pointer;
+  color: var(--series-1); background: none; border: none; text-decoration: underline;
+}
+
+/* Filters — one row, above everything they scope */
+.filters {
+  display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end;
+  background: var(--surface-1); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 12px var(--gap); margin-bottom: var(--gap);
+}
+.filters label { display: block; font-size: 0.72em; font-weight: 600; color: var(--text-secondary); margin-bottom: 3px; text-transform: uppercase; letter-spacing: 0.04em; }
+.filters select {
+  font: inherit; font-size: 0.88em; padding: 5px 8px; color: var(--text-primary);
+  background: var(--plane); border: 1px solid var(--border); border-radius: 6px;
+}
+.filters .match-count { margin-left: auto; font-size: 0.8em; color: var(--text-secondary); }
+
+/* Machine tiles */
+.tiles { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: var(--gap); margin-bottom: var(--gap); }
+.tile {
+  background: var(--surface-1); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 14px;
+}
+.tile-head { display: flex; align-items: center; gap: 7px; font-weight: 600; font-size: 0.92em; }
+.tile-key { width: 10px; height: 10px; border-radius: 2px; flex: none; }
+.tile-sub { color: var(--text-muted); font-size: 0.74em; margin-top: 2px; min-height: 2.2em; }
+.tile-value { font-size: 1.9em; font-weight: 650; line-height: 1.1; margin-top: 8px; }
+.tile-value .unit { font-size: 0.45em; font-weight: 500; color: var(--text-secondary); margin-left: 3px; }
+.tile-blank { font-size: 0.85em; color: var(--text-muted); margin-top: 12px; }
+.tile-delta { font-size: 0.78em; margin-top: 3px; color: var(--text-secondary); }
+.tile-delta .up { color: var(--good-text); font-weight: 600; }
+.tile-delta .down { color: var(--critical); font-weight: 600; }
+.tile-foot { color: var(--text-muted); font-size: 0.72em; margin-top: 8px; }
+.tile-foot .fails { color: var(--critical); }
+.tile svg { display: block; margin-top: 10px; overflow: visible; }
+
+/* Tables */
+table { border-collapse: collapse; width: 100%; font-size: 0.82em; }
+th, td { text-align: left; padding: 5px 10px 5px 0; border-bottom: 1px solid var(--grid); }
+th { color: var(--text-secondary); font-weight: 600; font-size: 0.92em; }
+td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+tbody tr:hover { background: var(--plane); }
+.matrix tbody tr { cursor: pointer; }
+.matrix tbody tr[aria-selected="true"] { background: var(--plane); }
+.matrix .scenario-cell { font-weight: 600; padding-left: 10px; border-left: 3px solid transparent; }
+.matrix tbody tr[aria-selected="true"] .scenario-cell { border-left-color: var(--series-1); }
+.matrix tbody tr:focus-visible { outline: 2px solid var(--series-1); outline-offset: -2px; }
+.cell-delta { font-size: 0.85em; margin-left: 6px; }
+.cell-delta.up { color: var(--good-text); }
+.cell-delta.down { color: var(--critical); }
+.cell-flat { color: var(--text-muted); }
+.machine-th { white-space: nowrap; }
+.machine-th .tile-key { display: inline-block; margin-right: 5px; vertical-align: baseline; }
+details summary { cursor: pointer; font-weight: 600; font-size: 0.95em; }
+details[open] summary { margin-bottom: 12px; }
+code { font-size: 0.92em; color: var(--text-secondary); }
+
+/* Charts */
+.chart-wrap { position: relative; }
+.legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin-top: 12px; }
+.legend-item { display: flex; align-items: center; gap: 6px; font-size: 0.8em; color: var(--text-secondary); }
+.legend-key { width: 18px; height: 2px; border-radius: 1px; flex: none; }
+.legend-item .legend-value { color: var(--text-primary); font-variant-numeric: tabular-nums; }
+.axis text { fill: var(--text-muted); font-size: 11px; }
+.axis path { display: none; }
+.axis line { stroke: var(--axis); }
+.grid line { stroke: var(--grid); }
+.tick-label { fill: var(--text-muted); font-size: 11px; }
+.end-label { fill: var(--text-secondary); font-size: 11px; font-weight: 600; }
+.tooltip {
+  position: fixed; pointer-events: none; z-index: 20; max-width: 300px;
+  background: var(--surface-1); color: var(--text-primary);
+  border: 1px solid var(--border); border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.18);
+  padding: 8px 10px; font-size: 0.78em; line-height: 1.45;
+}
+.tooltip .tt-head { color: var(--text-secondary); margin-bottom: 5px; }
+.tooltip .tt-row { display: flex; align-items: baseline; gap: 7px; }
+.tooltip .tt-key { width: 14px; height: 2px; border-radius: 1px; flex: none; position: relative; top: -3px; }
+.tooltip .tt-value { font-weight: 650; font-variant-numeric: tabular-nums; }
+.tooltip .tt-name { color: var(--text-secondary); }
+
+@media (max-width: 620px) {
+  .filters { flex-direction: column; align-items: stretch; }
+  .filters .match-count { margin-left: 0; }
+}
+</style>
+</head>
+<body>
+<header class="site-head">
+  <span class="brand">chucky benchmarks</span>
+  <nav>
+    <a href="index.html" aria-current="page">Over time</a>
+    <a href="explore.html">Sweep explorer</a>
+  </nav>
+  <button class="theme-toggle" id="theme-toggle" type="button">Dark</button>
+</header>
+
+<main>
+  <h1>How performance is moving</h1>
+  <p class="lede" id="lede"></p>
+
+  <section class="filters" aria-label="Filters">
+    <div>
+      <label for="metric-sel">Metric</label>
+      <select id="metric-sel"></select>
+    </div>
+    <div>
+      <label for="scenario-sel">Scenario</label>
+      <select id="scenario-sel"></select>
+    </div>
+    <div>
+      <label for="codec-sel">Codec</label>
+      <select id="codec-sel"></select>
+    </div>
+    <div>
+      <label for="backend-sel">Backend</label>
+      <select id="backend-sel"></select>
+    </div>
+    <div>
+      <label for="sink-sel">Sink</label>
+      <select id="sink-sel"></select>
+    </div>
+    <span class="match-count" id="match-count"></span>
+  </section>
+
+  <section class="tiles" id="tiles" aria-label="Machines"></section>
+
+  <section class="card">
+    <h2>Trend across sweeps</h2>
+    <p class="card-sub" id="trend-sub"></p>
+    <div class="chart-wrap" id="trend"></div>
+    <div class="legend" id="trend-legend"></div>
+    <p class="note" id="trend-note"></p>
+  </section>
+
+  <section class="card">
+    <h2>Latest sweep, every scenario</h2>
+    <p class="card-sub" id="matrix-sub"></p>
+    <div id="matrix"></div>
+  </section>
+
+  <section class="card">
+    <h2>Biggest changes since the previous sweep</h2>
+    <p class="card-sub" id="movers-sub"></p>
+    <div id="movers"></div>
+  </section>
+
+  <details class="card" id="table-view">
+    <summary>Table view of the trend</summary>
+    <div id="trend-table"></div>
+  </details>
+
+  <p class="note" id="footnotes"></p>
+</main>
+
+<script>
+const DATA = __DATA_PLACEHOLDER__;
+
+const MAX_SERIES = 8;
+const SERIES_VARS = Array.from({length: MAX_SERIES}, (_, i) => `var(--series-${i + 1})`);
+
+const METRICS = [
+  {key: "throughput_in_gibs", label: "Input throughput", unit: "GiB/s", better: "high"},
+  {key: "throughput_out_gibs", label: "Output throughput", unit: "GiB/s", better: "high"},
+  {key: "compression_fold", label: "Compression ratio", unit: "x", better: "high"},
+  {key: "wall_s", label: "Wall time", unit: "s", better: "low"},
+  {key: "init_s", label: "Init time", unit: "s", better: "low"},
+  {key: "stalls.max_append_ms", label: "Slowest append block", unit: "ms", better: "low",
+   note: "one append is a multi-frame block push, not a single frame"},
+  {key: "stalls.peak_pending_mib", label: "Peak pending bytes", unit: "MiB", better: "low"},
+  {key: "stalls.backpressure_ms", label: "Backpressure wait", unit: "ms", better: "low"},
+  {key: "stalls.flush_stall_ms", label: "Flush stall", unit: "ms", better: "low"},
+];
+
+const SCENARIO_GROUPS = [
+  {suffix: "_multiscale_dim0", rank: 2},
+  {suffix: "_multiscale", rank: 1},
+  {suffix: "_single", rank: 0},
+];
+
+// =========================================================================
+// Data model
+// =========================================================================
+
+const sweeps = DATA.sweeps.slice();
+sweeps.forEach(s => { s.dateObj = new Date(s.day + "T00:00:00"); });
+
+const machineOrder = (() => {
+  const seen = new Map();
+  for (const s of sweeps) {
+    if (!seen.has(s.machine)) seen.set(s.machine, {name: s.machine, first: s.day, last: s.day, gpu: s.gpu, hosts: [], sweeps: []});
+    const m = seen.get(s.machine);
+    m.last = s.day;
+    m.gpu = m.gpu || s.gpu;
+    if (s.host && !m.hosts.includes(s.host)) m.hosts.push(s.host);
+    m.sweeps.push(s);
+  }
+  return [...seen.values()];
+})();
+
+// Colour follows the machine, assigned in order of first appearance so an added
+// machine never repaints the ones already on screen. Past the palette's eight
+// slots the extra machines stay in the tables but leave the chart.
+machineOrder.forEach((m, i) => {
+  m.color = i < MAX_SERIES ? SERIES_VARS[i] : "var(--series-none)";
+  m.plotted = i < MAX_SERIES;
+});
+const machineByName = new Map(machineOrder.map(m => [m.name, m]));
+
+function metricValue(run, key) {
+  const parts = key.split(".");
+  let v = run;
+  for (const p of parts) {
+    if (v == null || typeof v !== "object") return null;
+    v = v[p];
+  }
+  return typeof v === "number" && isFinite(v) ? v : null;
+}
+
+function scenarioRank(name) {
+  for (const g of SCENARIO_GROUPS) if (name.endsWith(g.suffix)) return g.rank;
+  return 3;
+}
+
+function sortedScenarios(names) {
+  return [...names].sort((a, b) => scenarioRank(a) - scenarioRank(b) || a.localeCompare(b));
+}
+
+function distinct(key) {
+  const values = new Set();
+  for (const s of sweeps) for (const r of s.runs) if (r[key] != null) values.add(r[key]);
+  return [...values];
+}
+
+const ALL_SCENARIOS = sortedScenarios(distinct("scenario"));
+const ALL_CODECS = distinct("codec").sort();
+const ALL_BACKENDS = distinct("backend").sort();
+const ALL_SINKS = distinct("sink").sort();
+
+// =========================================================================
+// Selection
+// =========================================================================
+
+const state = {metric: METRICS[0].key, scenario: null, codec: null, backend: null, sink: null};
+
+function metricMeta(key) { return METRICS.find(m => m.key === key) || METRICS[0]; }
+
+/** The opening view should not be empty: pick the config the most sweeps ran. */
+function pickDefaults() {
+  const counts = new Map();
+  for (const s of sweeps) {
+    const here = new Set();
+    for (const r of s.runs) {
+      if (r.status !== "pass" || metricValue(r, state.metric) == null) continue;
+      here.add([r.scenario, r.codec, r.backend, r.sink].join(" "));
+    }
+    for (const combo of here) counts.set(combo, (counts.get(combo) || 0) + 1);
+  }
+  let best = null, bestCount = -1;
+  for (const [combo, count] of counts) {
+    if (count > bestCount) { best = combo; bestCount = count; }
+  }
+  const [scenario, codec, backend, sink] = best
+    ? best.split(" ")
+    : [ALL_SCENARIOS[0], ALL_CODECS[0], ALL_BACKENDS[0], ALL_SINKS[0]];
+  state.scenario = scenario; state.codec = codec; state.backend = backend; state.sink = sink;
+}
+
+function matchesConfig(run) {
+  return run.codec === state.codec && run.backend === state.backend && run.sink === state.sink;
+}
+
+function comparable(sweep) {
+  const leaf = state.metric.split(".").pop();
+  return !(sweep.retired || []).includes(leaf);
+}
+
+/** Best run of a sweep for one scenario under the current config filters. */
+function bestRun(sweep, scenario) {
+  const meta = metricMeta(state.metric);
+  const wantHigh = meta.better === "high";
+  let best = null, bestValue = null, count = 0;
+  for (const run of sweep.runs) {
+    if (run.scenario !== scenario || run.status !== "pass" || !matchesConfig(run)) continue;
+    const value = metricValue(run, state.metric);
+    if (value == null) continue;
+    count++;
+    if (bestValue == null || (wantHigh ? value > bestValue : value < bestValue)) {
+      best = run; bestValue = value;
+    }
+  }
+  return best ? {run: best, value: bestValue, count} : null;
+}
+
+/** Codec, backend, and sink combinations with at least one usable run. */
+function availableCombinations(scenario) {
+  const found = new Set();
+  for (const sweep of sweeps) {
+    if (!comparable(sweep)) continue;
+    for (const run of sweep.runs) {
+      if (run.status !== "pass" || metricValue(run, state.metric) == null) continue;
+      if (scenario && run.scenario !== scenario) continue;
+      found.add([run.codec, run.backend, run.sink].join("|"));
+    }
+  }
+  return found;
+}
+
+/**
+ * Nearest selections that would show something: one changed dimension first,
+ * so an empty view says where the data actually is instead of just "none".
+ */
+function nearestAlternatives(scenario, limit = 3) {
+  const available = availableCombinations(scenario);
+  const current = [state.codec, state.backend, state.sink];
+  // Backend and sink first: the codec is usually the deliberate choice, so
+  // suggest keeping it and moving where it ran.
+  const dimensions = [
+    {index: 1, key: "backend", label: "backend"},
+    {index: 2, key: "sink", label: "sink"},
+    {index: 0, key: "codec", label: "codec"},
+  ];
+  const out = [];
+  for (const dimension of dimensions) {
+    for (const combo of available) {
+      const parts = combo.split("|");
+      if (parts.every((p, i) => i === dimension.index || p === current[i]) && parts[dimension.index] !== current[dimension.index]) {
+        out.push({label: `${dimension.label} ${parts[dimension.index]}`, key: dimension.key, value: parts[dimension.index]});
+      }
+    }
+  }
+  if (!out.length) {
+    for (const combo of available) {
+      const [codec, backend, sink] = combo.split("|");
+      out.push({label: `${codec} · ${backend} · ${sink}`, codec, backend, sink});
+      if (out.length >= limit) break;
+    }
+  }
+  return out.slice(0, limit);
+}
+
+function emptyState(message, scenario) {
+  const node = el("p", "empty");
+  node.appendChild(document.createTextNode(message + " "));
+  const alternatives = nearestAlternatives(scenario);
+  if (!alternatives.length) return node;
+  node.appendChild(document.createTextNode("Try: "));
+  alternatives.forEach((alternative, i) => {
+    if (i) node.appendChild(document.createTextNode(", "));
+    const button = el("button", "link-button", alternative.label);
+    button.type = "button";
+    button.addEventListener("click", () => {
+      if (alternative.key) state[alternative.key] = alternative.value;
+      else Object.assign(state, {codec: alternative.codec, backend: alternative.backend, sink: alternative.sink});
+      syncControls();
+      render();
+    });
+    node.appendChild(button);
+  });
+  node.appendChild(document.createTextNode("."));
+  return node;
+}
+
+/** One point per sweep for a machine: {sweep, value, run, count}. */
+function series(machine, scenario) {
+  const points = [];
+  for (const sweep of machine.sweeps) {
+    if (!comparable(sweep)) continue;
+    const hit = bestRun(sweep, scenario);
+    if (hit) points.push({sweep, ...hit});
+  }
+  return points;
+}
+
+// =========================================================================
+// Formatting
+// =========================================================================
+
+function fmt(value) {
+  if (value == null) return "—";
+  const abs = Math.abs(value);
+  if (abs >= 1000) return d3.format(",.0f")(value);
+  if (abs >= 100) return d3.format(".0f")(value);
+  if (abs >= 10) return d3.format(".1f")(value);
+  if (abs >= 1) return d3.format(".2f")(value);
+  if (abs > 0) return d3.format(".3f")(value);
+  return "0";
+}
+
+function fmtDay(day) { return day || "unknown date"; }
+
+function percentChange(previous, latest) {
+  if (previous == null || latest == null || previous === 0) return null;
+  return (latest - previous) / Math.abs(previous) * 100;
+}
+
+/** Direction of a change, judged against what the metric wants. */
+function changeClass(pct) {
+  if (pct == null || Math.abs(pct) < 2) return "flat";
+  const better = metricMeta(state.metric).better === "high" ? pct > 0 : pct < 0;
+  return better ? "up" : "down";
+}
+
+const CHANGE_GLYPH = {up: "▲", down: "▼", flat: "≈"};
+const CHANGE_WORD = {up: "better", down: "worse", flat: "no real change"};
+const REAL_CHANGE_PCT = 2;
+
+function signedPercent(pct) {
+  const shown = Math.abs(pct) < 100 ? fmt(pct) : d3.format(".0f")(pct);
+  return `${pct > 0 ? "+" : ""}${shown}%`;
+}
+
+function explorerLink(sweep) {
+  return `explore.html?file=${encodeURIComponent(sweep.filename)}`;
+}
+
+function setText(node, text) { node.textContent = text; return node; }
+
+function el(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text != null) node.textContent = text;
+  return node;
+}
+
+function keySwatch(color, className) {
+  const node = el("span", className || "tile-key");
+  node.style.background = color;
+  return node;
+}
+
+function configLabel(run) {
+  return [run.dtype, run.chunk_bytes_label, run.fill].filter(Boolean).join(" · ");
+}
+
+// =========================================================================
+// Tooltip
+// =========================================================================
+
+const tooltip = el("div", "tooltip");
+tooltip.style.display = "none";
+document.body.appendChild(tooltip);
+
+function showTooltip(event, build) {
+  tooltip.replaceChildren();
+  build(tooltip);
+  tooltip.style.display = "block";
+  const box = tooltip.getBoundingClientRect();
+  const pad = 14;
+  let x = event.clientX + pad, y = event.clientY + pad;
+  if (x + box.width > window.innerWidth - 8) x = event.clientX - box.width - pad;
+  if (y + box.height > window.innerHeight - 8) y = event.clientY - box.height - pad;
+  tooltip.style.left = Math.max(8, x) + "px";
+  tooltip.style.top = Math.max(8, y) + "px";
+}
+
+function hideTooltip() { tooltip.style.display = "none"; }
+
+function tooltipRow(parent, color, name, value) {
+  const row = el("div", "tt-row");
+  if (color) row.appendChild(keySwatch(color, "tt-key"));
+  row.appendChild(el("span", "tt-value", value));
+  row.appendChild(el("span", "tt-name", name));
+  parent.appendChild(row);
+  return row;
+}
+
+// =========================================================================
+// Controls
+// =========================================================================
+
+function fillSelect(select, values, labels) {
+  select.replaceChildren();
+  values.forEach((value, i) => {
+    const option = el("option", null, labels ? labels[i] : value);
+    option.value = value;
+    select.appendChild(option);
+  });
+}
+
+const metricSel = document.getElementById("metric-sel");
+const scenarioSel = document.getElementById("scenario-sel");
+const codecSel = document.getElementById("codec-sel");
+const backendSel = document.getElementById("backend-sel");
+const sinkSel = document.getElementById("sink-sel");
+
+fillSelect(metricSel, METRICS.map(m => m.key), METRICS.map(m => `${m.label} (${m.unit})`));
+fillSelect(scenarioSel, ALL_SCENARIOS);
+fillSelect(codecSel, ALL_CODECS);
+fillSelect(backendSel, ALL_BACKENDS);
+fillSelect(sinkSel, ALL_SINKS);
+
+function syncControls() {
+  metricSel.value = state.metric;
+  scenarioSel.value = state.scenario;
+  codecSel.value = state.codec;
+  backendSel.value = state.backend;
+  sinkSel.value = state.sink;
+}
+
+metricSel.addEventListener("change", () => { state.metric = metricSel.value; render(); });
+scenarioSel.addEventListener("change", () => { state.scenario = scenarioSel.value; render(); });
+codecSel.addEventListener("change", () => { state.codec = codecSel.value; render(); });
+backendSel.addEventListener("change", () => { state.backend = backendSel.value; render(); });
+sinkSel.addEventListener("change", () => { state.sink = sinkSel.value; render(); });
+
+// =========================================================================
+// Theme
+// =========================================================================
+
+const themeToggle = document.getElementById("theme-toggle");
+
+function currentTheme() {
+  const stored = localStorage.getItem("bench-theme");
+  if (stored === "light" || stored === "dark") return stored;
+  return matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+  themeToggle.textContent = theme === "dark" ? "Light" : "Dark";
+}
+
+themeToggle.addEventListener("click", () => {
+  const next = currentTheme() === "dark" ? "light" : "dark";
+  localStorage.setItem("bench-theme", next);
+  applyTheme(next);
+  render();
+});
+
+applyTheme(currentTheme());
+
+// =========================================================================
+// Machine tiles
+// =========================================================================
+
+function sparkline(points, color) {
+  const W = 176, H = 30, r = 3;
+  const svg = d3.create("svg").attr("width", W).attr("height", H)
+    .attr("role", "img").attr("aria-hidden", "true");
+  if (points.length < 2) return svg.node();
+  const x = d3.scaleTime()
+    .domain(d3.extent(points, p => p.sweep.dateObj))
+    .range([r + 1, W - r - 1]);
+  const y = d3.scaleLinear()
+    .domain(d3.extent(points, p => p.value)).nice()
+    .range([H - r - 1, r + 1]);
+  svg.append("path")
+    .attr("fill", "none").attr("stroke", color).attr("stroke-width", 2)
+    .attr("stroke-linejoin", "round").attr("stroke-linecap", "round")
+    .attr("d", d3.line().x(p => x(p.sweep.dateObj)).y(p => y(p.value))(points));
+  const last = points[points.length - 1];
+  svg.append("circle")
+    .attr("cx", x(last.sweep.dateObj)).attr("cy", y(last.value)).attr("r", r)
+    .attr("fill", color).attr("stroke", "var(--surface-1)").attr("stroke-width", 2);
+  return svg.node();
+}
+
+function failureCount(sweep) {
+  let fails = 0;
+  for (const [status, n] of Object.entries(sweep.counts || {})) {
+    if (status !== "pass") fails += n;
+  }
+  return fails;
+}
+
+function renderTiles() {
+  const host = document.getElementById("tiles");
+  host.replaceChildren();
+  const meta = metricMeta(state.metric);
+
+  for (const machine of machineOrder) {
+    const points = series(machine, state.scenario);
+    const latest = points[points.length - 1] || null;
+    const previous = points[points.length - 2] || null;
+    const latestSweep = machine.sweeps[machine.sweeps.length - 1];
+
+    const tile = el("div", "tile");
+    const head = el("div", "tile-head");
+    head.appendChild(keySwatch(machine.color));
+    head.appendChild(el("span", null, machine.name));
+    tile.appendChild(head);
+
+    const hosts = machine.hosts.length > 1
+      ? `${machine.hosts.length} hosts`
+      : (machine.hosts[0] || "");
+    tile.appendChild(el("div", "tile-sub", [machine.gpu, hosts].filter(Boolean).join(" · ")));
+
+    if (latest) {
+      const value = el("div", "tile-value");
+      value.appendChild(document.createTextNode(fmt(latest.value)));
+      value.appendChild(el("span", "unit", meta.unit));
+      tile.appendChild(value);
+    } else {
+      tile.appendChild(el("div", "tile-blank", "No run matches this filter"));
+    }
+
+    const delta = el("div", "tile-delta");
+    if (latest && previous) {
+      const pct = percentChange(previous.value, latest.value);
+      const cls = changeClass(pct);
+      delta.appendChild(setText(el("span", cls), `${CHANGE_GLYPH[cls]} ${signedPercent(pct)}`));
+      delta.appendChild(document.createTextNode(
+        cls === "flat" ? ` vs ${previous.sweep.commit} — no real change`
+                       : ` ${CHANGE_WORD[cls]} than ${previous.sweep.commit}`));
+    } else if (latest) {
+      delta.appendChild(document.createTextNode("first sweep with this configuration"));
+    }
+    tile.appendChild(delta);
+
+    if (points.length >= 2) tile.appendChild(sparkline(points, machine.color));
+
+    const foot = el("div", "tile-foot");
+    foot.appendChild(document.createTextNode(
+      `${machine.sweeps.length} sweep${machine.sweeps.length === 1 ? "" : "s"} · latest `));
+    const link = el("a", null, latestSweep.commit);
+    link.href = explorerLink(latestSweep);
+    link.title = `Open ${latestSweep.filename} in the sweep explorer`;
+    foot.appendChild(link);
+    foot.appendChild(document.createTextNode(` on ${fmtDay(latestSweep.day)}`));
+    const fails = failureCount(latestSweep);
+    if (fails) {
+      foot.appendChild(document.createTextNode(" · "));
+      foot.appendChild(el("span", "fails", `${fails} run${fails === 1 ? "" : "s"} did not pass`));
+    }
+    tile.appendChild(foot);
+    host.appendChild(tile);
+  }
+}
+
+// =========================================================================
+// Trend chart
+// =========================================================================
+
+let trendRows = [];
+
+function renderTrend() {
+  const host = document.getElementById("trend");
+  host.replaceChildren();
+  const legendHost = document.getElementById("trend-legend");
+  legendHost.replaceChildren();
+  const meta = metricMeta(state.metric);
+
+  const lines = machineOrder
+    .filter(m => m.plotted)
+    .map(m => ({machine: m, points: series(m, state.scenario)}))
+    .filter(l => l.points.length > 0);
+
+  trendRows = lines;
+
+  document.getElementById("trend-sub").textContent =
+    `Best ${meta.label.toLowerCase()} per sweep — ${state.scenario}, ${state.codec} codec, ${state.backend} backend, ${state.sink} sink. Click a point to open that sweep in the explorer.`;
+
+  if (!lines.length) {
+    host.appendChild(emptyState(`No passing runs for ${state.scenario} with ${state.codec} on ${state.backend} into ${state.sink}.`, state.scenario));
+    return;
+  }
+
+  const width = Math.max(320, host.clientWidth || 860);
+  const height = 320;
+  const margin = {top: 12, right: 92, bottom: 28, left: 56};
+  const innerW = width - margin.left - margin.right;
+  const innerH = height - margin.top - margin.bottom;
+
+  const allPoints = lines.flatMap(l => l.points);
+  const svg = d3.select(host).append("svg")
+    .attr("width", width).attr("height", height)
+    .attr("role", "img")
+    .attr("aria-label", `${meta.label} over time, one line per machine`);
+  const g = svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
+
+  const dates = [...new Set(allPoints.map(p => +p.sweep.dateObj))].sort((a, b) => a - b).map(t => new Date(t));
+  const x = d3.scaleTime()
+    .domain(d3.extent(dates))
+    .range([0, innerW]);
+  if (dates.length === 1) x.domain([d3.timeDay.offset(dates[0], -1), d3.timeDay.offset(dates[0], 1)]);
+
+  const maxValue = d3.max(allPoints, p => p.value);
+  const y = d3.scaleLinear().domain([0, maxValue * 1.08 || 1]).nice().range([innerH, 0]);
+
+  g.append("g").attr("class", "grid")
+    .selectAll("line").data(y.ticks(5)).join("line")
+    .attr("x1", 0).attr("x2", innerW).attr("y1", d => y(d)).attr("y2", d => y(d));
+
+  g.append("g").attr("class", "axis")
+    .attr("transform", `translate(0,${innerH})`)
+    .call(d3.axisBottom(x).ticks(Math.min(6, dates.length)).tickSizeOuter(0).tickFormat(d3.timeFormat("%b %d")));
+  g.append("g").attr("class", "axis")
+    .call(d3.axisLeft(y).ticks(5).tickSize(0).tickFormat(d3.format("~s")));
+  g.append("text").attr("class", "tick-label")
+    .attr("x", 0).attr("y", -2).text(meta.unit);
+
+  const line = d3.line().x(p => x(p.sweep.dateObj)).y(p => y(p.value));
+
+  for (const {machine, points} of lines) {
+    g.append("path")
+      .attr("fill", "none").attr("stroke", machine.color).attr("stroke-width", 2)
+      .attr("stroke-linejoin", "round").attr("stroke-linecap", "round")
+      .attr("d", line(points));
+    g.selectAll(null).data(points).join("circle")
+      .attr("cx", p => x(p.sweep.dateObj)).attr("cy", p => y(p.value)).attr("r", 4)
+      .attr("fill", machine.color)
+      .attr("stroke", "var(--surface-1)").attr("stroke-width", 2);
+  }
+
+  // Direct end labels only while they stay attached to their own line.
+  const ends = lines.map(l => ({machine: l.machine, point: l.points[l.points.length - 1]}))
+    .sort((a, b) => y(a.point.value) - y(b.point.value));
+  const roomy = ends.every((e, i) => i === 0 || Math.abs(y(e.point.value) - y(ends[i - 1].point.value)) >= 13);
+  if (roomy && ends.length <= 4) {
+    for (const e of ends) {
+      g.append("text").attr("class", "end-label")
+        .attr("x", x(e.point.sweep.dateObj) + 9)
+        .attr("y", y(e.point.value) + 4)
+        .text(e.machine.name);
+    }
+  }
+
+  // Crosshair: aim at a sweep date, read every machine that ran that day.
+  const crosshair = g.append("line")
+    .attr("stroke", "var(--axis)").attr("stroke-width", 1)
+    .attr("y1", 0).attr("y2", innerH).style("display", "none");
+
+  const byDate = new Map();
+  for (const {machine, points} of lines) {
+    for (const p of points) {
+      const key = +p.sweep.dateObj;
+      if (!byDate.has(key)) byDate.set(key, []);
+      byDate.get(key).push({machine, point: p});
+    }
+  }
+
+  const nearestDate = px => {
+    const target = x.invert(px);
+    let nearest = dates[0];
+    for (const d of dates) if (Math.abs(d - target) < Math.abs(nearest - target)) nearest = d;
+    return nearest;
+  };
+  const nearestPoint = (px, py) => {
+    const rows = byDate.get(+nearestDate(px)) || [];
+    let best = null;
+    for (const row of rows) {
+      const distance = Math.abs(y(row.point.value) - py);
+      if (!best || distance < best.distance) best = {...row, distance};
+    }
+    return best;
+  };
+
+  svg.append("rect")
+    .attr("x", margin.left).attr("y", margin.top)
+    .attr("width", innerW).attr("height", innerH)
+    .attr("fill", "transparent")
+    .style("cursor", "pointer")
+    .on("pointerleave", () => { crosshair.style("display", "none"); hideTooltip(); })
+    .on("click", event => {
+      const [px, py] = d3.pointer(event, g.node());
+      const hit = nearestPoint(px, py);
+      if (hit) location.href = explorerLink(hit.point.sweep);
+    })
+    .on("pointermove", event => {
+      const [px] = d3.pointer(event, g.node());
+      const nearest = nearestDate(px);
+      crosshair.attr("x1", x(nearest)).attr("x2", x(nearest)).style("display", null);
+      const rows = byDate.get(+nearest) || [];
+      showTooltip(event, node => {
+        node.appendChild(el("div", "tt-head", d3.timeFormat("%Y-%m-%d")(nearest)));
+        for (const {machine, point} of rows) {
+          tooltipRow(node, machine.color, `${machine.name} · ${point.sweep.commit}`,
+            `${fmt(point.value)} ${meta.unit}`);
+          node.appendChild(el("div", "tt-head", `  ${configLabel(point.run)} — best of ${point.count} run${point.count === 1 ? "" : "s"}`));
+        }
+        node.appendChild(el("div", "tt-head", "click to open the nearest sweep in the explorer"));
+      });
+    });
+
+  for (const {machine, points} of lines) {
+    const item = el("div", "legend-item");
+    item.appendChild(keySwatch(machine.color, "legend-key"));
+    item.appendChild(el("span", null, machine.name));
+    item.appendChild(el("span", "legend-value", `${fmt(points[points.length - 1].value)} ${meta.unit}`));
+    legendHost.appendChild(item);
+  }
+
+  const hidden = machineOrder.filter(m => !m.plotted);
+  const noteParts = [];
+  if (hidden.length) noteParts.push(`${hidden.length} machine(s) beyond the eight-colour palette are in the tables only: ${hidden.map(m => m.name).join(", ")}.`);
+  if (meta.note) noteParts.push(`Reading this metric: ${meta.note}.`);
+  document.getElementById("trend-note").textContent = noteParts.join(" ");
+}
+
+// =========================================================================
+// Latest-sweep matrix
+// =========================================================================
+
+function renderMatrix() {
+  const host = document.getElementById("matrix");
+  host.replaceChildren();
+  const meta = metricMeta(state.metric);
+  document.getElementById("matrix-sub").textContent =
+    `Best ${meta.label.toLowerCase()} (${meta.unit}) in each machine's most recent sweep, with the change from its previous sweep. Every scenario is listed; pick one to plot it above.`;
+
+  const table = el("table", "matrix");
+  const thead = el("thead");
+  const headRow = el("tr");
+  headRow.appendChild(el("th", null, "Scenario"));
+  for (const machine of machineOrder) {
+    const th = el("th", "machine-th num");
+    th.appendChild(keySwatch(machine.color));
+    th.appendChild(document.createTextNode(machine.name));
+    headRow.appendChild(th);
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = el("tbody");
+  let anyValue = false;
+
+  for (const scenario of ALL_SCENARIOS) {
+    const row = el("tr");
+    row.setAttribute("aria-selected", scenario === state.scenario ? "true" : "false");
+    row.tabIndex = 0;
+    const pick = () => { state.scenario = scenario; syncControls(); render(); };
+    row.addEventListener("click", pick);
+    row.addEventListener("keydown", event => { if (event.key === "Enter" || event.key === " ") { event.preventDefault(); pick(); } });
+    row.appendChild(el("td", "scenario-cell", scenario));
+
+    for (const machine of machineOrder) {
+      const points = series(machine, scenario);
+      const latest = points[points.length - 1] || null;
+      const previous = points[points.length - 2] || null;
+      const cell = el("td", "num");
+      if (!latest) {
+        cell.appendChild(el("span", "cell-flat", "—"));
+      } else {
+        anyValue = true;
+        cell.appendChild(document.createTextNode(fmt(latest.value)));
+        const pct = percentChange(previous ? previous.value : null, latest.value);
+        if (pct != null) {
+          const cls = changeClass(pct);
+          const tag = el("span", `cell-delta ${cls}`, `${CHANGE_GLYPH[cls]} ${signedPercent(pct)}`);
+          tag.title = `${fmt(previous.value)} at ${previous.sweep.commit} (${fmtDay(previous.sweep.day)}) → ${fmt(latest.value)} at ${latest.sweep.commit} (${fmtDay(latest.sweep.day)}) — ${CHANGE_WORD[cls]}`;
+          cell.appendChild(tag);
+        }
+        cell.title = `${latest.sweep.commit} (${fmtDay(latest.sweep.day)}) · ${configLabel(latest.run)} · best of ${latest.count} run${latest.count === 1 ? "" : "s"}`;
+      }
+      row.appendChild(cell);
+    }
+    tbody.appendChild(row);
+  }
+  table.appendChild(tbody);
+
+  if (!anyValue) {
+    host.appendChild(emptyState(`No scenario has a passing run with ${state.codec} on ${state.backend} into ${state.sink}.`, null));
+    return;
+  }
+  host.appendChild(table);
+}
+
+// =========================================================================
+// Movers
+// =========================================================================
+
+const MOVERS_SHOWN = 12;
+
+function moversFor(machine) {
+  const index = sweep => {
+    const map = new Map();
+    for (const run of sweep.runs) {
+      if (run.status !== "pass" || !matchesConfig(run)) continue;
+      const value = metricValue(run, state.metric);
+      if (value != null) map.set(run.id, {run, value});
+    }
+    return map;
+  };
+
+  // The two most recent sweeps that ran anything matching, so a sweep that
+  // skipped this configuration does not hide the comparison.
+  const usable = machine.sweeps
+    .filter(comparable)
+    .map(sweep => ({sweep, runs: index(sweep)}))
+    .filter(entry => entry.runs.size);
+  if (usable.length < 2) return {rows: [], latest: null, previous: null};
+  const {sweep: latest, runs: after} = usable[usable.length - 1];
+  const {sweep: previous, runs: before} = usable[usable.length - 2];
+  const rows = [];
+  for (const [id, now] of after) {
+    const then = before.get(id);
+    if (!then) continue;
+    const pct = percentChange(then.value, now.value);
+    if (pct == null) continue;
+    rows.push({machine, id, run: now.run, previous: then.value, latest: now.value, pct, latestSweep: latest, previousSweep: previous});
+  }
+  return {rows, latest, previous};
+}
+
+function renderMovers() {
+  const host = document.getElementById("movers");
+  host.replaceChildren();
+  const meta = metricMeta(state.metric);
+
+  const all = [];
+  const pairs = [];
+  for (const machine of machineOrder) {
+    const {rows, latest, previous} = moversFor(machine);
+    if (latest && previous) pairs.push(`${machine.name} ${previous.commit}→${latest.commit}`);
+    all.push(...rows);
+  }
+  document.getElementById("movers-sub").textContent = pairs.length
+    ? `${meta.label} for configurations run in both of a machine's two most recent sweeps (${pairs.join(", ")}), across every scenario.`
+    : `${meta.label}, comparing each machine's two most recent sweeps.`;
+
+  if (!all.length) {
+    host.appendChild(el("p", "empty", "Nothing to compare: no configuration ran in two consecutive sweeps of the same machine under this filter."));
+    return;
+  }
+
+  // Take turns between machines so the busiest machine cannot fill the table,
+  // and put real movement ahead of the many configurations that barely moved.
+  const shown = [];
+  const queues = machineOrder
+    .map(machine => all.filter(r => r.machine === machine).sort((a, b) => Math.abs(b.pct) - Math.abs(a.pct)))
+    .filter(q => q.length);
+  const realCount = all.filter(r => Math.abs(r.pct) >= REAL_CHANGE_PCT).length;
+  for (const onlyReal of [true, false]) {
+    let took = true;
+    while (took && shown.length < MOVERS_SHOWN) {
+      took = false;
+      for (const queue of queues) {
+        if (shown.length >= MOVERS_SHOWN) break;
+        const next = queue.findIndex(r => !shown.includes(r) && (!onlyReal || Math.abs(r.pct) >= REAL_CHANGE_PCT));
+        if (next >= 0) { shown.push(queue[next]); took = true; }
+      }
+    }
+  }
+
+  const table = el("table");
+  const thead = el("thead");
+  const headRow = el("tr");
+  for (const [label, cls] of [["Machine", ""], ["Scenario", ""], ["Configuration", ""],
+                              ["Previous", "num"], ["Latest", "num"], ["Change", "num"]]) {
+    headRow.appendChild(el("th", cls, label));
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = el("tbody");
+  for (const row of shown) {
+    const tr = el("tr");
+    const machineCell = el("td");
+    machineCell.appendChild(keySwatch(row.machine.color));
+    machineCell.appendChild(document.createTextNode(" " + row.machine.name));
+    tr.appendChild(machineCell);
+    tr.appendChild(el("td", null, row.run.scenario));
+    tr.appendChild(el("td", null, configLabel(row.run)));
+    tr.appendChild(el("td", "num", fmt(row.previous)));
+    tr.appendChild(el("td", "num", fmt(row.latest)));
+    const cls = changeClass(row.pct);
+    const change = el("td", "num");
+    change.appendChild(el("span", `cell-delta ${cls}`,
+      `${CHANGE_GLYPH[cls]} ${signedPercent(row.pct)} ${CHANGE_WORD[cls]}`));
+    tr.appendChild(change);
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  host.appendChild(table);
+
+  if (all.length > shown.length) {
+    host.appendChild(el("p", "note",
+      `Showing ${shown.length} of ${all.length} shared configurations, taking turns between machines; ` +
+      `${realCount} moved by ${REAL_CHANGE_PCT}% or more. The rest are in the sweep explorer.`));
+  }
+}
+
+// =========================================================================
+// Table view (the twin of the trend chart)
+// =========================================================================
+
+function renderTrendTable() {
+  const host = document.getElementById("trend-table");
+  host.replaceChildren();
+  const meta = metricMeta(state.metric);
+
+  if (!trendRows.length) {
+    host.appendChild(el("p", "empty", "Nothing plotted."));
+    return;
+  }
+
+  const rows = [];
+  for (const {machine, points} of trendRows) {
+    for (const p of points) rows.push({machine, p});
+  }
+  rows.sort((a, b) => a.p.sweep.dateObj - b.p.sweep.dateObj || a.machine.name.localeCompare(b.machine.name));
+
+  const table = el("table");
+  const thead = el("thead");
+  const headRow = el("tr");
+  for (const [label, cls] of [["Date", ""], ["Machine", ""], ["Commit", ""],
+                              [`${meta.label} (${meta.unit})`, "num"], ["Best configuration", ""], ["Runs", "num"]]) {
+    headRow.appendChild(el("th", cls, label));
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = el("tbody");
+  for (const {machine, p} of rows) {
+    const tr = el("tr");
+    tr.appendChild(el("td", null, fmtDay(p.sweep.day)));
+    const machineCell = el("td");
+    machineCell.appendChild(keySwatch(machine.color));
+    machineCell.appendChild(document.createTextNode(" " + machine.name));
+    tr.appendChild(machineCell);
+    tr.appendChild(el("td", null, p.sweep.commit));
+    tr.appendChild(el("td", "num", fmt(p.value)));
+    tr.appendChild(el("td", null, configLabel(p.run)));
+    tr.appendChild(el("td", "num", String(p.count)));
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  host.appendChild(el("p", "card-sub", `${state.scenario}, ${state.codec} codec, ${state.backend} backend, ${state.sink} sink.`));
+  host.appendChild(table);
+}
+
+// =========================================================================
+// Page
+// =========================================================================
+
+function renderLede() {
+  const days = sweeps.map(s => s.day).filter(Boolean).sort();
+  const span = days.length ? `${days[0]} to ${days[days.length - 1]}` : "no dates";
+  document.getElementById("lede").textContent =
+    `${sweeps.length} sweeps · ${machineOrder.length} machines · ${span}`;
+
+  const versions = [...new Set(sweeps.map(s => s.migrated_from ?? s.version))].sort();
+  const notes = [
+    "Each plotted value is the best run of a sweep for the chosen scenario and configuration; the remaining dimensions (data type, chunk size, fill) are searched, not averaged.",
+    "Only passing runs count. A missing point means that sweep ran nothing matching the filter.",
+  ];
+  if (versions.length > 1) {
+    notes.push(`Sweeps here were written at result-schema versions ${versions.join(", ")}; a metric whose meaning changed between them is dropped from comparisons rather than converted.`);
+  }
+  document.getElementById("footnotes").textContent = notes.join(" ");
+}
+
+function renderMatchCount() {
+  let runs = 0, sweepsHit = 0;
+  for (const sweep of sweeps) {
+    let here = 0;
+    for (const run of sweep.runs) {
+      if (run.status === "pass" && matchesConfig(run) && metricValue(run, state.metric) != null) here++;
+    }
+    runs += here;
+    if (here) sweepsHit++;
+  }
+  document.getElementById("match-count").textContent =
+    `${runs} passing runs in ${sweepsHit} of ${sweeps.length} sweeps match`;
+}
+
+function render() {
+  renderMatchCount();
+  renderTiles();
+  renderTrend();
+  renderMatrix();
+  renderMovers();
+  renderTrendTable();
+}
+
+pickDefaults();
+syncControls();
+renderLede();
+render();
+
+let resizeTimer = null;
+addEventListener("resize", () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => { renderTrend(); }, 120);
+});
+</script>
+</body>
+</html>

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -5,15 +5,18 @@
 # ]
 # ///
 """
-Generate a self-contained HTML+D3 report from benchmark sweep results.
+Generate the benchmark site from sweep result files.
+
+Two pages, both self-contained (data embedded at generation time):
+    index.html    every sweep at once — per-machine trend, latest standings, movers
+    explore.html  one sweep at a time, down to per-stage timing
 
 Usage:
-    uv run scripts/sweep/report.py results.json -o build/html/report.html
-    uv run scripts/sweep/report.py bench/results/*.json
-    uv run scripts/sweep/report.py --results-dir bench/results/
+    uv run scripts/sweep/report.py --results-dir bench/results/ -o _site
+    uv run scripts/sweep/report.py bench/results/*.json -o _site
+    uv run scripts/sweep/report.py --results-dir bench/results/ -o _site/index.html
 
-Note: The report embeds JSON data at generation time. Re-run this script
-after modifying results files to see updated data.
+Re-run after changing any results file; nothing is read at page load.
 """
 
 from __future__ import annotations
@@ -26,13 +29,17 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from models import migrate_results, validate_results
+from summary import build_summary, machine_identity
 
-TEMPLATE_PATH = Path(__file__).parent / "template.html"
+TEMPLATE_DIR = Path(__file__).parent
+EXPLORER_TEMPLATE = TEMPLATE_DIR / "template.html"
+OVERVIEW_TEMPLATE = TEMPLATE_DIR / "overview.html"
+PLACEHOLDER = "__DATA_PLACEHOLDER__"
 
 
-def load_files(paths: list[Path], *, warn: bool = True) -> list[dict]:
-    """Load result files, returning a list of {label, machine, runs} dicts."""
-    files = []
+def load_files(paths: list[Path], *, warn: bool = True) -> list[tuple[Path, dict]]:
+    """Read, migrate, and validate result files, skipping ones that will not parse."""
+    loaded: list[tuple[Path, dict]] = []
     for p in paths:
         with open(p) as f:
             try:
@@ -51,28 +58,44 @@ def load_files(paths: list[Path], *, warn: bool = True) -> list[dict]:
                     loc = " -> ".join(str(x) for x in err["loc"])
                     print(f"Warning: {p.name}: {loc}: {err['msg']}", file=sys.stderr)
 
+        loaded.append((p, data))
+    return loaded
+
+
+def explorer_payload(loaded: list[tuple[Path, dict]]) -> dict:
+    """What the one-sweep-at-a-time page needs: full runs, including stages."""
+    files = []
+    for path, data in loaded:
         machine = data.get("machine", {})
-        hostname = machine.get("hostname", "")
-        commit = machine.get("commit", "unknown")
-        date = machine.get("date", "")[:10]
-        parts = [x for x in [hostname, commit, date] if x]
-        label = " ".join(parts) if parts else "unknown"
+        name, commit = machine_identity(path, machine)
+        day = str(machine.get("date", ""))[:10]
+        label = " ".join(x for x in [name, commit, day] if x) or "unknown"
         files.append({
             "label": label,
-            "filename": p.name,
+            "filename": path.name,
             "machine": machine,
             "runs": data.get("runs", []),
         })
-    return files
+    return {"version": 2, "files": files}
+
+
+def write_page(template: Path, payload: dict, output: Path) -> None:
+    text = template.read_text()
+    if PLACEHOLDER not in text:
+        raise SystemExit(f"{template.name} has no {PLACEHOLDER} to fill")
+    embedded = json.dumps(payload, separators=(",", ":")).replace("</", "<\\/")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text.replace(PLACEHOLDER, embedded))
+    print(f"Wrote {output} ({output.stat().st_size / 1024:.0f} KiB)", file=sys.stderr)
 
 
 def main():
-    ap = argparse.ArgumentParser(description="Generate HTML report from sweep results")
+    ap = argparse.ArgumentParser(description="Generate the benchmark site from sweep results")
     ap.add_argument("input", type=Path, nargs="*", help="Result JSON file(s) from sweep.py")
     ap.add_argument("--results-dir", type=Path, default=None,
                     help="Directory to glob for *.json result files")
-    ap.add_argument("-o", "--output", type=Path, default=Path("build/html/report.html"),
-                    help="Output HTML path")
+    ap.add_argument("-o", "--output", type=Path, default=Path("build/html"),
+                    help="Output directory (a path ending in .html names the overview page)")
     args = ap.parse_args()
 
     paths: list[Path] = list(args.input or [])
@@ -81,20 +104,19 @@ def main():
     if not paths:
         ap.error("No input files. Provide paths or use --results-dir.")
 
-    files = load_files(paths)
-    total_runs = sum(len(f["runs"]) for f in files)
-    print(f"Loaded {len(files)} file(s), {total_runs} runs", file=sys.stderr)
+    loaded = load_files(paths)
+    if not loaded:
+        raise SystemExit("No readable result files.")
+    total_runs = sum(len(data.get("runs", [])) for _, data in loaded)
+    print(f"Loaded {len(loaded)} file(s), {total_runs} runs", file=sys.stderr)
 
-    data = {"version": 2, "files": files}
+    if args.output.suffix == ".html":
+        out_dir, overview_name = args.output.parent, args.output.name
+    else:
+        out_dir, overview_name = args.output, "index.html"
 
-    template = TEMPLATE_PATH.read_text()
-    json_str = json.dumps(data).replace("</", "<\\/")
-    html = template.replace("__DATA_PLACEHOLDER__", json_str)
-
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(html)
-    print(f"Wrote {args.output} ({args.output.stat().st_size / 1024:.0f} KiB)",
-          file=sys.stderr)
+    write_page(OVERVIEW_TEMPLATE, build_summary(loaded), out_dir / overview_name)
+    write_page(EXPLORER_TEMPLATE, explorer_payload(loaded), out_dir / "explore.html")
 
 
 if __name__ == "__main__":

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from models import migrate_results, validate_results
-from summary import build_summary, machine_identity
+from summary import build_summary, find_registry, load_registry, machine_identity
 
 TEMPLATE_DIR = Path(__file__).parent
 EXPLORER_TEMPLATE = TEMPLATE_DIR / "template.html"
@@ -96,6 +96,8 @@ def main():
                     help="Directory to glob for *.json result files")
     ap.add_argument("-o", "--output", type=Path, default=Path("build/html"),
                     help="Output directory (a path ending in .html names the overview page)")
+    ap.add_argument("--machines", type=Path, default=None,
+                    help="Machine registry TOML (default: machines.toml beside the results)")
     args = ap.parse_args()
 
     paths: list[Path] = list(args.input or [])
@@ -110,12 +112,21 @@ def main():
     total_runs = sum(len(data.get("runs", [])) for _, data in loaded)
     print(f"Loaded {len(loaded)} file(s), {total_runs} runs", file=sys.stderr)
 
+    registry_path = args.machines or find_registry(args.results_dir, paths)
+    if args.machines and not args.machines.is_file():
+        raise SystemExit(f"No machine registry at {args.machines}")
+    registry = load_registry(registry_path)
+    if registry_path:
+        print(f"Machine registry: {registry_path} ({len(registry)} machines)", file=sys.stderr)
+    else:
+        print("No machine registry found; each sweep name is its own machine", file=sys.stderr)
+
     if args.output.suffix == ".html":
         out_dir, overview_name = args.output.parent, args.output.name
     else:
         out_dir, overview_name = args.output, "index.html"
 
-    write_page(OVERVIEW_TEMPLATE, build_summary(loaded), out_dir / overview_name)
+    write_page(OVERVIEW_TEMPLATE, build_summary(loaded, registry), out_dir / overview_name)
     write_page(EXPLORER_TEMPLATE, explorer_payload(loaded), out_dir / "explore.html")
 
 

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -112,9 +112,9 @@ def main():
     total_runs = sum(len(data.get("runs", [])) for _, data in loaded)
     print(f"Loaded {len(loaded)} file(s), {total_runs} runs", file=sys.stderr)
 
-    registry_path = args.machines or find_registry(args.results_dir, paths)
     if args.machines and not args.machines.is_file():
         raise SystemExit(f"No machine registry at {args.machines}")
+    registry_path = args.machines or find_registry(args.results_dir, paths)
     registry = load_registry(registry_path)
     if registry_path:
         print(f"Machine registry: {registry_path} ({len(registry)} machines)", file=sys.stderr)

--- a/scripts/sweep/summary.py
+++ b/scripts/sweep/summary.py
@@ -7,7 +7,10 @@ and drops the per-stage detail, which only the explorer page uses.
 
 from __future__ import annotations
 
+import fnmatch
 import re
+import sys
+import tomllib
 from pathlib import Path
 
 from models import retired_metrics
@@ -42,12 +45,84 @@ def parse_filename(path: Path) -> tuple[str | None, str | None, str | None]:
 
 
 def machine_identity(path: Path, machine: dict) -> tuple[str, str]:
-    """Machine name shown everywhere, and the commit the sweep ran at."""
+    """What this one sweep calls itself, and the commit it ran at.
+
+    The file name wins: renaming a results file is how a sweep gets reassigned
+    after the fact. `machine.name` is what sweep.py --machine recorded, and the
+    hostname is the last resort.
+    """
     name, commit, _ = parse_filename(path)
     return (
-        name or machine.get("hostname") or path.stem,
+        name or machine.get("name") or machine.get("hostname") or path.stem,
         commit or machine.get("commit") or "unknown",
     )
+
+
+# ---------------------------------------------------------------------------
+# Machine registry — which sweep names are the same machine
+# ---------------------------------------------------------------------------
+
+REGISTRY_NAME = "machines.toml"
+_REGISTRY_KEYS = {"name", "description", "names", "hosts", "specs"}
+
+
+def find_registry(results_dir: Path | None, inputs: list[Path]) -> Path | None:
+    """Look for machines.toml beside the results, then one level up."""
+    base = results_dir or (inputs[0].parent if inputs else None)
+    if base is None:
+        return None
+    for candidate in (base / REGISTRY_NAME, base.parent / REGISTRY_NAME):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def load_registry(path: Path | None) -> list[dict]:
+    """Read the registry, refusing anything malformed rather than guessing."""
+    if path is None:
+        return []
+    with open(path, "rb") as f:
+        try:
+            data = tomllib.load(f)
+        except tomllib.TOMLDecodeError as e:
+            raise SystemExit(f"{path}: {e}")
+
+    entries = data.get("machine", [])
+    if not isinstance(entries, list):
+        raise SystemExit(f"{path}: expected a list of [[machine]] entries")
+
+    registry: list[dict] = []
+    seen: set[str] = set()
+    for position, entry in enumerate(entries, start=1):
+        name = entry.get("name")
+        if not name:
+            raise SystemExit(f"{path}: machine #{position} has no name")
+        if name in seen:
+            raise SystemExit(f"{path}: two machines are named {name}")
+        seen.add(name)
+        unknown = sorted(set(entry) - _REGISTRY_KEYS)
+        if unknown:
+            print(f"Warning: {path}: {name}: ignoring unknown key(s) {', '.join(unknown)}",
+                  file=sys.stderr)
+        registry.append({
+            "name": name,
+            "description": str(entry.get("description", "")),
+            "specs": {str(k): str(v) for k, v in (entry.get("specs") or {}).items()},
+            "names": [str(x) for x in entry.get("names", [])],
+            "hosts": [str(x) for x in entry.get("hosts", [])],
+        })
+    return registry
+
+
+def match_registry(registry: list[dict], name: str, host: str) -> dict | None:
+    for entry in registry:
+        for pattern in entry["names"]:
+            if fnmatch.fnmatch(name.lower(), pattern.lower()):
+                return entry
+        for pattern in entry["hosts"]:
+            if host and fnmatch.fnmatch(host.lower(), pattern.lower()):
+                return entry
+    return None
 
 
 def sweep_day(machine: dict, path: Path) -> str:
@@ -83,12 +158,18 @@ def status_counts(runs: list[dict]) -> dict[str, int]:
     return counts
 
 
-def summarize_sweep(path: Path, data: dict) -> dict:
+def summarize_sweep(path: Path, data: dict, registry: list[dict]) -> dict:
     machine = data.get("machine", {})
-    name, commit = machine_identity(path, machine)
+    member, commit = machine_identity(path, machine)
+    host = machine.get("hostname", "")
+    entry = match_registry(registry, member, host)
     runs = data.get("runs", [])
     return {
-        "machine": name,
+        "machine": entry["name"] if entry else member,
+        "member": member,
+        "description": entry["description"] if entry else "",
+        "specs": entry["specs"] if entry else {},
+        "registered": entry is not None,
         "commit": commit,
         "host": machine.get("hostname", ""),
         "gpu": machine.get("gpu", ""),
@@ -103,26 +184,31 @@ def summarize_sweep(path: Path, data: dict) -> dict:
     }
 
 
-def build_summary(files: list[tuple[Path, dict]]) -> dict:
+def build_summary(files: list[tuple[Path, dict]], registry: list[dict] | None = None) -> dict:
     """Every sweep, ordered oldest first so the overview can read it as history."""
-    sweeps = [summarize_sweep(path, data) for path, data in files]
+    sweeps = [summarize_sweep(path, data, registry or []) for path, data in files]
     sweeps.sort(key=lambda s: (s["day"], s["date"], s["machine"]))
 
     machines: dict[str, dict] = {}
     for sweep in sweeps:
         entry = machines.setdefault(sweep["machine"], {
             "name": sweep["machine"],
-            "gpu": sweep["gpu"],
+            "description": sweep["description"],
+            "specs": sweep["specs"],
+            "registered": sweep["registered"],
+            "gpus": [],
             "hosts": [],
+            "members": [],
             "sweeps": 0,
             "first_day": sweep["day"],
             "last_day": sweep["day"],
         })
         entry["sweeps"] += 1
         entry["last_day"] = sweep["day"]
-        entry["gpu"] = entry["gpu"] or sweep["gpu"]
-        if sweep["host"] and sweep["host"] not in entry["hosts"]:
-            entry["hosts"].append(sweep["host"])
+        for key, value in (("gpus", sweep["gpu"]), ("hosts", sweep["host"]),
+                           ("members", sweep["member"])):
+            if value and value not in entry[key]:
+                entry[key].append(value)
 
     return {
         "version": 1,

--- a/scripts/sweep/summary.py
+++ b/scripts/sweep/summary.py
@@ -1,0 +1,131 @@
+"""Condense sweep result files into the payload the overview page draws.
+
+One results file is one sweep: one machine, one commit. The overview needs every
+sweep at once, so it gets a trimmed copy of each run (config plus a few numbers)
+and drops the per-stage detail, which only the explorer page uses.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from models import retired_metrics
+
+# <machine>-<commit>-<yyyymmdd>.json, the name sweep.py writes. The machine part
+# is the name a person chose, so it survives a cluster handing out a new hostname
+# for every allocation.
+FILENAME_RE = re.compile(r"^(?P<machine>.+)-(?P<commit>[0-9a-f]{7,40})-(?P<date>\d{8})$")
+
+CONFIG_KEYS = (
+    "scenario", "codec", "fill", "backend", "dtype",
+    "chunk_bytes", "chunk_bytes_label", "sink", "status",
+)
+
+RUN_METRICS = (
+    "throughput_in_gibs", "throughput_out_gibs", "compression_fold",
+    "input_gib", "compressed_gib", "elapsed_s", "wall_s", "init_s",
+)
+
+STALL_METRICS = (
+    "max_append_ms", "peak_pending_mib", "backpressure_ms",
+    "flush_stall_ms", "io_fence_ms",
+)
+
+
+def parse_filename(path: Path) -> tuple[str | None, str | None, str | None]:
+    m = FILENAME_RE.match(path.stem)
+    if not m:
+        return None, None, None
+    date = m["date"]
+    return m["machine"], m["commit"], f"{date[:4]}-{date[4:6]}-{date[6:]}"
+
+
+def machine_identity(path: Path, machine: dict) -> tuple[str, str]:
+    """Machine name shown everywhere, and the commit the sweep ran at."""
+    name, commit, _ = parse_filename(path)
+    return (
+        name or machine.get("hostname") or path.stem,
+        commit or machine.get("commit") or "unknown",
+    )
+
+
+def sweep_day(machine: dict, path: Path) -> str:
+    date = str(machine.get("date", ""))[:10]
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", date):
+        return date
+    return parse_filename(path)[2] or ""
+
+
+def trim_run(run: dict) -> dict:
+    out = {"id": run.get("id", "")}
+    for key in CONFIG_KEYS:
+        if key in run:
+            out[key] = run[key]
+    for key in RUN_METRICS:
+        value = run.get(key)
+        if isinstance(value, (int, float)):
+            out[key] = value
+    stalls = run.get("stalls")
+    if isinstance(stalls, dict):
+        kept = {k: stalls[k] for k in STALL_METRICS
+                if isinstance(stalls.get(k), (int, float))}
+        if kept:
+            out["stalls"] = kept
+    return out
+
+
+def status_counts(runs: list[dict]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for run in runs:
+        status = run.get("status", "unknown")
+        counts[status] = counts.get(status, 0) + 1
+    return counts
+
+
+def summarize_sweep(path: Path, data: dict) -> dict:
+    machine = data.get("machine", {})
+    name, commit = machine_identity(path, machine)
+    runs = data.get("runs", [])
+    return {
+        "machine": name,
+        "commit": commit,
+        "host": machine.get("hostname", ""),
+        "gpu": machine.get("gpu", ""),
+        "date": machine.get("date", ""),
+        "day": sweep_day(machine, path),
+        "filename": path.name,
+        "version": data.get("version"),
+        "migrated_from": data.get("migrated_from"),
+        "retired": list(retired_metrics(data)),
+        "counts": status_counts(runs),
+        "runs": [trim_run(r) for r in runs],
+    }
+
+
+def build_summary(files: list[tuple[Path, dict]]) -> dict:
+    """Every sweep, ordered oldest first so the overview can read it as history."""
+    sweeps = [summarize_sweep(path, data) for path, data in files]
+    sweeps.sort(key=lambda s: (s["day"], s["date"], s["machine"]))
+
+    machines: dict[str, dict] = {}
+    for sweep in sweeps:
+        entry = machines.setdefault(sweep["machine"], {
+            "name": sweep["machine"],
+            "gpu": sweep["gpu"],
+            "hosts": [],
+            "sweeps": 0,
+            "first_day": sweep["day"],
+            "last_day": sweep["day"],
+        })
+        entry["sweeps"] += 1
+        entry["last_day"] = sweep["day"]
+        entry["gpu"] = entry["gpu"] or sweep["gpu"]
+        if sweep["host"] and sweep["host"] not in entry["hosts"]:
+            entry["hosts"].append(sweep["host"])
+
+    return {
+        "version": 1,
+        "machines": sorted(machines.values(), key=lambda m: m["name"].lower()),
+        "sweeps": sweeps,
+    }

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -411,20 +411,25 @@ def status_style(status: str) -> str:
               help="S3 endpoint URL.")
 @click.option("--tmpdir", "tmpdir_root", type=click.Path(path_type=Path), default=None,
               help="Parent directory for fs-sink scratch dirs (default: system temp).")
+@click.option("--machine", "machine_name", default=None, envvar="CHUCKY_MACHINE",
+              help="Name this machine goes by in the report (default: hostname). "
+                   "Give a stable name where the hostname changes between runs, as "
+                   "it does on a cluster; group names live in bench/machines.toml.")
 def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
-         s3_bucket, s3_region, s3_endpoint, tmpdir_root):
+         s3_bucket, s3_region, s3_endpoint, tmpdir_root, machine_name):
     """Benchmark sweep runner for chucky."""
     commit = git_commit()
     hostname = platform.node()
+    machine_name = machine_name or hostname
 
     if output is None:
         results_dir = Path("bench/results")
-        existing_files = sorted(results_dir.glob(f"{hostname}-{commit}-*.json"))
+        existing_files = sorted(results_dir.glob(f"{machine_name}-{commit}-*.json"))
         if existing_files:
             output = existing_files[-1]
         else:
             date_str = time.strftime("%Y%m%d")
-            output = results_dir / f"{hostname}-{commit}-{date_str}.json"
+            output = results_dir / f"{machine_name}-{commit}-{date_str}.json"
 
     # Resolve tiers
     if run_all:
@@ -494,6 +499,7 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
         data = {
             "version": CURRENT_VERSION,
             "machine": {
+                "name": machine_name,
                 "hostname": platform.node(),
                 "gpu": gpu_name(),
                 "commit": commit,

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -38,7 +38,6 @@ from models import (
     VALID_DTYPES,
     VALID_FILLS,
     VALID_SINKS,
-    VALID_STATUSES,
     validate_results,
 )
 from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn, TimeElapsedColumn
@@ -491,9 +490,8 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
     if output.exists():
         with open(output) as f:
             raw_data = json.load(f)
-        # Validate loaded results
         try:
-            validated = validate_results(raw_data)
+            validate_results(raw_data)
         except Exception as e:
             console.print(f"[yellow]Warning: results file validation failed: {e}[/yellow]")
             console.print("[yellow]Continuing with raw data.[/yellow]")

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import platform
+import re
 import subprocess
 import sys
 import tempfile
@@ -421,6 +422,15 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
     commit = git_commit()
     hostname = platform.node()
     machine_name = machine_name or hostname
+
+    # The name becomes a file name and a glob pattern, so keep it to characters
+    # that mean the same thing in both.
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", machine_name):
+        raise click.BadParameter(
+            f"machine name {machine_name!r} may only contain letters, digits, dot, "
+            "underscore, and dash",
+            param_hint="--machine",
+        )
 
     if output is None:
         results_dir = Path("bench/results")

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -1,26 +1,59 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Benchmark Sweep Report</title>
+<title>Sweep explorer</title>
+<script>
+document.documentElement.setAttribute("data-theme", (() => {
+  const stored = localStorage.getItem("bench-theme");
+  if (stored === "light" || stored === "dark") return stored;
+  return matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+})());
+</script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <style>
 :root {
   --pico-font-family: "Inter", "Segoe UI", system-ui, sans-serif;
-  --color-primary: #6366f1;
+  --color-primary: #2a78d6;
   --color-primary-bg: #e0e7ff;
-  --color-text: #1a1a2e;
-  --color-muted: #666;
-  --color-border: #ccc;
-  --color-error: #b91c1c;
+  --color-primary-text: #1c5cab;
+  --color-text: #0b0b0b;
+  --color-muted: #52514e;
+  --color-border: #c3c2b7;
+  --color-error: #d03b3b;
+  --color-surface: #fcfcfb;
+  --color-plane: #f9f9f7;
+  --color-grid: #e1e0d9;
+  --color-axis: #c3c2b7;
+  --color-axis-text: #52514e;
+  --color-cell-empty: #ededea;
+  --color-ring: #fcfcfb;
+  --color-error-bg: #fef2f2;
   --gap-sm: 4px;
   --gap-md: 12px;
   --gap-lg: 24px;
   --radius: 6px;
 }
-body { background: #f8f9fa; color: var(--color-text); }
+:root[data-theme="dark"] {
+  --color-primary: #3987e5;
+  --color-primary-bg: #24304a;
+  --color-primary-text: #b7d3f6;
+  --color-text: #ffffff;
+  --color-muted: #c3c2b7;
+  --color-border: #383835;
+  --color-error: #e66767;
+  --color-surface: #1a1a19;
+  --color-plane: #0d0d0d;
+  --color-grid: #2c2c2a;
+  --color-axis: #383835;
+  --color-axis-text: #c3c2b7;
+  --color-cell-empty: #262624;
+  --color-ring: #1a1a19;
+  --color-error-bg: #2a1a1a;
+}
+html, body { background: var(--color-plane); color: var(--color-text); }
 h1 { font-size: 1.4em; margin-bottom: var(--gap-sm); --pico-typography-spacing-vertical: 0; color: var(--color-text); }
 .subtitle { color: var(--color-muted); font-size: 0.85em; margin-bottom: 2px; }
 
@@ -29,7 +62,7 @@ h1 { font-size: 1.4em; margin-bottom: var(--gap-sm); --pico-typography-spacing-v
   display: flex; flex-wrap: wrap; gap: var(--gap-md);
   margin-bottom: var(--gap-md); align-items: flex-start;
 }
-.controls label { font-size: 0.8em; font-weight: 600; color: #444; display: block; margin-bottom: 2px; }
+.controls label { font-size: 0.8em; font-weight: 600; color: var(--color-muted); display: block; margin-bottom: 2px; }
 .controls select {
   font-size: 0.8em; padding: 4px 24px 4px 8px; margin-bottom: 0; width: auto;
   --pico-form-element-spacing-vertical: 0.1rem;
@@ -48,7 +81,7 @@ h1 { font-size: 1.4em; margin-bottom: var(--gap-sm); --pico-typography-spacing-v
 .radio-group { display: flex; gap: 2px; }
 .radio-group label {
   font-weight: 400; padding: 3px 8px; border: 1px solid var(--color-border);
-  cursor: pointer; font-size: 0.78em; background: #fff; margin-bottom: 0;
+  cursor: pointer; font-size: 0.78em; background: var(--color-surface); margin-bottom: 0;
 }
 .radio-group label:first-child { border-radius: var(--radius) 0 0 var(--radius); }
 .radio-group label:last-child { border-radius: 0 var(--radius) var(--radius) 0; }
@@ -63,16 +96,17 @@ h1 { font-size: 1.4em; margin-bottom: var(--gap-sm); --pico-typography-spacing-v
 /* Charts */
 main.container { overflow: visible; }
 #chart, #stage-chart {
-  background: #fff; border-radius: var(--radius); padding: var(--gap-md);
+  background: var(--color-surface); border-radius: var(--radius); padding: var(--gap-md);
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
   width: fit-content; min-width: 100%;
 }
 #stage-chart { margin-top: var(--gap-md); }
+#chart:empty, #stage-chart:empty { display: none; }
 
 /* SVG axes */
-.axis text { font-size: 12px; fill: #333; }
-.axis path, .axis line { stroke: #888; stroke-width: 2; }
-.grid line { stroke: #ddd; }
+.axis text { font-size: 12px; fill: var(--color-axis-text); }
+.axis path, .axis line { stroke: var(--color-axis); stroke-width: 2; }
+.grid line { stroke: var(--color-grid); }
 
 /* Tooltip */
 .tooltip {
@@ -86,15 +120,15 @@ main.container { overflow: visible; }
 .btn-toggle {
   cursor: pointer; font-size: 0.8em; padding: 4px 10px;
   border: 1px solid var(--color-primary); background: var(--color-primary-bg);
-  border-radius: var(--radius); color: #3730a3;
+  border-radius: var(--radius); color: var(--color-primary-text);
 }
-.btn-toggle.active { background: var(--color-primary); color: #fff; }
+.btn-toggle.active { background: var(--color-primary); color: var(--color-surface); }
 
 /* Scenarios */
 .scenario-groups { display: flex; flex-wrap: wrap; gap: 6px 20px; }
 .scenario-group-box { font-size: 0.78em; }
 .scenario-group-box .group-header {
-  font-weight: 600; color: #555; font-size: 0.9em; margin-bottom: 2px;
+  font-weight: 600; color: var(--color-muted); font-size: 0.9em; margin-bottom: 2px;
   display: flex; align-items: center; gap: 6px;
 }
 .scenario-group-box .group-header button {
@@ -107,7 +141,7 @@ main.container { overflow: visible; }
 /* Failure badge */
 .fail-badge {
   font-size: 0.5em; font-weight: 600; color: var(--color-error);
-  background: #fef2f2; border: 1px solid #fecaca;
+  background: var(--color-error-bg); border: 1px solid var(--color-error);
   border-radius: var(--radius); padding: 2px 8px;
   vertical-align: middle; white-space: nowrap;
 }
@@ -116,11 +150,30 @@ main.container { overflow: visible; }
 #failures { margin-top: var(--gap-md); }
 #failures summary { font-size: 0.85em; font-weight: 600; cursor: pointer; color: var(--color-error); }
 #failures table { border-collapse: collapse; font-size: 0.75em; margin-top: 6px; width: 100%; }
-#failures th, #failures td { text-align: left; padding: 3px 10px; border-bottom: 1px solid #eee; }
+#failures th, #failures td { text-align: left; padding: 3px 10px; border-bottom: 1px solid var(--color-grid); }
 #failures th { color: var(--color-muted); font-weight: 600; }
 #failures .status-error { color: var(--color-error); font-weight: 600; }
 #failures .status-timeout { color: #c2410c; font-weight: 600; }
 #failures .status-missing { color: #6b7280; font-weight: 600; }
+
+/* Site navigation — shared with the overview page */
+.site-head {
+  display: flex; align-items: center; gap: var(--gap-lg); flex-wrap: wrap;
+  padding: 12px 24px; margin-bottom: var(--gap-md);
+  background: var(--color-surface); border-bottom: 1px solid var(--color-border);
+}
+.site-head .brand { font-weight: 650; }
+.site-head nav { display: flex; gap: 4px; margin-right: auto; }
+.site-head nav a {
+  padding: 4px 10px; border-radius: var(--radius); text-decoration: none;
+  color: var(--color-muted); font-size: 0.9em;
+}
+.site-head nav a[aria-current="page"] { background: var(--color-plane); color: var(--color-text); font-weight: 600; }
+.theme-toggle {
+  font: inherit; font-size: 0.85em; padding: 4px 10px; cursor: pointer; width: auto;
+  background: var(--color-surface); color: var(--color-muted);
+  border: 1px solid var(--color-border); border-radius: var(--radius);
+}
 
 /* Mobile */
 @media (max-width: 640px) {
@@ -137,9 +190,17 @@ main.container { overflow: visible; }
 </style>
 </head>
 <body>
+<header class="site-head">
+  <span class="brand">chucky benchmarks</span>
+  <nav>
+    <a href="index.html">Over time</a>
+    <a href="explore.html" aria-current="page">Sweep explorer</a>
+  </nav>
+  <button class="theme-toggle" id="theme-toggle" type="button">Dark</button>
+</header>
 <main class="container">
 
-<h1>Benchmark Sweep Report <span class="fail-badge" id="fail-badge" style="display:none"></span></h1>
+<h1>One sweep at a time <span class="fail-badge" id="fail-badge" style="display:none"></span></h1>
 <div class="subtitle" id="machine-info"></div>
 <div class="subtitle" id="s3-info" style="display:none"></div>
 
@@ -220,7 +281,7 @@ const DATA = __DATA_PLACEHOLDER__;
 // =========================================================================
 
 const LAYOUT = {
-  margin:    {top: 40, right: 200, bottom: 60, left: 160},
+  margin:    {top: 40, right: 200, bottom: 60, left: 195},
   heatmap:   {cellW: 70, cellH: 50},
   lines:     {W: 800, H: 400},
   subChart:  {W: 700, H: 200, margin: {top: 30, right: 180, bottom: 40, left: 80}},
@@ -753,8 +814,8 @@ function renderHeatmap(filtered, presentChunks, presentScenarios, metricKey) {
         .attr("x", x(cl)).attr("y", y(sc))
         .attr("width", x.bandwidth()).attr("height", y.bandwidth())
         .attr("rx", 3)
-        .attr("fill", val != null ? color(val) : "#eee")
-        .attr("stroke", "#fff").attr("stroke-width", 1)
+        .attr("fill", val != null ? color(val) : "var(--color-cell-empty)")
+        .attr("stroke", "var(--color-ring)").attr("stroke-width", 1)
         .style("cursor", r ? "pointer" : "default");
 
       if (val != null) {
@@ -781,7 +842,7 @@ function renderHeatmap(filtered, presentChunks, presentScenarios, metricKey) {
   g.append("g").attr("class","axis").attr("transform",`translate(0,${innerH})`)
     .call(d3.axisBottom(x)).selectAll("text").attr("font-size","12px");
   g.append("text").attr("x", innerW/2).attr("y", innerH + margin.bottom - 10)
-    .attr("text-anchor","middle").attr("font-size","12px").attr("fill","#666").text("Chunk Size");
+    .attr("text-anchor","middle").attr("font-size","12px").attr("fill","var(--color-muted)").text("Chunk Size");
   g.append("g").attr("class","axis").call(d3.axisLeft(y))
     .selectAll("text").attr("font-size","12px");
 
@@ -821,7 +882,7 @@ function renderLines(filtered, presentChunks, presentScenarios, metricKey, useOv
 
   const colors = d3.scaleOrdinal(d3.schemeTableau10).domain(allScenarios);
 
-  g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","#eee");
+  g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","var(--color-grid)");
 
   const lineLookup = new Map();
   filtered.forEach(r => lineLookup.set(`${r.scenario}__${r.chunk_bytes_label}__${r.backend}`, r));
@@ -856,7 +917,7 @@ function renderLines(filtered, presentChunks, presentScenarios, metricKey, useOv
     pts.forEach(p => {
       const circle = g.append("circle").attr("cx", x(p.x)).attr("cy", y(p.y)).attr("r", 4)
         .attr("fill", colors(s.scenario)).style("cursor","pointer");
-      if (s.dashed) circle.attr("stroke", "#fff").attr("stroke-width", 1);
+      if (s.dashed) circle.attr("stroke", "var(--color-ring)").attr("stroke-width", 1);
       circle
         .on("mousemove", (ev) => {
           tooltip.style("display","block")
@@ -924,11 +985,11 @@ function renderStageLines(filtered, presentChunks, presentScenarios, stageMetric
     if (useOverlay) {
       const oy = stageNames.length * 15 + 6;
       lg.append("line").attr("x1", 0).attr("y1", oy + 4).attr("x2", 14).attr("y2", oy + 4)
-        .attr("stroke", "#666").attr("stroke-width", 1.5);
-      lg.append("text").attr("x", 18).attr("y", oy + 8).attr("font-size", "9px").attr("fill", "#666").text("gpu");
+        .attr("stroke", "var(--color-muted)").attr("stroke-width", 1.5);
+      lg.append("text").attr("x", 18).attr("y", oy + 8).attr("font-size", "9px").attr("fill", "var(--color-muted)").text("gpu");
       lg.append("line").attr("x1", 0).attr("y1", oy + 18).attr("x2", 14).attr("y2", oy + 18)
-        .attr("stroke", "#666").attr("stroke-width", 1.5).attr("stroke-dasharray", "4,2");
-      lg.append("text").attr("x", 18).attr("y", oy + 22).attr("font-size", "9px").attr("fill", "#666").text("cpu");
+        .attr("stroke", "var(--color-muted)").attr("stroke-width", 1.5).attr("stroke-dasharray", "4,2");
+      lg.append("text").attr("x", 18).attr("y", oy + 22).attr("font-size", "9px").attr("fill", "var(--color-muted)").text("cpu");
     }
   }
 
@@ -958,7 +1019,7 @@ function renderStageLines(filtered, presentChunks, presentScenarios, stageMetric
     const x = d3.scaleLog().domain(xExtent).range([0, innerW]);
     const y = d3.scaleLinear().domain([0, globalYMax]).range([innerH, 0]);
 
-    g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","#eee");
+    g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","var(--color-grid)");
 
     const backends = useOverlay
       ? [...new Set(filtered.filter(r => r.scenario === sc).map(r => r.backend))].sort()
@@ -983,7 +1044,7 @@ function renderStageLines(filtered, presentChunks, presentScenarios, stageMetric
         pts.forEach(p => {
           const circle = g.append("circle").attr("cx", x(p.x)).attr("cy", y(p.y)).attr("r", 3)
             .attr("fill", stageColors(p.stage)).style("cursor","pointer");
-          if (dashed) circle.attr("stroke", "#fff").attr("stroke-width", 1);
+          if (dashed) circle.attr("stroke", "var(--color-ring)").attr("stroke-width", 1);
           circle
             .on("mousemove", (ev) => {
               tooltip.style("display","block")
@@ -1045,11 +1106,11 @@ function renderStagesTiming(run, stages) {
   stages.forEach(([name, s], i) => {
     const yy = i * (barH + gap);
     g.append("rect").attr("x",0).attr("y", yy).attr("width", x(s.avg_ms)).attr("height", barH)
-      .attr("fill", "#6366f1").attr("rx", 3);
+      .attr("fill", "var(--color-primary)").attr("rx", 3);
     g.append("text").attr("x", -6).attr("y", yy + barH/2).attr("text-anchor","end")
       .attr("dominant-baseline","central").attr("font-size","12px").text(name);
     g.append("text").attr("x", x(s.avg_ms) + 4).attr("y", yy + barH/2)
-      .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","#666")
+      .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--color-muted)")
       .text(`${s.avg_ms.toFixed(1)} ms`);
   });
 
@@ -1093,7 +1154,7 @@ function renderStagesThroughput(run, stages) {
     g.append("rect").attr("x",0).attr("y", yy + 4).attr("width", xMs(s.avg_ms)).attr("height", rowH - 8)
       .attr("fill", "#a5b4fc").attr("rx", 3);
     g.append("text").attr("x", xMs(s.avg_ms) + 3).attr("y", yy + rowH/2)
-      .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","#666")
+      .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--color-muted)")
       .text(`${s.avg_ms.toFixed(1)} ms`);
 
     const inVal = s.in_gibs || 0;
@@ -1103,22 +1164,22 @@ function renderStagesThroughput(run, stages) {
       g.append("rect").attr("x", thruX0).attr("y", yy).attr("width", xGibs(inVal)).attr("height", barH)
         .attr("fill", colorIn).attr("rx", 2);
       g.append("text").attr("x", thruX0 + xGibs(inVal) + 3).attr("y", yy + barH/2)
-        .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","#666")
+        .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--color-muted)")
         .text(`${inVal.toFixed(2)}`);
     }
     if (outVal > 0) {
       g.append("rect").attr("x", thruX0).attr("y", yy + barH + 2).attr("width", xGibs(outVal)).attr("height", barH)
         .attr("fill", colorOut).attr("rx", 2);
       g.append("text").attr("x", thruX0 + xGibs(outVal) + 3).attr("y", yy + barH + 2 + barH/2)
-        .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","#666")
+        .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--color-muted)")
         .text(`${outVal.toFixed(2)}`);
     }
   });
 
   g.append("text").attr("x", timingW/2).attr("y", -8).attr("text-anchor","middle")
-    .attr("font-size","12px").attr("fill","#888").text("avg ms");
+    .attr("font-size","12px").attr("fill","var(--color-muted)").text("avg ms");
   g.append("text").attr("x", thruX0 + thruW/2).attr("y", -8).attr("text-anchor","middle")
-    .attr("font-size","12px").attr("fill","#888").text("GiB/s");
+    .attr("font-size","12px").attr("fill","var(--color-muted)").text("GiB/s");
 
   g.append("g").attr("class","axis").attr("transform",`translate(0,${stages.length*(rowH+gap)})`)
     .call(d3.axisBottom(xMs).ticks(4).tickFormat(d => d + " ms"));
@@ -1140,15 +1201,29 @@ function renderStagesThroughput(run, stages) {
 // 5. INITIALIZATION
 // =========================================================================
 
-// Results file selector
+// Results file selector. ?file=<name> lets the overview page link to one sweep.
 files.forEach((f, i) => {
   const opt = document.createElement("option");
   opt.value = i;
   opt.textContent = f.label || f.filename;
   resultsSel.appendChild(opt);
 });
-resultsSel.value = files.length - 1;
+const requestedFile = new URLSearchParams(location.search).get("file");
+const requestedIndex = requestedFile ? files.findIndex(f => f.filename === requestedFile) : -1;
+resultsSel.value = requestedIndex >= 0 ? requestedIndex : files.length - 1;
 if (files.length <= 1) document.getElementById("results-wrap").style.display = "none";
+
+const themeToggle = document.getElementById("theme-toggle");
+function currentTheme() { return document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"; }
+function paintToggle() { themeToggle.textContent = currentTheme() === "dark" ? "Light" : "Dark"; }
+themeToggle.addEventListener("click", () => {
+  const next = currentTheme() === "dark" ? "light" : "dark";
+  localStorage.setItem("bench-theme", next);
+  document.documentElement.setAttribute("data-theme", next);
+  paintToggle();
+  render();
+});
+paintToggle();
 
 // Static radio setup
 makeRadio("view-group", ["heatmap", "lines", "stages"], "heatmap");

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -6,7 +6,12 @@
 <title>Sweep explorer</title>
 <script>
 document.documentElement.setAttribute("data-theme", (() => {
-  const stored = localStorage.getItem("bench-theme");
+  let stored = null;
+  try {
+    stored = localStorage.getItem("bench-theme");
+  } catch {
+    stored = null;
+  }
   if (stored === "light" || stored === "dark") return stored;
   return matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 })());
@@ -1218,7 +1223,11 @@ function currentTheme() { return document.documentElement.getAttribute("data-the
 function paintToggle() { themeToggle.textContent = currentTheme() === "dark" ? "Light" : "Dark"; }
 themeToggle.addEventListener("click", () => {
   const next = currentTheme() === "dark" ? "light" : "dark";
-  localStorage.setItem("bench-theme", next);
+  try {
+    localStorage.setItem("bench-theme", next);
+  } catch {
+    // Applies to this page; it just will not be remembered.
+  }
   document.documentElement.setAttribute("data-theme", next);
   paintToggle();
   render();


### PR DESCRIPTION
The report showed one sweep at a time behind nine filter rows, so it could
not say whether performance was moving, or which machine a number came
from. report.py now writes two pages instead of one.

index.html is the new landing page: a card per machine (current value,
change against that machine's previous sweep, sparkline, failed runs), a
trend chart with one line per machine over sweep dates, a
scenario-by-machine table of the latest standings, and a table of the
largest changes since each machine's previous sweep. One filter row scopes
all of it, a table view mirrors the chart, and points link through to the
sweep they came from.

explore.html is the existing dashboard, unchanged in behaviour, now
addressable per sweep with ?file=. Both pages share light and dark themes.

bench/machines.toml declares which sweeps are the same machine. Neither the
sweep name nor the GPU model can decide that on its own: one box boots two
systems, a cluster hands out a different node per allocation, and storage
and network matter as much as the card. Entries match the sweep name or the
hostname, both with wildcards, and carry a description plus free-form
specs. Grouping stays a view — the overview splits a machine back into its
members, and says so when a comparison crosses two of them.

sweep.py --machine, or CHUCKY_MACHINE, names the results file and records
machine.name, so cluster runs no longer need renaming by hand.

report.py -o now names an output directory; pages.yml passes _site.
