### PR TITLE
One scatter launch per dispatch

### DIFF
--- a/dev/gpu-orchestration.md
+++ b/dev/gpu-orchestration.md
@@ -79,11 +79,11 @@ data itself.
 **Dispatch groups appends** (#173). An append copies into the pinned staging
 buffer and returns. Nothing reaches the device until that buffer fills or the
 caller flushes, at which point one transfer moves the whole buffer and one
-scatter runs per epoch it covers. A dispatch is capped at the room left in the
-batch, since that is what the chunk pool holds — or at one epoch for a
-multiscale stream, whose linear buffer holds one. So `buffer_capacity_bytes`
-sets the transfer size, and the append cursor runs ahead of the epochs the
-schedule has counted by whatever is still staged.
+scatter covers it, whichever epochs it spans. A dispatch is capped at the room
+left in the batch, since that is what the chunk pool holds — or at one epoch
+for a multiscale stream, whose linear buffer holds one. So
+`buffer_capacity_bytes` sets the transfer size, and the append cursor runs
+ahead of the epochs the schedule has counted by whatever is still staged.
 
 ### Cost of grouped dispatch
 

--- a/dev/gpu-orchestration.md
+++ b/dev/gpu-orchestration.md
@@ -284,12 +284,13 @@ pointer with no ordering attached, and has seven non-test callers in
 Each is correct today because a comment says so. Two zero a pool; the rest read
 at an offset inside a generation the caller already holds.
 
-#173 added a second way past the pool API — the scatter stepped a raw device
+#173 added a third way past the pool API — the scatter stepped a raw device
 pointer from one epoch's region to the next — and #181 removed it by scattering
 a whole buffer in one launch. The kernel derives the region from the element
-index and the stride it is handed, so nothing steps pool memory by hand.
+index and the stride it is handed, so nothing steps pool memory by hand. The two
+`gpu_pool_at` uses above remain.
 
-Work: give the pool an operation for the remaining use, then remove
+Work: give the pool an operation for each of those two uses, then remove
 `gpu_pool_at`.
 
 *Done when:* the rule is checkable with grep instead of by reading comments.

--- a/dev/gpu-orchestration.md
+++ b/dev/gpu-orchestration.md
@@ -284,11 +284,10 @@ pointer with no ordering attached, and has seven non-test callers in
 Each is correct today because a comment says so. Two zero a pool; the rest read
 at an offset inside a generation the caller already holds.
 
-#173 added a third way past the pool API — the scatter stepped a raw device
-pointer from one epoch's region to the next — and #181 removed it by scattering
-a whole buffer in one launch. The kernel derives the region from the element
-index and the stride it is handed, so nothing steps pool memory by hand. The two
-`gpu_pool_at` uses above remain.
+#173 added another way past the pool API — the scatter stepped a raw device
+pointer from one epoch's region to the next — and #181 removed it: the host no
+longer mints pool pointers, since the kernel finds each region from the element
+index and a stride. Both kinds of `gpu_pool_at` call above remain.
 
 Work: give the pool an operation for each of those two uses, then remove
 `gpu_pool_at`.

--- a/dev/gpu-orchestration.md
+++ b/dev/gpu-orchestration.md
@@ -22,8 +22,8 @@ using chucky are in `docs/`.
   of them.
 - **Append** — one call handing data to the writer. Appends accumulate in the
   staging buffer and do not reach the device on their own.
-- **Dispatch** — one transfer of a filled staging buffer, and the scatters that
-  place it. Covers as many epochs as the buffer spans.
+- **Dispatch** — one transfer of a filled staging buffer, and the scatter that
+  places it. Covers as many epochs as the buffer spans.
 - **Shard** — a group of chunks written as one file, ending with an index of
   each chunk's offset and size.
 - **Sink** — whatever finished shards are handed to: files, object storage, or
@@ -284,12 +284,12 @@ pointer with no ordering attached, and has seven non-test callers in
 Each is correct today because a comment says so. Two zero a pool; the rest read
 at an offset inside a generation the caller already holds.
 
-#173 added a second way past the pool API: the scatter steps a raw device
-pointer from one epoch's region to the next, so those derivations never appear
-in a search for `gpu_pool_at`. #181 would remove them by scattering a whole
-buffer in one launch.
+#173 added a second way past the pool API — the scatter stepped a raw device
+pointer from one epoch's region to the next — and #181 removed it by scattering
+a whole buffer in one launch. The kernel derives the region from the element
+index and the stride it is handed, so nothing steps pool memory by hand.
 
-Work: give the pool an operation for each of those two uses, then remove
+Work: give the pool an operation for the remaining use, then remove
 `gpu_pool_at`.
 
 *Done when:* the rule is checkable with grep instead of by reading comments.

--- a/dev/gpu-orchestration.md
+++ b/dev/gpu-orchestration.md
@@ -79,11 +79,11 @@ data itself.
 **Dispatch groups appends** (#173). An append copies into the pinned staging
 buffer and returns. Nothing reaches the device until that buffer fills or the
 caller flushes, at which point one transfer moves the whole buffer and one
-scatter covers it, whichever epochs it spans. A dispatch is capped at the room
-left in the batch, since that is what the chunk pool holds — or at one epoch
-for a multiscale stream, whose linear buffer holds one. So
-`buffer_capacity_bytes` sets the transfer size, and the append cursor runs
-ahead of the epochs the schedule has counted by whatever is still staged.
+scatter places it. A dispatch is capped at the room left in the batch, since
+that is what the chunk pool holds — or at one epoch for a multiscale stream,
+whose linear buffer holds one. So `buffer_capacity_bytes` sets the transfer
+size, and the append cursor runs ahead of the epochs the schedule has counted
+by whatever is still staged.
 
 ### Cost of grouped dispatch
 
@@ -284,10 +284,10 @@ pointer with no ordering attached, and has seven non-test callers in
 Each is correct today because a comment says so. Two zero a pool; the rest read
 at an offset inside a generation the caller already holds.
 
-#173 added another way past the pool API — the scatter stepped a raw device
-pointer from one epoch's region to the next — and #181 removed it: the host no
-longer mints pool pointers, since the kernel finds each region from the element
-index and a stride. Both kinds of `gpu_pool_at` call above remain.
+#173 added another way past the pool API: the scatter stepped a raw device
+pointer from one epoch's region to the next. #181 removed it. The kernel finds
+each region from the element index and a stride, so the host hands out no pool
+pointers of its own. Both kinds of `gpu_pool_at` call above remain.
 
 Work: give the pool an operation for each of those two uses, then remove
 `gpu_pool_at`.

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -28,10 +28,9 @@ struct pool_state
 // pool payloads — non-init code reaches them through d_pool/h_pool only.
 struct staging_slot
 {
-  void* h_in;          // pinned host, size = buffer_capacity_bytes
-  CUdeviceptr d_in;    // device, size = buffer_capacity_bytes plus the room the
-                       // scatter reads past its source
-  CUevent t_h2d_start; // recorded before H2D memcpy (timing)
+  void* h_in;              // pinned host, size = buffer_capacity_bytes
+  CUdeviceptr d_in;        // device, size = buffer_capacity_bytes
+  CUevent t_h2d_start;     // recorded before H2D memcpy (timing)
   size_t dispatched_bytes; // bytes transferred in last dispatch
   int h2d_pending;         // dispatched, interval not yet folded into metrics
 };

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -173,9 +173,7 @@ ingest_dispatch_scatter(struct staging_state* stage,
   const uint64_t epoch_elements = layout->epoch_elements;
   const uint64_t in_epoch = first_element % epoch_elements;
   // Regions past the ones the caller acquired belong to the next pool slot.
-  CHECK(Error,
-        (in_epoch + elements + epoch_elements - 1) / epoch_elements <=
-          dst.epochs);
+  CHECK(Error, ceildiv(in_epoch + elements, epoch_elements) <= dst.epochs);
 
   const int idx = stage->current;
   struct staging_slot* ss = &stage->slot[idx];

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -168,11 +168,8 @@ ingest_dispatch_scatter(struct staging_state* stage,
   if (elements == 0)
     return 0;
 
-  // The chunk position a scatter computes repeats every epoch_elements, because
-  // compute_level_layout zeroes the append dims' chunk strides and
-  // dims_n_append allows a chunk size above 1 only on the first append dim. So
-  // the kernel gets the position within the epoch and finds the later regions
-  // itself.
+  // A chunk position repeats every epoch, since the append dimensions do not
+  // reach it.
   const uint64_t epoch_elements = layout->epoch_elements;
   const uint64_t in_epoch = first_element % epoch_elements;
   // Regions past the ones the caller acquired belong to the next pool slot.

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -49,15 +49,7 @@ ingest_init(struct staging_state* stage,
   gpu_pool_init(&stage->h_pool, ord, GPU_EDGE_COUNT, GPU_EDGE_STAGING_FREE);
   for (int i = 0; i < 2; ++i) {
     CU(Fail, cuMemHostAlloc(&stage->slot[i].h_in, buffer_capacity_bytes, 0));
-    CU(Fail,
-       cuMemAlloc(&stage->slot[i].d_in,
-                  buffer_capacity_bytes + TRANSPOSE_SOURCE_PAD_BYTES));
-    // The scatter's word-aligned reads can run past the last element; see
-    // TRANSPOSE_SOURCE_PAD_BYTES.
-    CU(Fail,
-       cuMemsetD8(stage->slot[i].d_in,
-                  0,
-                  buffer_capacity_bytes + TRANSPOSE_SOURCE_PAD_BYTES));
+    CU(Fail, cuMemAlloc(&stage->slot[i].d_in, buffer_capacity_bytes));
     gpu_pool_bind(&stage->h_pool, i, stage->slot[i].h_in);
     gpu_pool_bind(&stage->d_pool, i, (void*)(uintptr_t)stage->slot[i].d_in);
     CU(Fail, cuEventCreate(&stage->slot[i].t_h2d_start, CU_EVENT_DEFAULT));
@@ -161,49 +153,37 @@ Error:
 
 // The chunk position a scatter computes repeats every epoch_elements, because
 // compute_level_layout zeroes the append dims' chunk strides and dims_n_append
-// allows a chunk size above 1 only on the first append dim. So each epoch the
-// buffer covers gets its own call against its own region of the pool.
+// allows a chunk size above 1 only on the first append dim. So the kernel needs
+// only the position within the epoch, and steps to the next pool region itself
+// for the elements past the end of one.
 static int
-scatter_by_epoch(const struct tile_stream_layout* layout,
-                 const struct tile_stream_layout_gpu* layout_gpu,
-                 struct scatter_destination dst,
-                 struct gpu_pool_view d_in,
-                 size_t bytes,
-                 uint64_t first_element,
-                 size_t bpe,
-                 CUstream compute)
+scatter(const struct tile_stream_layout* layout,
+        const struct tile_stream_layout_gpu* layout_gpu,
+        struct scatter_destination dst,
+        struct gpu_pool_view d_in,
+        size_t bytes,
+        uint64_t first_element,
+        size_t bpe,
+        CUstream compute)
 {
   const uint64_t epoch_elements = layout->epoch_elements;
-  uint64_t element = first_element;
-  CUdeviceptr d_epoch = gpu_pool_view_d(dst.first_epoch);
-  uint32_t epoch = 0;
+  const uint64_t in_epoch = first_element % epoch_elements;
+  const uint64_t reach = in_epoch + bytes / bpe;
 
-  for (size_t at = 0; at < bytes;) {
-    // The transpose below writes at d_epoch, so stepping past the regions the
-    // caller acquired would scatter into the next pool slot.
-    CHECK(Error, epoch < dst.epochs);
-    const uint64_t in_epoch = element % epoch_elements;
-    const uint64_t room = (epoch_elements - in_epoch) * bpe;
-    const uint64_t left = bytes - at;
-    const uint64_t n = room < left ? room : left;
+  // Regions past the ones the caller acquired belong to the next pool slot.
+  CHECK(Error, (reach + epoch_elements - 1) / epoch_elements <= dst.epochs);
 
-    transpose(d_epoch,
-              gpu_pool_view_d(d_in) + at,
-              n,
-              (uint8_t)bpe,
-              element,
-              layout->lifted_rank,
-              layout_gpu->d_lifted_shape,
-              layout_gpu->d_lifted_strides,
-              compute);
-
-    at += (size_t)n;
-    element += n / bpe;
-    if (element % epoch_elements == 0) {
-      d_epoch += dst.epoch_bytes;
-      epoch++;
-    }
-  }
+  transpose(gpu_pool_view_d(dst.first_epoch),
+            gpu_pool_view_d(d_in),
+            bytes,
+            (uint8_t)bpe,
+            in_epoch,
+            epoch_elements,
+            dst.epoch_bytes,
+            layout->lifted_rank,
+            layout_gpu->d_lifted_shape,
+            layout_gpu->d_lifted_strides,
+            compute);
   return 0;
 
 Error:
@@ -241,14 +221,14 @@ ingest_dispatch_scatter(struct staging_state* stage,
   struct scatter_timing* st = scatter_timing_begin(stage, ss->dispatched_bytes);
   CU(Error, cuEventRecord(st->t_start, compute));
   CHECK(Error,
-        scatter_by_epoch(layout,
-                         layout_gpu,
-                         dst,
-                         d_in,
-                         ss->dispatched_bytes,
-                         first_element,
-                         bpe,
-                         compute) == 0);
+        scatter(layout,
+                layout_gpu,
+                dst,
+                d_in,
+                ss->dispatched_bytes,
+                first_element,
+                bpe,
+                compute) == 0);
   CU(Error, cuEventRecord(st->t_end, compute));
   CHECK(Error, gpu_pool_release_consume(&stage->d_pool, idx, compute) == 0);
 

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -151,45 +151,6 @@ Error:
   return 1;
 }
 
-// The chunk position a scatter computes repeats every epoch_elements, because
-// compute_level_layout zeroes the append dims' chunk strides and dims_n_append
-// allows a chunk size above 1 only on the first append dim. So the kernel needs
-// only the position within the epoch, and steps to the next pool region itself
-// for the elements past the end of one.
-static int
-scatter(const struct tile_stream_layout* layout,
-        const struct tile_stream_layout_gpu* layout_gpu,
-        struct scatter_destination dst,
-        struct gpu_pool_view d_in,
-        size_t bytes,
-        uint64_t first_element,
-        size_t bpe,
-        CUstream compute)
-{
-  const uint64_t epoch_elements = layout->epoch_elements;
-  const uint64_t in_epoch = first_element % epoch_elements;
-  const uint64_t reach = in_epoch + bytes / bpe;
-
-  // Regions past the ones the caller acquired belong to the next pool slot.
-  CHECK(Error, (reach + epoch_elements - 1) / epoch_elements <= dst.epochs);
-
-  transpose(gpu_pool_view_d(dst.first_epoch),
-            gpu_pool_view_d(d_in),
-            bytes,
-            (uint8_t)bpe,
-            in_epoch,
-            epoch_elements,
-            dst.epoch_bytes,
-            layout->lifted_rank,
-            layout_gpu->d_lifted_shape,
-            layout_gpu->d_lifted_strides,
-            compute);
-  return 0;
-
-Error:
-  return 1;
-}
-
 int
 ingest_dispatch_scatter(struct staging_state* stage,
                         const struct tile_stream_layout* layout,
@@ -207,6 +168,18 @@ ingest_dispatch_scatter(struct staging_state* stage,
   if (elements == 0)
     return 0;
 
+  // The chunk position a scatter computes repeats every epoch_elements, because
+  // compute_level_layout zeroes the append dims' chunk strides and
+  // dims_n_append allows a chunk size above 1 only on the first append dim. So
+  // the kernel gets the position within the epoch and finds the later regions
+  // itself.
+  const uint64_t epoch_elements = layout->epoch_elements;
+  const uint64_t in_epoch = first_element % epoch_elements;
+  // Regions past the ones the caller acquired belong to the next pool slot.
+  CHECK(Error,
+        (in_epoch + elements + epoch_elements - 1) / epoch_elements <=
+          dst.epochs);
+
   const int idx = stage->current;
   struct staging_slot* ss = &stage->slot[idx];
 
@@ -220,15 +193,17 @@ ingest_dispatch_scatter(struct staging_state* stage,
         gpu_pool_acquire_consume(&stage->d_pool, idx, compute, &d_in) == 0);
   struct scatter_timing* st = scatter_timing_begin(stage, ss->dispatched_bytes);
   CU(Error, cuEventRecord(st->t_start, compute));
-  CHECK(Error,
-        scatter(layout,
-                layout_gpu,
-                dst,
-                d_in,
-                ss->dispatched_bytes,
-                first_element,
-                bpe,
-                compute) == 0);
+  transpose(gpu_pool_view_d(dst.first_epoch),
+            gpu_pool_view_d(d_in),
+            ss->dispatched_bytes,
+            (uint8_t)bpe,
+            in_epoch,
+            epoch_elements,
+            dst.epoch_bytes,
+            layout->lifted_rank,
+            layout_gpu->d_lifted_shape,
+            layout_gpu->d_lifted_strides,
+            compute);
   CU(Error, cuEventRecord(st->t_end, compute));
   CHECK(Error, gpu_pool_release_consume(&stage->d_pool, idx, compute) == 0);
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -478,7 +478,6 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
 
   // Staging (ingest_init): 2 slots, device + pinned host each.
   info->staging_bytes = 2 * lim.buffer_capacity;
-  const size_t staging_host = info->staging_bytes;
 
   // Chunk pools (stream_engine_init): 2 buffers.
   info->chunk_pool_bytes = 2 * lim.pool_bytes;
@@ -506,7 +505,7 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
   info->device_bytes = info->staging_bytes + info->chunk_pool_bytes +
                        info->compressed_pool_bytes + info->aggregate_bytes +
                        info->lod_bytes + info->codec_bytes;
-  info->host_pinned_bytes = staging_host + aggregate_host;
+  info->host_pinned_bytes = info->staging_bytes + aggregate_host;
 
   info->chunks_per_epoch = cl.layouts[0].chunks_per_epoch;
   info->total_chunks = cl.levels.total_chunks;

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -2,7 +2,6 @@
 #include "gpu/flush.d2h_deliver.h"
 #include "gpu/stream.ingest.h"
 #include "gpu/stream.lod.h"
-#include "gpu/transpose.h"
 
 #include "defs.limits.h"
 #include "gpu/prelude.cuda.h"
@@ -478,8 +477,8 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
     goto Fail;
 
   // Staging (ingest_init): 2 slots, device + pinned host each.
-  info->staging_bytes = 2 * (lim.buffer_capacity + TRANSPOSE_SOURCE_PAD_BYTES);
-  const size_t staging_host = 2 * lim.buffer_capacity;
+  info->staging_bytes = 2 * lim.buffer_capacity;
+  const size_t staging_host = info->staging_bytes;
 
   // Chunk pools (stream_engine_init): 2 buffers.
   info->chunk_pool_bytes = 2 * lim.pool_bytes;

--- a/src/gpu/transpose.cu
+++ b/src/gpu/transpose.cu
@@ -7,8 +7,6 @@ template<typename T>
 constexpr int ELEMENTS_PER_BLOCK = (1 << 12) / (int)sizeof(T);
 
 // Transpose data kernel - v0
-// Each element's destination comes from its own index, so one launch covers the
-// buffer however many epochs it spans.
 template<typename T>
 __global__ void __launch_bounds__(256, 4)
   transpose_v0_k(T* d_dst,

--- a/src/gpu/transpose.cu
+++ b/src/gpu/transpose.cu
@@ -2,9 +2,7 @@
 #include <assert.h>
 #include <stdint.h>
 
-// A block covers 4KB of source rather than one element per thread: the loop
-// that implies gives the compiler several destination computations to overlap,
-// worth 50 -> 56 GiB/s on 256cube.
+// Tiling the source per block measures faster than one element per thread.
 template<typename T>
 constexpr int ELEMENTS_PER_BLOCK = (1 << 12) / (int)sizeof(T);
 

--- a/src/gpu/transpose.cu
+++ b/src/gpu/transpose.cu
@@ -16,7 +16,7 @@ __global__ void __launch_bounds__(256, 4)
                  uint64_t src_size,
                  uint64_t i_offset,
                  uint64_t epoch_elements,
-                 uint64_t epoch_stride,
+                 uint64_t region_stride,
                  uint8_t rank,
                  const uint64_t* shape,
                  const int64_t* strides)
@@ -28,7 +28,7 @@ __global__ void __launch_bounds__(256, 4)
 
   for (int i = threadIdx.x; i < elements; i += blockDim.x) {
     uint64_t rest = i_offset + block_offset + i;
-    uint64_t out_offset = (rest / epoch_elements) * epoch_stride;
+    uint64_t out_offset = (rest / epoch_elements) * region_stride;
 
     for (int d = rank - 1; d >= 0; --d) {
       const uint64_t coord = rest % shape[d];
@@ -40,42 +40,46 @@ __global__ void __launch_bounds__(256, 4)
   }
 }
 
+struct transpose_args
+{
+  CUdeviceptr d_dst_beg;
+  CUdeviceptr d_src_beg;
+  uint64_t src_bytes;
+  uint64_t i_offset;
+  uint64_t epoch_elements;
+  uint64_t region_bytes;
+  uint8_t rank;
+  const uint64_t* d_shape;
+  const int64_t* d_strides;
+  CUstream stream;
+};
+
 template<typename T>
 static void
-transpose_launch(CUdeviceptr d_dst_beg,
-                 CUdeviceptr d_src_beg,
-                 uint64_t src_bytes,
-                 uint64_t i_offset,
-                 uint64_t epoch_elements,
-                 uint64_t epoch_bytes,
-                 uint8_t rank,
-                 const uint64_t* d_shape,
-                 const int64_t* d_strides,
-                 CUstream stream)
+transpose_launch(const struct transpose_args& a)
 {
-  const uint64_t src_size = src_bytes / sizeof(T);
+  const uint64_t src_size = a.src_bytes / sizeof(T);
   if (src_size == 0)
     return;
 
-  cudaStream_t cuda_stream = (cudaStream_t)stream;
-  const int block_size = 256;
+  assert(a.d_src_beg % sizeof(T) == 0);
+  assert(a.region_bytes % sizeof(T) == 0);
+  assert(a.epoch_elements > 0);
 
-  assert(d_src_beg % sizeof(T) == 0);
-  assert(epoch_bytes % sizeof(T) == 0);
-  assert(epoch_elements > 0);
+  const int block_size = 256;
   const unsigned grid_size =
     (unsigned)((src_size + ELEMENTS_PER_BLOCK<T> - 1) / ELEMENTS_PER_BLOCK<T>);
 
-  transpose_v0_k<T>
-    <<<grid_size, block_size, 0, cuda_stream>>>((T*)d_dst_beg,
-                                                (T*)d_src_beg,
-                                                src_size,
-                                                i_offset,
-                                                epoch_elements,
-                                                epoch_bytes / sizeof(T),
-                                                rank,
-                                                d_shape,
-                                                d_strides);
+  transpose_v0_k<T><<<grid_size, block_size, 0, (cudaStream_t)a.stream>>>(
+    (T*)a.d_dst_beg,
+    (T*)a.d_src_beg,
+    src_size,
+    a.i_offset,
+    a.epoch_elements,
+    a.region_bytes / sizeof(T),
+    a.rank,
+    a.d_shape,
+    a.d_strides);
 }
 
 extern "C" void
@@ -85,60 +89,28 @@ transpose(CUdeviceptr d_dst_beg,
           uint8_t bpe,
           uint64_t i_offset,
           uint64_t epoch_elements,
-          uint64_t epoch_bytes,
+          uint64_t region_bytes,
           uint8_t rank,
           const uint64_t* d_shape,
           const int64_t* d_strides,
           CUstream stream)
 {
+  const struct transpose_args a = { d_dst_beg, d_src_beg,      src_bytes,
+                                    i_offset,  epoch_elements, region_bytes,
+                                    rank,      d_shape,        d_strides,
+                                    stream };
   switch (bpe) {
     case 1:
-      transpose_launch<uint8_t>(d_dst_beg,
-                                d_src_beg,
-                                src_bytes,
-                                i_offset,
-                                epoch_elements,
-                                epoch_bytes,
-                                rank,
-                                d_shape,
-                                d_strides,
-                                stream);
+      transpose_launch<uint8_t>(a);
       break;
     case 2:
-      transpose_launch<uint16_t>(d_dst_beg,
-                                 d_src_beg,
-                                 src_bytes,
-                                 i_offset,
-                                 epoch_elements,
-                                 epoch_bytes,
-                                 rank,
-                                 d_shape,
-                                 d_strides,
-                                 stream);
+      transpose_launch<uint16_t>(a);
       break;
     case 4:
-      transpose_launch<uint32_t>(d_dst_beg,
-                                 d_src_beg,
-                                 src_bytes,
-                                 i_offset,
-                                 epoch_elements,
-                                 epoch_bytes,
-                                 rank,
-                                 d_shape,
-                                 d_strides,
-                                 stream);
+      transpose_launch<uint32_t>(a);
       break;
     case 8:
-      transpose_launch<uint64_t>(d_dst_beg,
-                                 d_src_beg,
-                                 src_bytes,
-                                 i_offset,
-                                 epoch_elements,
-                                 epoch_bytes,
-                                 rank,
-                                 d_shape,
-                                 d_strides,
-                                 stream);
+      transpose_launch<uint64_t>(a);
       break;
     default:
       assert(!"transpose: unsupported bpe");

--- a/src/gpu/transpose.cu
+++ b/src/gpu/transpose.cu
@@ -3,57 +3,31 @@
 #include <stdint.h>
 
 // Transpose data kernel - v0
-// Uses shared memory to stage data before computing output positions.
-//
-// d_src must be aligned to sizeof(T); see TRANSPOSE_SOURCE_PAD_BYTES for the
-// room the loads need on either side of the requested elements.
+// Each element's destination comes from its own index, so one launch covers the
+// buffer however many epochs it spans.
 template<typename T>
-__global__ void __launch_bounds__(256, 4) transpose_v0_k(T* d_dst,
-                                                         const T* d_src,
-                                                         uint64_t src_size,
-                                                         uint64_t i_offset,
-                                                         uint8_t rank,
-                                                         const uint64_t* shape,
-                                                         const int64_t* strides)
+__global__ void __launch_bounds__(256, 4)
+  transpose_v0_k(T* d_dst,
+                 const T* d_src,
+                 uint64_t src_size,
+                 uint64_t i_offset,
+                 uint64_t epoch_elements,
+                 uint64_t epoch_stride,
+                 uint8_t rank,
+                 const uint64_t* shape,
+                 const int64_t* strides)
 {
   constexpr int ELEMENTS_PER_BLOCK = (1 << 12) / sizeof(T); // 4KB
-  constexpr int T_PER_LOAD =
-    sizeof(T) < sizeof(uint32_t) ? (int)(sizeof(uint32_t) / sizeof(T)) : 1;
-  static_assert(ELEMENTS_PER_BLOCK % T_PER_LOAD == 0);
-
-  // One word of slack: an unaligned d_src shifts the whole block's load.
-  __shared__ __align__(sizeof(uint32_t))
-    T shared_buf[ELEMENTS_PER_BLOCK + T_PER_LOAD];
 
   const int tid = threadIdx.x;
-  const int block_offset = blockIdx.x * ELEMENTS_PER_BLOCK;
-  const uint64_t left = src_size - (uint64_t)block_offset;
+  const uint64_t block_offset = (uint64_t)blockIdx.x * ELEMENTS_PER_BLOCK;
+  const uint64_t left = src_size - block_offset;
   const int elements =
     left < ELEMENTS_PER_BLOCK ? (int)left : ELEMENTS_PER_BLOCK;
 
-  // Elements between the word boundary below d_src and d_src itself. Always 0
-  // for types of 4 bytes or more, which cannot straddle a word boundary.
-  const int lead_elements =
-    (int)(((uintptr_t)d_src & (sizeof(uint32_t) - 1)) / sizeof(T));
-
-  if constexpr (sizeof(T) < sizeof(uint32_t)) {
-    const uint32_t* src_words =
-      (const uint32_t*)(d_src - lead_elements) + block_offset / T_PER_LOAD;
-    uint32_t* buf_words = (uint32_t*)shared_buf;
-    const int words = (lead_elements + elements + T_PER_LOAD - 1) / T_PER_LOAD;
-    for (int i = tid; i < words; i += blockDim.x)
-      buf_words[i] = src_words[i];
-  } else {
-    const T* src = d_src + block_offset;
-    for (int i = tid; i < elements; i += blockDim.x)
-      shared_buf[i] = src[i];
-  }
-
-  __syncthreads();
-
   for (int i = tid; i < elements; i += blockDim.x) {
-    uint64_t out_offset = 0;
     uint64_t rest = i_offset + block_offset + i;
+    uint64_t out_offset = (rest / epoch_elements) * epoch_stride;
 
     for (int d = rank - 1; d >= 0; --d) {
       const uint64_t coord = rest % shape[d];
@@ -61,7 +35,7 @@ __global__ void __launch_bounds__(256, 4) transpose_v0_k(T* d_dst,
       out_offset += coord * strides[d];
     }
 
-    d_dst[out_offset] = shared_buf[lead_elements + i];
+    d_dst[out_offset] = d_src[block_offset + i];
   }
 }
 
@@ -71,6 +45,8 @@ transpose_launch(CUdeviceptr d_dst_beg,
                  CUdeviceptr d_src_beg,
                  uint64_t src_bytes,
                  uint64_t i_offset,
+                 uint64_t epoch_elements,
+                 uint64_t epoch_bytes,
                  uint8_t rank,
                  const uint64_t* d_shape,
                  const int64_t* d_strides,
@@ -85,11 +61,21 @@ transpose_launch(CUdeviceptr d_dst_beg,
   const int elements_per_block = (1 << 12) / (int)sizeof(T);
 
   assert(d_src_beg % sizeof(T) == 0);
+  assert(epoch_bytes % sizeof(T) == 0);
+  assert(epoch_elements > 0);
   const int grid_size =
     (int)((src_size + elements_per_block - 1) / elements_per_block);
 
-  transpose_v0_k<T><<<grid_size, block_size, 0, cuda_stream>>>(
-    (T*)d_dst_beg, (T*)d_src_beg, src_size, i_offset, rank, d_shape, d_strides);
+  transpose_v0_k<T>
+    <<<grid_size, block_size, 0, cuda_stream>>>((T*)d_dst_beg,
+                                                (T*)d_src_beg,
+                                                src_size,
+                                                i_offset,
+                                                epoch_elements,
+                                                epoch_bytes / sizeof(T),
+                                                rank,
+                                                d_shape,
+                                                d_strides);
 }
 
 extern "C" void
@@ -98,6 +84,8 @@ transpose(CUdeviceptr d_dst_beg,
           uint64_t src_bytes,
           uint8_t bpe,
           uint64_t i_offset,
+          uint64_t epoch_elements,
+          uint64_t epoch_bytes,
           uint8_t rank,
           const uint64_t* d_shape,
           const int64_t* d_strides,
@@ -109,6 +97,8 @@ transpose(CUdeviceptr d_dst_beg,
                                 d_src_beg,
                                 src_bytes,
                                 i_offset,
+                                epoch_elements,
+                                epoch_bytes,
                                 rank,
                                 d_shape,
                                 d_strides,
@@ -119,6 +109,8 @@ transpose(CUdeviceptr d_dst_beg,
                                  d_src_beg,
                                  src_bytes,
                                  i_offset,
+                                 epoch_elements,
+                                 epoch_bytes,
                                  rank,
                                  d_shape,
                                  d_strides,
@@ -129,6 +121,8 @@ transpose(CUdeviceptr d_dst_beg,
                                  d_src_beg,
                                  src_bytes,
                                  i_offset,
+                                 epoch_elements,
+                                 epoch_bytes,
                                  rank,
                                  d_shape,
                                  d_strides,
@@ -139,6 +133,8 @@ transpose(CUdeviceptr d_dst_beg,
                                  d_src_beg,
                                  src_bytes,
                                  i_offset,
+                                 epoch_elements,
+                                 epoch_bytes,
                                  rank,
                                  d_shape,
                                  d_strides,

--- a/src/gpu/transpose.cu
+++ b/src/gpu/transpose.cu
@@ -2,6 +2,12 @@
 #include <assert.h>
 #include <stdint.h>
 
+// A block covers 4KB of source rather than one element per thread: the loop
+// that implies gives the compiler several destination computations to overlap,
+// worth 50 -> 56 GiB/s on 256cube.
+template<typename T>
+constexpr int ELEMENTS_PER_BLOCK = (1 << 12) / (int)sizeof(T);
+
 // Transpose data kernel - v0
 // Each element's destination comes from its own index, so one launch covers the
 // buffer however many epochs it spans.
@@ -17,15 +23,12 @@ __global__ void __launch_bounds__(256, 4)
                  const uint64_t* shape,
                  const int64_t* strides)
 {
-  constexpr int ELEMENTS_PER_BLOCK = (1 << 12) / sizeof(T); // 4KB
-
-  const int tid = threadIdx.x;
-  const uint64_t block_offset = (uint64_t)blockIdx.x * ELEMENTS_PER_BLOCK;
+  const uint64_t block_offset = (uint64_t)blockIdx.x * ELEMENTS_PER_BLOCK<T>;
   const uint64_t left = src_size - block_offset;
   const int elements =
-    left < ELEMENTS_PER_BLOCK ? (int)left : ELEMENTS_PER_BLOCK;
+    left < ELEMENTS_PER_BLOCK<T> ? (int)left : ELEMENTS_PER_BLOCK<T>;
 
-  for (int i = tid; i < elements; i += blockDim.x) {
+  for (int i = threadIdx.x; i < elements; i += blockDim.x) {
     uint64_t rest = i_offset + block_offset + i;
     uint64_t out_offset = (rest / epoch_elements) * epoch_stride;
 
@@ -58,13 +61,12 @@ transpose_launch(CUdeviceptr d_dst_beg,
 
   cudaStream_t cuda_stream = (cudaStream_t)stream;
   const int block_size = 256;
-  const int elements_per_block = (1 << 12) / (int)sizeof(T);
 
   assert(d_src_beg % sizeof(T) == 0);
   assert(epoch_bytes % sizeof(T) == 0);
   assert(epoch_elements > 0);
-  const int grid_size =
-    (int)((src_size + elements_per_block - 1) / elements_per_block);
+  const unsigned grid_size =
+    (unsigned)((src_size + ELEMENTS_PER_BLOCK<T> - 1) / ELEMENTS_PER_BLOCK<T>);
 
   transpose_v0_k<T>
     <<<grid_size, block_size, 0, cuda_stream>>>((T*)d_dst_beg,

--- a/src/gpu/transpose.h
+++ b/src/gpu/transpose.h
@@ -5,20 +5,25 @@
 #include <cuda_runtime.h>
 #include <stdint.h>
 
-// transpose reads whole 4-byte words overlapping the elements it is given, so a
-// source buffer needs this much room past the last element
-#define TRANSPOSE_SOURCE_PAD_BYTES 4
-
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
+  // Write src_bytes worth of elements to the chunk positions the lifted shape
+  // and strides give them. d_src must be aligned to bpe.
+  //
+  // A destination position repeats every epoch_elements, so the elements past
+  // the first epoch go epoch_bytes further along per epoch crossed. d_dst is
+  // the region for the epoch holding the first element, and i_offset is that
+  // element's position within its epoch.
   void transpose(CUdeviceptr d_dst_beg,
                  CUdeviceptr d_src_beg,
                  uint64_t src_bytes,
                  uint8_t bpe,
                  uint64_t i_offset,
+                 uint64_t epoch_elements,
+                 uint64_t epoch_bytes,
                  uint8_t rank,
                  const uint64_t* d_shape,
                  const int64_t* d_strides,

--- a/src/gpu/transpose.h
+++ b/src/gpu/transpose.h
@@ -10,13 +10,8 @@ extern "C"
 {
 #endif
 
-  // Write src_bytes worth of elements to the chunk positions the lifted shape
-  // and strides give them. d_src must be aligned to bpe.
-  //
-  // A destination position repeats every epoch_elements, so the elements past
-  // the first epoch go epoch_bytes further along per epoch crossed. d_dst is
-  // the region for the epoch holding the first element, and i_offset is that
-  // element's position within its epoch.
+  // i_offset counts from the start of the epoch d_dst_beg points at, not from
+  // the start of the stream.
   void transpose(CUdeviceptr d_dst_beg,
                  CUdeviceptr d_src_beg,
                  uint64_t src_bytes,

--- a/src/gpu/transpose.h
+++ b/src/gpu/transpose.h
@@ -18,7 +18,7 @@ extern "C"
                  uint8_t bpe,
                  uint64_t i_offset,
                  uint64_t epoch_elements,
-                 uint64_t epoch_bytes,
+                 uint64_t region_bytes,
                  uint8_t rank,
                  const uint64_t* d_shape,
                  const int64_t* d_strides,

--- a/tests/experiments/index.ops.cuda.c
+++ b/tests/experiments/index.ops.cuda.c
@@ -209,6 +209,8 @@ test_transpose_u16_basic(void)
             n * sizeof(uint16_t),
             sizeof(uint16_t),
             0, // i_offset (start at input index 0)
+            n, // one epoch holds the whole array
+            0, // so no epoch stride to step by
             rank,
             (const uint64_t*)d_shape,
             (const int64_t*)d_strides,
@@ -350,6 +352,8 @@ test_transpose_u16_with_offset(void)
             count * sizeof(uint16_t),
             sizeof(uint16_t),
             i_offset,
+            n, // one epoch holds the whole array
+            0, // so no epoch stride to step by
             rank,
             (const uint64_t*)d_shape,
             (const int64_t*)d_strides,

--- a/tests/experiments/index.ops.cuda.c
+++ b/tests/experiments/index.ops.cuda.c
@@ -210,7 +210,7 @@ test_transpose_u16_basic(void)
             sizeof(uint16_t),
             0, // i_offset (start at input index 0)
             n, // one epoch holds the whole array
-            0, // so no epoch stride to step by
+            0, // so there is no second region to step to
             rank,
             (const uint64_t*)d_shape,
             (const int64_t*)d_strides,
@@ -353,7 +353,7 @@ test_transpose_u16_with_offset(void)
             sizeof(uint16_t),
             i_offset,
             n, // one epoch holds the whole array
-            0, // so no epoch stride to step by
+            0, // so there is no second region to step to
             rank,
             (const uint64_t*)d_shape,
             (const int64_t*)d_strides,

--- a/tests/index.ops.util.c
+++ b/tests/index.ops.util.c
@@ -171,6 +171,19 @@ build_lifted_layout(int rank,
   *out_epoch_elements = *out_chunks_per_epoch * chunk_elements;
 }
 
+uint64_t
+expected_scatter_offset(uint8_t lifted_rank,
+                        const uint64_t* lifted_shape,
+                        const int64_t* lifted_strides,
+                        uint64_t epoch_elements,
+                        uint64_t region_elements,
+                        uint64_t offset)
+{
+  return (offset / epoch_elements) * region_elements +
+         ravel(
+           lifted_rank, lifted_shape, lifted_strides, offset % epoch_elements);
+}
+
 uint32_t
 cpu_perm(uint64_t i,
          uint8_t lifted_rank,

--- a/tests/index.ops.util.h
+++ b/tests/index.ops.util.h
@@ -78,4 +78,16 @@ build_lifted_layout(int rank,
                     uint64_t* out_chunks_per_epoch,
                     uint64_t* out_epoch_elements);
 
+// Where a scatter should put the element sitting `offset` elements past the
+// start of the first epoch's region: its place within the epoch, plus one
+// region per epoch boundary crossed. region_elements is the distance between
+// regions, which the pool pads and so exceeds epoch_elements.
+uint64_t
+expected_scatter_offset(uint8_t lifted_rank,
+                        const uint64_t* lifted_shape,
+                        const int64_t* lifted_strides,
+                        uint64_t epoch_elements,
+                        uint64_t region_elements,
+                        uint64_t offset);
+
 #endif // INDEX_OPS_UTIL_H

--- a/tests/index.ops.util.h
+++ b/tests/index.ops.util.h
@@ -78,10 +78,13 @@ build_lifted_layout(int rank,
                     uint64_t* out_chunks_per_epoch,
                     uint64_t* out_epoch_elements);
 
-// Where a scatter should put the element sitting `offset` elements past the
+// The pool pads each chunk out to the codec's alignment, so a region is wider
+// than an epoch's worth of elements.
+#define TEST_REGION_PAD_ELEMENTS 3
+
+// Where a scatter should put the element sitting this many elements past the
 // start of the first epoch's region: its place within the epoch, plus one
-// region per epoch boundary crossed. region_elements is the distance between
-// regions, which the pool pads and so exceeds epoch_elements.
+// region per epoch boundary crossed.
 uint64_t
 expected_scatter_offset(uint8_t lifted_rank,
                         const uint64_t* lifted_shape,

--- a/tests/index.ops.util.h
+++ b/tests/index.ops.util.h
@@ -83,8 +83,7 @@ build_lifted_layout(int rank,
 #define TEST_REGION_PAD_ELEMENTS 3
 
 // Where a scatter should put the element sitting this many elements past the
-// start of the first epoch's region: its place within the epoch, plus one
-// region per epoch boundary crossed.
+// start of the first epoch's region.
 uint64_t
 expected_scatter_offset(uint8_t lifted_rank,
                         const uint64_t* lifted_shape,

--- a/tests/test_cross_validate.c
+++ b/tests/test_cross_validate.c
@@ -278,10 +278,8 @@ Fail:
 }
 
 // A staging buffer that is not a whole number of epochs: every dispatch after
-// the first starts partway into an epoch and still covers several, so the
-// scatter runs once per epoch from an unaligned start (#173). Epochs are 9
-// elements, so a slice boundary lands on an odd element and the scatter's
-// combined load starts partway into a word.
+// the first starts partway into an epoch and still covers several, so one
+// scatter has to place data in several pool regions (#173, #181).
 static int
 test_cross_validate_dispatch_spans_epochs(void)
 {

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -289,19 +289,20 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   CU(Fail, cuMemcpyDtoH(h_pool, d_pool, pool_bytes));
 
   {
-    const uint64_t first_epoch = first_element / epoch_elements;
     int errors = 0;
     for (uint64_t i = 0; i < src_elements; ++i) {
-      const uint64_t element = first_element + i;
-      const uint64_t region = element / epoch_elements - first_epoch;
-      const uint64_t base = region * epoch_bytes / bytes_per_element;
-      const uint64_t off = ravel(
-        lifted_rank, lifted_shape, lifted_strides, element % epoch_elements);
-      uint16_t dst_val = ((uint16_t*)h_pool)[base + off];
+      const uint64_t off =
+        expected_scatter_offset(lifted_rank,
+                                lifted_shape,
+                                lifted_strides,
+                                epoch_elements,
+                                epoch_bytes / bytes_per_element,
+                                first_element % epoch_elements + i);
+      uint16_t dst_val = ((uint16_t*)h_pool)[off];
       if (dst_val != h_src[i]) {
         if (errors < 5)
           log_error("  element %lu: expected %u, got %u",
-                    (unsigned long)element,
+                    (unsigned long)(first_element + i),
                     h_src[i],
                     dst_val);
         errors++;
@@ -344,8 +345,8 @@ test_ingest_many_epochs_one_dispatch(void)
   return run_epochs_from(3, 0);
 }
 
-// Starting one element in leaves every epoch after the first at an odd element
-// offset, so the scatter's combined load starts partway into a word.
+// Starting one element in splits the dispatch unevenly across epochs, so the
+// first and last regions each take part of one.
 static int
 test_ingest_many_epochs_from_mid_epoch(void)
 {

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -221,7 +221,8 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
                       &epoch_elements);
 
   const size_t epoch_bytes =
-    chunks_per_epoch * chunk_stride * bytes_per_element;
+    (chunks_per_epoch * chunk_stride + TEST_REGION_PAD_ELEMENTS) *
+    bytes_per_element;
   const uint64_t src_elements = n_epochs * epoch_elements;
   const size_t src_bytes = src_elements * bytes_per_element;
   // The dispatch runs past its first epoch by however far first_element sits

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -157,7 +157,13 @@ test_ingest_incremental(void)
   {
     int errors = 0;
     for (uint64_t i = 0; i < epoch_elements; ++i) {
-      uint64_t off = ravel(lifted_rank, lifted_shape, lifted_strides, i);
+      const uint64_t off =
+        expected_scatter_offset(lifted_rank,
+                                lifted_shape,
+                                lifted_strides,
+                                epoch_elements,
+                                pool_bytes / bytes_per_element,
+                                i);
       uint16_t src_val = h_src[i];
       uint16_t dst_val = ((uint16_t*)h_pool)[off];
       if (dst_val != src_val) {

--- a/tests/test_transpose.c
+++ b/tests/test_transpose.c
@@ -15,12 +15,6 @@ fill_elements(uint8_t* dst, uint64_t n, uint8_t bpe)
       dst[i * bpe + b] = (uint8_t)((i * 131 + b * 17 + 1) & 0xFF);
 }
 
-// The pool pads each chunk out to the codec's alignment, so the distance
-// between epoch regions is wider than an epoch's elements. Any nonzero value
-// here catches a kernel that steps regions by epoch_elements instead of by the
-// stride it is handed.
-#define REGION_PAD_ELEMENTS 3
-
 // Run transpose kernel and verify against CPU ravel() reference.
 // dim_sizes/chunk_sizes: per-dimension sizes.
 // bpe: bytes per element.
@@ -60,7 +54,7 @@ run_transpose_test(const char* name,
                       &chunks_per_epoch,
                       &epoch_elements);
   const uint64_t region_elements =
-    chunks_per_epoch * chunk_stride + REGION_PAD_ELEMENTS;
+    chunks_per_epoch * chunk_stride + TEST_REGION_PAD_ELEMENTS;
   const uint64_t src_elements = n_epochs * epoch_elements;
   const size_t src_bytes = src_elements * bpe;
   // A start partway into an epoch pushes the last elements into one more region

--- a/tests/test_transpose.c
+++ b/tests/test_transpose.c
@@ -15,12 +15,17 @@ fill_elements(uint8_t* dst, uint64_t n, uint8_t bpe)
       dst[i * bpe + b] = (uint8_t)((i * 131 + b * 17 + 1) & 0xFF);
 }
 
+// The pool pads each chunk out to the codec's alignment, so the distance
+// between epoch regions is wider than an epoch's elements. Any nonzero value
+// here catches a kernel that steps regions by epoch_elements instead of by the
+// stride it is handed.
+#define REGION_PAD_ELEMENTS 3
+
 // Run transpose kernel and verify against CPU ravel() reference.
 // dim_sizes/chunk_sizes: per-dimension sizes.
 // bpe: bytes per element.
 // n_epochs: epochs worth of source to hand the kernel in one call.
-// first_element: where the source starts in the stream, so it can begin partway
-// into an epoch.
+// in_epoch_offset: how far into its epoch the first element sits.
 // Returns 0 on success.
 static int
 run_transpose_test(const char* name,
@@ -30,13 +35,13 @@ run_transpose_test(const char* name,
                    const uint8_t* storage_order,
                    uint8_t bpe,
                    uint32_t n_epochs,
-                   uint64_t first_element)
+                   uint64_t in_epoch_offset)
 {
   log_info("=== %s (bpe=%u epochs=%u from=%lu) ===",
            name,
            bpe,
            n_epochs,
-           (unsigned long)first_element);
+           (unsigned long)in_epoch_offset);
 
   uint8_t lifted_rank;
   uint64_t lifted_shape[MAX_RANK];
@@ -54,13 +59,14 @@ run_transpose_test(const char* name,
                       &chunk_stride,
                       &chunks_per_epoch,
                       &epoch_elements);
-  const uint64_t pool_elements = chunks_per_epoch * chunk_stride;
+  const uint64_t region_elements =
+    chunks_per_epoch * chunk_stride + REGION_PAD_ELEMENTS;
   const uint64_t src_elements = n_epochs * epoch_elements;
   const size_t src_bytes = src_elements * bpe;
   // A start partway into an epoch pushes the last elements into one more region
   // than the epochs they cover.
   const uint32_t regions = n_epochs + 1;
-  const size_t dst_bytes = regions * pool_elements * bpe;
+  const size_t dst_bytes = regions * region_elements * bpe;
 
   log_info("  rank=%d lifted_rank=%d chunk_elements=%lu chunk_stride=%lu "
            "chunks_per_epoch=%lu epoch_elements=%lu",
@@ -98,9 +104,9 @@ run_transpose_test(const char* name,
             d_src,
             src_bytes,
             bpe,
-            first_element % epoch_elements,
+            in_epoch_offset,
             epoch_elements,
-            pool_elements * bpe,
+            region_elements * bpe,
             lifted_rank,
             (const uint64_t*)d_shape,
             (const int64_t*)d_strides,
@@ -111,20 +117,19 @@ run_transpose_test(const char* name,
 
   // Verify against CPU ravel reference
   int errors = 0;
-  const uint64_t first_epoch = first_element / epoch_elements;
   for (uint64_t i = 0; i < src_elements; ++i) {
-    const uint64_t element = first_element + i;
-    const uint64_t region = element / epoch_elements - first_epoch;
-    const uint64_t expected_off =
-      region * pool_elements +
-      ravel(
-        lifted_rank, lifted_shape, lifted_strides, element % epoch_elements);
+    const uint64_t expected_off = expected_scatter_offset(lifted_rank,
+                                                          lifted_shape,
+                                                          lifted_strides,
+                                                          epoch_elements,
+                                                          region_elements,
+                                                          in_epoch_offset + i);
     if (memcmp((uint8_t*)h_dst + expected_off * bpe,
                (uint8_t*)h_src + i * bpe,
                bpe) != 0) {
       if (errors < 5)
         log_error("  elem %lu: dst[%lu] does not match source",
-                  (unsigned long)element,
+                  (unsigned long)(in_epoch_offset + i),
                   (unsigned long)expected_off);
       errors++;
     }

--- a/tests/test_transpose.c
+++ b/tests/test_transpose.c
@@ -18,8 +18,9 @@ fill_elements(uint8_t* dst, uint64_t n, uint8_t bpe)
 // Run transpose kernel and verify against CPU ravel() reference.
 // dim_sizes/chunk_sizes: per-dimension sizes.
 // bpe: bytes per element.
-// element_offset: where the source sits in its buffer, so the kernel can be
-// given a start that is not word aligned.
+// n_epochs: epochs worth of source to hand the kernel in one call.
+// first_element: where the source starts in the stream, so it can begin partway
+// into an epoch.
 // Returns 0 on success.
 static int
 run_transpose_test(const char* name,
@@ -28,10 +29,14 @@ run_transpose_test(const char* name,
                    const uint64_t* chunk_sizes,
                    const uint8_t* storage_order,
                    uint8_t bpe,
-                   uint64_t element_offset)
+                   uint32_t n_epochs,
+                   uint64_t first_element)
 {
-  log_info(
-    "=== %s (bpe=%u offset=%lu) ===", name, bpe, (unsigned long)element_offset);
+  log_info("=== %s (bpe=%u epochs=%u from=%lu) ===",
+           name,
+           bpe,
+           n_epochs,
+           (unsigned long)first_element);
 
   uint8_t lifted_rank;
   uint64_t lifted_shape[MAX_RANK];
@@ -49,9 +54,13 @@ run_transpose_test(const char* name,
                       &chunk_stride,
                       &chunks_per_epoch,
                       &epoch_elements);
-  uint64_t pool_elements = chunks_per_epoch * chunk_stride;
-  size_t src_bytes = epoch_elements * bpe;
-  size_t dst_bytes = pool_elements * bpe;
+  const uint64_t pool_elements = chunks_per_epoch * chunk_stride;
+  const uint64_t src_elements = n_epochs * epoch_elements;
+  const size_t src_bytes = src_elements * bpe;
+  // A start partway into an epoch pushes the last elements into one more region
+  // than the epochs they cover.
+  const uint32_t regions = n_epochs + 1;
+  const size_t dst_bytes = regions * pool_elements * bpe;
 
   log_info("  rank=%d lifted_rank=%d chunk_elements=%lu chunk_stride=%lu "
            "chunks_per_epoch=%lu epoch_elements=%lu",
@@ -68,32 +77,30 @@ run_transpose_test(const char* name,
   CUstream stream = 0;
   int ok = 0;
 
-  const size_t src_alloc =
-    element_offset * bpe + src_bytes + TRANSPOSE_SOURCE_PAD_BYTES;
-
   h_src = malloc(src_bytes);
   h_dst = calloc(1, dst_bytes);
   CHECK(Fail, h_src && h_dst);
-  fill_elements((uint8_t*)h_src, epoch_elements, bpe);
+  fill_elements((uint8_t*)h_src, src_elements, bpe);
 
   CU(Fail, cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
-  CU(Fail, cuMemAlloc(&d_src, src_alloc));
+  CU(Fail, cuMemAlloc(&d_src, src_bytes));
   CU(Fail, cuMemAlloc(&d_dst, dst_bytes));
-  CU(Fail, cuMemsetD8(d_src, 0, src_alloc));
   CU(Fail, cuMemsetD8(d_dst, 0, dst_bytes));
   CU(Fail, cuMemAlloc(&d_shape, lifted_rank * sizeof(uint64_t)));
   CU(Fail, cuMemAlloc(&d_strides, lifted_rank * sizeof(int64_t)));
 
-  CU(Fail, cuMemcpyHtoD(d_src + element_offset * bpe, h_src, src_bytes));
+  CU(Fail, cuMemcpyHtoD(d_src, h_src, src_bytes));
   CU(Fail, cuMemcpyHtoD(d_shape, lifted_shape, lifted_rank * sizeof(uint64_t)));
   CU(Fail,
      cuMemcpyHtoD(d_strides, lifted_strides, lifted_rank * sizeof(int64_t)));
 
   transpose(d_dst,
-            d_src + element_offset * bpe,
+            d_src,
             src_bytes,
             bpe,
-            0,
+            first_element % epoch_elements,
+            epoch_elements,
+            pool_elements * bpe,
             lifted_rank,
             (const uint64_t*)d_shape,
             (const int64_t*)d_strides,
@@ -104,23 +111,28 @@ run_transpose_test(const char* name,
 
   // Verify against CPU ravel reference
   int errors = 0;
-  for (uint64_t i = 0; i < epoch_elements; ++i) {
-    uint64_t expected_off = ravel(lifted_rank, lifted_shape, lifted_strides, i);
+  const uint64_t first_epoch = first_element / epoch_elements;
+  for (uint64_t i = 0; i < src_elements; ++i) {
+    const uint64_t element = first_element + i;
+    const uint64_t region = element / epoch_elements - first_epoch;
+    const uint64_t expected_off =
+      region * pool_elements +
+      ravel(
+        lifted_rank, lifted_shape, lifted_strides, element % epoch_elements);
     if (memcmp((uint8_t*)h_dst + expected_off * bpe,
                (uint8_t*)h_src + i * bpe,
                bpe) != 0) {
       if (errors < 5)
         log_error("  elem %lu: dst[%lu] does not match source",
-                  (unsigned long)i,
+                  (unsigned long)element,
                   (unsigned long)expected_off);
       errors++;
     }
   }
 
   if (errors > 0) {
-    log_error("  %d mismatches (of %lu elements)",
-              errors,
-              (unsigned long)epoch_elements);
+    log_error(
+      "  %d mismatches (of %lu elements)", errors, (unsigned long)src_elements);
     goto Fail;
   }
 
@@ -150,7 +162,7 @@ test_transpose_2d(void)
   uint64_t dim_sizes[] = { 4, 6 };
   uint64_t chunk_sizes[] = { 2, 3 };
   return run_transpose_test(
-    "test_transpose_2d", 2, dim_sizes, chunk_sizes, NULL, 2, 0);
+    "test_transpose_2d", 2, dim_sizes, chunk_sizes, NULL, 2, 1, 0);
 }
 
 static int
@@ -160,7 +172,7 @@ test_transpose_3d(void)
   uint64_t dim_sizes[] = { 4, 4, 6 };
   uint64_t chunk_sizes[] = { 2, 2, 3 };
   return run_transpose_test(
-    "test_transpose_3d", 3, dim_sizes, chunk_sizes, NULL, 2, 0);
+    "test_transpose_3d", 3, dim_sizes, chunk_sizes, NULL, 2, 1, 0);
 }
 
 static int
@@ -170,7 +182,7 @@ test_transpose_identity(void)
   uint64_t dim_sizes[] = { 6, 4 };
   uint64_t chunk_sizes[] = { 6, 4 };
   return run_transpose_test(
-    "test_transpose_identity", 2, dim_sizes, chunk_sizes, NULL, 2, 0);
+    "test_transpose_identity", 2, dim_sizes, chunk_sizes, NULL, 2, 1, 0);
 }
 
 static int
@@ -180,7 +192,7 @@ test_transpose_bpe4(void)
   uint64_t dim_sizes[] = { 4, 4, 6 };
   uint64_t chunk_sizes[] = { 2, 2, 3 };
   return run_transpose_test(
-    "test_transpose_bpe4", 3, dim_sizes, chunk_sizes, NULL, 4, 0);
+    "test_transpose_bpe4", 3, dim_sizes, chunk_sizes, NULL, 4, 1, 0);
 }
 
 static int
@@ -197,6 +209,7 @@ test_transpose_3d_storage_order(void)
                             chunk_sizes,
                             storage_order,
                             2,
+                            1,
                             0);
 }
 
@@ -214,27 +227,29 @@ test_transpose_4d_storage_order(void)
                             chunk_sizes,
                             storage_order,
                             2,
+                            1,
                             0);
 }
 
-// A scatter split across epochs hands the kernel a start partway into the
-// staging buffer, so it has to cope with one that is not word aligned. The
-// shape spans several blocks, since each block offsets the load itself.
+// One call covering several epochs, each landing in its own destination region.
+// The shape spans several blocks, so blocks on either side of an epoch boundary
+// have to find the boundary themselves.
 static int
-test_transpose_unaligned_source(void)
+test_transpose_many_epochs(void)
 {
   uint64_t dim_sizes[] = { 4, 64, 96 };
   uint64_t chunk_sizes[] = { 2, 16, 24 };
   int err = 0;
-  for (uint8_t bpe = 1; bpe <= 2; bpe = (uint8_t)(bpe * 2))
-    for (uint64_t off = 0; off < sizeof(uint32_t) / bpe; ++off)
-      err |= run_transpose_test("test_transpose_unaligned_source",
+  for (uint8_t bpe = 1; bpe <= 8; bpe = (uint8_t)(bpe * 2))
+    for (uint64_t from = 0; from < 2; ++from)
+      err |= run_transpose_test("test_transpose_many_epochs",
                                 3,
                                 dim_sizes,
                                 chunk_sizes,
                                 NULL,
                                 bpe,
-                                off);
+                                3,
+                                from);
   return err;
 }
 
@@ -244,7 +259,7 @@ test_transpose_bpe8(void)
   uint64_t dim_sizes[] = { 4, 4, 6 };
   uint64_t chunk_sizes[] = { 2, 2, 3 };
   return run_transpose_test(
-    "test_transpose_bpe8", 3, dim_sizes, chunk_sizes, NULL, 8, 0);
+    "test_transpose_bpe8", 3, dim_sizes, chunk_sizes, NULL, 8, 1, 0);
 }
 
 RUN_GPU_TESTS({ "transpose_2d", test_transpose_2d },
@@ -254,5 +269,4 @@ RUN_GPU_TESTS({ "transpose_2d", test_transpose_2d },
               { "transpose_3d_storage_order", test_transpose_3d_storage_order },
               { "transpose_4d_storage_order", test_transpose_4d_storage_order },
               { "transpose_bpe8", test_transpose_bpe8 },
-              { "transpose_unaligned_source",
-                test_transpose_unaligned_source }, )
+              { "transpose_many_epochs", test_transpose_many_epochs }, )


### PR DESCRIPTION
A dispatch can cover several epochs. The scatter issued one kernel launch per
epoch, walking a device pointer forward one region at a time, and that slicing
forced everything around it: a stage stepping through pool memory by hand, a
source starting partway into the staging buffer, the kernel's word-aligned load
path with its lead handling, and the padding and zeroing that kept its reads in
bounds.

`transpose_v0_k` already computed each element's destination from its own index.
It now also takes the epoch size and the distance between epoch regions, so it
adds the region step itself and one launch covers the buffer whichever epochs it
spans. The check against the regions the caller holds moves to the host, where
it is one comparison instead of one per epoch and runs before the transfer is
queued.

With the source always the staging base, the kernel reads it directly. That
removed the shared-memory staging, the word load with its lead and surplus
handling, `TRANSPOSE_SOURCE_PAD_BYTES`, the allocation slack, and the memset at
init. The transpose tests that covered every sub-word start offset now cover
several epochs in one call, for each element size, starting both on an epoch
boundary and one element in. Destination regions in the tests are padded, so a
kernel that stepped by epoch instead of by the stride it is handed no longer
passes.

One launch is faster, not slower: the launches cost more than the per-element
division that replaces them. On one L40 the scatter stage goes 87 to 188 GiB/s
on smallepoch and 46 to 56 GiB/s on 256cube.

Closes #181
