### PR TITLE
Build the benchmarks on machines without a GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,7 @@ add_subdirectory(src)
 enable_testing()
 add_subdirectory(tests)
 
-if(CHUCKY_ENABLE_GPU)
-    add_subdirectory(bench)
-endif()
+add_subdirectory(bench)
 
 # --- Install rules: aggregate library, public headers, CMake/pkg-config ---
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -45,8 +45,7 @@ target_link_libraries(
     PRIVATE warnings
 )
 
-# The GPU pipeline sits behind bench_gpu.h so the rest of the benchmarks build
-# without CUDA. bench_gpu.none.c reports "built without GPU support" instead.
+# Without CUDA the benchmarks link a stand-in that fails at startup.
 if(CHUCKY_ENABLE_GPU)
     target_sources(bench_util PRIVATE bench_gpu.cuda.c)
     target_link_libraries(
@@ -69,9 +68,13 @@ set(BENCH_STREAM_SOURCES
     bench_stream_medfmt_multiscale.c
     bench_stream_medfmt_multiscale_dim0.c
     bench_stream_smallepoch_single.c
-    bench_stream_256cube_two_streams.c
     bench_stream_aqz_single.c
 )
+
+# Two streams share one GPU, so there is nothing to run without one.
+if(CHUCKY_ENABLE_GPU)
+    list(APPEND BENCH_STREAM_SOURCES bench_stream_256cube_two_streams.c)
+endif()
 
 foreach(src IN LISTS BENCH_STREAM_SOURCES)
     string(REPLACE ".c" "" target ${src})

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(
     PRIVATE warnings
 )
 
-# Without CUDA the benchmarks link a stand-in that fails at startup.
+# Without CUDA the benchmarks link a stand-in, and only a gpu run fails.
 if(CHUCKY_ENABLE_GPU)
     target_sources(bench_util PRIVATE bench_gpu.cuda.c)
     target_link_libraries(

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
     STATIC
     bench_util.c
     bench_util.h
+    bench_gpu.h
     sink_discard.c
     sink_discard.h
     sink_throttled.c
@@ -29,7 +30,6 @@ target_include_directories(bench_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
     bench_util
     PUBLIC
-        stream
         stream_cpu
         zarr_array
         ngff_multiscale
@@ -42,9 +42,20 @@ target_link_libraries(
         dimension
         format_bytes
         test_data
-        CUDA::cuda_driver
     PRIVATE warnings
 )
+
+# The GPU pipeline sits behind bench_gpu.h so the rest of the benchmarks build
+# without CUDA. bench_gpu.none.c reports "built without GPU support" instead.
+if(CHUCKY_ENABLE_GPU)
+    target_sources(bench_util PRIVATE bench_gpu.cuda.c)
+    target_link_libraries(
+        bench_util
+        PUBLIC stream CUDA::cuda_driver CUDA::cudart_static
+    )
+else()
+    target_sources(bench_util PRIVATE bench_gpu.none.c)
+endif()
 
 # bench_stream: per-scenario, per-mode executables
 set(BENCH_STREAM_SOURCES
@@ -64,5 +75,5 @@ set(BENCH_STREAM_SOURCES
 
 foreach(src IN LISTS BENCH_STREAM_SOURCES)
     string(REPLACE ".c" "" target ${src})
-    add_bench(${target} ${src} bench_util CUDA::cudart_static Zstd::Zstd)
+    add_bench(${target} ${src} bench_util Zstd::Zstd)
 endforeach()

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -45,7 +45,6 @@ target_link_libraries(
     PRIVATE warnings
 )
 
-# Without CUDA the benchmarks link a stand-in, and only a gpu run fails.
 if(CHUCKY_ENABLE_GPU)
     target_sources(bench_util PRIVATE bench_gpu.cuda.c)
     target_link_libraries(

--- a/bench/bench_gpu.cuda.c
+++ b/bench/bench_gpu.cuda.c
@@ -66,7 +66,7 @@ bench_gpu_advise_layout(struct tile_stream_configuration* config,
                                        diag);
 }
 
-int
+void
 bench_gpu_report_memory(const struct tile_stream_configuration* config,
                         uint64_t* total_chunks,
                         size_t* device_bytes,
@@ -74,7 +74,7 @@ bench_gpu_report_memory(const struct tile_stream_configuration* config,
 {
   struct tile_stream_memory_info mem;
   if (tile_stream_gpu_memory_estimate(config, 0, &mem) != 0)
-    return 1;
+    return;
 
   *total_chunks = mem.total_chunks;
   *device_bytes = mem.device_bytes;
@@ -99,7 +99,6 @@ bench_gpu_report_memory(const struct tile_stream_configuration* config,
     (unsigned long long)mem.total_chunks,
     mem.nlod,
     mem.epochs_per_batch);
-  return 0;
 }
 
 void

--- a/bench/bench_gpu.cuda.c
+++ b/bench/bench_gpu.cuda.c
@@ -1,0 +1,162 @@
+#include "bench_gpu.h"
+
+#include "bench_report.h"
+#include "gpu/prelude.cuda.h"
+#include "stream.gpu.h"
+#include "util/format_bytes.h"
+
+static CUcontext context;
+
+int
+bench_gpu_enabled(void)
+{
+  return 1;
+}
+
+int
+bench_gpu_context_create(void)
+{
+  CUdevice dev;
+  CU(Fail, cuInit(0));
+  CU(Fail, cuDeviceGet(&dev, 0));
+  CU(Fail, cu_ctx_create(&context, 0, dev));
+  return 0;
+Fail:
+  return 1;
+}
+
+void
+bench_gpu_context_destroy(void)
+{
+  if (context)
+    cuCtxDestroy(context);
+  context = 0;
+}
+
+size_t
+bench_gpu_free_memory(void)
+{
+  size_t free_mem = 0, total_mem = 0;
+  if (cuMemGetInfo(&free_mem, &total_mem) != CUDA_SUCCESS)
+    return 0;
+  return free_mem;
+}
+
+int
+bench_gpu_advise_layout(struct tile_stream_configuration* config,
+                        size_t target_chunk_bytes,
+                        size_t min_chunk_bytes,
+                        const int* ratios,
+                        size_t budget_bytes,
+                        size_t min_shard_bytes,
+                        uint32_t target_concurrent_shards,
+                        uint32_t min_append_shards,
+                        size_t shard_alignment,
+                        struct advise_layout_diagnostic* diag)
+{
+  return tile_stream_gpu_advise_layout(config,
+                                       target_chunk_bytes,
+                                       min_chunk_bytes,
+                                       ratios,
+                                       budget_bytes,
+                                       min_shard_bytes,
+                                       target_concurrent_shards,
+                                       min_append_shards,
+                                       shard_alignment,
+                                       diag);
+}
+
+int
+bench_gpu_report_memory(const struct tile_stream_configuration* config,
+                        uint64_t* total_chunks,
+                        size_t* device_bytes,
+                        size_t* pinned_bytes)
+{
+  struct tile_stream_memory_info mem;
+  if (tile_stream_gpu_memory_estimate(config, 0, &mem) != 0)
+    return 1;
+
+  *total_chunks = mem.total_chunks;
+  *device_bytes = mem.device_bytes;
+  *pinned_bytes = mem.host_pinned_bytes;
+
+  char a[32], b[32];
+  format_bytes(a, sizeof(a), mem.device_bytes);
+  format_bytes(b, sizeof(b), mem.host_pinned_bytes);
+  print_report("  GPU memory:  %s device, %s pinned", a, b);
+  format_bytes(a, sizeof(a), mem.staging_bytes);
+  format_bytes(b, sizeof(b), mem.chunk_pool_bytes);
+  print_report("    staging:   %s   chunk_pool: %s", a, b);
+  format_bytes(a, sizeof(a), mem.compressed_pool_bytes);
+  format_bytes(b, sizeof(b), mem.aggregate_bytes);
+  print_report("    comp_pool: %s   aggregate: %s", a, b);
+  format_bytes(a, sizeof(a), mem.lod_bytes);
+  format_bytes(b, sizeof(b), mem.codec_bytes);
+  print_report("    lod:       %s   codec:     %s", a, b);
+  print_report(
+    "    chunks:    %llu/epoch, %llu total (%d LOD levels, batch=%u)",
+    (unsigned long long)mem.chunks_per_epoch,
+    (unsigned long long)mem.total_chunks,
+    mem.nlod,
+    mem.epochs_per_batch);
+  return 0;
+}
+
+void
+bench_gpu_report_memory_pair(const struct tile_stream_configuration* config)
+{
+  struct tile_stream_memory_info mem;
+  if (tile_stream_gpu_memory_estimate(config, 0, &mem) != 0)
+    return;
+
+  char a[32], b[32];
+  format_bytes(a, sizeof(a), mem.device_bytes);
+  format_bytes(b, sizeof(b), mem.host_pinned_bytes);
+  print_report("  GPU memory (per stream): %s device, %s pinned", a, b);
+  format_bytes(a, sizeof(a), 2 * mem.device_bytes);
+  format_bytes(b, sizeof(b), 2 * mem.host_pinned_bytes);
+  print_report("  GPU memory (total x2):   %s device, %s pinned", a, b);
+}
+
+struct tile_stream_gpu*
+bench_gpu_create(const struct tile_stream_configuration* config,
+                 struct shard_sink* sink)
+{
+  return tile_stream_gpu_create(config, sink);
+}
+
+void
+bench_gpu_destroy(struct tile_stream_gpu* s)
+{
+  tile_stream_gpu_destroy(s);
+}
+
+const struct tile_stream_layout*
+bench_gpu_layout(const struct tile_stream_gpu* s)
+{
+  return tile_stream_gpu_layout(s);
+}
+
+struct stream_metrics
+bench_gpu_get_metrics(const struct tile_stream_gpu* s)
+{
+  return tile_stream_gpu_get_metrics(s);
+}
+
+struct tile_stream_status
+bench_gpu_status(const struct tile_stream_gpu* s)
+{
+  return tile_stream_gpu_status(s);
+}
+
+struct writer*
+bench_gpu_writer(struct tile_stream_gpu* s)
+{
+  return tile_stream_gpu_writer(s);
+}
+
+uint64_t
+bench_gpu_cursor(const struct tile_stream_gpu* s)
+{
+  return tile_stream_gpu_cursor(s);
+}

--- a/bench/bench_gpu.h
+++ b/bench/bench_gpu.h
@@ -1,9 +1,8 @@
 #pragma once
 
-// The GPU pipeline behind a CUDA-free interface, so the benchmarks build on
-// machines without CUDA. bench_gpu.cuda.c forwards to tile_stream_gpu;
-// bench_gpu.none.c stands in when CHUCKY_ENABLE_GPU is off, where
-// bench_gpu_enabled() returns 0 and the rest fail.
+// The GPU pipeline behind an interface with no CUDA in it, so the benchmarks
+// build on machines that have no CUDA headers. A build without GPU support
+// links a stand-in whose calls all fail.
 
 #include "types.stream.h"
 

--- a/bench/bench_gpu.h
+++ b/bench/bench_gpu.h
@@ -1,8 +1,8 @@
 #pragma once
 
 // The GPU pipeline behind an interface with no CUDA in it, so the benchmarks
-// build on machines that have no CUDA headers. A build without GPU support
-// links a stand-in whose calls all fail.
+// build and run on machines that have no CUDA headers. A build without GPU
+// support links a stand-in, which reports that there is no GPU to use.
 
 #include "types.stream.h"
 

--- a/bench/bench_gpu.h
+++ b/bench/bench_gpu.h
@@ -1,0 +1,76 @@
+#pragma once
+
+// The GPU pipeline behind a CUDA-free interface, so the benchmarks build on
+// machines without CUDA. bench_gpu.cuda.c forwards to tile_stream_gpu;
+// bench_gpu.none.c stands in when CHUCKY_ENABLE_GPU is off, where
+// bench_gpu_enabled() returns 0 and the rest fail.
+
+#include "types.stream.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct shard_sink;
+struct tile_stream_gpu;
+struct tile_stream_layout;
+struct writer;
+
+int
+bench_gpu_enabled(void);
+
+// Create the process-wide context on device 0. Returns 0 on success.
+int
+bench_gpu_context_create(void);
+
+void
+bench_gpu_context_destroy(void);
+
+// Free device memory in bytes, or 0 when it can't be read.
+size_t
+bench_gpu_free_memory(void);
+
+int
+bench_gpu_advise_layout(struct tile_stream_configuration* config,
+                        size_t target_chunk_bytes,
+                        size_t min_chunk_bytes,
+                        const int* ratios,
+                        size_t budget_bytes,
+                        size_t min_shard_bytes,
+                        uint32_t target_concurrent_shards,
+                        uint32_t min_append_shards,
+                        size_t shard_alignment,
+                        struct advise_layout_diagnostic* diag);
+
+// Print the device memory breakdown and report the totals the summary needs.
+// Returns 0 when the estimate succeeded.
+int
+bench_gpu_report_memory(const struct tile_stream_configuration* config,
+                        uint64_t* total_chunks,
+                        size_t* device_bytes,
+                        size_t* pinned_bytes);
+
+// Print per-stream and doubled device memory for the two-stream driver.
+void
+bench_gpu_report_memory_pair(const struct tile_stream_configuration* config);
+
+struct tile_stream_gpu*
+bench_gpu_create(const struct tile_stream_configuration* config,
+                 struct shard_sink* sink);
+
+void
+bench_gpu_destroy(struct tile_stream_gpu* s);
+
+const struct tile_stream_layout*
+bench_gpu_layout(const struct tile_stream_gpu* s);
+
+struct stream_metrics
+bench_gpu_get_metrics(const struct tile_stream_gpu* s);
+
+struct tile_stream_status
+bench_gpu_status(const struct tile_stream_gpu* s);
+
+struct writer*
+bench_gpu_writer(struct tile_stream_gpu* s);
+
+uint64_t
+bench_gpu_cursor(const struct tile_stream_gpu* s);

--- a/bench/bench_gpu.h
+++ b/bench/bench_gpu.h
@@ -1,8 +1,7 @@
 #pragma once
 
 // The GPU pipeline behind an interface with no CUDA in it, so the benchmarks
-// build and run on machines that have no CUDA headers. A build without GPU
-// support links a stand-in, which reports that there is no GPU to use.
+// build on machines that have no CUDA headers.
 
 #include "types.stream.h"
 

--- a/bench/bench_gpu.h
+++ b/bench/bench_gpu.h
@@ -40,15 +40,12 @@ bench_gpu_advise_layout(struct tile_stream_configuration* config,
                         size_t shard_alignment,
                         struct advise_layout_diagnostic* diag);
 
-// Print the device memory breakdown and report the totals the summary needs.
-// Returns 0 when the estimate succeeded.
-int
+void
 bench_gpu_report_memory(const struct tile_stream_configuration* config,
                         uint64_t* total_chunks,
                         size_t* device_bytes,
                         size_t* pinned_bytes);
 
-// Print per-stream and doubled device memory for the two-stream driver.
 void
 bench_gpu_report_memory_pair(const struct tile_stream_configuration* config);
 

--- a/bench/bench_gpu.none.c
+++ b/bench/bench_gpu.none.c
@@ -1,0 +1,132 @@
+#include "bench_gpu.h"
+
+#include "log/log.h"
+
+static void
+no_gpu(void)
+{
+  log_error("  built without GPU support: reconfigure with "
+            "-DCHUCKY_ENABLE_GPU=ON or run with --backend cpu");
+}
+
+int
+bench_gpu_enabled(void)
+{
+  return 0;
+}
+
+int
+bench_gpu_context_create(void)
+{
+  no_gpu();
+  return 1;
+}
+
+void
+bench_gpu_context_destroy(void)
+{
+}
+
+size_t
+bench_gpu_free_memory(void)
+{
+  return 0;
+}
+
+int
+bench_gpu_advise_layout(struct tile_stream_configuration* config,
+                        size_t target_chunk_bytes,
+                        size_t min_chunk_bytes,
+                        const int* ratios,
+                        size_t budget_bytes,
+                        size_t min_shard_bytes,
+                        uint32_t target_concurrent_shards,
+                        uint32_t min_append_shards,
+                        size_t shard_alignment,
+                        struct advise_layout_diagnostic* diag)
+{
+  (void)config;
+  (void)target_chunk_bytes;
+  (void)min_chunk_bytes;
+  (void)ratios;
+  (void)budget_bytes;
+  (void)min_shard_bytes;
+  (void)target_concurrent_shards;
+  (void)min_append_shards;
+  (void)shard_alignment;
+  (void)diag;
+  no_gpu();
+  return 1;
+}
+
+int
+bench_gpu_report_memory(const struct tile_stream_configuration* config,
+                        uint64_t* total_chunks,
+                        size_t* device_bytes,
+                        size_t* pinned_bytes)
+{
+  (void)config;
+  (void)total_chunks;
+  (void)device_bytes;
+  (void)pinned_bytes;
+  return 1;
+}
+
+void
+bench_gpu_report_memory_pair(const struct tile_stream_configuration* config)
+{
+  (void)config;
+}
+
+struct tile_stream_gpu*
+bench_gpu_create(const struct tile_stream_configuration* config,
+                 struct shard_sink* sink)
+{
+  (void)config;
+  (void)sink;
+  no_gpu();
+  return NULL;
+}
+
+void
+bench_gpu_destroy(struct tile_stream_gpu* s)
+{
+  (void)s;
+}
+
+const struct tile_stream_layout*
+bench_gpu_layout(const struct tile_stream_gpu* s)
+{
+  (void)s;
+  return NULL;
+}
+
+struct stream_metrics
+bench_gpu_get_metrics(const struct tile_stream_gpu* s)
+{
+  (void)s;
+  struct stream_metrics m = { 0 };
+  return m;
+}
+
+struct tile_stream_status
+bench_gpu_status(const struct tile_stream_gpu* s)
+{
+  (void)s;
+  struct tile_stream_status st = { 0 };
+  return st;
+}
+
+struct writer*
+bench_gpu_writer(struct tile_stream_gpu* s)
+{
+  (void)s;
+  return NULL;
+}
+
+uint64_t
+bench_gpu_cursor(const struct tile_stream_gpu* s)
+{
+  (void)s;
+  return 0;
+}

--- a/bench/bench_gpu.none.c
+++ b/bench/bench_gpu.none.c
@@ -59,7 +59,7 @@ bench_gpu_advise_layout(struct tile_stream_configuration* config,
   return 1;
 }
 
-int
+void
 bench_gpu_report_memory(const struct tile_stream_configuration* config,
                         uint64_t* total_chunks,
                         size_t* device_bytes,
@@ -69,7 +69,6 @@ bench_gpu_report_memory(const struct tile_stream_configuration* config,
   (void)total_chunks;
   (void)device_bytes;
   (void)pinned_bytes;
-  return 1;
 }
 
 void

--- a/bench/bench_parse.c
+++ b/bench/bench_parse.c
@@ -10,8 +10,8 @@
 
 // --- Byte-size parser: "256K", "1M", "8G" etc. ---
 
-// Accept the "B" and "iB" tails people write, so "256KB" and "1GiB" mean what
-// they look like. A lone "i" or a bare "1Ki" is a typo, not a size.
+// Accept the "B" and "iB" tails people write, so "256KB" and "1GiB" mean
+// what they look like.
 static int
 is_byte_tail(const char* s)
 {
@@ -28,8 +28,7 @@ is_byte_tail(const char* s)
 int
 parse_bytes(const char* s, size_t* out)
 {
-  // strtoull skips leading space and accepts a sign; a negative would wrap
-  // to a huge size, so refuse it before we get there.
+  // strtoull would turn a negative into a huge size, so refuse it first.
   while (isspace((unsigned char)*s))
     ++s;
   if (*s == '-')

--- a/bench/bench_parse.c
+++ b/bench/bench_parse.c
@@ -9,9 +9,26 @@
 
 // --- Byte-size parser: "256K", "1M", "8G" etc. ---
 
+// Accept the "B", "iB" and "ib" tails people write, so "256KB" and "1GiB"
+// mean what they look like.
+static int
+is_byte_tail(const char* s)
+{
+  if (*s == 'i' || *s == 'I')
+    ++s;
+  if (*s == 'b' || *s == 'B')
+    ++s;
+  return *s == '\0';
+}
+
 int
 parse_bytes(const char* s, size_t* out)
 {
+  while (*s == ' ' || *s == '\t')
+    ++s;
+  if (*s == '-' || *s == '+')
+    return 1;
+
   char* end = NULL;
   errno = 0;
   unsigned long long val = strtoull(s, &end, 10);
@@ -19,26 +36,28 @@ parse_bytes(const char* s, size_t* out)
     return 1;
 
   unsigned shift = 0;
-  if (*end) {
-    switch (*end) {
-      case 'k':
-      case 'K':
-        shift = 10;
-        break;
-      case 'm':
-      case 'M':
-        shift = 20;
-        break;
-      case 'g':
-      case 'G':
-        shift = 30;
-        break;
-      default:
-        return 1;
-    }
-    if (end[1])
-      return 1;
+  const char* tail = end;
+  switch (*tail) {
+    case 'k':
+    case 'K':
+      shift = 10;
+      ++tail;
+      break;
+    case 'm':
+    case 'M':
+      shift = 20;
+      ++tail;
+      break;
+    case 'g':
+    case 'G':
+      shift = 30;
+      ++tail;
+      break;
+    default:
+      break;
   }
+  if (!is_byte_tail(tail))
+    return 1;
 
   if (shift) {
     if (val > (ULLONG_MAX >> shift))

--- a/bench/bench_parse.c
+++ b/bench/bench_parse.c
@@ -9,13 +9,16 @@
 
 // --- Byte-size parser: "256K", "1M", "8G" etc. ---
 
-// Accept the "B", "iB" and "ib" tails people write, so "256KB" and "1GiB"
-// mean what they look like.
+// Accept the "B" and "iB" tails people write, so "256KB" and "1GiB" mean what
+// they look like. A lone "i" or a bare "1Ki" is a typo, not a size.
 static int
 is_byte_tail(const char* s)
 {
-  if (*s == 'i' || *s == 'I')
+  if (*s == 'i' || *s == 'I') {
     ++s;
+    if (*s != 'b' && *s != 'B')
+      return 0;
+  }
   if (*s == 'b' || *s == 'B')
     ++s;
   return *s == '\0';
@@ -24,9 +27,12 @@ is_byte_tail(const char* s)
 int
 parse_bytes(const char* s, size_t* out)
 {
-  while (*s == ' ' || *s == '\t')
+  // strtoull skips leading whitespace and accepts a sign; a negative would
+  // wrap to a huge size, so refuse it before we get there.
+  while (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r' || *s == '\v' ||
+         *s == '\f')
     ++s;
-  if (*s == '-' || *s == '+')
+  if (*s == '-')
     return 1;
 
   char* end = NULL;

--- a/bench/bench_parse.c
+++ b/bench/bench_parse.c
@@ -1,5 +1,7 @@
 #include "bench_parse.h"
 
+#include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,24 +12,35 @@ size_t
 parse_bytes(const char* s)
 {
   char* end = NULL;
-  size_t val = (size_t)strtoull(s, &end, 10);
+  unsigned long long val = strtoull(s, &end, 10);
+  unsigned shift = 0;
   if (end && *end) {
     switch (*end) {
       case 'k':
       case 'K':
-        val <<= 10;
+        shift = 10;
         break;
       case 'm':
       case 'M':
-        val <<= 20;
+        shift = 20;
         break;
       case 'g':
       case 'G':
-        val <<= 30;
+        shift = 30;
         break;
     }
   }
-  return val;
+  // Saturate rather than wrap, so callers can range-check the result.
+  if (shift) {
+    if (val > (ULLONG_MAX >> shift))
+      return SIZE_MAX;
+    val <<= shift;
+  }
+#if SIZE_MAX < ULLONG_MAX
+  if (val > SIZE_MAX)
+    return SIZE_MAX;
+#endif
+  return (size_t)val;
 }
 
 // --- dtype helpers ---

--- a/bench/bench_parse.c
+++ b/bench/bench_parse.c
@@ -1,5 +1,6 @@
 #include "bench_parse.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdint.h>
@@ -27,19 +28,18 @@ is_byte_tail(const char* s)
 int
 parse_bytes(const char* s, size_t* out)
 {
-  // strtoull skips leading whitespace and accepts a sign; a negative would
-  // wrap to a huge size, so refuse it before we get there.
-  while (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r' || *s == '\v' ||
-         *s == '\f')
+  // strtoull skips leading space and accepts a sign; a negative would wrap
+  // to a huge size, so refuse it before we get there.
+  while (isspace((unsigned char)*s))
     ++s;
   if (*s == '-')
-    return 1;
+    return 0;
 
   char* end = NULL;
   errno = 0;
   unsigned long long val = strtoull(s, &end, 10);
   if (end == s || errno == ERANGE)
-    return 1;
+    return 0;
 
   unsigned shift = 0;
   const char* tail = end;
@@ -63,19 +63,19 @@ parse_bytes(const char* s, size_t* out)
       break;
   }
   if (!is_byte_tail(tail))
-    return 1;
+    return 0;
 
   if (shift) {
     if (val > (ULLONG_MAX >> shift))
-      return 1;
+      return 0;
     val <<= shift;
   }
 #if SIZE_MAX < ULLONG_MAX
   if (val > SIZE_MAX)
-    return 1;
+    return 0;
 #endif
   *out = (size_t)val;
-  return 0;
+  return 1;
 }
 
 // --- dtype helpers ---

--- a/bench/bench_parse.c
+++ b/bench/bench_parse.c
@@ -1,5 +1,6 @@
 #include "bench_parse.h"
 
+#include <errno.h>
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -8,13 +9,17 @@
 
 // --- Byte-size parser: "256K", "1M", "8G" etc. ---
 
-size_t
-parse_bytes(const char* s)
+int
+parse_bytes(const char* s, size_t* out)
 {
   char* end = NULL;
+  errno = 0;
   unsigned long long val = strtoull(s, &end, 10);
+  if (end == s || errno == ERANGE)
+    return 1;
+
   unsigned shift = 0;
-  if (end && *end) {
+  if (*end) {
     switch (*end) {
       case 'k':
       case 'K':
@@ -28,19 +33,24 @@ parse_bytes(const char* s)
       case 'G':
         shift = 30;
         break;
+      default:
+        return 1;
     }
+    if (end[1])
+      return 1;
   }
-  // Saturate rather than wrap, so callers can range-check the result.
+
   if (shift) {
     if (val > (ULLONG_MAX >> shift))
-      return SIZE_MAX;
+      return 1;
     val <<= shift;
   }
 #if SIZE_MAX < ULLONG_MAX
   if (val > SIZE_MAX)
-    return SIZE_MAX;
+    return 1;
 #endif
-  return (size_t)val;
+  *out = (size_t)val;
+  return 0;
 }
 
 // --- dtype helpers ---

--- a/bench/bench_parse.c
+++ b/bench/bench_parse.c
@@ -26,7 +26,7 @@ is_byte_tail(const char* s)
 }
 
 int
-parse_bytes(const char* s, size_t* out)
+parse_bytes(const char* s, uint64_t* out)
 {
   // strtoull would turn a negative into a huge size, so refuse it first.
   while (isspace((unsigned char)*s))
@@ -69,11 +69,7 @@ parse_bytes(const char* s, size_t* out)
       return 0;
     val <<= shift;
   }
-#if SIZE_MAX < ULLONG_MAX
-  if (val > SIZE_MAX)
-    return 0;
-#endif
-  *out = (size_t)val;
+  *out = val;
   return 1;
 }
 

--- a/bench/bench_parse.h
+++ b/bench/bench_parse.h
@@ -13,9 +13,10 @@ enum bench_backend
   BENCH_CPU,
 };
 
-// Byte-size parser: "256K", "1M", "8G" etc.
-size_t
-parse_bytes(const char* s);
+// Byte-size parser: "256K", "1M", "8G" etc. Returns non-zero and leaves *out
+// alone when the text is not a size this platform can hold.
+int
+parse_bytes(const char* s, size_t* out);
 
 // CLI option parsers. parse_fill returns NULL on error.
 // The int-returning parsers return non-zero on success, 0 on error.

--- a/bench/bench_parse.h
+++ b/bench/bench_parse.h
@@ -6,6 +6,7 @@
 #include "types.lod.h"
 
 #include <stddef.h>
+#include <stdint.h>
 
 enum bench_backend
 {
@@ -14,9 +15,9 @@ enum bench_backend
 };
 
 // Byte-size parser: "256K", "1M", "8G" etc. Leaves *out alone when the text
-// is not a size this platform can hold.
+// is not a size that fits.
 int
-parse_bytes(const char* s, size_t* out);
+parse_bytes(const char* s, uint64_t* out);
 
 // CLI option parsers. parse_fill returns NULL on error.
 // The int-returning parsers return non-zero on success, 0 on error.

--- a/bench/bench_parse.h
+++ b/bench/bench_parse.h
@@ -19,7 +19,7 @@ int
 parse_bytes(const char* s, size_t* out);
 
 // CLI option parsers. parse_fill returns NULL on error.
-// The int-returning parsers return non-zero on success, 0 on error.
+// The int-returning parsers below return non-zero on success, 0 on error.
 fill_fn
 parse_fill(const char* s);
 

--- a/bench/bench_parse.h
+++ b/bench/bench_parse.h
@@ -13,13 +13,13 @@ enum bench_backend
   BENCH_CPU,
 };
 
-// Byte-size parser: "256K", "1M", "8G" etc. Returns non-zero and leaves *out
-// alone when the text is not a size this platform can hold.
+// Byte-size parser: "256K", "1M", "8G" etc. Leaves *out alone when the text
+// is not a size this platform can hold.
 int
 parse_bytes(const char* s, size_t* out);
 
 // CLI option parsers. parse_fill returns NULL on error.
-// The int-returning parsers below return non-zero on success, 0 on error.
+// The int-returning parsers return non-zero on success, 0 on error.
 fill_fn
 parse_fill(const char* s);
 

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -90,8 +90,6 @@ resolved_batch_bytes(const struct bench_config* cfg)
                                  : 512u << 20;
 }
 
-// Report a failure that happened before the run started. Keeps stdout to the
-// JSON document alone, so --json output stays parseable.
 static int
 bench_failed(int json_output)
 {
@@ -623,10 +621,9 @@ struct bench_cli_args
 static int
 read_size(const char* flag, const char* text, size_t* out)
 {
-  if (parse_bytes(text, out)) {
-    fprintf(stderr, "%s: cannot read \"%s\" as a size\n", flag, text);
+  if (parse_bytes(text, out))
     return 1;
-  }
+  fprintf(stderr, "%s: cannot read \"%s\" as a size\n", flag, text);
   return 0;
 }
 
@@ -686,11 +683,11 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
     } else if (strcmp(av[i], "--json") == 0) {
       out->json_output = 1;
     } else if (strcmp(av[i], "--chunk-bytes") == 0 && i + 1 < ac) {
-      if (read_size(av[i], av[i + 1], &out->target_chunk_bytes))
+      if (!read_size(av[i], av[i + 1], &out->target_chunk_bytes))
         return 1;
       ++i;
     } else if (strcmp(av[i], "--batch-bytes") == 0 && i + 1 < ac) {
-      if (read_size(av[i], av[i + 1], &out->target_batch_bytes))
+      if (!read_size(av[i], av[i + 1], &out->target_batch_bytes))
         return 1;
       ++i;
       if ((uint64_t)out->target_batch_bytes > UINT32_MAX) {
@@ -698,7 +695,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
         return 1;
       }
     } else if (strcmp(av[i], "--memory-budget") == 0 && i + 1 < ac) {
-      if (read_size(av[i], av[i + 1], &out->memory_budget))
+      if (!read_size(av[i], av[i + 1], &out->memory_budget))
         return 1;
       ++i;
     } else if (strcmp(av[i], "-o") == 0 && i + 1 < ac) {
@@ -718,7 +715,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
     } else if (strcmp(av[i], "--io-latency-us") == 0 && i + 1 < ac) {
       out->io_latency_us = strtoull(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--backpressure") == 0 && i + 1 < ac) {
-      if (read_size(av[i], av[i + 1], &out->backpressure_bytes))
+      if (!read_size(av[i], av[i + 1], &out->backpressure_bytes))
         return 1;
       ++i;
     } else if (strcmp(av[i], "--max-threads") == 0 && i + 1 < ac) {
@@ -1121,13 +1118,11 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
 
   // This driver reports to stderr only, so a JSON error document on the way
   // out would be the sole thing a caller ever parsed.
-  if (a.json_output) {
+  if (a.json_output)
     print_report("  note: the two-stream benchmark does not write JSON");
-    a.json_output = 0;
-  }
 
   if (bench_gpu_context_create())
-    return bench_failed(a.json_output);
+    return bench_failed(0);
 
   struct bench_config cfg = {
     .label = spec.label,

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -1,12 +1,10 @@
 #include "bench_util.h"
+#include "bench_gpu.h"
 #include "bench_parse.h"
 #include "bench_report.h"
 #include "bench_zarr.h"
 #include "defs.limits.h"
 #include "dimension.h"
-#include "gpu/compress.h"
-#include "gpu/lod.h"
-#include "gpu/prelude.cuda.h"
 #include "platform/platform.h"
 #include "sink_discard.h"
 #include "sink_metering.h"
@@ -45,28 +43,28 @@ static const struct tile_stream_layout*
 bench_layout(const struct bench_handle* h)
 {
   return h->backend == BENCH_CPU ? tile_stream_cpu_layout(h->cpu)
-                                 : tile_stream_gpu_layout(h->gpu);
+                                 : bench_gpu_layout(h->gpu);
 }
 
 static struct stream_metrics
 bench_get_metrics(const struct bench_handle* h)
 {
   return h->backend == BENCH_CPU ? tile_stream_cpu_get_metrics(h->cpu)
-                                 : tile_stream_gpu_get_metrics(h->gpu);
+                                 : bench_gpu_get_metrics(h->gpu);
 }
 
 static struct writer*
 bench_writer(struct bench_handle* h)
 {
   return h->backend == BENCH_CPU ? tile_stream_cpu_writer(h->cpu)
-                                 : tile_stream_gpu_writer(h->gpu);
+                                 : bench_gpu_writer(h->gpu);
 }
 
 static uint64_t
 bench_cursor(const struct bench_handle* h)
 {
   return h->backend == BENCH_CPU ? tile_stream_cpu_cursor(h->cpu)
-                                 : tile_stream_gpu_cursor(h->gpu);
+                                 : bench_gpu_cursor(h->gpu);
 }
 
 static void
@@ -75,7 +73,7 @@ bench_destroy(struct bench_handle* h)
   if (h->backend == BENCH_CPU)
     tile_stream_cpu_destroy(h->cpu);
   else
-    tile_stream_gpu_destroy(h->gpu);
+    bench_gpu_destroy(h->gpu);
 }
 
 static void
@@ -110,8 +108,8 @@ resolve_chunk_sizing(const struct bench_config* cfg,
   if (budget == 0) {
     char buf[32];
     if (cfg->backend == BENCH_GPU) {
-      size_t free_mem = 0, total_mem = 0;
-      if (cuMemGetInfo(&free_mem, &total_mem) == CUDA_SUCCESS && free_mem > 0) {
+      size_t free_mem = bench_gpu_free_memory();
+      if (free_mem > 0) {
         budget = (size_t)((double)free_mem * budget_fraction);
         format_bytes(buf, sizeof(buf), free_mem);
         print_report(
@@ -146,16 +144,16 @@ resolve_chunk_sizing(const struct bench_config* cfg,
     struct advise_layout_diagnostic diag = { 0 };
     int advise_ok;
     if (cfg->backend == BENCH_GPU) {
-      advise_ok = tile_stream_gpu_advise_layout(&fit_config,
-                                                target,
-                                                cfg->min_chunk_bytes,
-                                                cfg->chunk_ratios,
-                                                budget,
-                                                cfg->min_shard_bytes,
-                                                cfg->target_concurrent_shards,
-                                                cfg->min_append_shards,
-                                                0,
-                                                &diag);
+      advise_ok = bench_gpu_advise_layout(&fit_config,
+                                          target,
+                                          cfg->min_chunk_bytes,
+                                          cfg->chunk_ratios,
+                                          budget,
+                                          cfg->min_shard_bytes,
+                                          cfg->target_concurrent_shards,
+                                          cfg->min_append_shards,
+                                          0,
+                                          &diag);
     } else {
       advise_ok = tile_stream_cpu_advise_layout(&fit_config,
                                                 target,
@@ -419,33 +417,9 @@ run_bench(const struct bench_config* cfg)
   size_t est_total_bytes = 0;
   size_t est_pinned_bytes = 0;
 
-  if (cfg->backend == BENCH_GPU) {
-    struct tile_stream_memory_info mem;
-    if (tile_stream_gpu_memory_estimate(&config, 0, &mem) == 0) {
-      est_total_chunks = mem.total_chunks;
-      est_total_bytes = mem.device_bytes;
-      est_pinned_bytes = mem.host_pinned_bytes;
-      char a[32], b[32];
-      format_bytes(a, sizeof(a), mem.device_bytes);
-      format_bytes(b, sizeof(b), mem.host_pinned_bytes);
-      print_report("  GPU memory:  %s device, %s pinned", a, b);
-      format_bytes(a, sizeof(a), mem.staging_bytes);
-      format_bytes(b, sizeof(b), mem.chunk_pool_bytes);
-      print_report("    staging:   %s   chunk_pool: %s", a, b);
-      format_bytes(a, sizeof(a), mem.compressed_pool_bytes);
-      format_bytes(b, sizeof(b), mem.aggregate_bytes);
-      print_report("    comp_pool: %s   aggregate: %s", a, b);
-      format_bytes(a, sizeof(a), mem.lod_bytes);
-      format_bytes(b, sizeof(b), mem.codec_bytes);
-      print_report("    lod:       %s   codec:     %s", a, b);
-      print_report(
-        "    chunks:    %llu/epoch, %llu total (%d LOD levels, batch=%u)",
-        (unsigned long long)mem.chunks_per_epoch,
-        (unsigned long long)mem.total_chunks,
-        mem.nlod,
-        mem.epochs_per_batch);
-    }
-  }
+  if (cfg->backend == BENCH_GPU)
+    bench_gpu_report_memory(
+      &config, &est_total_chunks, &est_total_bytes, &est_pinned_bytes);
 
   if (cfg->backend == BENCH_CPU) {
     struct tile_stream_cpu_memory_info mem;
@@ -479,7 +453,7 @@ run_bench(const struct bench_config* cfg)
   if (cfg->backend == BENCH_CPU)
     h.cpu = tile_stream_cpu_create(&config, sink);
   else
-    h.gpu = tile_stream_gpu_create(&config, sink);
+    h.gpu = bench_gpu_create(&config, sink);
   CHECK(Fail, !bench_is_null(&h));
   float init_s = platform_toc(&init_clock);
 
@@ -488,7 +462,7 @@ run_bench(const struct bench_config* cfg)
   size_t codec_batch_size = 0;
   int nlod = 0;
   if (cfg->backend == BENCH_GPU) {
-    struct tile_stream_status st = tile_stream_gpu_status(h.gpu);
+    struct tile_stream_status st = bench_gpu_status(h.gpu);
     max_compressed_size = st.max_compressed_size;
     codec_batch_size = st.codec_batch_size;
     nlod = st.nlod;
@@ -644,7 +618,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
   out->fill = fill_xor;
   out->codec = (struct codec_config){ .id = CODEC_ZSTD };
   out->reduce = lod_reduce_mean;
-  out->backend = BENCH_GPU;
+  out->backend = bench_gpu_enabled() ? BENCH_GPU : BENCH_CPU;
   out->dtype = dtype_u16;
   out->target_chunk_bytes = 0;
   out->target_batch_bytes = 0;
@@ -742,14 +716,9 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
   if (a.frames > 0)
     dims[0].size = a.frames;
 
-  int ecode = 0;
-  CUcontext ctx = 0;
-
-  if (a.backend == BENCH_GPU) {
-    CUdevice dev;
-    CU(Fail, cuInit(0));
-    CU(Fail, cuDeviceGet(&dev, 0));
-    CU(Fail, cu_ctx_create(&ctx, 0, dev));
+  if (a.backend == BENCH_GPU && bench_gpu_context_create()) {
+    printf("FAIL\n");
+    return 1;
   }
 
   struct bench_config cfg = {
@@ -786,17 +755,11 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
     .backpressure_bytes = a.backpressure_bytes,
     .max_threads = a.max_threads,
   };
-  ecode = run_bench(&cfg);
+  int ecode = run_bench(&cfg);
 
   if (a.backend == BENCH_GPU)
-    cuCtxDestroy(ctx);
+    bench_gpu_context_destroy();
   return ecode;
-
-Fail:
-  printf("FAIL\n");
-  if (a.backend == BENCH_GPU)
-    cuCtxDestroy(ctx);
-  return 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -956,35 +919,23 @@ run_bench_two_streams(const struct bench_config* cfg)
     .max_threads = cfg->max_threads,
   };
 
-  // Memory estimates
-  {
-    struct tile_stream_memory_info mem;
-    if (tile_stream_gpu_memory_estimate(&config, 0, &mem) == 0) {
-      char a[32], b[32];
-      format_bytes(a, sizeof(a), mem.device_bytes);
-      format_bytes(b, sizeof(b), mem.host_pinned_bytes);
-      print_report("  GPU memory (per stream): %s device, %s pinned", a, b);
-      format_bytes(a, sizeof(a), 2 * mem.device_bytes);
-      format_bytes(b, sizeof(b), 2 * mem.host_pinned_bytes);
-      print_report("  GPU memory (total x2):   %s device, %s pinned", a, b);
-    }
-  }
+  bench_gpu_report_memory_pair(&config);
 
   // Create two GPU streams
   struct platform_clock init_clock = { 0 };
   platform_toc(&init_clock);
 
-  s0 = tile_stream_gpu_create(&config, sink[0]);
-  s1 = tile_stream_gpu_create(&config, sink[1]);
+  s0 = bench_gpu_create(&config, sink[0]);
+  s1 = bench_gpu_create(&config, sink[1]);
   CHECK(Fail, s0 && s1);
   float init_s = platform_toc(&init_clock);
 
-  const struct tile_stream_layout* layout = tile_stream_gpu_layout(s0);
+  const struct tile_stream_layout* layout = bench_gpu_layout(s0);
   log_bench_header(
     layout, dtype, cfg->codec, 0, 0, total_bytes, total_elements);
 
-  struct writer* w0 = tile_stream_gpu_writer(s0);
-  struct writer* w1 = tile_stream_gpu_writer(s1);
+  struct writer* w0 = bench_gpu_writer(s0);
+  struct writer* w1 = bench_gpu_writer(s1);
 
   // Interleaved pump
   struct platform_clock clock = { 0 };
@@ -1002,13 +953,13 @@ run_bench_two_streams(const struct bench_config* cfg)
   float wall_s = platform_toc(&clock);
 
   // Verify cursors
-  CHECK(Fail, tile_stream_gpu_cursor(s0) == total_elements);
-  CHECK(Fail, tile_stream_gpu_cursor(s1) == total_elements);
+  CHECK(Fail, bench_gpu_cursor(s0) == total_elements);
+  CHECK(Fail, bench_gpu_cursor(s1) == total_elements);
 
   // Collect metrics
   struct stream_metrics m[2] = {
-    tile_stream_gpu_get_metrics(s0),
-    tile_stream_gpu_get_metrics(s1),
+    bench_gpu_get_metrics(s0),
+    bench_gpu_get_metrics(s1),
   };
 
   size_t sink_bytes[2];
@@ -1090,8 +1041,8 @@ run_bench_two_streams(const struct bench_config* cfg)
   }
 
   print_report("  PASS");
-  tile_stream_gpu_destroy(s1);
-  tile_stream_gpu_destroy(s0);
+  bench_gpu_destroy(s1);
+  bench_gpu_destroy(s0);
   bench_zarr_close(&zarr[0]);
   bench_zarr_close(&zarr[1]);
   if (use_throttled) {
@@ -1108,9 +1059,9 @@ Fail:
   for (int k = 0; k < 2; ++k)
     bench_zarr_flush(&zarr[k]);
   if (s1)
-    tile_stream_gpu_destroy(s1);
+    bench_gpu_destroy(s1);
   if (s0)
-    tile_stream_gpu_destroy(s0);
+    bench_gpu_destroy(s0);
   bench_zarr_close(&zarr[0]);
   bench_zarr_close(&zarr[1]);
   if (use_throttled) {
@@ -1132,11 +1083,10 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
   if (a.frames > 0)
     dims[0].size = a.frames;
 
-  CUdevice dev;
-  CUcontext ctx = 0;
-  CU(Fail, cuInit(0));
-  CU(Fail, cuDeviceGet(&dev, 0));
-  CU(Fail, cu_ctx_create(&ctx, 0, dev));
+  if (bench_gpu_context_create()) {
+    printf("FAIL\n");
+    return 1;
+  }
 
   struct bench_config cfg = {
     .label = spec.label,
@@ -1168,11 +1118,6 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
   };
   int ecode = run_bench_two_streams(&cfg);
 
-  cuCtxDestroy(ctx);
+  bench_gpu_context_destroy();
   return ecode;
-
-Fail:
-  printf("FAIL\n");
-  cuCtxDestroy(ctx);
-  return 1;
 }

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -139,7 +139,8 @@ resolve_chunk_sizing(const struct bench_config* cfg,
       .reduce_method = cfg->reduce_method,
       .append_reduce_method = cfg->append_reduce_method,
       .target_batch_bytes =
-        cfg->target_batch_bytes ? cfg->target_batch_bytes : 512u << 20,
+        (uint32_t)(cfg->target_batch_bytes ? cfg->target_batch_bytes
+                                           : 512u << 20),
     };
     struct advise_layout_diagnostic diag = { 0 };
     int advise_ok;

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -1116,8 +1116,8 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
   if (a.frames > 0)
     dims[0].size = a.frames;
 
-  // This driver reports to stderr only, so a JSON error document on the way
-  // out would be the sole thing a caller ever parsed.
+  // This driver reports to stderr only, so an error document would be the
+  // only JSON a caller ever saw.
   if (a.json_output)
     print_report("  note: the two-stream benchmark does not write JSON");
 

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -81,13 +81,11 @@ print_advise_failure(const struct advise_layout_diagnostic* diag,
                      size_t budget,
                      size_t min_shard_bytes);
 
-// The stream configuration holds this in 32 bits; the CLI rejects anything
-// that would not fit.
-static uint32_t
+static uint64_t
 resolved_batch_bytes(const struct bench_config* cfg)
 {
-  return cfg->target_batch_bytes ? (uint32_t)cfg->target_batch_bytes
-                                 : 512u << 20;
+  return cfg->target_batch_bytes ? cfg->target_batch_bytes
+                                 : (uint64_t)512 << 20;
 }
 
 static int
@@ -600,9 +598,9 @@ struct bench_cli_args
   enum lod_reduce_method reduce;
   enum bench_backend backend;
   enum dtype dtype;
-  size_t target_chunk_bytes;
-  size_t target_batch_bytes;
-  size_t memory_budget;
+  uint64_t target_chunk_bytes;
+  uint64_t target_batch_bytes;
+  uint64_t memory_budget;
   uint64_t frames;
   size_t append_elements; // 0 = default block
   int json_output;
@@ -614,12 +612,12 @@ struct bench_cli_args
   double s3_throughput_gbps;
   uint64_t io_bw_mbps;
   uint64_t io_latency_us;
-  size_t backpressure_bytes;
+  uint64_t backpressure_bytes;
   int max_threads;
 };
 
 static int
-read_size(const char* flag, const char* text, size_t* out)
+read_size(const char* flag, const char* text, uint64_t* out)
 {
   if (parse_bytes(text, out))
     return 1;
@@ -690,10 +688,6 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
       if (!read_size(av[i], av[i + 1], &out->target_batch_bytes))
         return 1;
       ++i;
-      if ((uint64_t)out->target_batch_bytes > UINT32_MAX) {
-        fprintf(stderr, "--batch-bytes must be less than 4 GiB\n");
-        return 1;
-      }
     } else if (strcmp(av[i], "--memory-budget") == 0 && i + 1 < ac) {
       if (!read_size(av[i], av[i + 1], &out->memory_budget))
         return 1;

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -620,6 +620,16 @@ struct bench_cli_args
   int max_threads;
 };
 
+static int
+read_size(const char* flag, const char* text, size_t* out)
+{
+  if (parse_bytes(text, out)) {
+    fprintf(stderr, "%s: cannot read \"%s\" as a size\n", flag, text);
+    return 1;
+  }
+  return 0;
+}
+
 // Parse the shared bench CLI flags into out. Unknown options print a usage
 // string and return 1. Flags accepted:
 //   --fill --codec --reduce --backend --dtype --frames --json --chunk-bytes
@@ -676,15 +686,21 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
     } else if (strcmp(av[i], "--json") == 0) {
       out->json_output = 1;
     } else if (strcmp(av[i], "--chunk-bytes") == 0 && i + 1 < ac) {
-      out->target_chunk_bytes = parse_bytes(av[++i]);
+      if (read_size(av[i], av[i + 1], &out->target_chunk_bytes))
+        return 1;
+      ++i;
     } else if (strcmp(av[i], "--batch-bytes") == 0 && i + 1 < ac) {
-      out->target_batch_bytes = parse_bytes(av[++i]);
+      if (read_size(av[i], av[i + 1], &out->target_batch_bytes))
+        return 1;
+      ++i;
       if ((uint64_t)out->target_batch_bytes > UINT32_MAX) {
         fprintf(stderr, "--batch-bytes must be less than 4 GiB\n");
         return 1;
       }
     } else if (strcmp(av[i], "--memory-budget") == 0 && i + 1 < ac) {
-      out->memory_budget = parse_bytes(av[++i]);
+      if (read_size(av[i], av[i + 1], &out->memory_budget))
+        return 1;
+      ++i;
     } else if (strcmp(av[i], "-o") == 0 && i + 1 < ac) {
       out->output_path = av[++i];
     } else if (strcmp(av[i], "--s3-bucket") == 0 && i + 1 < ac) {
@@ -702,7 +718,9 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
     } else if (strcmp(av[i], "--io-latency-us") == 0 && i + 1 < ac) {
       out->io_latency_us = strtoull(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--backpressure") == 0 && i + 1 < ac) {
-      out->backpressure_bytes = parse_bytes(av[++i]);
+      if (read_size(av[i], av[i + 1], &out->backpressure_bytes))
+        return 1;
+      ++i;
     } else if (strcmp(av[i], "--max-threads") == 0 && i + 1 < ac) {
       out->max_threads = (int)strtol(av[++i], NULL, 10);
     } else {

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -579,10 +579,7 @@ run_bench(const struct bench_config* cfg)
   goto Cleanup;
 
 Fail:
-  if (cfg->json_output)
-    print_bench_json_error();
-  print_report("  FAIL");
-  rc = 1;
+  rc = bench_failed(cfg->json_output);
 
 Cleanup:
   // Flush before destroying the stream — pending write_direct jobs
@@ -1103,6 +1100,13 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
   struct dimension* dims = spec.dims;
   if (a.frames > 0)
     dims[0].size = a.frames;
+
+  // This driver reports to stderr only, so a JSON error document on the way
+  // out would be the sole thing a caller ever parsed.
+  if (a.json_output) {
+    print_report("  note: the two-stream benchmark does not write JSON");
+    a.json_output = 0;
+  }
 
   if (bench_gpu_context_create())
     return bench_failed(a.json_output);

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -81,6 +81,26 @@ print_advise_failure(const struct advise_layout_diagnostic* diag,
                      size_t budget,
                      size_t min_shard_bytes);
 
+// The stream configuration holds this in 32 bits; the CLI rejects anything
+// that would not fit.
+static uint32_t
+resolved_batch_bytes(const struct bench_config* cfg)
+{
+  return cfg->target_batch_bytes ? (uint32_t)cfg->target_batch_bytes
+                                 : 512u << 20;
+}
+
+// Report a failure that happened before the run started. Keeps stdout to the
+// JSON document alone, so --json output stays parseable.
+static int
+bench_failed(int json_output)
+{
+  if (json_output)
+    print_bench_json_error();
+  print_report("  FAIL");
+  return 1;
+}
+
 // Resolve the chunk + shard geometry for cfg->dims using cfg->chunk_ratios.
 // When cfg->memory_budget is 0, auto-detects from backend free memory using
 // budget_fraction (e.g. 0.8 for single-stream, 0.4 per stream for the
@@ -138,9 +158,7 @@ resolve_chunk_sizing(const struct bench_config* cfg,
       .codec = cfg->codec,
       .reduce_method = cfg->reduce_method,
       .append_reduce_method = cfg->append_reduce_method,
-      .target_batch_bytes =
-        (uint32_t)(cfg->target_batch_bytes ? cfg->target_batch_bytes
-                                           : 512u << 20),
+      .target_batch_bytes = resolved_batch_bytes(cfg),
     };
     struct advise_layout_diagnostic diag = { 0 };
     int advise_ok;
@@ -409,7 +427,7 @@ run_bench(const struct bench_config* cfg)
     .reduce_method = cfg->reduce_method,
     .append_reduce_method = cfg->append_reduce_method,
     .epochs_per_batch = chosen_epochs_per_batch,
-    .target_batch_bytes = 512u << 20,
+    .target_batch_bytes = resolved_batch_bytes(cfg),
     .backpressure_bytes = cfg->backpressure_bytes,
     .max_threads = cfg->max_threads,
   };
@@ -664,6 +682,10 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
       out->target_chunk_bytes = parse_bytes(av[++i]);
     } else if (strcmp(av[i], "--batch-bytes") == 0 && i + 1 < ac) {
       out->target_batch_bytes = parse_bytes(av[++i]);
+      if ((uint64_t)out->target_batch_bytes > UINT32_MAX) {
+        fprintf(stderr, "--batch-bytes must be less than 4 GiB\n");
+        return 1;
+      }
     } else if (strcmp(av[i], "--memory-budget") == 0 && i + 1 < ac) {
       out->memory_budget = parse_bytes(av[++i]);
     } else if (strcmp(av[i], "-o") == 0 && i + 1 < ac) {
@@ -717,10 +739,8 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
   if (a.frames > 0)
     dims[0].size = a.frames;
 
-  if (a.backend == BENCH_GPU && bench_gpu_context_create()) {
-    printf("FAIL\n");
-    return 1;
-  }
+  if (a.backend == BENCH_GPU && bench_gpu_context_create())
+    return bench_failed(a.json_output);
 
   struct bench_config cfg = {
     .label = spec.label,
@@ -915,7 +935,7 @@ run_bench_two_streams(const struct bench_config* cfg)
     .reduce_method = cfg->reduce_method,
     .append_reduce_method = cfg->append_reduce_method,
     .epochs_per_batch = chosen_epochs_per_batch,
-    .target_batch_bytes = 512u << 20,
+    .target_batch_bytes = resolved_batch_bytes(cfg),
     .backpressure_bytes = cfg->backpressure_bytes,
     .max_threads = cfg->max_threads,
   };
@@ -1084,10 +1104,8 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
   if (a.frames > 0)
     dims[0].size = a.frames;
 
-  if (bench_gpu_context_create()) {
-    printf("FAIL\n");
-    return 1;
-  }
+  if (bench_gpu_context_create())
+    return bench_failed(a.json_output);
 
   struct bench_config cfg = {
     .label = spec.label,

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -33,15 +33,15 @@ struct bench_config
   enum lod_reduce_method reduce_method;
   enum lod_reduce_method append_reduce_method;
   enum bench_backend backend;
-  enum dtype dtype;          // element type (default dtype_u16)
-  const int* chunk_ratios;   // power-of-2 distribution ratios; see
-                             // dims_budget_chunk_size for the -1/0/>0
-                             // conventions
-  size_t target_chunk_bytes; // 0 = use 1MB default
-  size_t min_chunk_bytes;    // auto-fit floor; 0 = no floor
-  size_t target_batch_bytes; // 0 = 512 MiB default; controls auto-K
-  size_t memory_budget;      // 0 = auto-detect
-  size_t min_shard_bytes;    // minimum uncompressed bytes per shard
+  enum dtype dtype;            // element type (default dtype_u16)
+  const int* chunk_ratios;     // power-of-2 distribution ratios; see
+                               // dims_budget_chunk_size for the -1/0/>0
+                               // conventions
+  size_t target_chunk_bytes;   // 0 = use 1MB default
+  size_t min_chunk_bytes;      // auto-fit floor; 0 = no floor
+  uint64_t target_batch_bytes; // 0 = 512 MiB default; controls auto-K
+  size_t memory_budget;        // 0 = auto-detect
+  size_t min_shard_bytes;      // minimum uncompressed bytes per shard
   uint32_t
     target_concurrent_shards; // cap on inner shard product (active files)
   uint32_t min_append_shards; // require at least N shards along the outer

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -76,15 +76,11 @@ struct bench_spec
   uint32_t min_append_shards; // 0 = no minimum (see bench_config)
 };
 
-// CLI driver: parses --fill, --codec, --reduce, --dtype, --frames, --json,
-// -o flags, creates the GPU context when the backend is gpu, calls run_bench,
-// handles xor_pattern_init/free. The backend defaults to gpu, or to cpu in a
-// build without GPU support.
+// Parse the shared bench flags and run one benchmark. The backend defaults to
+// gpu, or to cpu in a build without GPU support.
 int
 bench_stream_main(int ac, char* av[], struct bench_spec spec);
 
-// Two-stream variant: creates two GPU pipelines on the same CUDA context and
-// interleaves writer_append calls for balanced GPU utilisation. GPU only —
-// fails with a message in a build without GPU support.
+// Run two pipelines on one GPU, appending to each in turn. Needs a GPU.
 int
 bench_two_streams_main(int ac, char* av[], struct bench_spec spec);

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -81,6 +81,6 @@ struct bench_spec
 int
 bench_stream_main(int ac, char* av[], struct bench_spec spec);
 
-// Run two pipelines on one GPU, appending to each in turn. Needs a GPU.
+// Run two pipelines on one GPU, appending to each in turn.
 int
 bench_two_streams_main(int ac, char* av[], struct bench_spec spec);

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -8,7 +8,6 @@
 #include "sink_discard.h"
 #include "sink_metering.h"
 #include "sink_throttled.h"
-#include "stream.gpu.h"
 #include "test_data.h"
 #include "types.codec.h"
 #include "types.lod.h"
@@ -78,11 +77,14 @@ struct bench_spec
 };
 
 // CLI driver: parses --fill, --codec, --reduce, --dtype, --frames, --json,
-// -o flags, inits CUDA, calls run_bench, handles xor_pattern_init/free.
+// -o flags, creates the GPU context when the backend is gpu, calls run_bench,
+// handles xor_pattern_init/free. The backend defaults to gpu, or to cpu in a
+// build without GPU support.
 int
 bench_stream_main(int ac, char* av[], struct bench_spec spec);
 
 // Two-stream variant: creates two GPU pipelines on the same CUDA context and
-// interleaves writer_append calls for balanced GPU utilisation.
+// interleaves writer_append calls for balanced GPU utilisation. GPU only —
+// fails with a message in a build without GPU support.
 int
 bench_two_streams_main(int ac, char* av[], struct bench_spec spec);

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -299,11 +299,6 @@ def gpu_name() -> str:
 # Runner
 # ---------------------------------------------------------------------------
 
-# Everything CMake treats as false. A value CMake would treat as true, or a
-# cache we cannot read, means we assume the gpu backend is available.
-CMAKE_FALSE = {"", "0", "OFF", "FALSE", "NO", "N", "IGNORE", "NOTFOUND"}
-
-
 @functools.cache
 def build_has_gpu(build_dir: Path) -> bool:
     """Whether this build can run the gpu backend, per its CMake cache."""
@@ -314,8 +309,8 @@ def build_has_gpu(build_dir: Path) -> bool:
     m = re.search(r"^CHUCKY_ENABLE_GPU:BOOL=(.*)$", cache, re.MULTILINE)
     if not m:
         return True
-    value = m.group(1).strip().upper()
-    return not (value in CMAKE_FALSE or value.endswith("-NOTFOUND"))
+    # A value we cannot read as false means we assume a gpu is available.
+    return m.group(1).strip().upper() not in {"", "0", "OFF", "FALSE", "NO", "N"}
 
 
 def bench_exe(spec: RunSpec, build_dir: Path) -> Path:
@@ -542,11 +537,10 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
 
     # -- load existing results for resumability --
     output.parent.mkdir(parents=True, exist_ok=True)
-    # `records` is everything the file will hold, in the order it was read;
-    # `existing` is the subset that counts as done. A run held back for a redo
-    # stays in `records`, so a redo that never happens erases nothing.
+    # A run held back for a redo is still written out, so a redo that never
+    # happens erases nothing.
     records: dict = {}
-    existing: dict = {}
+    done: set[str] = set()
     if output.exists():
         with open(output) as f:
             raw_data = json.load(f)
@@ -563,7 +557,7 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
                 continue
             if rerun and any(pat in rid for pat in rerun):
                 continue
-            existing[rid] = r
+            done.add(rid)
     else:
         data = {
             "version": CURRENT_VERSION,
@@ -577,9 +571,8 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             "runs": [],
         }
 
-
     # -- count how many actually need to run --
-    to_run = [spec for spec in runs if spec.id not in existing]
+    to_run = [spec for spec in runs if spec.id not in done]
     skip_count = len(runs) - len(to_run)
 
     if skip_count:
@@ -630,7 +623,6 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             style = status_style(st)
             progress.console.print(f"  {tag} [{style}]{st.upper()}[/{style}]{suffix}")
 
-            existing[spec.id] = result
             records[spec.id] = result
             save_results(output, data, records)
             progress.advance(task)

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import functools
 import json
+import os
 import platform
 import re
 import subprocess
@@ -322,10 +323,22 @@ def bench_exe(spec: RunSpec, build_dir: Path) -> Path:
     return exe.with_suffix(".exe") if sys.platform == "win32" else exe
 
 
-def save_results(output: Path, data: dict, existing: dict) -> None:
-    data["runs"] = list(existing.values())
-    with open(output, "w") as f:
+def save_results(output: Path, data: dict, existing: dict,
+                 superseded: dict | None = None) -> None:
+    """Write the results file. A kill mid-write leaves the old file intact."""
+    merged = {**(superseded or {}), **existing}
+    data["runs"] = list(merged.values())
+    tmp = output.with_suffix(output.suffix + ".tmp")
+    with open(tmp, "w") as f:
         json.dump(data, f, indent=2)
+    os.replace(tmp, output)
+
+
+def ensure_results_file(output: Path, data: dict, existing: dict,
+                        superseded: dict | None = None) -> None:
+    """Write the file if it is not there yet, so the path we report exists."""
+    if not output.exists():
+        save_results(output, data, existing, superseded)
 
 
 def skip_reason(spec: RunSpec, build_dir: Path) -> str | None:
@@ -523,6 +536,9 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
     # -- load existing results for resumability --
     output.parent.mkdir(parents=True, exist_ok=True)
     existing: dict = {}
+    # Runs held back for a redo. They stay in the file until a redo replaces
+    # them, so a redo that never happens does not erase what was there.
+    superseded: dict = {}
     if output.exists():
         with open(output) as f:
             raw_data = json.load(f)
@@ -535,8 +551,10 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
         for r in data.get("runs", []):
             rid = r["id"]
             if retry and r.get("status") != "pass":
+                superseded[rid] = r
                 continue
             if rerun and any(pat in rid for pat in rerun):
+                superseded[rid] = r
                 continue
             existing[rid] = r
     else:
@@ -552,12 +570,6 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             "runs": [],
         }
 
-    # Create the file up front so the path we report always exists. Never
-    # rewrite one that is already there: --retry and --rerun drop runs from
-    # `existing` on purpose, and those records are only replaced as reruns
-    # finish.
-    if not Path(output).exists():
-        save_results(output, data, existing)
 
     # -- count how many actually need to run --
     to_run = [spec for spec in runs if spec.id not in existing]
@@ -567,6 +579,7 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
         console.print(f"Skipping [bold]{skip_count}[/bold] existing runs")
 
     if not to_run:
+        ensure_results_file(output, data, existing, superseded)
         console.print(f"[green]All {len(runs)} runs already complete.[/green]")
         console.print(f"Results: {output}")
         return
@@ -611,9 +624,10 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             progress.console.print(f"  {tag} [{style}]{st.upper()}[/{style}]{suffix}")
 
             existing[spec.id] = result
-            save_results(output, data, existing)
+            save_results(output, data, existing, superseded)
             progress.advance(task)
 
+    ensure_results_file(output, data, existing, superseded)
     console.print(f"\n[bold green]Done.[/bold green] Results: {output} ({len(existing)} runs)")
 
 

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -19,9 +19,7 @@ Usage:
 
 from __future__ import annotations
 
-import functools
 import json
-import os
 import platform
 import re
 import subprocess
@@ -299,64 +297,15 @@ def gpu_name() -> str:
 # Runner
 # ---------------------------------------------------------------------------
 
-@functools.cache
-def build_has_gpu(build_dir: Path) -> bool:
-    """Whether this build can run the gpu backend, per its CMake cache."""
-    try:
-        cache = (build_dir / "CMakeCache.txt").read_text(errors="replace")
-    except OSError:
-        return True
-    m = re.search(r"^CHUCKY_ENABLE_GPU:BOOL=(.*)$", cache, re.MULTILINE)
-    if not m:
-        return True
-    # Anything we cannot read as false is treated as a gpu build.
-    return m.group(1).strip().upper() not in {"", "0", "OFF", "FALSE", "NO", "N"}
-
-
-def bench_exe(spec: RunSpec, build_dir: Path) -> Path:
-    exe = build_dir / "bench" / f"bench_stream_{spec.scenario}"
-    return exe.with_suffix(".exe") if sys.platform == "win32" else exe
-
-
-def save_results(output: Path, data: dict, records: dict) -> None:
-    """Write the results file. A kill mid-write leaves the old file intact."""
-    data["runs"] = list(records.values())
-    tmp = output.with_suffix(output.suffix + ".tmp")
-    try:
-        with open(tmp, "w") as f:
-            json.dump(data, f, indent=2)
-        try:
-            os.replace(tmp, output)
-        except OSError:
-            # Windows cannot rename over a file another process holds open.
-            with open(output, "w") as f:
-                json.dump(data, f, indent=2)
-            tmp.unlink(missing_ok=True)
-    except BaseException:
-        tmp.unlink(missing_ok=True)
-        raise
-
-
-def ensure_results_file(output: Path, data: dict, records: dict) -> None:
-    """Write the file if it is not there yet, so the path we report exists."""
-    if not output.exists():
-        save_results(output, data, records)
-
-
-def skip_reason(spec: RunSpec, build_dir: Path) -> str | None:
-    """Why this spec cannot run here, or None if it can."""
-    if not bench_exe(spec, build_dir).exists():
-        return "exe not found"
-    if spec.backend == "gpu" and not build_has_gpu(build_dir):
-        return "build has no gpu"
-    return None
-
-
 def run_one(spec: RunSpec, build_dir: Path, s3_bucket: str | None = None,
             s3_region: str | None = None, s3_endpoint: str | None = None,
-            tmpdir_root: Path | None = None) -> dict:
-    """Execute a single benchmark run. Callers check for a skip first."""
-    exe = bench_exe(spec, build_dir)
+            tmpdir_root: Path | None = None) -> dict | None:
+    """Execute a single benchmark run, return result dict or None if exe missing."""
+    exe = build_dir / "bench" / f"bench_stream_{spec.scenario}"
+    if sys.platform == "win32":
+        exe = exe.with_suffix(".exe")
+    if not exe.exists():
+        return None
 
     frames = SCENARIOS[spec.scenario]
     cmd = [
@@ -537,10 +486,7 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
 
     # -- load existing results for resumability --
     output.parent.mkdir(parents=True, exist_ok=True)
-    # A run held back for a redo is still written out, so a redo that never
-    # happens erases nothing.
-    records: dict = {}
-    done: set[str] = set()
+    existing: dict = {}
     if output.exists():
         with open(output) as f:
             raw_data = json.load(f)
@@ -552,12 +498,11 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
         data = raw_data
         for r in data.get("runs", []):
             rid = r["id"]
-            records[rid] = r
             if retry and r.get("status") != "pass":
                 continue
             if rerun and any(pat in rid for pat in rerun):
                 continue
-            done.add(rid)
+            existing[rid] = r
     else:
         data = {
             "version": CURRENT_VERSION,
@@ -572,14 +517,13 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
         }
 
     # -- count how many actually need to run --
-    to_run = [spec for spec in runs if spec.id not in done]
+    to_run = [spec for spec in runs if spec.id not in existing]
     skip_count = len(runs) - len(to_run)
 
     if skip_count:
         console.print(f"Skipping [bold]{skip_count}[/bold] existing runs")
 
     if not to_run:
-        ensure_results_file(output, data, records)
         console.print(f"[green]All {len(runs)} runs already complete.[/green]")
         console.print(f"Results: {output}")
         return
@@ -600,12 +544,6 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
                 tag += f" {spec.sink}"
             progress.update(task, description=f"[bold]{tag}")
 
-            reason = skip_reason(spec, build_dir)
-            if reason:
-                progress.console.print(f"  {tag} [dim]SKIP ({reason})[/dim]")
-                progress.advance(task)
-                continue
-
             try:
                 result = run_one(spec, build_dir,
                                  s3_bucket=s3_bucket,
@@ -617,18 +555,27 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             except Exception as e:
                 result = {**spec.base_result(), "status": "error", "error": str(e)}
 
+            if result is None:
+                progress.console.print(f"  {tag} [dim]SKIP (exe not found)[/dim]")
+                progress.advance(task)
+                continue
+
             st = result.get("status", "?")
             tp = result.get("throughput_in_gibs")
             suffix = f" {tp:.2f} GiB/s" if tp else ""
             style = status_style(st)
             progress.console.print(f"  {tag} [{style}]{st.upper()}[/{style}]{suffix}")
 
-            records[spec.id] = result
-            save_results(output, data, records)
+            existing[spec.id] = result
+
+            # Save incrementally
+            data["runs"] = list(existing.values())
+            with open(output, "w") as f:
+                json.dump(data, f, indent=2)
+
             progress.advance(task)
 
-    ensure_results_file(output, data, records)
-    console.print(f"\n[bold green]Done.[/bold green] Results: {output} ({len(records)} runs)")
+    console.print(f"\n[bold green]Done.[/bold green] Results: {output} ({len(existing)} runs)")
 
 
 if __name__ == "__main__":

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -339,11 +339,9 @@ def skip_reason(spec: RunSpec, build_dir: Path) -> str | None:
 
 def run_one(spec: RunSpec, build_dir: Path, s3_bucket: str | None = None,
             s3_region: str | None = None, s3_endpoint: str | None = None,
-            tmpdir_root: Path | None = None) -> dict | None:
-    """Execute a single benchmark run, return result dict or None to skip it."""
+            tmpdir_root: Path | None = None) -> dict:
+    """Execute a single benchmark run. Callers gate on skip_reason first."""
     exe = bench_exe(spec, build_dir)
-    if skip_reason(spec, build_dir):
-        return None
 
     frames = SCENARIOS[spec.scenario]
     cmd = [
@@ -554,6 +552,13 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             "runs": [],
         }
 
+    # Create the file up front so the path we report always exists. Never
+    # rewrite one that is already there: --retry and --rerun drop runs from
+    # `existing` on purpose, and those records are only replaced as reruns
+    # finish.
+    if not Path(output).exists():
+        save_results(output, data, existing)
+
     # -- count how many actually need to run --
     to_run = [spec for spec in runs if spec.id not in existing]
     skip_count = len(runs) - len(to_run)
@@ -599,11 +604,6 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             except Exception as e:
                 result = {**spec.base_result(), "status": "error", "error": str(e)}
 
-            if result is None:
-                progress.console.print(f"  {tag} [dim]SKIP[/dim]")
-                progress.advance(task)
-                continue
-
             st = result.get("status", "?")
             tp = result.get("throughput_in_gibs")
             suffix = f" {tp:.2f} GiB/s" if tp else ""
@@ -614,8 +614,6 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             save_results(output, data, existing)
             progress.advance(task)
 
-    # Write even when every run was skipped, so the reported path always exists.
-    save_results(output, data, existing)
     console.print(f"\n[bold green]Done.[/bold green] Results: {output} ({len(existing)} runs)")
 
 

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -298,26 +298,51 @@ def gpu_name() -> str:
 # Runner
 # ---------------------------------------------------------------------------
 
+# Everything CMake treats as false. A value CMake would treat as true, or a
+# cache we cannot read, means we assume the gpu backend is available.
+CMAKE_FALSE = {"", "0", "OFF", "FALSE", "NO", "N", "IGNORE", "NOTFOUND"}
+
+
 @functools.cache
 def build_has_gpu(build_dir: Path) -> bool:
     """Whether this build can run the gpu backend, per its CMake cache."""
     try:
-        cache = (build_dir / "CMakeCache.txt").read_text()
+        cache = (build_dir / "CMakeCache.txt").read_text(errors="replace")
     except OSError:
         return True
-    return "CHUCKY_ENABLE_GPU:BOOL=OFF" not in cache
+    m = re.search(r"^CHUCKY_ENABLE_GPU:BOOL=(.*)$", cache, re.MULTILINE)
+    if not m:
+        return True
+    value = m.group(1).strip().upper()
+    return not (value in CMAKE_FALSE or value.endswith("-NOTFOUND"))
+
+
+def bench_exe(spec: RunSpec, build_dir: Path) -> Path:
+    exe = build_dir / "bench" / f"bench_stream_{spec.scenario}"
+    return exe.with_suffix(".exe") if sys.platform == "win32" else exe
+
+
+def save_results(output: Path, data: dict, existing: dict) -> None:
+    data["runs"] = list(existing.values())
+    with open(output, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def skip_reason(spec: RunSpec, build_dir: Path) -> str | None:
+    """Why this spec cannot run here, or None if it can."""
+    if not bench_exe(spec, build_dir).exists():
+        return "exe not found"
+    if spec.backend == "gpu" and not build_has_gpu(build_dir):
+        return "build has no gpu"
+    return None
 
 
 def run_one(spec: RunSpec, build_dir: Path, s3_bucket: str | None = None,
             s3_region: str | None = None, s3_endpoint: str | None = None,
             tmpdir_root: Path | None = None) -> dict | None:
     """Execute a single benchmark run, return result dict or None to skip it."""
-    exe = build_dir / "bench" / f"bench_stream_{spec.scenario}"
-    if sys.platform == "win32":
-        exe = exe.with_suffix(".exe")
-    if not exe.exists():
-        return None
-    if spec.backend == "gpu" and not build_has_gpu(build_dir):
+    exe = bench_exe(spec, build_dir)
+    if skip_reason(spec, build_dir):
         return None
 
     frames = SCENARIOS[spec.scenario]
@@ -557,6 +582,12 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
                 tag += f" {spec.sink}"
             progress.update(task, description=f"[bold]{tag}")
 
+            reason = skip_reason(spec, build_dir)
+            if reason:
+                progress.console.print(f"  {tag} [dim]SKIP ({reason})[/dim]")
+                progress.advance(task)
+                continue
+
             try:
                 result = run_one(spec, build_dir,
                                  s3_bucket=s3_bucket,
@@ -569,7 +600,7 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
                 result = {**spec.base_result(), "status": "error", "error": str(e)}
 
             if result is None:
-                progress.console.print(f"  {tag} [dim]SKIP (not in this build)[/dim]")
+                progress.console.print(f"  {tag} [dim]SKIP[/dim]")
                 progress.advance(task)
                 continue
 
@@ -580,14 +611,11 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             progress.console.print(f"  {tag} [{style}]{st.upper()}[/{style}]{suffix}")
 
             existing[spec.id] = result
-
-            # Save incrementally
-            data["runs"] = list(existing.values())
-            with open(output, "w") as f:
-                json.dump(data, f, indent=2)
-
+            save_results(output, data, existing)
             progress.advance(task)
 
+    # Write even when every run was skipped, so the reported path always exists.
+    save_results(output, data, existing)
     console.print(f"\n[bold green]Done.[/bold green] Results: {output} ({len(existing)} runs)")
 
 

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -19,6 +19,7 @@ Usage:
 
 from __future__ import annotations
 
+import functools
 import json
 import platform
 import re
@@ -297,14 +298,26 @@ def gpu_name() -> str:
 # Runner
 # ---------------------------------------------------------------------------
 
+@functools.cache
+def build_has_gpu(build_dir: Path) -> bool:
+    """Whether this build can run the gpu backend, per its CMake cache."""
+    try:
+        cache = (build_dir / "CMakeCache.txt").read_text()
+    except OSError:
+        return True
+    return "CHUCKY_ENABLE_GPU:BOOL=OFF" not in cache
+
+
 def run_one(spec: RunSpec, build_dir: Path, s3_bucket: str | None = None,
             s3_region: str | None = None, s3_endpoint: str | None = None,
             tmpdir_root: Path | None = None) -> dict | None:
-    """Execute a single benchmark run, return result dict or None if exe missing."""
+    """Execute a single benchmark run, return result dict or None to skip it."""
     exe = build_dir / "bench" / f"bench_stream_{spec.scenario}"
     if sys.platform == "win32":
         exe = exe.with_suffix(".exe")
     if not exe.exists():
+        return None
+    if spec.backend == "gpu" and not build_has_gpu(build_dir):
         return None
 
     frames = SCENARIOS[spec.scenario]
@@ -556,7 +569,7 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
                 result = {**spec.base_result(), "status": "error", "error": str(e)}
 
             if result is None:
-                progress.console.print(f"  {tag} [dim]SKIP (exe not found)[/dim]")
+                progress.console.print(f"  {tag} [dim]SKIP (not in this build)[/dim]")
                 progress.advance(task)
                 continue
 

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -323,22 +323,29 @@ def bench_exe(spec: RunSpec, build_dir: Path) -> Path:
     return exe.with_suffix(".exe") if sys.platform == "win32" else exe
 
 
-def save_results(output: Path, data: dict, existing: dict,
-                 superseded: dict | None = None) -> None:
+def save_results(output: Path, data: dict, records: dict) -> None:
     """Write the results file. A kill mid-write leaves the old file intact."""
-    merged = {**(superseded or {}), **existing}
-    data["runs"] = list(merged.values())
+    data["runs"] = list(records.values())
     tmp = output.with_suffix(output.suffix + ".tmp")
-    with open(tmp, "w") as f:
-        json.dump(data, f, indent=2)
-    os.replace(tmp, output)
+    try:
+        with open(tmp, "w") as f:
+            json.dump(data, f, indent=2)
+        try:
+            os.replace(tmp, output)
+        except OSError:
+            # Windows cannot rename over a file another process holds open.
+            with open(output, "w") as f:
+                json.dump(data, f, indent=2)
+            tmp.unlink(missing_ok=True)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
-def ensure_results_file(output: Path, data: dict, existing: dict,
-                        superseded: dict | None = None) -> None:
+def ensure_results_file(output: Path, data: dict, records: dict) -> None:
     """Write the file if it is not there yet, so the path we report exists."""
     if not output.exists():
-        save_results(output, data, existing, superseded)
+        save_results(output, data, records)
 
 
 def skip_reason(spec: RunSpec, build_dir: Path) -> str | None:
@@ -535,10 +542,11 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
 
     # -- load existing results for resumability --
     output.parent.mkdir(parents=True, exist_ok=True)
+    # `records` is everything the file will hold, in the order it was read;
+    # `existing` is the subset that counts as done. A run held back for a redo
+    # stays in `records`, so a redo that never happens erases nothing.
+    records: dict = {}
     existing: dict = {}
-    # Runs held back for a redo. They stay in the file until a redo replaces
-    # them, so a redo that never happens does not erase what was there.
-    superseded: dict = {}
     if output.exists():
         with open(output) as f:
             raw_data = json.load(f)
@@ -550,11 +558,10 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
         data = raw_data
         for r in data.get("runs", []):
             rid = r["id"]
+            records[rid] = r
             if retry and r.get("status") != "pass":
-                superseded[rid] = r
                 continue
             if rerun and any(pat in rid for pat in rerun):
-                superseded[rid] = r
                 continue
             existing[rid] = r
     else:
@@ -579,7 +586,7 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
         console.print(f"Skipping [bold]{skip_count}[/bold] existing runs")
 
     if not to_run:
-        ensure_results_file(output, data, existing, superseded)
+        ensure_results_file(output, data, records)
         console.print(f"[green]All {len(runs)} runs already complete.[/green]")
         console.print(f"Results: {output}")
         return
@@ -624,11 +631,12 @@ def main(tier, run_all, build_dir, output, skip, retry, rerun, dry_run,
             progress.console.print(f"  {tag} [{style}]{st.upper()}[/{style}]{suffix}")
 
             existing[spec.id] = result
-            save_results(output, data, existing, superseded)
+            records[spec.id] = result
+            save_results(output, data, records)
             progress.advance(task)
 
-    ensure_results_file(output, data, existing, superseded)
-    console.print(f"\n[bold green]Done.[/bold green] Results: {output} ({len(existing)} runs)")
+    ensure_results_file(output, data, records)
+    console.print(f"\n[bold green]Done.[/bold green] Results: {output} ({len(records)} runs)")
 
 
 if __name__ == "__main__":

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -309,7 +309,7 @@ def build_has_gpu(build_dir: Path) -> bool:
     m = re.search(r"^CHUCKY_ENABLE_GPU:BOOL=(.*)$", cache, re.MULTILINE)
     if not m:
         return True
-    # A value we cannot read as false means we assume a gpu is available.
+    # Anything we cannot read as false is treated as a gpu build.
     return m.group(1).strip().upper() not in {"", "0", "OFF", "FALSE", "NO", "N"}
 
 
@@ -355,7 +355,7 @@ def skip_reason(spec: RunSpec, build_dir: Path) -> str | None:
 def run_one(spec: RunSpec, build_dir: Path, s3_bucket: str | None = None,
             s3_region: str | None = None, s3_endpoint: str | None = None,
             tmpdir_root: Path | None = None) -> dict:
-    """Execute a single benchmark run. Callers gate on skip_reason first."""
+    """Execute a single benchmark run. Callers check for a skip first."""
     exe = bench_exe(spec, build_dir)
 
     frames = SCENARIOS[spec.scenario]

--- a/src/stream/config.c
+++ b/src/stream/config.c
@@ -27,9 +27,9 @@ compute_epochs_per_batch(const struct tile_stream_configuration* config,
   if (config->epochs_per_batch > 0)
     return config->epochs_per_batch;
 
-  size_t target = config->target_batch_bytes;
+  uint64_t target = config->target_batch_bytes;
   if (target == 0)
-    target = (size_t)512 << 20; // 512 MiB default
+    target = (uint64_t)512 << 20; // 512 MiB default
   if (bytes_per_epoch == 0)
     return 1;
   uint64_t K = ceildiv(target, bytes_per_epoch);

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -101,7 +101,7 @@ struct tile_stream_configuration
   int preserve_aspect_ratio; // 0 = drop dims independently (default),
                              // 1 = stop when any dim reaches chunk_size
   uint32_t epochs_per_batch; // K: 0 = auto (from target_batch_bytes)
-  uint32_t
+  uint64_t
     target_batch_bytes; // target uncompressed bytes per batch (default 512 MiB)
   float metadata_update_interval_s;
   size_t backpressure_bytes; // 0 = disabled; >0 = stall after handing a


### PR DESCRIPTION
The benchmarks only built when CHUCKY_ENABLE_GPU was on, so a CPU-only
checkout had none. bench/ is now added unconditionally.

The GPU pipeline sits behind bench/bench_gpu.h, which has no CUDA in it.
bench_gpu.cuda.c forwards to tile_stream_gpu; bench_gpu.none.c stands in
when GPU support is off, and bench_util.c no longer reaches for cuda.h
or stream.gpu.h. The two-stream benchmark needs a GPU, so it is built
only where there is one, the way the GPU-only tests already are.
Without GPU support the --backend default is cpu, and asking for
--backend gpu fails with a message to reconfigure.

The batch-size target in the stream configuration is now 64 bits rather
than 32, so a batch above 4 GiB works and nothing has to be narrowed on
the way in. The benchmark command line reads sizes with fixed-width
types throughout, and --chunk-bytes, --batch-bytes, --memory-budget and
--backpressure now reject text they cannot read instead of parsing it as
something else. --batch-bytes also reaches runs that skip the auto-fit
path, which ignored it.

Closes #97.
