### PR TITLE
Report pages: one title bar, a machine picker, sweeps in date order

### DIFF
--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -30,6 +30,7 @@ The pages are code only. Their data is written beside them and fetched at load:
 | file | holds |
 |---|---|
 | `site.css` | the palette and the title bar, linked by both pages |
+| `theme.js` | light or dark, applied before either page paints |
 | `decode.js` | unpacks the columns, imported by both pages |
 | `data/overview.json` | every sweep, trimmed, for `index.html` |
 | `data/sweeps.json` | the sweep list `explore.html` offers |

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -11,6 +11,10 @@ push to `main` (`.github/workflows/pages.yml`).
 Clicking a point on a trend chart, or a commit on a machine card, opens that
 sweep in `explore.html`.
 
+The explorer picks a machine first and then one of its sweeps, newest at the
+top, so it opens on the most recent sweep run anywhere. A control disappears
+when the open sweep leaves it nothing to choose.
+
 ## Generating the site
 
 ```sh
@@ -25,6 +29,7 @@ The pages are code only. Their data is written beside them and fetched at load:
 
 | file | holds |
 |---|---|
+| `site.css` | the palette and the title bar, linked by both pages |
 | `decode.js` | unpacks the columns, imported by both pages |
 | `data/overview.json` | every sweep, trimmed, for `index.html` |
 | `data/sweeps.json` | the sweep list `explore.html` offers |
@@ -58,10 +63,13 @@ uv run scripts/sweep/sweep.py --all --machine reef-l40
 `bench/machines.toml` says which names belong to the same machine and describes
 each one. The comment at the top of that file explains the fields.
 
-The overview groups machines that way. A **Group** checkbox turns the grouping
-off, so you can check that the names under one machine really do agree. When a
+Both pages group machines that way: the overview's cards and the explorer's
+machine list. A **Group** checkbox on the overview turns the grouping off, so
+you can check that the names under one machine really do agree. When a
 comparison uses two of those names, the last sweep from one and the sweep before
-it from another, the page says so.
+it from another, the page says so. The explorer marks the sweeps that ran under
+another name, so `livescreen` shows which of its sweeps came from
+`LiveScreen-1`.
 
 A machine keeps its color as other machines are added. Eight colors are
 available; machines past that appear in the tables but not in the chart, and the

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Benchmarks over time</title>
+<script src="theme.js"></script>
 <link rel="stylesheet" href="site.css">
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <style>
-main { max-width: 1180px; margin: 0 auto; padding: 24px; }
 .lede { color: var(--text-secondary); font-size: 0.9em; margin: 0 0 var(--gap); }
 h1 { font-size: 1.35em; margin: 0 0 4px; }
 h2 { font-size: 1.02em; margin: 0; }
@@ -29,17 +29,12 @@ h2 { font-size: 1.02em; margin: 0; }
   background: var(--surface-1); border: 1px solid var(--border);
   border-radius: var(--radius); padding: 12px var(--gap); margin-bottom: var(--gap);
 }
-.filters label { display: block; font-size: 0.72em; font-weight: 600; color: var(--text-secondary); margin-bottom: 3px; text-transform: uppercase; letter-spacing: 0.04em; }
-.filters select {
-  font: inherit; font-size: 0.88em; padding: 5px 8px; color: var(--text-primary);
-  background: var(--plane); border: 1px solid var(--border); border-radius: 6px;
-}
 .filters .match-count { margin-left: auto; font-size: 0.8em; color: var(--text-secondary); }
 .filters .check {
   display: flex; align-items: center; gap: 5px; cursor: pointer;
   font-size: 0.88em; font-weight: 400; text-transform: none; letter-spacing: 0;
   color: var(--text-primary); padding: 5px 8px;
-  background: var(--plane); border: 1px solid var(--border); border-radius: 6px;
+  background: var(--plane); border: 1px solid var(--border); border-radius: var(--radius-sm);
 }
 
 /* Machine tiles */
@@ -574,41 +569,7 @@ sinkSel.addEventListener("change", () => { state.sink = sinkSel.value; render();
 // Theme
 // =========================================================================
 
-const themeToggle = document.getElementById("theme-toggle");
-
-// Reading storage throws in some file:// and private-browsing contexts, and this
-// runs before the page is drawn, so a theme preference must never be fatal.
-function storedTheme() {
-  try {
-    return localStorage.getItem("bench-theme");
-  } catch {
-    return null;
-  }
-}
-
-function currentTheme() {
-  const stored = storedTheme();
-  if (stored === "light" || stored === "dark") return stored;
-  return matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
-
-function applyTheme(theme) {
-  document.documentElement.setAttribute("data-theme", theme);
-  themeToggle.textContent = theme === "dark" ? "Light" : "Dark";
-}
-
-themeToggle.addEventListener("click", () => {
-  const next = currentTheme() === "dark" ? "light" : "dark";
-  try {
-    localStorage.setItem("bench-theme", next);
-  } catch {
-    // The choice still applies to this page; it just will not be remembered.
-  }
-  applyTheme(next);
-  render();
-});
-
-applyTheme(currentTheme());
+wireThemeToggle(render);
 
 // =========================================================================
 // Machine tiles

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -4,103 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Benchmarks over time</title>
+<link rel="stylesheet" href="site.css">
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <style>
-:root {
-  color-scheme: light;
-  --surface-1: #fcfcfb;
-  --plane: #f9f9f7;
-  --text-primary: #0b0b0b;
-  --text-secondary: #52514e;
-  --text-muted: #898781;
-  --grid: #e1e0d9;
-  --axis: #c3c2b7;
-  --border: rgba(11,11,11,0.10);
-  --good: #0ca30c;
-  --good-text: #006300;
-  --critical: #d03b3b;
-  --series-1: #2a78d6;
-  --series-2: #eb6834;
-  --series-3: #1baf7a;
-  --series-4: #eda100;
-  --series-5: #e87ba4;
-  --series-6: #008300;
-  --series-7: #4a3aa7;
-  --series-8: #e34948;
-  --series-none: #898781;
-  --radius: 8px;
-  --gap: 16px;
-}
-@media (prefers-color-scheme: dark) {
-  :root:where(:not([data-theme="light"])) {
-    color-scheme: dark;
-    --surface-1: #1a1a19;
-    --plane: #0d0d0d;
-    --text-primary: #ffffff;
-    --text-secondary: #c3c2b7;
-    --text-muted: #898781;
-    --grid: #2c2c2a;
-    --axis: #383835;
-    --border: rgba(255,255,255,0.10);
-    --good-text: #0ca30c;
-    --series-1: #3987e5;
-    --series-2: #d95926;
-    --series-3: #199e70;
-    --series-4: #c98500;
-    --series-5: #d55181;
-    --series-6: #008300;
-    --series-7: #9085e9;
-    --series-8: #e66767;
-  }
-}
-:root[data-theme="dark"] {
-  color-scheme: dark;
-  --surface-1: #1a1a19;
-  --plane: #0d0d0d;
-  --text-primary: #ffffff;
-  --text-secondary: #c3c2b7;
-  --text-muted: #898781;
-  --grid: #2c2c2a;
-  --axis: #383835;
-  --border: rgba(255,255,255,0.10);
-  --good-text: #0ca30c;
-  --series-1: #3987e5;
-  --series-2: #d95926;
-  --series-3: #199e70;
-  --series-4: #c98500;
-  --series-5: #d55181;
-  --series-6: #008300;
-  --series-7: #9085e9;
-  --series-8: #e66767;
-}
-
-* { box-sizing: border-box; }
-body {
-  margin: 0;
-  background: var(--plane);
-  color: var(--text-primary);
-  font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
-}
-a { color: var(--series-1); }
-
-.site-head {
-  display: flex; align-items: center; gap: var(--gap);
-  padding: 12px 24px; border-bottom: 1px solid var(--border);
-  background: var(--surface-1); flex-wrap: wrap;
-}
-.brand { font-weight: 650; }
-.site-head nav { display: flex; gap: 4px; margin-right: auto; }
-.site-head nav a {
-  padding: 4px 10px; border-radius: var(--radius); text-decoration: none;
-  color: var(--text-secondary); font-size: 0.9em;
-}
-.site-head nav a[aria-current="page"] { background: var(--plane); color: var(--text-primary); font-weight: 600; }
-.theme-toggle {
-  font: inherit; font-size: 0.85em; padding: 4px 10px; cursor: pointer;
-  background: var(--surface-1); color: var(--text-secondary);
-  border: 1px solid var(--border); border-radius: var(--radius);
-}
-
 main { max-width: 1180px; margin: 0 auto; padding: 24px; }
 .lede { color: var(--text-secondary); font-size: 0.9em; margin: 0 0 var(--gap); }
 h1 { font-size: 1.35em; margin: 0 0 4px; }
@@ -216,6 +122,7 @@ code { font-size: 0.92em; color: var(--text-secondary); }
     <a href="index.html" aria-current="page">Over time</a>
     <a href="explore.html">Benchmark explorer</a>
   </nav>
+  <a class="repo-link" href="https://github.com/acquire-project/chucky">Source</a>
   <button class="theme-toggle" id="theme-toggle" type="button">Dark</button>
 </header>
 

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -13,6 +13,7 @@ Two pages:
 
 The pages are code only; their data sits beside them and is fetched at load:
     site.css                    the palette and the title bar, used by both pages
+    theme.js                    light or dark, applied before either page paints
     decode.js                   unpacks the columns, imported by both pages
     data/overview.json          every sweep, trimmed, for the overview
     data/sweeps.json            the sweep list the explorer offers
@@ -43,26 +44,27 @@ from pydantic import ValidationError
 
 from columnar import pack
 from models import migrate_results, validate_results
-from summary import (
-    build_summary,
-    find_registry,
-    load_registry,
-    machine_identity,
-    match_registry,
-    sweep_day,
-)
+from summary import build_summary, find_registry, load_registry
 
 SOURCE_DIR = Path(__file__).parent
-EXPLORER_PAGE = SOURCE_DIR / "template.html"
 OVERVIEW_PAGE = SOURCE_DIR / "overview.html"
-DECODER = SOURCE_DIR / "decode.js"
-STYLESHEET = SOURCE_DIR / "site.css"
+
+# Copied beside the overview page, which is the only one the -o argument renames.
+SITE_FILES = {
+    "explore.html": SOURCE_DIR / "template.html",
+    "decode.js": SOURCE_DIR / "decode.js",
+    "theme.js": SOURCE_DIR / "theme.js",
+    "site.css": SOURCE_DIR / "site.css",
+}
 
 # The explorer draws from the config fields and never reads the recorded id,
 # which is the longest string in a sweep. The overview keeps it, because its
 # movers panel matches runs between sweeps by it.
 EXPLORER_OMITS = ("id",)
 EXPLORER_VERSION = 4
+
+# What the explorer's sweep list keeps from each summarized sweep.
+EXPLORER_INDEX_KEYS = ("filename", "machine", "member", "commit", "day", "date", "host", "gpu")
 
 
 def load_files(paths: list[Path], *, warn: bool = True) -> list[tuple[Path, dict]]:
@@ -90,26 +92,13 @@ def load_files(paths: list[Path], *, warn: bool = True) -> list[tuple[Path, dict
     return loaded
 
 
-def explorer_index(loaded: list[tuple[Path, dict]], registry: list[dict]) -> dict:
+def explorer_index(sweeps: list[dict]) -> dict:
     """The sweep list the explorer shows before anything is opened.
 
-    Ordered oldest first, the way build_summary orders the overview, so the last
-    entry is the newest sweep and that is the one the explorer opens on.
+    The summary already names each machine and orders the sweeps oldest first,
+    so the last entry is the newest one and that is what the explorer opens on.
     """
-    files = []
-    for path, data in loaded:
-        machine = data.get("machine", {})
-        member, commit = machine_identity(path, machine)
-        entry = match_registry(registry, member, machine.get("hostname", ""))
-        files.append({
-            "filename": path.name,
-            "machine_name": entry["name"] if entry else member,
-            "member": member,
-            "commit": commit,
-            "day": sweep_day(machine, path),
-            "machine": machine,
-        })
-    files.sort(key=lambda f: (f["day"], str(f["machine"].get("date", "")), f["machine_name"]))
+    files = [{key: sweep[key] for key in EXPLORER_INDEX_KEYS} for sweep in sweeps]
     return {"version": EXPLORER_VERSION, "files": files}
 
 
@@ -125,7 +114,7 @@ def write_json(payload: dict, output: Path) -> int:
     return len(text.encode())
 
 
-def write_page(source: Path, output: Path) -> None:
+def copy_file(source: Path, output: Path) -> None:
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(source.read_text())
     print(f"Wrote {output} ({output.stat().st_size / 1024:.0f} KiB)", file=sys.stderr)
@@ -133,6 +122,7 @@ def write_page(source: Path, output: Path) -> None:
 
 def write_data(loaded: list[tuple[Path, dict]], registry: list[dict], data_dir: Path) -> None:
     overview = build_summary(loaded, registry)
+    write_json(explorer_index(overview["sweeps"]), data_dir / "sweeps.json")
     try:
         strings, blocks = pack([s["runs"] for s in overview["sweeps"]])
     except ValueError as e:
@@ -143,7 +133,6 @@ def write_data(loaded: list[tuple[Path, dict]], registry: list[dict], data_dir: 
     size = write_json(overview, data_dir / "overview.json")
     print(f"Wrote {data_dir / 'overview.json'} ({size / 1024:.0f} KiB)", file=sys.stderr)
 
-    write_json(explorer_index(loaded, registry), data_dir / "sweeps.json")
     biggest = 0
     for path, data in loaded:
         try:
@@ -197,10 +186,9 @@ def main():
     else:
         out_dir, overview_name = args.output, "index.html"
 
-    write_page(OVERVIEW_PAGE, out_dir / overview_name)
-    write_page(EXPLORER_PAGE, out_dir / "explore.html")
-    write_page(DECODER, out_dir / DECODER.name)
-    write_page(STYLESHEET, out_dir / STYLESHEET.name)
+    copy_file(OVERVIEW_PAGE, out_dir / overview_name)
+    for name, source in SITE_FILES.items():
+        copy_file(source, out_dir / name)
     write_data(loaded, registry, out_dir / "data")
 
     if args.serve is not None:

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -12,6 +12,7 @@ Two pages:
     explore.html  one sweep at a time, down to per-stage timing
 
 The pages are code only; their data sits beside them and is fetched at load:
+    site.css                    the palette and the title bar, used by both pages
     decode.js                   unpacks the columns, imported by both pages
     data/overview.json          every sweep, trimmed, for the overview
     data/sweeps.json            the sweep list the explorer offers
@@ -42,18 +43,26 @@ from pydantic import ValidationError
 
 from columnar import pack
 from models import migrate_results, validate_results
-from summary import build_summary, find_registry, load_registry, machine_identity
+from summary import (
+    build_summary,
+    find_registry,
+    load_registry,
+    machine_identity,
+    match_registry,
+    sweep_day,
+)
 
 SOURCE_DIR = Path(__file__).parent
 EXPLORER_PAGE = SOURCE_DIR / "template.html"
 OVERVIEW_PAGE = SOURCE_DIR / "overview.html"
 DECODER = SOURCE_DIR / "decode.js"
+STYLESHEET = SOURCE_DIR / "site.css"
 
 # The explorer draws from the config fields and never reads the recorded id,
 # which is the longest string in a sweep. The overview keeps it, because its
 # movers panel matches runs between sweeps by it.
 EXPLORER_OMITS = ("id",)
-EXPLORER_VERSION = 3
+EXPLORER_VERSION = 4
 
 
 def load_files(paths: list[Path], *, warn: bool = True) -> list[tuple[Path, dict]]:
@@ -81,19 +90,26 @@ def load_files(paths: list[Path], *, warn: bool = True) -> list[tuple[Path, dict
     return loaded
 
 
-def explorer_index(loaded: list[tuple[Path, dict]]) -> dict:
-    """The sweep list the explorer shows before anything is opened."""
+def explorer_index(loaded: list[tuple[Path, dict]], registry: list[dict]) -> dict:
+    """The sweep list the explorer shows before anything is opened.
+
+    Ordered oldest first, the way build_summary orders the overview, so the last
+    entry is the newest sweep and that is the one the explorer opens on.
+    """
     files = []
     for path, data in loaded:
         machine = data.get("machine", {})
-        name, commit = machine_identity(path, machine)
-        day = str(machine.get("date", ""))[:10]
-        label = " ".join(x for x in [name, commit, day] if x) or "unknown"
+        member, commit = machine_identity(path, machine)
+        entry = match_registry(registry, member, machine.get("hostname", ""))
         files.append({
-            "label": label,
             "filename": path.name,
+            "machine_name": entry["name"] if entry else member,
+            "member": member,
+            "commit": commit,
+            "day": sweep_day(machine, path),
             "machine": machine,
         })
+    files.sort(key=lambda f: (f["day"], str(f["machine"].get("date", "")), f["machine_name"]))
     return {"version": EXPLORER_VERSION, "files": files}
 
 
@@ -127,7 +143,7 @@ def write_data(loaded: list[tuple[Path, dict]], registry: list[dict], data_dir: 
     size = write_json(overview, data_dir / "overview.json")
     print(f"Wrote {data_dir / 'overview.json'} ({size / 1024:.0f} KiB)", file=sys.stderr)
 
-    write_json(explorer_index(loaded), data_dir / "sweeps.json")
+    write_json(explorer_index(loaded, registry), data_dir / "sweeps.json")
     biggest = 0
     for path, data in loaded:
         try:
@@ -184,6 +200,7 @@ def main():
     write_page(OVERVIEW_PAGE, out_dir / overview_name)
     write_page(EXPLORER_PAGE, out_dir / "explore.html")
     write_page(DECODER, out_dir / DECODER.name)
+    write_page(STYLESHEET, out_dir / STYLESHEET.name)
     write_data(loaded, registry, out_dir / "data")
 
     if args.serve is not None:

--- a/scripts/sweep/site.css
+++ b/scripts/sweep/site.css
@@ -1,6 +1,6 @@
-/* The palette and the title bar, shared by both pages. report.py copies this
-   next to them, the way it copies decode.js. Anything only one page draws stays
-   in that page. */
+/* The palette, the page frame and the title bar, shared by both pages. Anything
+   only one page draws stays in that page. theme.js picks light or dark before
+   the page paints, so the dark values only need the one selector. */
 
 :root {
   color-scheme: light;
@@ -12,7 +12,6 @@
   --grid: #e1e0d9;
   --axis: #c3c2b7;
   --border: rgba(11,11,11,0.10);
-  --good: #0ca30c;
   --good-text: #006300;
   --critical: #d03b3b;
   --critical-soft: #fef2f2;
@@ -31,33 +30,6 @@
   --radius: 8px;
   --radius-sm: 6px;
   --gap: 16px;
-}
-@media (prefers-color-scheme: dark) {
-  :root:where(:not([data-theme="light"])) {
-    color-scheme: dark;
-    --surface-1: #1a1a19;
-    --plane: #0d0d0d;
-    --text-primary: #ffffff;
-    --text-secondary: #c3c2b7;
-    --text-muted: #898781;
-    --grid: #2c2c2a;
-    --axis: #383835;
-    --border: rgba(255,255,255,0.10);
-    --good-text: #0ca30c;
-    --critical: #e66767;
-    --critical-soft: #2a1a1a;
-    --cell-empty: #262624;
-    --accent-soft: #24304a;
-    --accent-text: #b7d3f6;
-    --series-1: #3987e5;
-    --series-2: #d95926;
-    --series-3: #199e70;
-    --series-4: #c98500;
-    --series-5: #d55181;
-    --series-6: #008300;
-    --series-7: #9085e9;
-    --series-8: #e66767;
-  }
 }
 :root[data-theme="dark"] {
   color-scheme: dark;
@@ -94,6 +66,11 @@ body {
 }
 a { color: var(--series-1); }
 
+/* Chart titles, legends and axis names inherit this. SVG text is black unless
+   something says otherwise, which is invisible on the dark theme; anything that
+   picks its own colour, like a heatmap cell label, still wins. */
+svg { fill: var(--text-primary); }
+
 .site-head {
   display: flex; align-items: center; gap: var(--gap); flex-wrap: wrap;
   padding: 12px 24px; border-bottom: 1px solid var(--border);
@@ -117,4 +94,21 @@ a { color: var(--series-1); }
   font: inherit; font-size: 0.85em; padding: 4px 10px; cursor: pointer; width: auto;
   background: var(--surface-1); color: var(--text-secondary);
   border: 1px solid var(--border); border-radius: var(--radius);
+}
+
+main { max-width: 1180px; margin: 0 auto; padding: 24px; }
+
+/* The two control strips: the overview's filters and the explorer's controls.
+   A caption over each control, and one look for the menus under them. */
+.filters label,
+.control-group > div > label,
+.control-row > label {
+  display: block; margin-bottom: 3px;
+  font-size: 0.72em; font-weight: 600; color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+.filters select, .controls select {
+  font: inherit; font-size: 0.85em; padding: 5px 8px; width: auto;
+  color: var(--text-primary); background: var(--plane);
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
 }

--- a/scripts/sweep/site.css
+++ b/scripts/sweep/site.css
@@ -1,0 +1,120 @@
+/* The palette and the title bar, shared by both pages. report.py copies this
+   next to them, the way it copies decode.js. Anything only one page draws stays
+   in that page. */
+
+:root {
+  color-scheme: light;
+  --surface-1: #fcfcfb;
+  --plane: #f9f9f7;
+  --text-primary: #0b0b0b;
+  --text-secondary: #52514e;
+  --text-muted: #898781;
+  --grid: #e1e0d9;
+  --axis: #c3c2b7;
+  --border: rgba(11,11,11,0.10);
+  --good: #0ca30c;
+  --good-text: #006300;
+  --critical: #d03b3b;
+  --critical-soft: #fef2f2;
+  --cell-empty: #ededea;
+  --accent-soft: #e0e7ff;
+  --accent-text: #1c5cab;
+  --series-1: #2a78d6;
+  --series-2: #eb6834;
+  --series-3: #1baf7a;
+  --series-4: #eda100;
+  --series-5: #e87ba4;
+  --series-6: #008300;
+  --series-7: #4a3aa7;
+  --series-8: #e34948;
+  --series-none: #898781;
+  --radius: 8px;
+  --radius-sm: 6px;
+  --gap: 16px;
+}
+@media (prefers-color-scheme: dark) {
+  :root:where(:not([data-theme="light"])) {
+    color-scheme: dark;
+    --surface-1: #1a1a19;
+    --plane: #0d0d0d;
+    --text-primary: #ffffff;
+    --text-secondary: #c3c2b7;
+    --text-muted: #898781;
+    --grid: #2c2c2a;
+    --axis: #383835;
+    --border: rgba(255,255,255,0.10);
+    --good-text: #0ca30c;
+    --critical: #e66767;
+    --critical-soft: #2a1a1a;
+    --cell-empty: #262624;
+    --accent-soft: #24304a;
+    --accent-text: #b7d3f6;
+    --series-1: #3987e5;
+    --series-2: #d95926;
+    --series-3: #199e70;
+    --series-4: #c98500;
+    --series-5: #d55181;
+    --series-6: #008300;
+    --series-7: #9085e9;
+    --series-8: #e66767;
+  }
+}
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --surface-1: #1a1a19;
+  --plane: #0d0d0d;
+  --text-primary: #ffffff;
+  --text-secondary: #c3c2b7;
+  --text-muted: #898781;
+  --grid: #2c2c2a;
+  --axis: #383835;
+  --border: rgba(255,255,255,0.10);
+  --good-text: #0ca30c;
+  --critical: #e66767;
+  --critical-soft: #2a1a1a;
+  --cell-empty: #262624;
+  --accent-soft: #24304a;
+  --accent-text: #b7d3f6;
+  --series-1: #3987e5;
+  --series-2: #d95926;
+  --series-3: #199e70;
+  --series-4: #c98500;
+  --series-5: #d55181;
+  --series-6: #008300;
+  --series-7: #9085e9;
+  --series-8: #e66767;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--plane);
+  color: var(--text-primary);
+  font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+a { color: var(--series-1); }
+
+.site-head {
+  display: flex; align-items: center; gap: var(--gap); flex-wrap: wrap;
+  padding: 12px 24px; border-bottom: 1px solid var(--border);
+  background: var(--surface-1);
+}
+.site-head .brand { font-weight: 650; }
+.site-head nav { display: flex; gap: 4px; margin-right: auto; }
+.site-head nav a {
+  padding: 4px 10px; border-radius: var(--radius); text-decoration: none;
+  color: var(--text-secondary); font-size: 0.9em;
+}
+.site-head nav a[aria-current="page"] {
+  background: var(--plane); color: var(--text-primary); font-weight: 600;
+}
+.site-head .repo-link {
+  padding: 4px 10px; text-decoration: none;
+  color: var(--text-secondary); font-size: 0.85em;
+}
+.site-head .repo-link:hover { text-decoration: underline; }
+.theme-toggle {
+  font: inherit; font-size: 0.85em; padding: 4px 10px; cursor: pointer; width: auto;
+  background: var(--surface-1); color: var(--text-secondary);
+  border: 1px solid var(--border); border-radius: var(--radius);
+}

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -4,27 +4,14 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Benchmark explorer</title>
-<script>
-document.documentElement.setAttribute("data-theme", (() => {
-  let stored = null;
-  try {
-    stored = localStorage.getItem("bench-theme");
-  } catch {
-    stored = null;
-  }
-  if (stored === "light" || stored === "dark") return stored;
-  return matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-})());
-</script>
+<script src="theme.js"></script>
 <link rel="stylesheet" href="site.css">
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <style>
 :root {
   --gap-sm: 4px;
   --gap-md: 12px;
-  --gap-lg: 24px;
 }
-main.container { max-width: 1180px; margin: 0 auto; padding: 24px; overflow: visible; }
 h1 { font-size: 1.4em; margin: 0 0 var(--gap-sm); }
 .subtitle { color: var(--text-secondary); font-size: 0.85em; margin-bottom: 2px; }
 input { accent-color: var(--series-1); }
@@ -37,16 +24,6 @@ input { accent-color: var(--series-1); }
   background: var(--surface-1); border: 1px solid var(--border);
   border-radius: var(--radius); padding: var(--gap-md);
   margin: var(--gap-md) 0;
-}
-.control-group > div > label, .control-row > label {
-  display: block; margin-bottom: 3px;
-  font-size: 0.72em; font-weight: 600; color: var(--text-secondary);
-  text-transform: uppercase; letter-spacing: 0.04em;
-}
-.controls select {
-  font: inherit; font-size: 0.85em; padding: 5px 8px; width: auto;
-  color: var(--text-primary); background: var(--plane);
-  border: 1px solid var(--border); border-radius: var(--radius-sm);
 }
 .control-group { display: flex; flex-wrap: wrap; gap: var(--gap-md); align-items: flex-start; }
 .control-row {
@@ -81,11 +58,6 @@ input { accent-color: var(--series-1); }
 }
 #stage-chart { margin-top: var(--gap-md); }
 #chart:empty, #stage-chart:empty { display: none; }
-
-/* Titles, legends and axis names. SVG text is black unless something says
-   otherwise, which is invisible on the dark theme. Text that picks its own
-   colour — the heatmap's cell labels — carries a fill attribute and is left be. */
-#chart text:not([fill]), #stage-chart text:not([fill]) { fill: var(--text-primary); }
 
 /* SVG axes */
 .axis text { font-size: 12px; fill: var(--text-secondary); }
@@ -150,7 +122,7 @@ input { accent-color: var(--series-1); }
 
 /* Mobile */
 @media (max-width: 640px) {
-  main.container { padding: var(--gap-md); }
+  main { padding: var(--gap-md); }
   .controls { flex-direction: column; }
   .control-group { flex-direction: column; }
   .scenario-groups { flex-direction: column; gap: var(--gap-md); }
@@ -168,7 +140,7 @@ input { accent-color: var(--series-1); }
   <a class="repo-link" href="https://github.com/acquire-project/chucky">Source</a>
   <button class="theme-toggle" id="theme-toggle" type="button">Dark</button>
 </header>
-<main class="container">
+<main>
 
 <h1>Sweep <span class="fail-badge" id="fail-badge" style="display:none"></span></h1>
 <div class="subtitle" id="machine-info"></div>
@@ -211,7 +183,7 @@ input { accent-color: var(--series-1); }
       <div class="radio-group" id="s3-throughput-group"></div>
     </div>
   </div>
-  <div class="control-group" id="draw-controls">
+  <div class="control-group">
     <div id="metric-wrap">
       <label for="metric-sel">Metric</label>
       <select id="metric-sel"></select>
@@ -261,11 +233,13 @@ const DATA = await fetchJson("data/sweeps.json");
 const LAYOUT = {
   margin:    {top: 40, right: 200, bottom: 60, left: 195},
   heatmap:   {cellW: 70, cellH: 50},
-  lines:     {plotW: 600, plotH: 300, margin: {top: 40, right: 140, bottom: 60, left: 62}},
+  lines:     {plotW: 600, plotH: 300, margin: {top: 40, bottom: 60, left: 62}},
   subChart:  {W: 700, H: 200, margin: {top: 30, right: 180, bottom: 40, left: 80}},
   stageBar:  {W: 500, margin: {left: 100, right: 60, top: 30}},
   stageThru: {W: 600, margin: {left: 100, right: 80, top: 40}},
 };
+
+const LEGEND_FONT_PX = 12;
 
 const STAGE_ORDER = ["memcpy","h2d","scatter","lod_gather","lod_reduce","lod_append_fold","lod_morton_chunk","compress","aggregate","d2h","sink"];
 
@@ -280,9 +254,8 @@ const METRIC_LABELS = {
   init_s: "Startup time (s)",
 };
 
-// The run metrics the chart can draw. The stage views swap in their own list
-// and swap this one back, so both come from one place and the wording of an
-// option does not change as the view does.
+// The stage views swap in their own metrics and swap these back, so the wording
+// of an option cannot change with the view.
 const METRIC_OPTS = Object.entries(METRIC_LABELS);
 
 for (const [key, label] of METRIC_OPTS) {
@@ -577,17 +550,12 @@ let prevCodec = "zstd", prevFill = "xor", prevBackend = "gpu", prevDtype = "u16"
 
 function rebuildControls() {
   const file = getActiveFile();
-  const machine = file.machine || {};
-  document.getElementById("machine-info").textContent = [
-    file.machine_name,
-    machine.hostname || "?",
-    machine.gpu || "?",
-    machine.commit || file.commit,
-    machine.date || file.day || "?",
-  ].filter(Boolean).join(" | ");
+  document.getElementById("machine-info").textContent =
+    [file.machine, file.host, file.gpu, file.commit, file.date || file.day]
+      .filter(Boolean).join(" | ");
 
   // S3 metadata from runs (region, bucket, endpoint)
-  const s3Runs = (getActiveFile().runs || []).filter(r => r.sink === "s3");
+  const s3Runs = (file.runs || []).filter(r => r.sink === "s3");
   const s3Info = document.getElementById("s3-info");
   if (s3Runs.length > 0) {
     const regions = [...new Set(s3Runs.map(r => r.s3_region).filter(Boolean))];
@@ -645,8 +613,7 @@ function rebuildControls() {
   rebuildScenarios();
   rebuildStageFilters();
   rebuildFailures();
-  document.getElementById("scenario-controls").style.display =
-    allScenarios.length > 1 ? "" : "none";
+  autoHide("scenario-controls", allScenarios);
 }
 
 // --- Failures table ---
@@ -743,7 +710,6 @@ function updateControlVisibility(viewMode, useOverlay) {
   const showTp = sink === "s3" && allS3Throughputs.length > 1;
   document.getElementById("s3-throughput-wrap").style.display = showTp ? "" : "none";
 
-  hideEmptyGroup("source-controls");
   hideEmptyGroup("filter-controls");
 }
 
@@ -881,8 +847,8 @@ function lineSeries(filtered, presentScenarios, useOverlay) {
 }
 
 /** Room for the widest legend label, so a long scenario name is not cut off. */
-function legendRoom(labels, fontPx) {
-  const widest = Math.max(0, ...labels.map(l => l.length * fontPx * 0.55));
+function legendRoom(labels) {
+  const widest = Math.max(0, ...labels.map(l => l.length * LEGEND_FONT_PX * 0.55));
   return Math.round(Math.min(320, Math.max(120, widest + 34)));
 }
 
@@ -891,14 +857,12 @@ function renderLines(filtered, presentChunks, presentScenarios, metricKey, useOv
   if (allVals.length === 0) { d3.select("#chart").append("p").text("No data for this metric."); return; }
 
   const series = lineSeries(filtered, presentScenarios, useOverlay);
-  const {plotW, plotH} = LAYOUT.lines;
-  const margin = {...LAYOUT.lines.margin, right: legendRoom(series.map(s => s.label), 12)};
-  const W = margin.left + plotW + margin.right;
-  const H = margin.top + plotH + margin.bottom;
+  const {plotW: innerW, plotH: innerH} = LAYOUT.lines;
+  const margin = {...LAYOUT.lines.margin, right: legendRoom(series.map(s => s.label))};
+  const W = margin.left + innerW + margin.right;
+  const H = margin.top + innerH + margin.bottom;
   const svg = d3.select("#chart").append("svg").attr("width", W).attr("height", H);
   const g = svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
-  const innerW = plotW;
-  const innerH = plotH;
 
   const xVals = presentChunks.map(chunkLabelToBytes);
 
@@ -907,7 +871,7 @@ function renderLines(filtered, presentChunks, presentScenarios, metricKey, useOv
 
   const colors = d3.scaleOrdinal(d3.schemeTableau10).domain(allScenarios);
 
-  g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","var(--grid)");
+  g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat(""));
 
   const lineLookup = new Map();
   filtered.forEach(r => lineLookup.set(`${r.scenario}__${r.chunk_bytes_label}__${r.backend}`, r));
@@ -949,7 +913,7 @@ function renderLines(filtered, presentChunks, presentScenarios, metricKey, useOv
       .attr("stroke", colors(s.scenario)).attr("stroke-width", 2)
       .attr("stroke-dasharray", s.dashed ? "4,2" : "none");
     lg.append("circle").attr("cx",6).attr("cy",gy+6).attr("r",3).attr("fill",colors(s.scenario));
-    lg.append("text").attr("x",18).attr("y",gy+10).attr("font-size","12px").text(s.label);
+    lg.append("text").attr("x",18).attr("y",gy+10).attr("font-size",`${LEGEND_FONT_PX}px`).text(s.label);
   });
 
   svg.append("text").attr("x", margin.left).attr("y", 20)
@@ -1018,6 +982,7 @@ function renderStageLines(filtered, presentChunks, presentScenarios, stageMetric
   if (globalYMax === 0) globalYMax = 1;
 
   const selBackend = getRadio("backend-group");
+  const stageMetricLabel = document.getElementById("metric-sel").selectedOptions[0].textContent;
 
   presentScenarios.forEach(sc => {
     const hasData = filtered.some(r => r.scenario === sc && r.stages);
@@ -1029,7 +994,7 @@ function renderStageLines(filtered, presentChunks, presentScenarios, stageMetric
     const x = d3.scaleLog().domain(xExtent).range([0, innerW]);
     const y = d3.scaleLinear().domain([0, globalYMax]).range([innerH, 0]);
 
-    g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","var(--grid)");
+    g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat(""));
 
     const backends = useOverlay
       ? [...new Set(filtered.filter(r => r.scenario === sc).map(r => r.backend))].sort()
@@ -1071,7 +1036,6 @@ function renderStageLines(filtered, presentChunks, presentScenarios, stageMetric
       .call(d3.axisBottom(x).tickValues(xVals).tickFormat((_,i) => presentChunks[i]));
     g.append("g").attr("class","axis").call(d3.axisLeft(y).ticks(4));
 
-    const stageMetricLabel = document.getElementById("metric-sel").selectedOptions[0].textContent;
     svg.append("text").attr("x", subMargin.left).attr("y", 16)
       .attr("font-size","13px").attr("font-weight",700)
       .text(`${sc} — ${stageMetricLabel}`);
@@ -1214,27 +1178,26 @@ function renderStagesThroughput(run, stages) {
 
 // Machine, then one of its sweeps. report.py orders the list oldest first, so
 // the last entry is the newest sweep anywhere and that is what opens.
-// ?file=<name> lets the overview link to one sweep.
 const ALL_MACHINES = "";
 
 function sweepsFor(machine) {
-  return machine === ALL_MACHINES ? files.slice() : files.filter(f => f.machine_name === machine);
+  return files.filter(f => machine === ALL_MACHINES || f.machine === machine);
 }
 
 function sweepLabel(file, showMachine) {
   const parts = [file.day];
-  if (showMachine) parts.push(file.machine_name);
+  if (showMachine) parts.push(file.machine);
   parts.push(file.commit);
-  if (file.member !== file.machine_name) parts.push(`(${file.member})`);
+  if (file.member !== file.machine) parts.push(`(${file.member})`);
   return parts.filter(Boolean).join(" ");
 }
 
 function fillMachines() {
-  const names = [...new Set(files.map(f => f.machine_name))]
+  const names = [...new Set(files.map(f => f.machine))]
     .sort((a, b) => a.localeCompare(b, undefined, {sensitivity: "base"}));
   machineSel.appendChild(new Option("All machines", ALL_MACHINES));
   for (const name of names) machineSel.appendChild(new Option(name, name));
-  document.getElementById("machine-wrap").style.display = names.length > 1 ? "" : "none";
+  autoHide("machine-wrap", names);
 }
 
 function fillSweeps(selected) {
@@ -1244,32 +1207,19 @@ function fillSweeps(selected) {
   for (const file of newestFirst) {
     resultsSel.appendChild(new Option(sweepLabel(file, machine === ALL_MACHINES), file.filename));
   }
-  resultsSel.value = newestFirst.some(f => f.filename === selected)
-    ? selected : newestFirst[0].filename;
-  document.getElementById("results-wrap").style.display = newestFirst.length > 1 ? "" : "none";
+  resultsSel.value = selected ?? newestFirst[0].filename;
+  autoHide("results-wrap", newestFirst);
+  hideEmptyGroup("source-controls");
 }
 
+// ?file=<name> lets the overview link to one sweep.
 const requested = new URLSearchParams(location.search).get("file");
 const opening = fileByName.get(requested) || files[files.length - 1];
 fillMachines();
-machineSel.value = opening.machine_name;
+machineSel.value = opening.machine;
 fillSweeps(opening.filename);
 
-const themeToggle = document.getElementById("theme-toggle");
-function currentTheme() { return document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"; }
-function paintToggle() { themeToggle.textContent = currentTheme() === "dark" ? "Light" : "Dark"; }
-themeToggle.addEventListener("click", () => {
-  const next = currentTheme() === "dark" ? "light" : "dark";
-  try {
-    localStorage.setItem("bench-theme", next);
-  } catch {
-    // Applies to this page; it just will not be remembered.
-  }
-  document.documentElement.setAttribute("data-theme", next);
-  paintToggle();
-  render();
-});
-paintToggle();
+wireThemeToggle(render);
 
 // Static radio setup
 makeRadio("view-group", ["heatmap", "lines", "stages"], "heatmap");

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -79,6 +79,11 @@ input { accent-color: var(--series-1); }
 #stage-chart { margin-top: var(--gap-md); }
 #chart:empty, #stage-chart:empty { display: none; }
 
+/* Titles, legends and axis names. SVG text is black unless something says
+   otherwise, which is invisible on the dark theme. Text that picks its own
+   colour — the heatmap's cell labels — carries a fill attribute and is left be. */
+#chart text:not([fill]), #stage-chart text:not([fill]) { fill: var(--text-primary); }
+
 /* SVG axes */
 .axis text { font-size: 12px; fill: var(--text-secondary); }
 .axis path, .axis line { stroke: var(--axis); stroke-width: 2; }

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -70,11 +70,14 @@ input { accent-color: var(--series-1); }
 .checkbox-group { display: flex; flex-wrap: wrap; gap: var(--gap-sm) 10px; }
 .checkbox-group label { font-size: 0.78em; cursor: pointer; display: flex; align-items: center; gap: 3px; margin-bottom: 0; }
 
-/* Charts */
+/* Charts. A chart wider than the panel scrolls inside it — letting the panel
+   grow instead would drag the header and the controls off the side of a narrow
+   window. */
 #chart, #stage-chart {
-  background: var(--surface-1); border-radius: var(--radius-sm); padding: var(--gap-md);
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-  width: fit-content; min-width: 100%;
+  background: var(--surface-1); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: var(--gap-md);
+  display: flex; flex-direction: column; align-items: safe center;
+  overflow-x: auto;
 }
 #stage-chart { margin-top: var(--gap-md); }
 #chart:empty, #stage-chart:empty { display: none; }
@@ -88,6 +91,9 @@ input { accent-color: var(--series-1); }
 .axis text { font-size: 12px; fill: var(--text-secondary); }
 .axis path, .axis line { stroke: var(--axis); stroke-width: 2; }
 .grid line { stroke: var(--grid); }
+/* d3 gives a grid the same outer tick size as its inner one, which draws a full
+   width rule along the top of the plot. */
+.grid path { display: none; }
 
 /* Tooltip */
 .tooltip {
@@ -128,7 +134,12 @@ input { accent-color: var(--series-1); }
 }
 
 /* Failures details */
-#failures { margin-top: var(--gap-md); }
+#failures {
+  margin-top: var(--gap-md);
+  background: var(--surface-1); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: var(--gap-md);
+}
+#failures:empty { display: none; }
 #failures summary { font-size: 0.85em; font-weight: 600; cursor: pointer; color: var(--critical); }
 #failures table { border-collapse: collapse; font-size: 0.75em; margin-top: 6px; width: 100%; }
 #failures th, #failures td { text-align: left; padding: 3px 10px; border-bottom: 1px solid var(--grid); }
@@ -250,7 +261,7 @@ const DATA = await fetchJson("data/sweeps.json");
 const LAYOUT = {
   margin:    {top: 40, right: 200, bottom: 60, left: 195},
   heatmap:   {cellW: 70, cellH: 50},
-  lines:     {W: 800, H: 400},
+  lines:     {plotW: 600, plotH: 300, margin: {top: 40, right: 140, bottom: 60, left: 62}},
   subChart:  {W: 700, H: 200, margin: {top: 30, right: 180, bottom: 40, left: 80}},
   stageBar:  {W: 500, margin: {left: 100, right: 60, top: 30}},
   stageThru: {W: 600, margin: {left: 100, right: 80, top: 40}},
@@ -269,11 +280,13 @@ const METRIC_LABELS = {
   init_s: "Startup time (s)",
 };
 
-for (const [key, label] of Object.entries(METRIC_LABELS)) {
-  const option = document.createElement("option");
-  option.value = key;
-  option.textContent = label;
-  document.getElementById("metric-sel").appendChild(option);
+// The run metrics the chart can draw. The stage views swap in their own list
+// and swap this one back, so both come from one place and the wording of an
+// option does not change as the view does.
+const METRIC_OPTS = Object.entries(METRIC_LABELS);
+
+for (const [key, label] of METRIC_OPTS) {
+  document.getElementById("metric-sel").appendChild(new Option(label, key));
 }
 
 const COLOR_SCHEMES = {
@@ -692,13 +705,6 @@ function rebuildFailures() {
 const tooltip = d3.select("body").append("div").attr("class","tooltip").style("display","none");
 
 // --- Metric/stage-metric option swapping ---
-const METRIC_OPTS = [
-  ["throughput_in_gibs","Input Throughput (GiB/s)"],
-  ["throughput_out_gibs","Output Throughput (GiB/s)"],
-  ["compression_fold","Compression Ratio"],
-  ["wall_s","Wall Time (s)"],
-  ["init_s","Init Time (s)"],
-];
 const STAGE_METRIC_OPTS = [
   ["avg_ms","Avg Time (ms)"],
   ["best_ms","Best Time (ms)"],
@@ -856,28 +862,7 @@ function renderHeatmap(filtered, presentChunks, presentScenarios, metricKey) {
     .selectAll("text").attr("font-size","12px");
 }
 
-function renderLines(filtered, presentChunks, presentScenarios, metricKey, useOverlay) {
-  const margin = {...LAYOUT.margin, right: 140};
-  const {W, H} = LAYOUT.lines;
-  const svg = d3.select("#chart").append("svg").attr("width", W).attr("height", H);
-  const g = svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
-  const innerW = W - margin.left - margin.right;
-  const innerH = H - margin.top - margin.bottom;
-
-  const xVals = presentChunks.map(chunkLabelToBytes);
-
-  const x = d3.scaleLog().domain(d3.extent(xVals)).range([0, innerW]);
-  const allVals = filtered.map(r => r[metricKey]).filter(v => v != null);
-  if (allVals.length === 0) { d3.select("#chart").append("p").text("No data for this metric."); return; }
-  const y = d3.scaleLinear().domain([0, d3.max(allVals)*1.1]).range([innerH, 0]);
-
-  const colors = d3.scaleOrdinal(d3.schemeTableau10).domain(allScenarios);
-
-  g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","var(--grid)");
-
-  const lineLookup = new Map();
-  filtered.forEach(r => lineLookup.set(`${r.scenario}__${r.chunk_bytes_label}__${r.backend}`, r));
-
+function lineSeries(filtered, presentScenarios, useOverlay) {
   const series = [];
   if (useOverlay) {
     const backends = [...new Set(filtered.map(r => r.backend))].sort();
@@ -892,6 +877,40 @@ function renderLines(filtered, presentChunks, presentScenarios, metricKey, useOv
       series.push({scenario: sc, backend: selBackend, label: sc, dashed: false});
     }
   }
+  return series;
+}
+
+/** Room for the widest legend label, so a long scenario name is not cut off. */
+function legendRoom(labels, fontPx) {
+  const widest = Math.max(0, ...labels.map(l => l.length * fontPx * 0.55));
+  return Math.round(Math.min(320, Math.max(120, widest + 34)));
+}
+
+function renderLines(filtered, presentChunks, presentScenarios, metricKey, useOverlay) {
+  const allVals = filtered.map(r => r[metricKey]).filter(v => v != null);
+  if (allVals.length === 0) { d3.select("#chart").append("p").text("No data for this metric."); return; }
+
+  const series = lineSeries(filtered, presentScenarios, useOverlay);
+  const {plotW, plotH} = LAYOUT.lines;
+  const margin = {...LAYOUT.lines.margin, right: legendRoom(series.map(s => s.label), 12)};
+  const W = margin.left + plotW + margin.right;
+  const H = margin.top + plotH + margin.bottom;
+  const svg = d3.select("#chart").append("svg").attr("width", W).attr("height", H);
+  const g = svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
+  const innerW = plotW;
+  const innerH = plotH;
+
+  const xVals = presentChunks.map(chunkLabelToBytes);
+
+  const x = d3.scaleLog().domain(d3.extent(xVals)).range([0, innerW]);
+  const y = d3.scaleLinear().domain([0, d3.max(allVals)*1.1]).range([innerH, 0]);
+
+  const colors = d3.scaleOrdinal(d3.schemeTableau10).domain(allScenarios);
+
+  g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","var(--grid)");
+
+  const lineLookup = new Map();
+  filtered.forEach(r => lineLookup.set(`${r.scenario}__${r.chunk_bytes_label}__${r.backend}`, r));
 
   for (const s of series) {
     const pts = presentChunks.map((cl, i) => {
@@ -1115,7 +1134,9 @@ function renderStagesTiming(run, stages) {
 function renderStagesThroughput(run, stages) {
   const {W, margin: {left: mL, right: mR, top: mT}} = LAYOUT.stageThru;
   const rowH = 36, gap = 6;
-  const H = stages.length * (rowH + gap) + 80;
+  const rowsH = stages.length * (rowH + gap);
+  const legY = mT + rowsH + 36;
+  const H = legY + 26;
 
   const svg = d3.select("#stage-chart").append("svg").attr("width", W).attr("height", H);
   const g = svg.append("g").attr("transform", `translate(${mL},${mT})`);
@@ -1172,15 +1193,14 @@ function renderStagesThroughput(run, stages) {
   g.append("text").attr("x", thruX0 + thruW/2).attr("y", -8).attr("text-anchor","middle")
     .attr("font-size","12px").attr("fill","var(--text-secondary)").text("GiB/s");
 
-  g.append("g").attr("class","axis").attr("transform",`translate(0,${stages.length*(rowH+gap)})`)
+  g.append("g").attr("class","axis").attr("transform",`translate(0,${rowsH})`)
     .call(d3.axisBottom(xMs).ticks(4).tickFormat(d => d + " ms"));
-  g.append("g").attr("class","axis").attr("transform",`translate(${thruX0},${stages.length*(rowH+gap)})`)
+  g.append("g").attr("class","axis").attr("transform",`translate(${thruX0},${rowsH})`)
     .call(d3.axisBottom(xGibs).ticks(4).tickFormat(d3.format(".1f")));
 
   svg.append("text").attr("x", mL).attr("y", 18).attr("font-size","13px").attr("font-weight",700)
     .text(`Stage breakdown: ${run.scenario} ${run.chunk_bytes_label} ${run.codec} (${run.backend})`);
 
-  const legY = mT + stages.length * (rowH + gap) + 36;
   const leg = svg.append("g").attr("transform", `translate(${mL},${legY})`);
   leg.append("rect").attr("width",12).attr("height",12).attr("fill",colorIn).attr("rx",2);
   leg.append("text").attr("x",16).attr("y",10).attr("font-size","12px").text("in (GiB/s)");

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -16,92 +16,63 @@ document.documentElement.setAttribute("data-theme", (() => {
   return matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 })());
 </script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+<link rel="stylesheet" href="site.css">
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <style>
 :root {
-  --pico-font-family: "Inter", "Segoe UI", system-ui, sans-serif;
-  --color-primary: #2a78d6;
-  --color-primary-bg: #e0e7ff;
-  --color-primary-text: #1c5cab;
-  --color-text: #0b0b0b;
-  --color-muted: #52514e;
-  --color-border: #c3c2b7;
-  --color-error: #d03b3b;
-  --color-surface: #fcfcfb;
-  --color-plane: #f9f9f7;
-  --color-grid: #e1e0d9;
-  --color-axis: #c3c2b7;
-  --color-axis-text: #52514e;
-  --color-cell-empty: #ededea;
-  --color-ring: #fcfcfb;
-  --color-error-bg: #fef2f2;
   --gap-sm: 4px;
   --gap-md: 12px;
   --gap-lg: 24px;
-  --radius: 6px;
 }
-:root[data-theme="dark"] {
-  --color-primary: #3987e5;
-  --color-primary-bg: #24304a;
-  --color-primary-text: #b7d3f6;
-  --color-text: #ffffff;
-  --color-muted: #c3c2b7;
-  --color-border: #383835;
-  --color-error: #e66767;
-  --color-surface: #1a1a19;
-  --color-plane: #0d0d0d;
-  --color-grid: #2c2c2a;
-  --color-axis: #383835;
-  --color-axis-text: #c3c2b7;
-  --color-cell-empty: #262624;
-  --color-ring: #1a1a19;
-  --color-error-bg: #2a1a1a;
-}
-html, body { background: var(--color-plane); color: var(--color-text); }
-h1 { font-size: 1.4em; margin-bottom: var(--gap-sm); --pico-typography-spacing-vertical: 0; color: var(--color-text); }
-.subtitle { color: var(--color-muted); font-size: 0.85em; margin-bottom: 2px; }
+main.container { max-width: 1180px; margin: 0 auto; padding: 24px; overflow: visible; }
+h1 { font-size: 1.4em; margin: 0 0 var(--gap-sm); }
+.subtitle { color: var(--text-secondary); font-size: 0.85em; margin-bottom: 2px; }
+input { accent-color: var(--series-1); }
 
-/* Controls bar */
+/* Control strip. Three jobs, spaced apart: which sweep to look at, which runs
+   to keep, and how to draw them. */
 .controls {
-  display: flex; flex-wrap: wrap; gap: var(--gap-md);
-  margin-bottom: var(--gap-md); align-items: flex-start;
+  display: flex; flex-wrap: wrap; gap: var(--gap-md) 34px;
+  align-items: flex-start;
+  background: var(--surface-1); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: var(--gap-md);
+  margin: var(--gap-md) 0;
 }
-.controls label { font-size: 0.8em; font-weight: 600; color: var(--color-muted); display: block; margin-bottom: 2px; }
+.control-group > div > label, .control-row > label {
+  display: block; margin-bottom: 3px;
+  font-size: 0.72em; font-weight: 600; color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
 .controls select {
-  font-size: 0.8em; padding: 4px 24px 4px 8px; margin-bottom: 0; width: auto;
-  --pico-form-element-spacing-vertical: 0.1rem;
-  --pico-form-element-spacing-horizontal: 0.5rem;
+  font: inherit; font-size: 0.85em; padding: 5px 8px; width: auto;
+  color: var(--text-primary); background: var(--plane);
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
 }
-
-/* Control grouping */
 .control-group { display: flex; flex-wrap: wrap; gap: var(--gap-md); align-items: flex-start; }
-.control-group--primary { flex-wrap: nowrap; }
-.control-group--filters {
-  padding-left: var(--gap-md);
-  border-left: 2px solid var(--color-border);
+.control-row {
+  flex: 1 0 100%;
+  border-top: 1px solid var(--border); padding-top: var(--gap-md);
 }
 
-/* Segmented radio buttons — override Pico */
+/* Segmented radio buttons */
 .radio-group { display: flex; gap: 2px; }
 .radio-group label {
-  font-weight: 400; padding: 3px 8px; border: 1px solid var(--color-border);
-  cursor: pointer; font-size: 0.78em; background: var(--color-surface); margin-bottom: 0;
+  font-weight: 400; padding: 3px 8px; border: 1px solid var(--border);
+  cursor: pointer; font-size: 0.78em; background: var(--surface-1); margin-bottom: 0;
 }
-.radio-group label:first-child { border-radius: var(--radius) 0 0 var(--radius); }
-.radio-group label:last-child { border-radius: 0 var(--radius) var(--radius) 0; }
+.radio-group label:first-child { border-radius: var(--radius-sm) 0 0 var(--radius-sm); }
+.radio-group label:last-child { border-radius: 0 var(--radius-sm) var(--radius-sm) 0; }
 .radio-group input { display: none; }
 .radio-group input:checked + span { font-weight: 700; }
-.radio-group label:has(input:checked) { background: var(--color-primary-bg); border-color: var(--color-primary); }
+.radio-group label:has(input:checked) { background: var(--accent-soft); border-color: var(--series-1); }
 
 /* Checkbox groups */
 .checkbox-group { display: flex; flex-wrap: wrap; gap: var(--gap-sm) 10px; }
 .checkbox-group label { font-size: 0.78em; cursor: pointer; display: flex; align-items: center; gap: 3px; margin-bottom: 0; }
 
 /* Charts */
-main.container { overflow: visible; }
 #chart, #stage-chart {
-  background: var(--color-surface); border-radius: var(--radius); padding: var(--gap-md);
+  background: var(--surface-1); border-radius: var(--radius-sm); padding: var(--gap-md);
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
   width: fit-content; min-width: 100%;
 }
@@ -109,14 +80,14 @@ main.container { overflow: visible; }
 #chart:empty, #stage-chart:empty { display: none; }
 
 /* SVG axes */
-.axis text { font-size: 12px; fill: var(--color-axis-text); }
-.axis path, .axis line { stroke: var(--color-axis); stroke-width: 2; }
-.grid line { stroke: var(--color-grid); }
+.axis text { font-size: 12px; fill: var(--text-secondary); }
+.axis path, .axis line { stroke: var(--axis); stroke-width: 2; }
+.grid line { stroke: var(--grid); }
 
 /* Tooltip */
 .tooltip {
   position: absolute; background: rgba(20,20,40,0.92); color: #fff;
-  padding: 8px 12px; border-radius: var(--radius);
+  padding: 8px 12px; border-radius: var(--radius-sm);
   font-size: 0.75em; pointer-events: none; line-height: 1.5;
   max-width: 320px; white-space: pre-line; z-index: 100;
 }
@@ -124,71 +95,48 @@ main.container { overflow: visible; }
 /* Toggle button */
 .btn-toggle {
   cursor: pointer; font-size: 0.8em; padding: 4px 10px;
-  border: 1px solid var(--color-primary); background: var(--color-primary-bg);
-  border-radius: var(--radius); color: var(--color-primary-text);
+  border: 1px solid var(--series-1); background: var(--accent-soft);
+  border-radius: var(--radius-sm); color: var(--accent-text);
 }
-.btn-toggle.active { background: var(--color-primary); color: var(--color-surface); }
+.btn-toggle.active { background: var(--series-1); color: var(--surface-1); }
 
 /* Scenarios */
 .scenario-groups { display: flex; flex-wrap: wrap; gap: 6px 20px; }
 .scenario-group-box { font-size: 0.78em; }
 .scenario-group-box .group-header {
-  font-weight: 600; color: var(--color-muted); font-size: 0.9em; margin-bottom: 2px;
+  font-weight: 600; color: var(--text-secondary); font-size: 0.9em; margin-bottom: 2px;
   display: flex; align-items: center; gap: 6px;
 }
 .scenario-group-box .group-header button {
   font-size: 0.85em; border: none; background: none;
-  color: var(--color-primary); cursor: pointer; padding: 0;
+  color: var(--series-1); cursor: pointer; padding: 0;
 }
 .scenario-group-box .group-header button:hover { text-decoration: underline; }
 .scenario-group-box .checkbox-group { margin-left: 2px; }
 
 /* Failure badge */
 .fail-badge {
-  font-size: 0.5em; font-weight: 600; color: var(--color-error);
-  background: var(--color-error-bg); border: 1px solid var(--color-error);
-  border-radius: var(--radius); padding: 2px 8px;
+  font-size: 0.5em; font-weight: 600; color: var(--critical);
+  background: var(--critical-soft); border: 1px solid var(--critical);
+  border-radius: var(--radius-sm); padding: 2px 8px;
   vertical-align: middle; white-space: nowrap;
 }
 
 /* Failures details */
 #failures { margin-top: var(--gap-md); }
-#failures summary { font-size: 0.85em; font-weight: 600; cursor: pointer; color: var(--color-error); }
+#failures summary { font-size: 0.85em; font-weight: 600; cursor: pointer; color: var(--critical); }
 #failures table { border-collapse: collapse; font-size: 0.75em; margin-top: 6px; width: 100%; }
-#failures th, #failures td { text-align: left; padding: 3px 10px; border-bottom: 1px solid var(--color-grid); }
-#failures th { color: var(--color-muted); font-weight: 600; }
-#failures .status-error { color: var(--color-error); font-weight: 600; }
+#failures th, #failures td { text-align: left; padding: 3px 10px; border-bottom: 1px solid var(--grid); }
+#failures th { color: var(--text-secondary); font-weight: 600; }
+#failures .status-error { color: var(--critical); font-weight: 600; }
 #failures .status-timeout { color: #c2410c; font-weight: 600; }
 #failures .status-missing { color: #6b7280; font-weight: 600; }
 
-/* Site navigation — shared with the overview page */
-.site-head {
-  display: flex; align-items: center; gap: var(--gap-lg); flex-wrap: wrap;
-  padding: 12px 24px; margin-bottom: var(--gap-md);
-  background: var(--color-surface); border-bottom: 1px solid var(--color-border);
-}
-.site-head .brand { font-weight: 650; }
-.site-head nav { display: flex; gap: 4px; margin-right: auto; }
-.site-head nav a {
-  padding: 4px 10px; border-radius: var(--radius); text-decoration: none;
-  color: var(--color-muted); font-size: 0.9em;
-}
-.site-head nav a[aria-current="page"] { background: var(--color-plane); color: var(--color-text); font-weight: 600; }
-.theme-toggle {
-  font: inherit; font-size: 0.85em; padding: 4px 10px; cursor: pointer; width: auto;
-  background: var(--color-surface); color: var(--color-muted);
-  border: 1px solid var(--color-border); border-radius: var(--radius);
-}
-
 /* Mobile */
 @media (max-width: 640px) {
+  main.container { padding: var(--gap-md); }
   .controls { flex-direction: column; }
   .control-group { flex-direction: column; }
-  .control-group--primary { flex-wrap: wrap; }
-  .control-group--filters {
-    border-left: none; padding-left: 0;
-    border-top: 1px solid var(--color-border); padding-top: var(--gap-md);
-  }
   .scenario-groups { flex-direction: column; gap: var(--gap-md); }
   .checkbox-group { gap: var(--gap-sm) 14px; }
 }
@@ -201,6 +149,7 @@ main.container { overflow: visible; }
     <a href="index.html">Over time</a>
     <a href="explore.html" aria-current="page">Benchmark explorer</a>
   </nav>
+  <a class="repo-link" href="https://github.com/acquire-project/chucky">Source</a>
   <button class="theme-toggle" id="theme-toggle" type="button">Dark</button>
 </header>
 <main class="container">
@@ -210,21 +159,17 @@ main.container { overflow: visible; }
 <div class="subtitle" id="s3-info" style="display:none"></div>
 
 <div class="controls">
-  <div class="control-group control-group--primary">
+  <div class="control-group" id="source-controls">
+    <div id="machine-wrap">
+      <label for="machine-sel">Machine</label>
+      <select id="machine-sel"></select>
+    </div>
     <div id="results-wrap">
-      <label>Sweep</label>
+      <label for="results-sel">Sweep</label>
       <select id="results-sel"></select>
     </div>
-    <div id="metric-wrap">
-      <label>Metric</label>
-      <select id="metric-sel"></select>
-    </div>
   </div>
-  <div>
-    <label>View</label>
-    <div class="radio-group" id="view-group"></div>
-  </div>
-  <div class="control-group control-group--filters">
+  <div class="control-group" id="filter-controls">
     <div id="codec-wrap">
       <label>Codec</label>
       <div class="radio-group" id="codec-group"></div>
@@ -249,21 +194,29 @@ main.container { overflow: visible; }
       <label>S3 throughput (Gb/s)</label>
       <div class="radio-group" id="s3-throughput-group"></div>
     </div>
+  </div>
+  <div class="control-group" id="draw-controls">
+    <div id="metric-wrap">
+      <label for="metric-sel">Metric</label>
+      <select id="metric-sel"></select>
+    </div>
+    <div>
+      <label>View</label>
+      <div class="radio-group" id="view-group"></div>
+    </div>
     <div id="overlay-wrap" style="display:none">
       <label>&nbsp;</label>
       <button class="btn-toggle" id="overlay-toggle">Overlay Backends</button>
     </div>
   </div>
-</div>
-
-<div id="scenario-controls" style="margin-bottom: 12px;">
-  <label style="font-size:0.8em;font-weight:600;color:#444;">Scenarios</label>
-  <div class="scenario-groups" id="scenario-group"></div>
-</div>
-
-<div id="stage-filter-controls" style="margin-bottom: 12px; display:none;">
-  <label style="font-size:0.8em;font-weight:600;color:#444;">Stages</label>
-  <div class="checkbox-group" id="stage-filter-group"></div>
+  <div class="control-row" id="scenario-controls">
+    <label>Scenarios</label>
+    <div class="scenario-groups" id="scenario-group"></div>
+  </div>
+  <div class="control-row" id="stage-filter-controls" style="display:none">
+    <label>Stages</label>
+    <div class="checkbox-group" id="stage-filter-group"></div>
+  </div>
 </div>
 
 <div id="chart"></div>
@@ -358,6 +311,7 @@ function scenarioSort(a, b) {
 }
 
 const files = DATA.files;
+const fileByName = new Map(files.map(f => [f.filename, f]));
 
 // --- Active data (rebuilt on file switch) ---
 let runs = [];
@@ -368,10 +322,11 @@ let allStageNames = [];
 let allS3Throughputs = [];
 
 // --- UI state (declared here, wired in section 5) ---
+const machineSel = document.getElementById("machine-sel");
 const resultsSel = document.getElementById("results-sel");
 let overlayBackends = false;
 
-function getActiveFile() { return files[resultsSel.value]; }
+function getActiveFile() { return fileByName.get(resultsSel.value); }
 
 function rebuildData() {
   const file = getActiveFile();
@@ -491,6 +446,13 @@ function autoHide(wrapId, values) {
   document.getElementById(wrapId).style.display = values.length <= 1 ? "none" : "";
 }
 
+/** A group with every control hidden would otherwise hold its share of the spacing. */
+function hideEmptyGroup(groupId) {
+  const group = document.getElementById(groupId);
+  const shown = [...group.children].some(child => child.style.display !== "none");
+  group.style.display = shown ? "" : "none";
+}
+
 // --- Scenario checkboxes (grouped) ---
 const scenarioGroup = document.getElementById("scenario-group");
 
@@ -596,9 +558,15 @@ function getCheckedStages() {
 let prevCodec = "zstd", prevFill = "xor", prevBackend = "gpu", prevDtype = "u16", prevSink = "discard", prevS3tp = null;
 
 function rebuildControls() {
-  const machine = getActiveFile().machine || {};
-  document.getElementById("machine-info").textContent =
-    `${machine.hostname || "?"} | ${machine.gpu || "?"} | ${machine.commit ? machine.commit + " | " : ""}${machine.date || "?"}`;
+  const file = getActiveFile();
+  const machine = file.machine || {};
+  document.getElementById("machine-info").textContent = [
+    file.machine_name,
+    machine.hostname || "?",
+    machine.gpu || "?",
+    machine.commit || file.commit,
+    machine.date || file.day || "?",
+  ].filter(Boolean).join(" | ");
 
   // S3 metadata from runs (region, bucket, endpoint)
   const s3Runs = (getActiveFile().runs || []).filter(r => r.sink === "s3");
@@ -644,7 +612,9 @@ function rebuildControls() {
     makeRadio("s3-throughput-group", allS3Throughputs, allS3Throughputs.includes(prevS3tp) ? prevS3tp : undefined);
   }
 
+  autoHide("codec-wrap", allCodecs);
   autoHide("fill-wrap", allFills);
+  autoHide("backend-wrap", allBackends);
   autoHide("dtype-wrap", allDtypes);
   autoHide("sink-wrap", allSinks);
 
@@ -657,6 +627,8 @@ function rebuildControls() {
   rebuildScenarios();
   rebuildStageFilters();
   rebuildFailures();
+  document.getElementById("scenario-controls").style.display =
+    allScenarios.length > 1 ? "" : "none";
 }
 
 // --- Failures table ---
@@ -753,11 +725,15 @@ function updateControlVisibility(viewMode, useOverlay) {
   }
   document.getElementById("backend-wrap").style.opacity = useOverlay ? "0.4" : "";
   document.getElementById("backend-wrap").style.pointerEvents = useOverlay ? "none" : "";
-  document.getElementById("stage-filter-controls").style.display = isStages ? "" : "none";
+  document.getElementById("stage-filter-controls").style.display =
+    isStages && allStageNames.length > 1 ? "" : "none";
 
   const sink = getRadio("sink-group");
   const showTp = sink === "s3" && allS3Throughputs.length > 1;
   document.getElementById("s3-throughput-wrap").style.display = showTp ? "" : "none";
+
+  hideEmptyGroup("source-controls");
+  hideEmptyGroup("filter-controls");
 }
 
 function render() {
@@ -824,8 +800,8 @@ function renderHeatmap(filtered, presentChunks, presentScenarios, metricKey) {
         .attr("x", x(cl)).attr("y", y(sc))
         .attr("width", x.bandwidth()).attr("height", y.bandwidth())
         .attr("rx", 3)
-        .attr("fill", val != null ? color(val) : "var(--color-cell-empty)")
-        .attr("stroke", "var(--color-ring)").attr("stroke-width", 1)
+        .attr("fill", val != null ? color(val) : "var(--cell-empty)")
+        .attr("stroke", "var(--surface-1)").attr("stroke-width", 1)
         .style("cursor", r ? "pointer" : "default");
 
       if (val != null) {
@@ -852,7 +828,7 @@ function renderHeatmap(filtered, presentChunks, presentScenarios, metricKey) {
   g.append("g").attr("class","axis").attr("transform",`translate(0,${innerH})`)
     .call(d3.axisBottom(x)).selectAll("text").attr("font-size","12px");
   g.append("text").attr("x", innerW/2).attr("y", innerH + margin.bottom - 10)
-    .attr("text-anchor","middle").attr("font-size","12px").attr("fill","var(--color-muted)").text("Chunk Size");
+    .attr("text-anchor","middle").attr("font-size","12px").attr("fill","var(--text-secondary)").text("Chunk Size");
   g.append("g").attr("class","axis").call(d3.axisLeft(y))
     .selectAll("text").attr("font-size","12px");
 
@@ -892,7 +868,7 @@ function renderLines(filtered, presentChunks, presentScenarios, metricKey, useOv
 
   const colors = d3.scaleOrdinal(d3.schemeTableau10).domain(allScenarios);
 
-  g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","var(--color-grid)");
+  g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","var(--grid)");
 
   const lineLookup = new Map();
   filtered.forEach(r => lineLookup.set(`${r.scenario}__${r.chunk_bytes_label}__${r.backend}`, r));
@@ -927,7 +903,7 @@ function renderLines(filtered, presentChunks, presentScenarios, metricKey, useOv
     pts.forEach(p => {
       const circle = g.append("circle").attr("cx", x(p.x)).attr("cy", y(p.y)).attr("r", 4)
         .attr("fill", colors(s.scenario)).style("cursor","pointer");
-      if (s.dashed) circle.attr("stroke", "var(--color-ring)").attr("stroke-width", 1);
+      if (s.dashed) circle.attr("stroke", "var(--surface-1)").attr("stroke-width", 1);
       circle
         .on("mousemove", (ev) => {
           tooltip.style("display","block")
@@ -995,11 +971,11 @@ function renderStageLines(filtered, presentChunks, presentScenarios, stageMetric
     if (useOverlay) {
       const oy = stageNames.length * 15 + 6;
       lg.append("line").attr("x1", 0).attr("y1", oy + 4).attr("x2", 14).attr("y2", oy + 4)
-        .attr("stroke", "var(--color-muted)").attr("stroke-width", 1.5);
-      lg.append("text").attr("x", 18).attr("y", oy + 8).attr("font-size", "9px").attr("fill", "var(--color-muted)").text("gpu");
+        .attr("stroke", "var(--text-secondary)").attr("stroke-width", 1.5);
+      lg.append("text").attr("x", 18).attr("y", oy + 8).attr("font-size", "9px").attr("fill", "var(--text-secondary)").text("gpu");
       lg.append("line").attr("x1", 0).attr("y1", oy + 18).attr("x2", 14).attr("y2", oy + 18)
-        .attr("stroke", "var(--color-muted)").attr("stroke-width", 1.5).attr("stroke-dasharray", "4,2");
-      lg.append("text").attr("x", 18).attr("y", oy + 22).attr("font-size", "9px").attr("fill", "var(--color-muted)").text("cpu");
+        .attr("stroke", "var(--text-secondary)").attr("stroke-width", 1.5).attr("stroke-dasharray", "4,2");
+      lg.append("text").attr("x", 18).attr("y", oy + 22).attr("font-size", "9px").attr("fill", "var(--text-secondary)").text("cpu");
     }
   }
 
@@ -1029,7 +1005,7 @@ function renderStageLines(filtered, presentChunks, presentScenarios, stageMetric
     const x = d3.scaleLog().domain(xExtent).range([0, innerW]);
     const y = d3.scaleLinear().domain([0, globalYMax]).range([innerH, 0]);
 
-    g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","var(--color-grid)");
+    g.append("g").attr("class","grid").call(d3.axisLeft(y).tickSize(-innerW).tickFormat("")).selectAll("line").attr("stroke","var(--grid)");
 
     const backends = useOverlay
       ? [...new Set(filtered.filter(r => r.scenario === sc).map(r => r.backend))].sort()
@@ -1054,7 +1030,7 @@ function renderStageLines(filtered, presentChunks, presentScenarios, stageMetric
         pts.forEach(p => {
           const circle = g.append("circle").attr("cx", x(p.x)).attr("cy", y(p.y)).attr("r", 3)
             .attr("fill", stageColors(p.stage)).style("cursor","pointer");
-          if (dashed) circle.attr("stroke", "var(--color-ring)").attr("stroke-width", 1);
+          if (dashed) circle.attr("stroke", "var(--surface-1)").attr("stroke-width", 1);
           circle
             .on("mousemove", (ev) => {
               tooltip.style("display","block")
@@ -1116,11 +1092,11 @@ function renderStagesTiming(run, stages) {
   stages.forEach(([name, s], i) => {
     const yy = i * (barH + gap);
     g.append("rect").attr("x",0).attr("y", yy).attr("width", x(s.avg_ms)).attr("height", barH)
-      .attr("fill", "var(--color-primary)").attr("rx", 3);
+      .attr("fill", "var(--series-1)").attr("rx", 3);
     g.append("text").attr("x", -6).attr("y", yy + barH/2).attr("text-anchor","end")
       .attr("dominant-baseline","central").attr("font-size","12px").text(name);
     g.append("text").attr("x", x(s.avg_ms) + 4).attr("y", yy + barH/2)
-      .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--color-muted)")
+      .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--text-secondary)")
       .text(`${s.avg_ms.toFixed(1)} ms`);
   });
 
@@ -1164,7 +1140,7 @@ function renderStagesThroughput(run, stages) {
     g.append("rect").attr("x",0).attr("y", yy + 4).attr("width", xMs(s.avg_ms)).attr("height", rowH - 8)
       .attr("fill", "#a5b4fc").attr("rx", 3);
     g.append("text").attr("x", xMs(s.avg_ms) + 3).attr("y", yy + rowH/2)
-      .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--color-muted)")
+      .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--text-secondary)")
       .text(`${s.avg_ms.toFixed(1)} ms`);
 
     const inVal = s.in_gibs || 0;
@@ -1174,22 +1150,22 @@ function renderStagesThroughput(run, stages) {
       g.append("rect").attr("x", thruX0).attr("y", yy).attr("width", xGibs(inVal)).attr("height", barH)
         .attr("fill", colorIn).attr("rx", 2);
       g.append("text").attr("x", thruX0 + xGibs(inVal) + 3).attr("y", yy + barH/2)
-        .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--color-muted)")
+        .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--text-secondary)")
         .text(`${inVal.toFixed(2)}`);
     }
     if (outVal > 0) {
       g.append("rect").attr("x", thruX0).attr("y", yy + barH + 2).attr("width", xGibs(outVal)).attr("height", barH)
         .attr("fill", colorOut).attr("rx", 2);
       g.append("text").attr("x", thruX0 + xGibs(outVal) + 3).attr("y", yy + barH + 2 + barH/2)
-        .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--color-muted)")
+        .attr("dominant-baseline","central").attr("font-size","12px").attr("fill","var(--text-secondary)")
         .text(`${outVal.toFixed(2)}`);
     }
   });
 
   g.append("text").attr("x", timingW/2).attr("y", -8).attr("text-anchor","middle")
-    .attr("font-size","12px").attr("fill","var(--color-muted)").text("avg ms");
+    .attr("font-size","12px").attr("fill","var(--text-secondary)").text("avg ms");
   g.append("text").attr("x", thruX0 + thruW/2).attr("y", -8).attr("text-anchor","middle")
-    .attr("font-size","12px").attr("fill","var(--color-muted)").text("GiB/s");
+    .attr("font-size","12px").attr("fill","var(--text-secondary)").text("GiB/s");
 
   g.append("g").attr("class","axis").attr("transform",`translate(0,${stages.length*(rowH+gap)})`)
     .call(d3.axisBottom(xMs).ticks(4).tickFormat(d => d + " ms"));
@@ -1211,17 +1187,48 @@ function renderStagesThroughput(run, stages) {
 // 5. INITIALIZATION
 // =========================================================================
 
-// Results file selector. ?file=<name> lets the overview page link to one sweep.
-files.forEach((f, i) => {
-  const opt = document.createElement("option");
-  opt.value = i;
-  opt.textContent = f.label || f.filename;
-  resultsSel.appendChild(opt);
-});
-const requestedFile = new URLSearchParams(location.search).get("file");
-const requestedIndex = requestedFile ? files.findIndex(f => f.filename === requestedFile) : -1;
-resultsSel.value = requestedIndex >= 0 ? requestedIndex : files.length - 1;
-if (files.length <= 1) document.getElementById("results-wrap").style.display = "none";
+// Machine, then one of its sweeps. report.py orders the list oldest first, so
+// the last entry is the newest sweep anywhere and that is what opens.
+// ?file=<name> lets the overview link to one sweep.
+const ALL_MACHINES = "";
+
+function sweepsFor(machine) {
+  return machine === ALL_MACHINES ? files.slice() : files.filter(f => f.machine_name === machine);
+}
+
+function sweepLabel(file, showMachine) {
+  const parts = [file.day];
+  if (showMachine) parts.push(file.machine_name);
+  parts.push(file.commit);
+  if (file.member !== file.machine_name) parts.push(`(${file.member})`);
+  return parts.filter(Boolean).join(" ");
+}
+
+function fillMachines() {
+  const names = [...new Set(files.map(f => f.machine_name))]
+    .sort((a, b) => a.localeCompare(b, undefined, {sensitivity: "base"}));
+  machineSel.appendChild(new Option("All machines", ALL_MACHINES));
+  for (const name of names) machineSel.appendChild(new Option(name, name));
+  document.getElementById("machine-wrap").style.display = names.length > 1 ? "" : "none";
+}
+
+function fillSweeps(selected) {
+  const machine = machineSel.value;
+  const newestFirst = sweepsFor(machine).reverse();
+  resultsSel.innerHTML = "";
+  for (const file of newestFirst) {
+    resultsSel.appendChild(new Option(sweepLabel(file, machine === ALL_MACHINES), file.filename));
+  }
+  resultsSel.value = newestFirst.some(f => f.filename === selected)
+    ? selected : newestFirst[0].filename;
+  document.getElementById("results-wrap").style.display = newestFirst.length > 1 ? "" : "none";
+}
+
+const requested = new URLSearchParams(location.search).get("file");
+const opening = fileByName.get(requested) || files[files.length - 1];
+fillMachines();
+machineSel.value = opening.machine_name;
+fillSweeps(opening.filename);
 
 const themeToggle = document.getElementById("theme-toggle");
 function currentTheme() { return document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"; }
@@ -1260,6 +1267,11 @@ async function showActiveFile() {
 }
 
 resultsSel.addEventListener("change", showActiveFile);
+
+machineSel.addEventListener("change", () => {
+  fillSweeps(null);
+  showActiveFile();
+});
 
 // Initial load
 await showActiveFile();

--- a/scripts/sweep/theme.js
+++ b/scripts/sweep/theme.js
@@ -1,0 +1,41 @@
+// Light or dark, for both pages. Loaded before the body so a stored choice is
+// applied before the page paints rather than after its data arrives.
+
+function storedTheme() {
+  // Reading storage throws in some private-browsing contexts, and this runs
+  // before anything is drawn, so a preference must never be fatal.
+  try {
+    const stored = localStorage.getItem("bench-theme");
+    return stored === "light" || stored === "dark" ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+function currentTheme() {
+  return storedTheme() ?? (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+}
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
+/** Wire the title bar's button. onChange redraws whatever the page has drawn. */
+function wireThemeToggle(onChange) {
+  const button = document.getElementById("theme-toggle");
+  const paint = () => { button.textContent = currentTheme() === "dark" ? "Light" : "Dark"; };
+  button.addEventListener("click", () => {
+    const next = currentTheme() === "dark" ? "light" : "dark";
+    try {
+      localStorage.setItem("bench-theme", next);
+    } catch {
+      // The choice still applies to this page; it just will not be remembered.
+    }
+    applyTheme(next);
+    paint();
+    onChange();
+  });
+  paint();
+}
+
+applyTheme(currentTheme());


### PR DESCRIPTION
Four follow-ups from reviewing the report pages after #179.

**A link back to the repository.** The title bar carries a "Source" link to
`github.com/acquire-project/chucky`.

**One title bar on both pages.** The palette, the page frame and the header move
into `scripts/sweep/site.css`, which `report.py` copies beside the pages the way
it copies `decode.js`. Both pages now speak one variable vocabulary — the
overview's `--surface-1` / `--text-secondary` / `--border` — and the header
measures the same on each: 54.1 px tall, 16 px gaps, the same bottom border.
Dropping Pico from the explorer costs a CDN dependency and gains nothing lost:
the explorer supplies its own form, container and typography rules, which is
what the overview already did.

**Sweeps in date order.** `explorer_index` sorts by `(day, date, machine)`, the
same key `build_summary` uses, so the list is history rather than filenames. The
dropdown lists it newest first and opens on the newest sweep anywhere — today
2026-08-07 rather than 2026-06-13. `?file=` deep links are unaffected.

**A machine selector, and fewer controls on screen.** `explorer_index` now gets
`bench/machines.toml`, so the explorer groups sweep names the way the overview
does: `LiveScreen-1` and `livescreen-kubuntu` are one `livescreen` entry, and a
sweep that ran under another name says so in its label. Picking a machine cuts
22 entries to a handful; "All machines" keeps the flat list.

The control strip is now one panel holding three groups — which sweep to look at,
which runs to keep, how to draw them — with the scenario and stage checkboxes as
rows below a rule. Codec and Backend join Fill, Data type and Sink in
disappearing when the open sweep leaves nothing to choose, and a group whose
controls are all hidden stops taking up space. On the sweep the page opens with,
that removes Data type; on the reef-l40 sweep it removes Fill, Data type and
Sink.

Closes #182

Checked in headless Chromium against a site built from all 23 results files:
both pages' header metrics now match, no console errors, the overview's text and
SVG contents are byte-identical to `main`, and the explorer's machine switch,
sweep switch, deep link, and heatmap/lines/stages views all redraw.
