### PR TITLE
Fetch report data instead of embedding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: CI
 
+# A sweep result is data, not code: nothing it can change is what CI builds.
 on:
   push:
     branches: [main]
+    paths-ignore: ['bench/results/**']
   pull_request:
+    paths-ignore: ['bench/results/**']
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 vcpkg_installed/
 .pre-commit-config.yaml
 docker-compose.override.yml
+_site

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -14,10 +14,11 @@ sweep in `explore.html`.
 ## Generating the site
 
 ```sh
-uv run scripts/sweep/report.py --results-dir bench/results/ -o _site
-python3 -m http.server -d _site      # then open http://localhost:8000/
+uv run scripts/sweep/report.py --results-dir bench/results/ -o _site --serve
 ```
 
+That writes the site and serves it at http://127.0.0.1:8000/index.html. Pass a
+port to `--serve` to use another one, or drop the flag to only write the files.
 Run the command again after you add or change a results file.
 
 The pages are code only. Their data is written beside them and fetched at load:
@@ -31,10 +32,14 @@ The pages are code only. Their data is written beside them and fetched at load:
 So the explorer downloads one sweep instead of all of them, and adding a sweep
 leaves the other sweep files untouched for anything holding a cached copy. The
 cost is that the pages have to be served over http — opening `_site/index.html`
-from disk gets you an empty page, because the browser refuses the fetches.
+from disk gets you an empty page, because the browser refuses the fetches. That
+is what `--serve` is for.
 
 Inside those files the runs are stored as columns rather than one object per
 run, with the text in a shared table (`columnar.py`). The pages undo it on load.
+Floats are cut to four significant figures, which is finer than any page prints
+and about what the benchmarks resolve. `report.py` unpacks every sweep it packs
+and refuses to write one the pages would read back differently.
 
 `report.py` looks for `bench/machines.toml` next to the results directory, then
 one level up. Use `--machines` to point somewhere else.

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -25,6 +25,7 @@ The pages are code only. Their data is written beside them and fetched at load:
 
 | file | holds |
 |---|---|
+| `decode.js` | unpacks the columns, imported by both pages |
 | `data/overview.json` | every sweep, trimmed, for `index.html` |
 | `data/sweeps.json` | the sweep list `explore.html` offers |
 | `data/sweeps/<result>.json` | one sweep in full, fetched when it is opened |
@@ -36,10 +37,11 @@ from disk gets you an empty page, because the browser refuses the fetches. That
 is what `--serve` is for.
 
 Inside those files the runs are stored as columns rather than one object per
-run, with the text in a shared table (`columnar.py`). The pages undo it on load.
-Floats are cut to four significant figures, which is finer than any page prints
-and about what the benchmarks resolve. `report.py` unpacks every sweep it packs
-and refuses to write one the pages would read back differently.
+run, with the text in a shared table. `columnar.py` writes that and `decode.js`
+reads it. Floats are cut to four significant figures, which is finer than any
+page prints and about what the benchmarks resolve. `columnar.py` unpacks every
+sweep it packs and refuses to hand back one that does not match, so a broken
+encoding stops the build rather than reaching a page.
 
 `report.py` looks for `bench/machines.toml` next to the results directory, then
 one level up. Use `--machines` to point somewhere else.

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -15,11 +15,26 @@ sweep in `explore.html`.
 
 ```sh
 uv run scripts/sweep/report.py --results-dir bench/results/ -o _site
-python3 -m http.server -d _site      # or open _site/index.html
+python3 -m http.server -d _site      # then open http://localhost:8000/
 ```
 
-The data is embedded in the pages when they are written, so they need no server
-and load nothing. Run the command again after you add or change a results file.
+Run the command again after you add or change a results file.
+
+The pages are code only. Their data is written beside them and fetched at load:
+
+| file | holds |
+|---|---|
+| `data/overview.json` | every sweep, trimmed, for `index.html` |
+| `data/sweeps.json` | the sweep list `explore.html` offers |
+| `data/sweeps/<result>.json` | one sweep in full, fetched when it is opened |
+
+So the explorer downloads one sweep instead of all of them, and adding a sweep
+leaves the other sweep files untouched for anything holding a cached copy. The
+cost is that the pages have to be served over http — opening `_site/index.html`
+from disk gets you an empty page, because the browser refuses the fetches.
+
+Inside those files the runs are stored as columns rather than one object per
+run, with the text in a shared table (`columnar.py`). The pages undo it on load.
 
 `report.py` looks for `bench/machines.toml` next to the results directory, then
 one level up. Use `--machines` to point somewhere else.

--- a/scripts/sweep/columnar.py
+++ b/scripts/sweep/columnar.py
@@ -1,0 +1,130 @@
+"""Pack a list of runs into columns so the pages stay small.
+
+A sweep is thousands of runs with the same twenty-odd keys, so storing each run
+as its own object spends most of its bytes repeating key names. One array per
+key drops those. Text is worse than that: the same scenario and codec names, and
+the same run ids, come back in every sweep, so all the text in a file shares one
+table and the columns hold positions in it.
+
+The pages undo this at load time, so everything downstream still sees a plain
+list of run objects.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+
+# The explorer draws from the config fields, never from the recorded id, and the
+# id is the longest string in a sweep. It is kept in the overview, whose movers
+# panel matches runs between sweeps by it.
+EXPLORER_OMITS = ("id",)
+
+# What sweep.py already records, so this only guards against a future sweep
+# writing full float64 text. Cutting deeper is tempting — four digits is another
+# 30 KiB off the overview — but the movers panel reports differences smaller
+# than that, and at four digits some of them round away or change sign.
+SIGNIFICANT_DIGITS = 6
+
+
+class StringTable:
+    """Every distinct string in one output file, commonest first.
+
+    Frequency order is what keeps the indices short: the handful of names that
+    appear in every run land in the single digits.
+    """
+
+    def __init__(self, run_lists: list[list[dict]], omit: tuple[str, ...] = ()) -> None:
+        counts: Counter[str] = Counter()
+        for runs in run_lists:
+            for run in runs:
+                for value in flatten(run, omit).values():
+                    if isinstance(value, str):
+                        counts[value] += 1
+        self.items = [text for text, _ in counts.most_common()]
+        self._position = {text: i for i, text in enumerate(self.items)}
+
+    def index(self, value: str) -> int:
+        return self._position[value]
+
+
+def round_float(value):
+    if isinstance(value, float) and math.isfinite(value):
+        return float(f"%.{SIGNIFICANT_DIGITS}g" % value)
+    return value
+
+
+def flatten(run: dict, omit: tuple[str, ...] = ()) -> dict:
+    """Nested groups such as stalls and stages become dotted keys."""
+    out = {}
+    for key, value in run.items():
+        if key in omit:
+            continue
+        if isinstance(value, dict):
+            for sub, inner in value.items():
+                if isinstance(inner, dict):
+                    for leaf, number in inner.items():
+                        out[f"{key}.{sub}.{leaf}"] = number
+                else:
+                    out[f"{key}.{sub}"] = inner
+        else:
+            out[key] = value
+    return out
+
+
+def encode_column(values: list, strings: StringTable):
+    present = [v for v in values if v is not None]
+    if present and all(isinstance(v, str) for v in present):
+        return {"text": [None if v is None else strings.index(v) for v in values]}
+    return [round_float(v) for v in values]
+
+
+def decode_runs(block: dict, strings: list[str]) -> list[dict]:
+    """What the pages do on load. Here so report.py can check its own output."""
+    runs: list[dict] = [{} for _ in range(block["count"])]
+    for key, column in block["columns"].items():
+        text = column["text"] if isinstance(column, dict) else None
+        values = text if text is not None else column
+        *path, leaf = key.split(".")
+        for run, packed in zip(runs, values):
+            if packed is None:
+                continue
+            node = run
+            for step in path:
+                node = node.setdefault(step, {})
+            node[leaf] = strings[packed] if text is not None else packed
+    return runs
+
+
+def rounded(run: dict, omit: tuple[str, ...] = ()) -> dict:
+    """One run as the encoder will store it, for comparing against a decode.
+
+    An empty group is left out because flatten gives it no column, so unpacking
+    cannot bring it back and comparing against it would fail a sound encoding.
+    """
+    out = {}
+    for key, value in run.items():
+        if key in omit:
+            continue
+        if isinstance(value, dict):
+            group = rounded(value)
+            if group:
+                out[key] = group
+        elif value is not None:
+            out[key] = round_float(value)
+    return out
+
+
+def encode_runs(runs: list[dict], strings: StringTable, omit: tuple[str, ...] = ()) -> dict:
+    flat = [flatten(r, omit) for r in runs]
+    keys: list[str] = []
+    for run in flat:
+        for key in run:
+            if key not in keys:
+                keys.append(key)
+    return {
+        "count": len(flat),
+        "columns": {
+            key: encode_column([r.get(key) for r in flat], strings) for key in keys
+        },
+    }

--- a/scripts/sweep/columnar.py
+++ b/scripts/sweep/columnar.py
@@ -6,8 +6,8 @@ key drops those. Text is worse than that: the same scenario and codec names, and
 the same run ids, come back in every sweep, so all the text in a file shares one
 table and the columns hold positions in it.
 
-The pages undo this at load time, so everything downstream still sees a plain
-list of run objects.
+decode_runs is what the pages do on load, and pack checks every file against it
+before report.py writes one.
 """
 
 from __future__ import annotations
@@ -15,16 +15,9 @@ from __future__ import annotations
 import math
 from collections import Counter
 
-# The explorer draws from the config fields, never from the recorded id, and the
-# id is the longest string in a sweep. It is kept in the overview, whose movers
-# panel matches runs between sweeps by it.
-EXPLORER_OMITS = ("id",)
-
 # About what the benchmarks can actually resolve, and more than any page shows.
 # Keeping the digits below this only adds bytes gzip cannot squeeze, since they
-# look like noise to it. It does move the movers panel, which compares numbers
-# far finer than four digits — but those comparisons were reporting measurement
-# noise, so losing them is the point rather than a cost.
+# look like noise to it.
 SIGNIFICANT_DIGITS = 4
 
 
@@ -35,18 +28,15 @@ class StringTable:
     appear in every run land in the single digits.
     """
 
-    def __init__(self, run_lists: list[list[dict]], omit: tuple[str, ...] = ()) -> None:
+    def __init__(self, row_lists: list[list[dict]]) -> None:
         counts: Counter[str] = Counter()
-        for runs in run_lists:
-            for run in runs:
-                for value in flatten(run, omit).values():
+        for rows in row_lists:
+            for row in rows:
+                for value in row.values():
                     if isinstance(value, str):
                         counts[value] += 1
         self.items = [text for text, _ in counts.most_common()]
-        self._position = {text: i for i, text in enumerate(self.items)}
-
-    def index(self, value: str) -> int:
-        return self._position[value]
+        self.position = {text: i for i, text in enumerate(self.items)}
 
 
 def round_float(value):
@@ -73,15 +63,24 @@ def flatten(run: dict, omit: tuple[str, ...] = ()) -> dict:
     return out
 
 
-def encode_column(values: list, strings: StringTable):
-    present = [v for v in values if v is not None]
-    if present and all(isinstance(v, str) for v in present):
-        return {"text": [None if v is None else strings.index(v) for v in values]}
+def encode_column(values: list, table: StringTable):
+    # Only when every value present is text, so a column mixing text with
+    # numbers stays as it is rather than looking a number up in the table.
+    if {type(v) for v in values if v is not None} == {str}:
+        return {"text": [None if v is None else table.position[v] for v in values]}
     return [round_float(v) for v in values]
 
 
+def encode_rows(rows: list[dict], table: StringTable) -> dict:
+    keys = list(dict.fromkeys(key for row in rows for key in row))
+    return {
+        "count": len(rows),
+        "columns": {key: encode_column([r.get(key) for r in rows], table) for key in keys},
+    }
+
+
 def decode_runs(block: dict, strings: list[str]) -> list[dict]:
-    """What the pages do on load. Here so report.py can check its own output."""
+    """What the pages do on load."""
     runs: list[dict] = [{} for _ in range(block["count"])]
     for key, column in block["columns"].items():
         text = column["text"] if isinstance(column, dict) else None
@@ -97,35 +96,24 @@ def decode_runs(block: dict, strings: list[str]) -> list[dict]:
     return runs
 
 
-def rounded(run: dict, omit: tuple[str, ...] = ()) -> dict:
-    """One run as the encoder will store it, for comparing against a decode.
+def pack(run_lists: list[list[dict]], omit: tuple[str, ...] = ()):
+    """Columns for each list of runs, sharing one string table.
 
-    An empty group is left out because flatten gives it no column, so unpacking
-    cannot bring it back and comparing against it would fail a sound encoding.
+    Refuses to hand back a file the pages would unpack differently, so a broken
+    encoding stops the build instead of reaching a page.
     """
-    out = {}
-    for key, value in run.items():
-        if key in omit:
-            continue
-        if isinstance(value, dict):
-            group = rounded(value)
-            if group:
-                out[key] = group
-        elif value is not None:
-            out[key] = round_float(value)
-    return out
+    row_lists = [[flatten(run, omit) for run in runs] for runs in run_lists]
+    table = StringTable(row_lists)
+    blocks = [encode_rows(rows, table) for rows in row_lists]
+    for rows, block in zip(row_lists, blocks):
+        check(rows, block, table.items)
+    return table.items, blocks
 
 
-def encode_runs(runs: list[dict], strings: StringTable, omit: tuple[str, ...] = ()) -> dict:
-    flat = [flatten(r, omit) for r in runs]
-    keys: list[str] = []
-    for run in flat:
-        for key in run:
-            if key not in keys:
-                keys.append(key)
-    return {
-        "count": len(flat),
-        "columns": {
-            key: encode_column([r.get(key) for r in flat], strings) for key in keys
-        },
-    }
+def check(rows: list[dict], block: dict, strings: list[str]) -> None:
+    for index, (row, restored) in enumerate(zip(rows, decode_runs(block, strings))):
+        want = {k: round_float(v) for k, v in row.items() if v is not None}
+        got = flatten(restored)
+        if got != want:
+            differing = sorted(k for k in want.keys() | got.keys() if want.get(k) != got.get(k))
+            raise ValueError(f"run {index} ({row.get('id', 'no id')}) changed: {differing}")

--- a/scripts/sweep/columnar.py
+++ b/scripts/sweep/columnar.py
@@ -20,11 +20,12 @@ from collections import Counter
 # panel matches runs between sweeps by it.
 EXPLORER_OMITS = ("id",)
 
-# What sweep.py already records, so this only guards against a future sweep
-# writing full float64 text. Cutting deeper is tempting — four digits is another
-# 30 KiB off the overview — but the movers panel reports differences smaller
-# than that, and at four digits some of them round away or change sign.
-SIGNIFICANT_DIGITS = 6
+# About what the benchmarks can actually resolve, and more than any page shows.
+# Keeping the digits below this only adds bytes gzip cannot squeeze, since they
+# look like noise to it. It does move the movers panel, which compares numbers
+# far finer than four digits — but those comparisons were reporting measurement
+# noise, so losing them is the point rather than a cost.
+SIGNIFICANT_DIGITS = 4
 
 
 class StringTable:

--- a/scripts/sweep/decode.js
+++ b/scripts/sweep/decode.js
@@ -1,0 +1,28 @@
+// Reading side of the packing report.py applies. Both pages import this, so the
+// format has one implementation here and one in columnar.py, which checks
+// itself against this shape before writing a file.
+
+export async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`${url}: ${response.status}`);
+  return response.json();
+}
+
+/** Columns back to one object per run. */
+export function decodeRuns(block, strings) {
+  const runs = Array.from({length: block.count}, () => ({}));
+  for (const [key, column] of Object.entries(block.columns)) {
+    const text = column.text;
+    const values = text || column;
+    const path = key.split(".");
+    const leaf = path.pop();
+    for (let i = 0; i < block.count; i++) {
+      const packed = values[i];
+      if (packed == null) continue;
+      let node = runs[i];
+      for (const step of path) node = node[step] ??= {};
+      node[leaf] = text ? strings[packed] : packed;
+    }
+  }
+  return runs;
+}

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -214,13 +214,13 @@ code { font-size: 0.92em; color: var(--text-secondary); }
   <span class="brand">chucky benchmarks</span>
   <nav>
     <a href="index.html" aria-current="page">Over time</a>
-    <a href="explore.html">Sweep explorer</a>
+    <a href="explore.html">Benchmark explorer</a>
   </nav>
   <button class="theme-toggle" id="theme-toggle" type="button">Dark</button>
 </header>
 
 <main>
-  <h1>How performance is moving</h1>
+  <h1>Performance over time</h1>
   <p class="lede" id="lede"></p>
 
   <section class="filters" aria-label="Filters">
@@ -254,7 +254,7 @@ code { font-size: 0.92em; color: var(--text-secondary); }
   <section class="tiles" id="tiles" aria-label="Machines"></section>
 
   <section class="card">
-    <h2>Trend across sweeps</h2>
+    <h2>Trend</h2>
     <p class="card-sub" id="trend-sub"></p>
     <div class="chart-wrap" id="trend"></div>
     <div class="legend" id="trend-legend"></div>
@@ -262,19 +262,19 @@ code { font-size: 0.92em; color: var(--text-secondary); }
   </section>
 
   <section class="card">
-    <h2>Latest sweep, every scenario</h2>
+    <h2>Latest sweep</h2>
     <p class="card-sub" id="matrix-sub"></p>
     <div id="matrix"></div>
   </section>
 
   <section class="card">
-    <h2>Biggest changes since the previous sweep</h2>
+    <h2>Biggest changes</h2>
     <p class="card-sub" id="movers-sub"></p>
     <div id="movers"></div>
   </section>
 
   <details class="card" id="table-view">
-    <summary>Table view of the trend</summary>
+    <summary>Trend table</summary>
     <div id="trend-table"></div>
   </details>
 
@@ -313,8 +313,8 @@ const METRICS = [
   {key: "throughput_in_gibs", label: "Input throughput", unit: "GiB/s", better: "high"},
   {key: "throughput_out_gibs", label: "Output throughput", unit: "GiB/s", better: "high"},
   {key: "compression_fold", label: "Compression ratio", unit: "x", better: "high"},
-  {key: "wall_s", label: "Wall time", unit: "s", better: "low"},
-  {key: "init_s", label: "Init time", unit: "s", better: "low"},
+  {key: "wall_s", label: "Wall-clock time", unit: "s", better: "low"},
+  {key: "init_s", label: "Startup time", unit: "s", better: "low"},
   {key: "stalls.max_append_ms", label: "Slowest append block", unit: "ms", better: "low",
    note: "one append is a multi-frame block push, not a single frame"},
   {key: "stalls.peak_pending_mib", label: "Peak pending bytes", unit: "MiB", better: "low"},
@@ -820,7 +820,7 @@ function renderTiles() {
       `${machine.sweeps.length} sweep${machine.sweeps.length === 1 ? "" : "s"} · latest `));
     const link = el("a", null, latestSweep.commit);
     link.href = explorerLink(latestSweep);
-    link.title = `Open ${latestSweep.filename} in the sweep explorer`;
+    link.title = `Open ${latestSweep.filename} in the benchmark explorer`;
     foot.appendChild(link);
     foot.appendChild(document.createTextNode(
       machine.members.length > 1
@@ -1184,7 +1184,7 @@ function renderMovers() {
   if (all.length > shown.length) {
     host.appendChild(el("p", "note",
       `Showing ${shown.length} of ${all.length} shared configurations, taking turns between machines; ` +
-      `${realCount} moved by ${REAL_CHANGE_PCT}% or more. The rest are in the sweep explorer.`));
+      `${realCount} moved by ${REAL_CHANGE_PCT}% or more. The rest are in the benchmark explorer.`));
   }
 
   const crossing = [...new Set(shown

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -281,8 +281,30 @@ code { font-size: 0.92em; color: var(--text-secondary); }
   <p class="note" id="footnotes"></p>
 </main>
 
-<script>
-const DATA = __DATA_PLACEHOLDER__;
+<script type="module">
+/** Undo the column packing report.py applies, back to one object per run. */
+function decodeRuns(block, strings) {
+  const runs = Array.from({length: block.count}, () => ({}));
+  for (const [key, column] of Object.entries(block.columns)) {
+    const text = column.text;
+    const values = text || column;
+    const path = key.split(".");
+    const leaf = path.pop();
+    for (let i = 0; i < block.count; i++) {
+      const packed = values[i];
+      if (packed == null) continue;
+      let node = runs[i];
+      for (const step of path) node = node[step] ??= {};
+      node[leaf] = text ? strings[packed] : packed;
+    }
+  }
+  return runs;
+}
+
+const response = await fetch("data/overview.json");
+if (!response.ok) throw new Error(`data/overview.json: ${response.status}`);
+const DATA = await response.json();
+DATA.sweeps.forEach(s => { s.runs = decodeRuns(s.runs, DATA.strings); });
 
 const MAX_SERIES = 8;
 const SERIES_VARS = Array.from({length: MAX_SERIES}, (_, i) => `var(--series-${i + 1})`);

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -282,28 +282,9 @@ code { font-size: 0.92em; color: var(--text-secondary); }
 </main>
 
 <script type="module">
-/** Undo the column packing report.py applies, back to one object per run. */
-function decodeRuns(block, strings) {
-  const runs = Array.from({length: block.count}, () => ({}));
-  for (const [key, column] of Object.entries(block.columns)) {
-    const text = column.text;
-    const values = text || column;
-    const path = key.split(".");
-    const leaf = path.pop();
-    for (let i = 0; i < block.count; i++) {
-      const packed = values[i];
-      if (packed == null) continue;
-      let node = runs[i];
-      for (const step of path) node = node[step] ??= {};
-      node[leaf] = text ? strings[packed] : packed;
-    }
-  }
-  return runs;
-}
+import {decodeRuns, fetchJson} from "./decode.js";
 
-const response = await fetch("data/overview.json");
-if (!response.ok) throw new Error(`data/overview.json: ${response.status}`);
-const DATA = await response.json();
+const DATA = await fetchJson("data/overview.json");
 DATA.sweeps.forEach(s => { s.runs = decodeRuns(s.runs, DATA.strings); });
 
 const MAX_SERIES = 8;

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -7,16 +7,26 @@
 """
 Generate the benchmark site from sweep result files.
 
-Two pages, both self-contained (data embedded at generation time):
+Two pages:
     index.html    every sweep at once — per-machine trend, latest standings, movers
     explore.html  one sweep at a time, down to per-stage timing
+
+The pages are code only; their data sits beside them and is fetched at load:
+    data/overview.json          every sweep, trimmed, for the overview
+    data/sweeps.json            the sweep list the explorer offers
+    data/sweeps/<result>.json   one sweep in full, fetched when it is opened
+
+That keeps the explorer from downloading every sweep to show one, and lets an
+unchanged sweep revalidate instead of being re-sent. It also means the pages
+need to be served over http — opening them from a file:// path will not work.
 
 Usage:
     uv run scripts/sweep/report.py --results-dir bench/results/ -o _site
     uv run scripts/sweep/report.py bench/results/*.json -o _site
     uv run scripts/sweep/report.py --results-dir bench/results/ -o _site/index.html
+    python -m http.server -d _site      # then open http://localhost:8000/
 
-Re-run after changing any results file; nothing is read at page load.
+Re-run after changing any results file.
 """
 
 from __future__ import annotations
@@ -28,13 +38,13 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
+from columnar import EXPLORER_OMITS, StringTable, decode_runs, encode_runs, rounded
 from models import migrate_results, validate_results
 from summary import build_summary, find_registry, load_registry, machine_identity
 
 TEMPLATE_DIR = Path(__file__).parent
 EXPLORER_TEMPLATE = TEMPLATE_DIR / "template.html"
 OVERVIEW_TEMPLATE = TEMPLATE_DIR / "overview.html"
-PLACEHOLDER = "__DATA_PLACEHOLDER__"
 
 
 def load_files(paths: list[Path], *, warn: bool = True) -> list[tuple[Path, dict]]:
@@ -62,8 +72,8 @@ def load_files(paths: list[Path], *, warn: bool = True) -> list[tuple[Path, dict
     return loaded
 
 
-def explorer_payload(loaded: list[tuple[Path, dict]]) -> dict:
-    """What the one-sweep-at-a-time page needs: full runs, including stages."""
+def explorer_index(loaded: list[tuple[Path, dict]]) -> dict:
+    """The sweep list the explorer shows before anything is opened."""
     files = []
     for path, data in loaded:
         machine = data.get("machine", {})
@@ -74,19 +84,66 @@ def explorer_payload(loaded: list[tuple[Path, dict]]) -> dict:
             "label": label,
             "filename": path.name,
             "machine": machine,
-            "runs": data.get("runs", []),
         })
-    return {"version": 2, "files": files}
+    return {"version": 3, "files": files}
 
 
-def write_page(template: Path, payload: dict, output: Path) -> None:
-    text = template.read_text()
-    if PLACEHOLDER not in text:
-        raise SystemExit(f"{template.name} has no {PLACEHOLDER} to fill")
-    embedded = json.dumps(payload, separators=(",", ":")).replace("</", "<\\/")
+def check_roundtrip(runs: list[dict], block: dict, strings: list[str],
+                    where: str, omit: tuple[str, ...] = ()) -> None:
+    """Refuse to publish a packed sweep the pages would unpack differently."""
+    unpacked = decode_runs(block, strings)
+    if len(unpacked) != len(runs):
+        raise SystemExit(f"{where}: packed {len(runs)} runs, unpacked {len(unpacked)}")
+    for original, restored in zip(runs, unpacked):
+        want = rounded(original, omit)
+        if restored != want:
+            differing = sorted(set(want) ^ set(restored)) or \
+                sorted(k for k in want if want[k] != restored.get(k))
+            raise SystemExit(f"{where}: packing changed run "
+                             f"{original.get('id', '?')}: {differing}")
+
+
+def write_json(payload: dict, output: Path) -> int:
+    # allow_nan would write Infinity, which JSON.parse rejects — better to stop
+    # here than to publish a page that cannot read its own data.
+    try:
+        text = json.dumps(payload, separators=(",", ":"), allow_nan=False)
+    except ValueError as e:
+        raise SystemExit(f"{output}: {e}")
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(text.replace(PLACEHOLDER, embedded))
+    output.write_text(text)
+    return output.stat().st_size
+
+
+def write_page(template: Path, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(template.read_text())
     print(f"Wrote {output} ({output.stat().st_size / 1024:.0f} KiB)", file=sys.stderr)
+
+
+def write_data(loaded: list[tuple[Path, dict]], registry: list[dict], data_dir: Path) -> None:
+    overview = build_summary(loaded, registry)
+    strings = StringTable([s["runs"] for s in overview["sweeps"]])
+    for sweep in overview["sweeps"]:
+        packed = encode_runs(sweep["runs"], strings)
+        check_roundtrip(sweep["runs"], packed, strings.items, sweep["filename"])
+        sweep["runs"] = packed
+    overview["version"] = 2
+    overview["strings"] = strings.items
+    total = write_json(overview, data_dir / "overview.json")
+    print(f"Wrote {data_dir / 'overview.json'} ({total / 1024:.0f} KiB)", file=sys.stderr)
+
+    write_json(explorer_index(loaded), data_dir / "sweeps.json")
+    biggest = 0
+    for path, data in loaded:
+        runs = data.get("runs", [])
+        sweep_strings = StringTable([runs], EXPLORER_OMITS)
+        packed = encode_runs(runs, sweep_strings, EXPLORER_OMITS)
+        check_roundtrip(runs, packed, sweep_strings.items, path.name, EXPLORER_OMITS)
+        payload = {"version": 3, "strings": sweep_strings.items, "runs": packed}
+        biggest = max(biggest, write_json(payload, data_dir / "sweeps" / path.name))
+    print(f"Wrote {len(loaded)} sweep file(s) to {data_dir / 'sweeps'} "
+          f"(largest {biggest / 1024:.0f} KiB)", file=sys.stderr)
 
 
 def main():
@@ -126,8 +183,9 @@ def main():
     else:
         out_dir, overview_name = args.output, "index.html"
 
-    write_page(OVERVIEW_TEMPLATE, build_summary(loaded, registry), out_dir / overview_name)
-    write_page(EXPLORER_TEMPLATE, explorer_payload(loaded), out_dir / "explore.html")
+    write_page(OVERVIEW_TEMPLATE, out_dir / overview_name)
+    write_page(EXPLORER_TEMPLATE, out_dir / "explore.html")
+    write_data(loaded, registry, out_dir / "data")
 
 
 if __name__ == "__main__":

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 from pydantic import ValidationError
@@ -155,6 +157,10 @@ def main():
                     help="Output directory (a path ending in .html names the overview page)")
     ap.add_argument("--machines", type=Path, default=None,
                     help="Machine registry TOML (default: machines.toml beside the results)")
+    ap.add_argument("--serve", nargs="?", type=int, const=8000, default=None,
+                    metavar="PORT",
+                    help="Serve the site after writing it (default port 8000). The pages "
+                         "fetch their data, so they need this rather than a file:// path.")
     args = ap.parse_args()
 
     paths: list[Path] = list(args.input or [])
@@ -186,6 +192,23 @@ def main():
     write_page(OVERVIEW_TEMPLATE, out_dir / overview_name)
     write_page(EXPLORER_TEMPLATE, out_dir / "explore.html")
     write_data(loaded, registry, out_dir / "data")
+
+    if args.serve is not None:
+        serve(out_dir, overview_name, args.serve)
+
+
+def serve(out_dir: Path, overview_name: str, port: int) -> None:
+    handler = partial(SimpleHTTPRequestHandler, directory=str(out_dir))
+    try:
+        httpd = ThreadingHTTPServer(("127.0.0.1", port), handler)
+    except OSError as e:
+        raise SystemExit(f"Cannot serve on port {port}: {e}")
+    print(f"\nServing {out_dir} at http://127.0.0.1:{port}/{overview_name}\n"
+          f"Ctrl-C to stop.", file=sys.stderr)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -12,6 +12,7 @@ Two pages:
     explore.html  one sweep at a time, down to per-stage timing
 
 The pages are code only; their data sits beside them and is fetched at load:
+    decode.js                   unpacks the columns, imported by both pages
     data/overview.json          every sweep, trimmed, for the overview
     data/sweeps.json            the sweep list the explorer offers
     data/sweeps/<result>.json   one sweep in full, fetched when it is opened
@@ -21,10 +22,9 @@ unchanged sweep revalidate instead of being re-sent. It also means the pages
 need to be served over http — opening them from a file:// path will not work.
 
 Usage:
-    uv run scripts/sweep/report.py --results-dir bench/results/ -o _site
+    uv run scripts/sweep/report.py --results-dir bench/results/ -o _site --serve
     uv run scripts/sweep/report.py bench/results/*.json -o _site
     uv run scripts/sweep/report.py --results-dir bench/results/ -o _site/index.html
-    python -m http.server -d _site      # then open http://localhost:8000/
 
 Re-run after changing any results file.
 """
@@ -40,13 +40,20 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
-from columnar import EXPLORER_OMITS, StringTable, decode_runs, encode_runs, rounded
+from columnar import pack
 from models import migrate_results, validate_results
 from summary import build_summary, find_registry, load_registry, machine_identity
 
-TEMPLATE_DIR = Path(__file__).parent
-EXPLORER_TEMPLATE = TEMPLATE_DIR / "template.html"
-OVERVIEW_TEMPLATE = TEMPLATE_DIR / "overview.html"
+SOURCE_DIR = Path(__file__).parent
+EXPLORER_PAGE = SOURCE_DIR / "template.html"
+OVERVIEW_PAGE = SOURCE_DIR / "overview.html"
+DECODER = SOURCE_DIR / "decode.js"
+
+# The explorer draws from the config fields and never reads the recorded id,
+# which is the longest string in a sweep. The overview keeps it, because its
+# movers panel matches runs between sweeps by it.
+EXPLORER_OMITS = ("id",)
+EXPLORER_VERSION = 3
 
 
 def load_files(paths: list[Path], *, warn: bool = True) -> list[tuple[Path, dict]]:
@@ -87,22 +94,7 @@ def explorer_index(loaded: list[tuple[Path, dict]]) -> dict:
             "filename": path.name,
             "machine": machine,
         })
-    return {"version": 3, "files": files}
-
-
-def check_roundtrip(runs: list[dict], block: dict, strings: list[str],
-                    where: str, omit: tuple[str, ...] = ()) -> None:
-    """Refuse to publish a packed sweep the pages would unpack differently."""
-    unpacked = decode_runs(block, strings)
-    if len(unpacked) != len(runs):
-        raise SystemExit(f"{where}: packed {len(runs)} runs, unpacked {len(unpacked)}")
-    for original, restored in zip(runs, unpacked):
-        want = rounded(original, omit)
-        if restored != want:
-            differing = sorted(set(want) ^ set(restored)) or \
-                sorted(k for k in want if want[k] != restored.get(k))
-            raise SystemExit(f"{where}: packing changed run "
-                             f"{original.get('id', '?')}: {differing}")
+    return {"version": EXPLORER_VERSION, "files": files}
 
 
 def write_json(payload: dict, output: Path) -> int:
@@ -114,35 +106,35 @@ def write_json(payload: dict, output: Path) -> int:
         raise SystemExit(f"{output}: {e}")
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(text)
-    return output.stat().st_size
+    return len(text.encode())
 
 
-def write_page(template: Path, output: Path) -> None:
+def write_page(source: Path, output: Path) -> None:
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(template.read_text())
+    output.write_text(source.read_text())
     print(f"Wrote {output} ({output.stat().st_size / 1024:.0f} KiB)", file=sys.stderr)
 
 
 def write_data(loaded: list[tuple[Path, dict]], registry: list[dict], data_dir: Path) -> None:
     overview = build_summary(loaded, registry)
-    strings = StringTable([s["runs"] for s in overview["sweeps"]])
-    for sweep in overview["sweeps"]:
-        packed = encode_runs(sweep["runs"], strings)
-        check_roundtrip(sweep["runs"], packed, strings.items, sweep["filename"])
-        sweep["runs"] = packed
-    overview["version"] = 2
-    overview["strings"] = strings.items
-    total = write_json(overview, data_dir / "overview.json")
-    print(f"Wrote {data_dir / 'overview.json'} ({total / 1024:.0f} KiB)", file=sys.stderr)
+    try:
+        strings, blocks = pack([s["runs"] for s in overview["sweeps"]])
+    except ValueError as e:
+        raise SystemExit(f"overview.json: {e}")
+    for sweep, block in zip(overview["sweeps"], blocks):
+        sweep["runs"] = block
+    overview["strings"] = strings
+    size = write_json(overview, data_dir / "overview.json")
+    print(f"Wrote {data_dir / 'overview.json'} ({size / 1024:.0f} KiB)", file=sys.stderr)
 
     write_json(explorer_index(loaded), data_dir / "sweeps.json")
     biggest = 0
     for path, data in loaded:
-        runs = data.get("runs", [])
-        sweep_strings = StringTable([runs], EXPLORER_OMITS)
-        packed = encode_runs(runs, sweep_strings, EXPLORER_OMITS)
-        check_roundtrip(runs, packed, sweep_strings.items, path.name, EXPLORER_OMITS)
-        payload = {"version": 3, "strings": sweep_strings.items, "runs": packed}
+        try:
+            strings, blocks = pack([data.get("runs", [])], EXPLORER_OMITS)
+        except ValueError as e:
+            raise SystemExit(f"{path.name}: {e}")
+        payload = {"version": EXPLORER_VERSION, "strings": strings, "runs": blocks[0]}
         biggest = max(biggest, write_json(payload, data_dir / "sweeps" / path.name))
     print(f"Wrote {len(loaded)} sweep file(s) to {data_dir / 'sweeps'} "
           f"(largest {biggest / 1024:.0f} KiB)", file=sys.stderr)
@@ -189,8 +181,9 @@ def main():
     else:
         out_dir, overview_name = args.output, "index.html"
 
-    write_page(OVERVIEW_TEMPLATE, out_dir / overview_name)
-    write_page(EXPLORER_TEMPLATE, out_dir / "explore.html")
+    write_page(OVERVIEW_PAGE, out_dir / overview_name)
+    write_page(EXPLORER_PAGE, out_dir / "explore.html")
+    write_page(DECODER, out_dir / DECODER.name)
     write_data(loaded, registry, out_dir / "data")
 
     if args.serve is not None:

--- a/scripts/sweep/summary.py
+++ b/scripts/sweep/summary.py
@@ -20,6 +20,9 @@ from models import retired_metrics
 # for every allocation.
 FILENAME_RE = re.compile(r"^(?P<machine>.+)-(?P<commit>[0-9a-f]{7,40})-(?P<date>\d{8})$")
 
+# Bumped to 2 when report.py started packing the runs into columns.
+OVERVIEW_VERSION = 2
+
 CONFIG_KEYS = (
     "scenario", "codec", "fill", "backend", "dtype",
     "chunk_bytes", "chunk_bytes_label", "sink", "status",
@@ -211,7 +214,7 @@ def build_summary(files: list[tuple[Path, dict]], registry: list[dict] | None = 
                 entry[key].append(value)
 
     return {
-        "version": 1,
+        "version": OVERVIEW_VERSION,
         "machines": sorted(machines.values(), key=lambda m: m["name"].lower()),
         "sweeps": sweeps,
     }

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -217,13 +217,7 @@ main.container { overflow: visible; }
     </div>
     <div id="metric-wrap">
       <label>Metric</label>
-      <select id="metric-sel">
-        <option value="throughput_in_gibs" selected>Input throughput (GiB/s)</option>
-        <option value="throughput_out_gibs">Output throughput (GiB/s)</option>
-        <option value="compression_fold">Compression ratio</option>
-        <option value="wall_s">Wall-clock time (s)</option>
-        <option value="init_s">Startup time (s)</option>
-      </select>
+      <select id="metric-sel"></select>
     </div>
   </div>
   <div>
@@ -279,30 +273,7 @@ main.container { overflow: visible; }
 </main>
 
 <script type="module">
-/** Undo the column packing report.py applies, back to one object per run. */
-function decodeRuns(block, strings) {
-  const runs = Array.from({length: block.count}, () => ({}));
-  for (const [key, column] of Object.entries(block.columns)) {
-    const text = column.text;
-    const values = text || column;
-    const path = key.split(".");
-    const leaf = path.pop();
-    for (let i = 0; i < block.count; i++) {
-      const packed = values[i];
-      if (packed == null) continue;
-      let node = runs[i];
-      for (const step of path) node = node[step] ??= {};
-      node[leaf] = text ? strings[packed] : packed;
-    }
-  }
-  return runs;
-}
-
-async function fetchJson(url) {
-  const response = await fetch(url);
-  if (!response.ok) throw new Error(`${url}: ${response.status}`);
-  return response.json();
-}
+import {decodeRuns, fetchJson} from "./decode.js";
 
 /** One sweep is only downloaded when it is first opened, then kept. */
 async function ensureRuns(file) {
@@ -310,7 +281,6 @@ async function ensureRuns(file) {
     const sweep = await fetchJson(`data/sweeps/${file.filename}`);
     file.runs = decodeRuns(sweep.runs, sweep.strings);
   }
-  return file;
 }
 
 const DATA = await fetchJson("data/sweeps.json");
@@ -340,6 +310,13 @@ const METRIC_LABELS = {
   wall_s: "Wall-clock time (s)",
   init_s: "Startup time (s)",
 };
+
+for (const [key, label] of Object.entries(METRIC_LABELS)) {
+  const option = document.createElement("option");
+  option.value = key;
+  option.textContent = label;
+  document.getElementById("metric-sel").appendChild(option);
+}
 
 const COLOR_SCHEMES = {
   throughput_in_gibs: d3.interpolateViridis,

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Sweep explorer</title>
+<title>Benchmark explorer</title>
 <script>
 document.documentElement.setAttribute("data-theme", (() => {
   let stored = null;
@@ -199,30 +199,30 @@ main.container { overflow: visible; }
   <span class="brand">chucky benchmarks</span>
   <nav>
     <a href="index.html">Over time</a>
-    <a href="explore.html" aria-current="page">Sweep explorer</a>
+    <a href="explore.html" aria-current="page">Benchmark explorer</a>
   </nav>
   <button class="theme-toggle" id="theme-toggle" type="button">Dark</button>
 </header>
 <main class="container">
 
-<h1>One sweep at a time <span class="fail-badge" id="fail-badge" style="display:none"></span></h1>
+<h1>Sweep <span class="fail-badge" id="fail-badge" style="display:none"></span></h1>
 <div class="subtitle" id="machine-info"></div>
 <div class="subtitle" id="s3-info" style="display:none"></div>
 
 <div class="controls">
   <div class="control-group control-group--primary">
     <div id="results-wrap">
-      <label>Results</label>
+      <label>Sweep</label>
       <select id="results-sel"></select>
     </div>
     <div id="metric-wrap">
       <label>Metric</label>
       <select id="metric-sel">
-        <option value="throughput_in_gibs" selected>Input Throughput (GiB/s)</option>
-        <option value="throughput_out_gibs">Output Throughput (GiB/s)</option>
-        <option value="compression_fold">Compression Ratio</option>
-        <option value="wall_s">Wall Time (s)</option>
-        <option value="init_s">Init Time (s)</option>
+        <option value="throughput_in_gibs" selected>Input throughput (GiB/s)</option>
+        <option value="throughput_out_gibs">Output throughput (GiB/s)</option>
+        <option value="compression_fold">Compression ratio</option>
+        <option value="wall_s">Wall-clock time (s)</option>
+        <option value="init_s">Startup time (s)</option>
       </select>
     </div>
   </div>
@@ -244,7 +244,7 @@ main.container { overflow: visible; }
       <div class="radio-group" id="backend-group"></div>
     </div>
     <div id="dtype-wrap">
-      <label>Dtype</label>
+      <label>Data type</label>
       <div class="radio-group" id="dtype-group"></div>
     </div>
     <div id="sink-wrap">
@@ -252,7 +252,7 @@ main.container { overflow: visible; }
       <div class="radio-group" id="sink-group"></div>
     </div>
     <div id="s3-throughput-wrap" style="display:none">
-      <label>S3 Target (Gb/s)</label>
+      <label>S3 throughput (Gb/s)</label>
       <div class="radio-group" id="s3-throughput-group"></div>
     </div>
     <div id="overlay-wrap" style="display:none">
@@ -334,11 +334,11 @@ const GROUP_LABELS = { single: "Single", multiscale: "Multiscale", dim0: "Dim0" 
 const GROUP_ORDER = ["single", "multiscale", "dim0"];
 
 const METRIC_LABELS = {
-  throughput_in_gibs: "Input Throughput (GiB/s)",
-  throughput_out_gibs: "Output Throughput (GiB/s)",
-  compression_fold: "Compression Ratio",
-  wall_s: "Wall Time (s)",
-  init_s: "Init Time (s)",
+  throughput_in_gibs: "Input throughput (GiB/s)",
+  throughput_out_gibs: "Output throughput (GiB/s)",
+  compression_fold: "Compression ratio",
+  wall_s: "Wall-clock time (s)",
+  init_s: "Startup time (s)",
 };
 
 const COLOR_SCHEMES = {
@@ -449,7 +449,7 @@ function metricLabel(key) {
 
 function tooltipText(r) {
   let t = `${r.scenario} | ${r.chunk_bytes_label}\n`;
-  t += `codec: ${r.codec}  fill: ${r.fill}  backend: ${r.backend}  dtype: ${r.dtype}\n`;
+  t += `codec: ${r.codec}  fill: ${r.fill}  backend: ${r.backend}  data type: ${r.dtype}\n`;
   if (r.sink && r.sink !== "discard") {
     t += `sink: ${r.sink}`;
     if (r.s3_throughput_gbps) t += `  target: ${r.s3_throughput_gbps} Gb/s`;
@@ -457,7 +457,7 @@ function tooltipText(r) {
   }
   if (r.throughput_in_gibs != null) t += `throughput: ${r.throughput_in_gibs.toFixed(2)} in, ${(r.throughput_out_gibs||0).toFixed(2)} out GiB/s\n`;
   if (r.compression_fold != null) t += `compression: ${r.compression_fold.toFixed(1)}x\n`;
-  if (r.wall_s != null) t += `wall: ${r.wall_s.toFixed(3)}s  init: ${(r.init_s||0).toFixed(3)}s  flush: ${(r.flush_s||0).toFixed(3)}s\n`;
+  if (r.wall_s != null) t += `wall clock: ${r.wall_s.toFixed(3)}s  startup: ${(r.init_s||0).toFixed(3)}s  flush: ${(r.flush_s||0).toFixed(3)}s\n`;
   if (r.total_chunks != null) t += `chunks: ${r.total_chunks} (${r.chunks_per_epoch}/epoch)\n`;
   if (r.memory) {
     const m = r.memory;

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -278,8 +278,42 @@ main.container { overflow: visible; }
 
 </main>
 
-<script>
-const DATA = __DATA_PLACEHOLDER__;
+<script type="module">
+/** Undo the column packing report.py applies, back to one object per run. */
+function decodeRuns(block, strings) {
+  const runs = Array.from({length: block.count}, () => ({}));
+  for (const [key, column] of Object.entries(block.columns)) {
+    const text = column.text;
+    const values = text || column;
+    const path = key.split(".");
+    const leaf = path.pop();
+    for (let i = 0; i < block.count; i++) {
+      const packed = values[i];
+      if (packed == null) continue;
+      let node = runs[i];
+      for (const step of path) node = node[step] ??= {};
+      node[leaf] = text ? strings[packed] : packed;
+    }
+  }
+  return runs;
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`${url}: ${response.status}`);
+  return response.json();
+}
+
+/** One sweep is only downloaded when it is first opened, then kept. */
+async function ensureRuns(file) {
+  if (!file.runs) {
+    const sweep = await fetchJson(`data/sweeps/${file.filename}`);
+    file.runs = decodeRuns(sweep.runs, sweep.strings);
+  }
+  return file;
+}
+
+const DATA = await fetchJson("data/sweeps.json");
 
 // =========================================================================
 // 1. CONSTANTS
@@ -346,13 +380,7 @@ function scenarioSort(a, b) {
   return a.localeCompare(b);
 }
 
-// --- Support both v1 (single file) and v2 (multi-file) formats ---
-const files = DATA.files || [{
-  label: "results",
-  filename: "results.json",
-  machine: DATA.machine || {},
-  runs: DATA.runs || [],
-}];
+const files = DATA.files;
 
 // --- Active data (rebuilt on file switch) ---
 let runs = [];
@@ -1247,16 +1275,17 @@ overlayBtn.addEventListener("click", () => {
   render();
 });
 
-resultsSel.addEventListener("change", () => {
+async function showActiveFile() {
+  await ensureRuns(getActiveFile());
   rebuildData();
   rebuildControls();
   render();
-});
+}
+
+resultsSel.addEventListener("change", showActiveFile);
 
 // Initial load
-rebuildData();
-rebuildControls();
-render();
+await showActiveFile();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Both report pages embedded every sweep, so they grew linearly with
`bench/results/` and the explorer downloaded all 22 sweeps to show one.

The pages are now code only. Their data is written beside them and fetched at
load: `data/overview.json` for the overview, and one file per sweep under
`data/sweeps/` that the explorer fetches when that sweep is opened. Inside those
files the runs are stored as columns instead of one object per run, with all the
text in a shared table (`columnar.py`), which drops the repeated key names and
run ids that were most of the payload. Floats are cut to four significant
figures, finer than any page prints and about what the benchmarks resolve.

At 22 sweeps / 5,111 runs:

| | before | after |
|---|---|---|
| overview first load | 2,268 KiB raw / 216 KiB gzip | 537 KiB raw / 115 KiB gzip |
| explorer first load | 5,121 KiB raw / 702 KiB gzip | 228 KiB raw / 48 KiB gzip |

Adding a sweep now leaves the other sweep files byte-identical, so anything
holding a cached copy can revalidate them instead of re-downloading.

The pages must be served over http, which is what `--serve` is for:

```sh
uv run scripts/sweep/report.py --results-dir bench/results/ -o _site --serve
```

Opening `_site/index.html` from disk no longer works, because the browser
refuses the fetches. That was the tradeoff accepted for splitting the data out.

`report.py` unpacks each sweep it just packed and refuses to write one the pages
would read back differently. CI no longer builds on results-only commits.

Closes #171.
