### PR TITLE
Record whose bytes staging holds

### DIFF
--- a/src/gpu/compress.cu
+++ b/src/gpu/compress.cu
@@ -99,7 +99,7 @@ codec_alignment(enum compression_codec type)
 extern "C" size_t
 codec_output_alignment(enum compression_codec type)
 {
-  nvcompAlignmentRequirements_t written = { 0 }, read = { 0 };
+  nvcompAlignmentRequirements_t written = {}, read = {};
   switch (type) {
     case CODEC_LZ4_NON_STANDARD:
       NVCOMP(Fail,

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -75,16 +75,6 @@ stream_engine_pool_epoch(struct stream_engine* e,
     &e->pools.p, e->sched.fill, (size_t)epoch_in_batch * pool_epoch_bytes(ctx));
 }
 
-// The append cursor counts everything the caller has passed in, including what
-// is still sitting in staging.
-static uint64_t
-dispatched_elements(const struct stream_engine* e,
-                    const struct stream_context* ctx)
-{
-  return ctx->cursor_elements -
-         e->stage.bytes_written / dtype_bpe(ctx->config.dtype);
-}
-
 static int
 engine_dispatch_ingest(struct stream_engine* e,
                        struct stream_context* ctx,
@@ -116,22 +106,22 @@ engine_dispatch_ingest(struct stream_engine* e,
 }
 
 struct writer_result
-stream_dispatch_staged(struct stream_engine* e, struct stream_context* ctx)
+stream_dispatch_staged(struct stream_engine* e)
 {
-  if (ctx->append_failed)
-    return writer_error();
-  if (e->stage.bytes_written == 0)
+  struct stream_context* ctx = e->stage.owner;
+  if (!ctx)
     return writer_ok();
 
-  const uint64_t first = dispatched_elements(e, ctx);
+  const uint64_t first = e->stage.first_element;
   if (engine_dispatch_ingest(e, ctx, first)) {
     ctx->append_failed = 1;
-    // Staging is shared with the stream's other arrays, and these bytes are
-    // never going to reach this one's pool, so let go of them.
+    // These bytes will never reach this array's pool, and the buffer is shared.
     e->stage.bytes_written = 0;
+    e->stage.owner = NULL;
     return writer_error();
   }
   e->stage.bytes_written = 0;
+  e->stage.owner = NULL;
 
   const uint64_t epoch = ctx->layout.epoch_elements;
   const uint64_t crossed = ctx->cursor_elements / epoch - first / epoch;
@@ -156,9 +146,10 @@ dispatch_target_bytes(const struct stream_engine* e,
   const uint32_t epochs = ctx->levels.enable_multiscale
                             ? 1
                             : e->sched.epochs_per_batch - e->sched.accumulated;
-  const uint64_t room =
-    ((uint64_t)epochs * epoch - dispatched_elements(e, ctx) % epoch) *
-    dtype_bpe(ctx->config.dtype);
+  const uint64_t staged_from =
+    e->stage.owner ? e->stage.first_element : ctx->cursor_elements;
+  const uint64_t room = ((uint64_t)epochs * epoch - staged_from % epoch) *
+                        dtype_bpe(ctx->config.dtype);
   const size_t capacity = ctx->config.buffer_capacity_bytes;
   return room < capacity ? (size_t)room : capacity;
 }
@@ -246,6 +237,9 @@ stream_append_body(struct stream_engine* e,
       // samples come from the ring whenever they finish.
       ingest_collect_h2d_timing(&e->stage, &e->metrics.h2d);
       ingest_collect_scatter_timing(&e->stage, &e->metrics.scatter);
+
+      e->stage.owner = ctx;
+      e->stage.first_element = ctx->cursor_elements;
     }
 
     {
@@ -270,7 +264,7 @@ stream_append_body(struct stream_engine* e,
     if (e->stage.bytes_written < target)
       continue;
 
-    struct writer_result r = stream_dispatch_staged(e, ctx);
+    struct writer_result r = stream_dispatch_staged(e);
     if (r.error)
       return writer_error_at(src, end);
     apply_backpressure(e, ctx);
@@ -355,7 +349,10 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
   if (ctx->layout.epoch_elements == 0)
     return writer_ok();
 
-  struct writer_result r = stream_dispatch_staged(e, ctx);
+  // An array that stopped taking data cannot be completed, but what it already
+  // handed to the delivery worker still has to be joined below.
+  struct writer_result r =
+    ctx->append_failed ? writer_error() : stream_dispatch_staged(e);
 
   // Whatever happened above, batches already handed to the delivery worker have
   // to be joined: the worker writes the shard state this function goes on to

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -255,7 +255,6 @@ stream_append_body(struct stream_engine* e,
     {
       struct platform_clock mc = { 0 };
       platform_toc(&mc);
-      // Same h_in generation as the acquire above.
       ingest_copy(
         e->copy_pool,
         gpu_pool_at(&e->stage.h_pool, e->stage.current, e->stage.bytes_written)

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -106,6 +106,13 @@ engine_dispatch_ingest(struct stream_engine* e,
 }
 
 static void
+staging_claim(struct staging_state* stage, struct stream_context* ctx)
+{
+  stage->owner = ctx;
+  stage->first_element = ctx->cursor_elements;
+}
+
+static void
 staging_release(struct staging_state* stage)
 {
   stage->bytes_written = 0;
@@ -120,13 +127,12 @@ stream_dispatch_staged(struct stream_engine* e)
     return writer_ok();
 
   const uint64_t first = e->stage.first_element;
-  if (engine_dispatch_ingest(e, ctx, first)) {
+  const int dispatch_failed = engine_dispatch_ingest(e, ctx, first);
+  staging_release(&e->stage);
+  if (dispatch_failed) {
     ctx->append_failed = 1;
-    // These bytes will never reach this array's pool.
-    staging_release(&e->stage);
     return writer_error();
   }
-  staging_release(&e->stage);
 
   const uint64_t epoch = ctx->layout.epoch_elements;
   const uint64_t crossed = ctx->cursor_elements / epoch - first / epoch;
@@ -243,14 +249,13 @@ stream_append_body(struct stream_engine* e,
       ingest_collect_h2d_timing(&e->stage, &e->metrics.h2d);
       ingest_collect_scatter_timing(&e->stage, &e->metrics.scatter);
 
-      e->stage.owner = ctx;
-      e->stage.first_element = ctx->cursor_elements;
+      staging_claim(&e->stage, ctx);
     }
 
     {
       struct platform_clock mc = { 0 };
       platform_toc(&mc);
-      // Same h_in generation as the bytes_written==0 acquire above.
+      // Same h_in generation as the acquire above.
       ingest_copy(
         e->copy_pool,
         gpu_pool_at(&e->stage.h_pool, e->stage.current, e->stage.bytes_written)

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -105,6 +105,13 @@ engine_dispatch_ingest(struct stream_engine* e,
   }
 }
 
+static void
+staging_release(struct staging_state* stage)
+{
+  stage->bytes_written = 0;
+  stage->owner = NULL;
+}
+
 struct writer_result
 stream_dispatch_staged(struct stream_engine* e)
 {
@@ -115,13 +122,11 @@ stream_dispatch_staged(struct stream_engine* e)
   const uint64_t first = e->stage.first_element;
   if (engine_dispatch_ingest(e, ctx, first)) {
     ctx->append_failed = 1;
-    // These bytes will never reach this array's pool, and the buffer is shared.
-    e->stage.bytes_written = 0;
-    e->stage.owner = NULL;
+    // These bytes will never reach this array's pool.
+    staging_release(&e->stage);
     return writer_error();
   }
-  e->stage.bytes_written = 0;
-  e->stage.owner = NULL;
+  staging_release(&e->stage);
 
   const uint64_t epoch = ctx->layout.epoch_elements;
   const uint64_t crossed = ctx->cursor_elements / epoch - first / epoch;
@@ -225,7 +230,7 @@ stream_append_body(struct stream_engine* e,
 
     const size_t payload = (size_t)(elements * bpe);
 
-    if (e->stage.bytes_written == 0) {
+    if (!e->stage.owner) {
       // Poll instead of cuEventSynchronize to keep the producer thread hot —
       // it has memcpy work queued up immediately after.
       if (gpu_pool_host_acquire_produce(
@@ -349,8 +354,7 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
   if (ctx->layout.epoch_elements == 0)
     return writer_ok();
 
-  // An array that stopped taking data cannot be completed, but what it already
-  // handed to the delivery worker still has to be joined below.
+  // An array that stopped taking data cannot be completed.
   struct writer_result r =
     ctx->append_failed ? writer_error() : stream_dispatch_staged(e);
 

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -57,10 +57,10 @@ struct staging_state
   int current;            // 0 or 1: which buffer the host is filling
   size_t bytes_written;   // bytes written to current slot's h_in so far
 
-  // One buffer serves every array of a multiarray stream, so the bytes in it
-  // belong to one array at a time. NULL while it holds none.
+  // One buffer serves every array of a multiarray stream, so its bytes belong
+  // to one array at a time. NULL while it holds none.
   struct stream_context* owner;
-  uint64_t first_element; // owner's append position of the first staged byte
+  uint64_t first_element; // append position of the first staged byte
 
   struct scatter_timing timing[SCATTER_TIMING_SLOTS];
   int next_timing;
@@ -408,11 +408,9 @@ stream_append_body(struct stream_engine* e,
                    struct slice input);
 
 // Hand whatever staging holds to the device and count into the batch every
-// epoch that completes. The append cursor runs ahead of the device between
-// dispatches, so flush and array switches have to call this before reading the
-// cursor as the position of delivered data — and while the owner is still the
-// bound array, since the dispatch reads per-array engine state that a bind
-// swaps wholesale.
+// epoch that completes. Callers that read the append cursor as the position of
+// delivered data must call this first. A bind swaps the per-array engine state
+// the dispatch reads, so the owner must still be the bound array.
 struct writer_result
 stream_dispatch_staged(struct stream_engine* e);
 

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -408,8 +408,11 @@ stream_append_body(struct stream_engine* e,
                    struct slice input);
 
 // Hand whatever staging holds to the device and count into the batch every
-// epoch that completes. Call it while the owner is still the bound array: the
-// dispatch reads the engine's per-array state, which a bind swaps wholesale.
+// epoch that completes. The append cursor runs ahead of the device between
+// dispatches, so flush and array switches have to call this before reading the
+// cursor as the position of delivered data — and while the owner is still the
+// bound array, since the dispatch reads per-array engine state that a bind
+// swaps wholesale.
 struct writer_result
 stream_dispatch_staged(struct stream_engine* e);
 

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -13,6 +13,7 @@
 #include <stddef.h>
 
 struct threadpool;
+struct stream_context;
 
 // --- Sub-struct definitions (shared between engine and internal headers) ---
 
@@ -55,6 +56,11 @@ struct staging_state
                           //       order (fill precedes dispatch)
   int current;            // 0 or 1: which buffer the host is filling
   size_t bytes_written;   // bytes written to current slot's h_in so far
+
+  // One buffer serves every array of a multiarray stream, so the bytes in it
+  // belong to one array at a time. NULL while it holds none.
+  struct stream_context* owner;
+  uint64_t first_element; // owner's append position of the first staged byte
 
   struct scatter_timing timing[SCATTER_TIMING_SLOTS];
   int next_timing;
@@ -402,12 +408,10 @@ stream_append_body(struct stream_engine* e,
                    struct slice input);
 
 // Hand whatever staging holds to the device and count into the batch every
-// epoch that completes. The append cursor runs ahead of the device between
-// dispatches, so anything reading it as the position of delivered data — flush,
-// an array switch — has to call this first. Staging is engine-wide, so ctx must
-// be the array that filled it.
+// epoch that completes. Call it while the owner is still the bound array: the
+// dispatch reads the engine's per-array state, which a bind swaps wholesale.
 struct writer_result
-stream_dispatch_staged(struct stream_engine* e, struct stream_context* ctx);
+stream_dispatch_staged(struct stream_engine* e);
 
 // Flush the stream: partial epoch, accumulated batch, partial append
 // accumulators, finalize shards, update metadata.

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -145,7 +145,7 @@ switch_to_array(struct multiarray_tile_stream_gpu* ms, int array_index)
         return multiarray_writer_not_flushable;
 
       // A failure in either step belongs to the array being left, which reports
-      // it when it is flushed; the array being switched to is still usable.
+      // it when flushed. The array being switched to stays usable.
       if (!stream_dispatch_staged(e).error && e->sched.accumulated > 0 &&
           schedule_flush_accumulated(e, &departing->ctx).error)
         departing->ctx.append_failed = 1;

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -144,12 +144,9 @@ switch_to_array(struct multiarray_tile_stream_gpu* ms, int array_index)
           0)
         return multiarray_writer_not_flushable;
 
-      // Staging is engine-wide, so the departing array's data has to reach its
-      // own pool before another array's geometry binds in. Either step failing
-      // belongs to the array being left, which reports it when it is flushed;
-      // the array being switched to is still usable.
-      if (!stream_dispatch_staged(e, &departing->ctx).error &&
-          e->sched.accumulated > 0 &&
+      // Either failure belongs to the array being left, which reports it when
+      // it is flushed; the array being switched to is still usable.
+      if (!stream_dispatch_staged(e).error && e->sched.accumulated > 0 &&
           schedule_flush_accumulated(e, &departing->ctx).error)
         departing->ctx.append_failed = 1;
     }
@@ -229,11 +226,10 @@ flush_impl(struct multiarray_writer* self)
   // runs and the first failure is what gets reported.
   int failed = 0;
 
-  // Save current array's state. Staging is engine-wide, so this array's data
-  // has to reach its own pool before another array's flush reuses the buffer.
+  // Empty staging before the loop binds another array.
   if (ms->active >= 0) {
     struct array_descriptor_gpu* desc = &ms->arrays[ms->active];
-    if (stream_dispatch_staged(&ms->engine, &desc->ctx).error)
+    if (stream_dispatch_staged(&ms->engine).error)
       failed = 1;
     unbind_context(&ms->engine, desc);
   }

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -144,8 +144,8 @@ switch_to_array(struct multiarray_tile_stream_gpu* ms, int array_index)
           0)
         return multiarray_writer_not_flushable;
 
-      // Either failure belongs to the array being left, which reports it when
-      // it is flushed; the array being switched to is still usable.
+      // A failure in either step belongs to the array being left, which reports
+      // it when it is flushed; the array being switched to is still usable.
       if (!stream_dispatch_staged(e).error && e->sched.accumulated > 0 &&
           schedule_flush_accumulated(e, &departing->ctx).error)
         departing->ctx.append_failed = 1;


### PR DESCRIPTION
`struct staging_state` is one buffer shared by every array of a multiarray
stream. Its bytes belong to one array at a time, and nothing recorded which;
the rule lived in a comment upheld by hand at three call sites.

Staging now names its owner. It gains `owner` and `first_element`, set when the
buffer starts filling and cleared when it empties, so `stream_dispatch_staged`
takes only the engine and passing the wrong array is no longer expressible.
`dispatched_elements()` is gone: it subtracted an engine-wide byte count from a
per-array cursor, which meant nothing unless the precondition held. Empty
staging returns `writer_ok()`, and the `append_failed` test moves to
`stream_flush_body`, the only caller that reached the dispatch without one.

Refactor only, no behaviour change.
