### PR TITLE
Fewer divisions in the scatter kernel

### DIFF
--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -96,7 +96,6 @@ engine_dispatch_ingest(struct stream_engine* e,
     };
     return ingest_dispatch_scatter(&e->stage,
                                    &ctx->layout,
-                                   &ctx->layout_gpu,
                                    dst,
                                    first_element,
                                    dtype_bpe(ctx->config.dtype),

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -121,7 +121,6 @@ struct lod_state
 
   // Per-level chunk layouts [0..nlod-1]
   struct tile_stream_layout layouts[LOD_MAX_LEVELS];
-  struct tile_stream_layout_gpu layout_gpu[LOD_MAX_LEVELS];
 
   // Morton-to-chunk scatter LUTs (precomputed)
   CUdeviceptr d_morton_chunk_lut[LOD_MAX_LEVELS];
@@ -280,7 +279,6 @@ struct stream_context
   struct tile_stream_configuration config;
   struct shard_sink* sink;
   struct tile_stream_layout layout;
-  struct tile_stream_layout_gpu layout_gpu;
   struct level_geometry levels;
   struct dim_info dims;
   uint64_t cursor_elements;

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -122,8 +122,42 @@ scatter_timing_begin(struct staging_state* stage, size_t bytes)
     stage->scatter_samples_lost++;
   stage->next_timing = (stage->next_timing + 1) % SCATTER_TIMING_SLOTS;
   st->bytes = bytes;
-  st->pending = 1;
+  st->pending = 0;
   return st;
+}
+
+// The measurement only counts once both ends are recorded: an interval with one
+// end reports whatever its events still hold.
+static int
+scatter_with_timing(struct staging_state* stage,
+                    const struct tile_stream_layout* layout,
+                    struct scatter_destination dst,
+                    struct gpu_pool_view d_in,
+                    uint64_t bytes,
+                    uint64_t in_epoch,
+                    size_t bpe,
+                    CUstream compute)
+{
+  struct scatter_timing* st = scatter_timing_begin(stage, bytes);
+  CU(Fail, cuEventRecord(st->t_start, compute));
+  CHECK_SILENT(Fail,
+               transpose(gpu_pool_view_d(dst.first_epoch),
+                         gpu_pool_view_d(d_in),
+                         bytes,
+                         (uint8_t)bpe,
+                         in_epoch,
+                         layout->epoch_elements,
+                         dst.epoch_bytes,
+                         layout->lifted_rank,
+                         layout->lifted_shape,
+                         layout->lifted_strides,
+                         compute) == 0);
+  CU(Fail, cuEventRecord(st->t_end, compute));
+  st->pending = 1;
+  return 0;
+
+Fail:
+  return 1;
 }
 
 // The produce-acquire keeps the H2D copy from overwriting d_in while the
@@ -185,22 +219,13 @@ ingest_dispatch_scatter(struct staging_state* stage,
   // Scatter into chunk pool
   CHECK(Error,
         gpu_pool_acquire_consume(&stage->d_pool, idx, compute, &d_in) == 0);
-  struct scatter_timing* st = scatter_timing_begin(stage, ss->dispatched_bytes);
-  CU(Error, cuEventRecord(st->t_start, compute));
-  CHECK(Error,
-        transpose(gpu_pool_view_d(dst.first_epoch),
-                  gpu_pool_view_d(d_in),
-                  ss->dispatched_bytes,
-                  (uint8_t)bpe,
-                  in_epoch,
-                  epoch_elements,
-                  dst.epoch_bytes,
-                  layout->lifted_rank,
-                  layout->lifted_shape,
-                  layout->lifted_strides,
-                  compute) == 0);
-  CU(Error, cuEventRecord(st->t_end, compute));
+  const int scattered =
+    scatter_with_timing(
+      stage, layout, dst, d_in, ss->dispatched_bytes, in_epoch, bpe, compute) ==
+    0;
+  // Nothing reads the input either way, so hand the slot back before failing.
   CHECK(Error, gpu_pool_release_consume(&stage->d_pool, idx, compute) == 0);
+  CHECK_SILENT(Error, scattered);
 
   stage->current ^= 1;
   return 0;

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -112,8 +112,9 @@ ingest_collect_scatter_timing(struct staging_state* stage,
   }
 }
 
-// Claims the next measurement in the ring. An entry still outstanding here has
-// outlived its slack, so count it rather than lose it silently.
+// Claims the next measurement in the ring; the caller marks it once both ends
+// are recorded. An entry still outstanding here has outlived its slack, so
+// count it rather than lose it silently.
 static struct scatter_timing*
 scatter_timing_begin(struct staging_state* stage, size_t bytes)
 {
@@ -274,6 +275,7 @@ ingest_dispatch_multiscale(struct staging_state* stage,
                          compute));
   }
   CU(Error, cuEventRecord(st->t_end, compute));
+  st->pending = 1;
   CHECK(Error, gpu_pool_release_consume(&stage->d_pool, idx, compute) == 0);
 
   stage->current ^= 1;

--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -154,7 +154,6 @@ Error:
 int
 ingest_dispatch_scatter(struct staging_state* stage,
                         const struct tile_stream_layout* layout,
-                        const struct tile_stream_layout_gpu* layout_gpu,
                         struct scatter_destination dst,
                         uint64_t first_element,
                         size_t bpe,
@@ -188,17 +187,18 @@ ingest_dispatch_scatter(struct staging_state* stage,
         gpu_pool_acquire_consume(&stage->d_pool, idx, compute, &d_in) == 0);
   struct scatter_timing* st = scatter_timing_begin(stage, ss->dispatched_bytes);
   CU(Error, cuEventRecord(st->t_start, compute));
-  transpose(gpu_pool_view_d(dst.first_epoch),
-            gpu_pool_view_d(d_in),
-            ss->dispatched_bytes,
-            (uint8_t)bpe,
-            in_epoch,
-            epoch_elements,
-            dst.epoch_bytes,
-            layout->lifted_rank,
-            layout_gpu->d_lifted_shape,
-            layout_gpu->d_lifted_strides,
-            compute);
+  CHECK(Error,
+        transpose(gpu_pool_view_d(dst.first_epoch),
+                  gpu_pool_view_d(d_in),
+                  ss->dispatched_bytes,
+                  (uint8_t)bpe,
+                  in_epoch,
+                  epoch_elements,
+                  dst.epoch_bytes,
+                  layout->lifted_rank,
+                  layout->lifted_shape,
+                  layout->lifted_strides,
+                  compute) == 0);
   CU(Error, cuEventRecord(st->t_end, compute));
   CHECK(Error, gpu_pool_release_consume(&stage->d_pool, idx, compute) == 0);
 

--- a/src/gpu/stream.ingest.h
+++ b/src/gpu/stream.ingest.h
@@ -52,7 +52,6 @@ struct scatter_destination
 int
 ingest_dispatch_scatter(struct staging_state* stage,
                         const struct tile_stream_layout* layout,
-                        const struct tile_stream_layout_gpu* layout_gpu,
                         struct scatter_destination dst,
                         uint64_t first_element,
                         size_t bpe,

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -226,9 +226,9 @@ engine_array_state_init(struct engine_array_state* st,
 
   st->sched.epochs_per_batch = cl->epochs_per_batch;
 
-  // Move LOD plan and level layouts (always, including L0). st->lod owns
-  // plan, layouts[], CSRs, accumulators, and LOD LUTs — but
-  // NOT d_linear/d_morton/timing, which are engine-owned shared resources.
+  // Move LOD plan and level layouts (always, including L0). st->lod owns plan,
+  // layouts[], CSRs, accumulators, and LOD LUTs — but NOT
+  // d_linear/d_morton/timing, which are engine-owned shared resources.
   st->lod.plan = cl->plan;
   cl->plan = (struct lod_plan){ 0 }; // ownership transferred
   for (int lv = 0; lv < cl->levels.nlod; ++lv)

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -227,7 +227,7 @@ engine_array_state_init(struct engine_array_state* st,
   st->sched.epochs_per_batch = cl->epochs_per_batch;
 
   // Move LOD plan and level layouts (always, including L0). st->lod owns
-  // plan, layouts[], layout_gpu[], CSRs, accumulators, and LOD LUTs — but
+  // plan, layouts[], CSRs, accumulators, and LOD LUTs — but
   // NOT d_linear/d_morton/timing, which are engine-owned shared resources.
   st->lod.plan = cl->plan;
   cl->plan = (struct lod_plan){ 0 }; // ownership transferred
@@ -235,8 +235,6 @@ engine_array_state_init(struct engine_array_state* st,
     st->lod.layouts[lv] = cl->layouts[lv];
 
   CHECK(Fail, lod_state_init(&st->lod, &ctx->levels, &ctx->config) == 0);
-  // View, not owned — freed with st->lod.
-  ctx->layout_gpu = st->lod.layout_gpu[0];
 
   if (ctx->levels.enable_multiscale && ctx->dims.append_downsample)
     CHECK(Fail, lod_state_init_accumulators(&st->lod, &ctx->config) == 0);

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -491,10 +491,11 @@ lod_state_device_bytes(const struct computed_stream_layouts* cl,
                        const struct tile_stream_configuration* config)
 {
   const struct lod_plan* p = &cl->plan;
-  size_t bytes = 0;
 
   if (!cl->levels.enable_multiscale)
-    return bytes;
+    return 0;
+
+  size_t bytes = 0;
 
   const struct level_dims* l0 = &p->levels.level[0];
 

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -182,31 +182,6 @@ Fail:
   return 1;
 }
 
-// Upload pre-computed LOD level layouts to GPU.
-// Host fields in lod->layouts must already be populated.
-static int
-upload_lod_level_layouts(struct lod_state* lod)
-{
-  for (int lv = 0; lv < lod->plan.levels.nlod; ++lv) {
-    const struct tile_stream_layout* layout = &lod->layouts[lv];
-    struct tile_stream_layout_gpu* gpu = &lod->layout_gpu[lv];
-    const size_t sb = layout->lifted_rank * sizeof(uint64_t);
-    const size_t stb = layout->lifted_rank * sizeof(int64_t);
-    CU(Fail, cuMemAlloc((CUdeviceptr*)&gpu->d_lifted_shape, sb));
-    CU(Fail, cuMemAlloc((CUdeviceptr*)&gpu->d_lifted_strides, stb));
-    CU(
-      Fail,
-      cuMemcpyHtoD((CUdeviceptr)gpu->d_lifted_shape, layout->lifted_shape, sb));
-    CU(Fail,
-       cuMemcpyHtoD(
-         (CUdeviceptr)gpu->d_lifted_strides, layout->lifted_strides, stb));
-  }
-
-  return 0;
-Fail:
-  return 1;
-}
-
 // Upload chunk sizes/strides to GPU and build chunk scatter LUT.
 // Owns d_chunk_sizes and d_chunk_strides — freed in both success and failure.
 static int
@@ -357,9 +332,6 @@ lod_state_init(struct lod_state* lod,
                struct level_geometry* levels,
                const struct tile_stream_configuration* config)
 {
-  // Always upload level layouts (L0 included).
-  CHECK(Fail, upload_lod_level_layouts(lod) == 0);
-
   if (!levels->enable_multiscale)
     return 0;
 
@@ -521,10 +493,6 @@ lod_state_device_bytes(const struct computed_stream_layouts* cl,
   const struct lod_plan* p = &cl->plan;
   size_t bytes = 0;
 
-  // upload_lod_level_layouts: every level, L0 included.
-  for (int lv = 0; lv < p->levels.nlod; ++lv)
-    bytes += cl->layouts[lv].lifted_rank * (sizeof(uint64_t) + sizeof(int64_t));
-
   if (!cl->levels.enable_multiscale)
     return bytes;
 
@@ -602,10 +570,6 @@ lod_state_destroy(struct lod_state* lod)
   }
   for (int i = 0; i < lod->plan.levels.nlod - 1; ++i) {
     reduce_csr_gpu_free(&lod->csrs[i]);
-  }
-  for (int i = 0; i < lod->plan.levels.nlod; ++i) {
-    CUWARN(cuMemFree((CUdeviceptr)lod->layout_gpu[i].d_lifted_shape));
-    CUWARN(cuMemFree((CUdeviceptr)lod->layout_gpu[i].d_lifted_strides));
   }
   lod_plan_free(&lod->plan);
   // Zero so a second destroy (init-failure cleanup, then owner teardown)

--- a/src/gpu/stream.lod.h
+++ b/src/gpu/stream.lod.h
@@ -3,8 +3,8 @@
 #include "gpu/stream.internal.h"
 #include "stream/dim_info.h"
 
-// Upload level layouts to GPU (always, including L0). When multiscale is
-// enabled, also uploads LOD plan shapes and builds scatter/reduce LUTs.
+// When multiscale is enabled, uploads LOD plan shapes and builds
+// scatter/reduce LUTs; does nothing otherwise.
 // Plan and level layouts must already be populated in lod->plan and
 // lod->layouts (from compute_stream_layouts). Sets levels->nlod.
 // Returns 0 on success.

--- a/src/gpu/transpose.cu
+++ b/src/gpu/transpose.cu
@@ -2,24 +2,19 @@
 #include "gpu/transpose.h"
 #include "util/prelude.h"
 #include <stdint.h>
-#include <type_traits>
 
 // Tiling the source per block measures faster than one element per thread.
 template<typename T>
 constexpr int ELEMENTS_PER_BLOCK = (1 << 12) / (int)sizeof(T);
 
-// Riding along in the launch parameters puts the shape and strides in the
-// constant bank, so the kernel no longer loads one of each from global memory
-// per dimension per element.
+// Travels in the launch parameters, so the kernel reads it from the constant
+// bank instead of paying a load per dimension per element.
 template<typename Index>
 struct scatter_layout
 {
-  typedef typename std::make_signed<Index>::type stride_type;
-
   Index shape[MAX_RANK];
-  stride_type strides[MAX_RANK];
-  int rank;
-  int first_dim; // dimensions before this one never move the destination
+  Index strides[MAX_RANK];
+  int ndims;
 };
 
 // Transpose data kernel - v0
@@ -41,14 +36,13 @@ __global__ void __launch_bounds__(256, 4)
     Index rest = i_offset + block_offset + (Index)i;
     Index out_offset = 0;
 
-    for (int d = layout.rank - 1; d >= layout.first_dim; --d) {
+    for (int d = layout.ndims - 1; d >= 0; --d) {
       const Index coord = rest % layout.shape[d];
       rest /= layout.shape[d];
-      out_offset += coord * (Index)layout.strides[d];
+      out_offset += coord * layout.strides[d];
     }
 
-    // What the decomposition left over counts whole epochs, and each epoch
-    // lands in the next region of the destination.
+    // The visited extents span one epoch, so what is left counts epochs.
     d_dst[out_offset + rest * region_stride] = d_src[block_offset + i];
   }
 }
@@ -67,11 +61,24 @@ struct transpose_args
   CUstream stream;
 };
 
-// The trailing dimensions multiply out to one epoch, so dividing the element
-// index by them leaves the epoch number — no separate division by
-// epoch_elements, and no iterations for the dimensions in front. Returns the
-// dimension the decomposition can stop at, or -1 when the shape does not
-// factor that way or a skipped dimension would have moved the destination.
+template<typename T>
+static int
+args_valid(const struct transpose_args& a)
+{
+  CHECK(Invalid, a.rank <= MAX_RANK);
+  CHECK(Invalid, a.d_src_beg % sizeof(T) == 0);
+  CHECK(Invalid, a.region_bytes % sizeof(T) == 0);
+  CHECK(Invalid, a.epoch_elements > 0);
+  return 1;
+
+Invalid:
+  return 0;
+}
+
+// Finds where to start decomposing an element index so that what the
+// decomposition leaves behind is the epoch number. Returns -1 when no run of
+// trailing extents makes an epoch, or when a dimension it would skip can still
+// reach the destination.
 static int
 first_decomposed_dim(const struct transpose_args& a)
 {
@@ -80,19 +87,31 @@ first_decomposed_dim(const struct transpose_args& a)
 
   while (product != a.epoch_elements) {
     if (first == 0)
-      return -1;
+      goto NoEpoch;
     const uint64_t n = a.shape[first - 1];
     if (n == 0 || n > a.epoch_elements / product)
-      return -1;
+      goto NoEpoch;
     product *= n;
     --first;
   }
 
   for (int d = 0; d < first; ++d) {
-    if (a.strides[d] != 0 && a.shape[d] != 1)
+    if (a.strides[d] != 0 && a.shape[d] != 1) {
+      log_error("transpose: lifted dimension %d lies outside an epoch, but its "
+                "extent %llu and stride %lld still reach the destination",
+                d,
+                (unsigned long long)a.shape[d],
+                (long long)a.strides[d]);
       return -1;
+    }
   }
   return first;
+
+NoEpoch:
+  log_error("transpose: no run of trailing extents multiplies out to an epoch "
+            "of %llu elements",
+            (unsigned long long)a.epoch_elements);
+  return -1;
 }
 
 static int
@@ -104,8 +123,8 @@ add_within_32_bits(uint64_t* total, uint64_t count, uint64_t step)
   return 1;
 }
 
-// 32-bit indexing takes the per-element divisions off the 64-bit division
-// subroutine, so use it whenever every index the kernel forms fits.
+// 32-bit division inlines where the 64-bit routine does not, so narrow indexing
+// is worth taking wherever every index the kernel forms fits.
 static int
 indices_fit_32_bits(const struct transpose_args& a,
                     uint64_t src_size,
@@ -113,7 +132,7 @@ indices_fit_32_bits(const struct transpose_args& a,
                     uint64_t region_stride)
 {
   const uint64_t last = a.i_offset + src_size - 1;
-  if (last < a.i_offset || last > UINT32_MAX)
+  if (src_size > UINT32_MAX || last < a.i_offset || last > UINT32_MAX)
     return 0;
 
   uint64_t max_offset = 0;
@@ -131,25 +150,26 @@ indices_fit_32_bits(const struct transpose_args& a,
 }
 
 template<typename T, typename Index>
-static void
-launch(const struct transpose_args& a,
-       uint64_t src_size,
-       uint64_t region_stride,
-       int first_dim)
+static int
+launch(const struct transpose_args& a, int first_dim)
 {
+  const uint64_t src_size = a.src_bytes / sizeof(T);
+  const uint64_t region_stride = a.region_bytes / sizeof(T);
+
   scatter_layout<Index> layout = {};
-  layout.rank = a.rank;
-  layout.first_dim = first_dim;
-  for (int d = first_dim; d < a.rank; ++d) {
-    layout.shape[d] = (Index)a.shape[d];
-    layout.strides[d] =
-      (typename scatter_layout<Index>::stride_type)a.strides[d];
+  layout.ndims = a.rank - first_dim;
+  for (int d = 0; d < layout.ndims; ++d) {
+    layout.shape[d] = (Index)a.shape[first_dim + d];
+    layout.strides[d] = (Index)a.strides[first_dim + d];
   }
 
   const int block_size = 256;
   const unsigned grid_size =
-    (unsigned)((src_size + ELEMENTS_PER_BLOCK<T> - 1) / ELEMENTS_PER_BLOCK<T>);
+    (unsigned)ceildiv(src_size, (uint64_t)ELEMENTS_PER_BLOCK<T>);
 
+  // Kernels elsewhere never read this per-thread error, so clear it or one of
+  // their leftovers arrives below as a refused scatter.
+  cudaGetLastError();
   transpose_v0_k<T, Index>
     <<<grid_size, block_size, 0, (cudaStream_t)a.stream>>>(
       (T*)a.d_dst_beg,
@@ -158,6 +178,13 @@ launch(const struct transpose_args& a,
       (Index)a.i_offset,
       (Index)region_stride,
       layout);
+
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    log_error("transpose: launch failed: %s", cudaGetErrorString(err));
+    return 1;
+  }
+  return 0;
 }
 
 template<typename T>
@@ -167,25 +194,16 @@ transpose_launch(const struct transpose_args& a)
   const uint64_t src_size = a.src_bytes / sizeof(T);
   if (src_size == 0)
     return 0;
+  if (!args_valid<T>(a))
+    return 1;
 
-  // Every declaration comes before the checks: a goto may not jump past one.
   const int first_dim = first_decomposed_dim(a);
-  const uint64_t region_stride = a.region_bytes / sizeof(T);
+  if (first_dim < 0)
+    return 1;
 
-  CHECK(Error, a.d_src_beg % sizeof(T) == 0);
-  CHECK(Error, a.region_bytes % sizeof(T) == 0);
-  CHECK(Error, a.epoch_elements > 0);
-  CHECK(Error, a.rank <= MAX_RANK);
-  CHECK(Error, first_dim >= 0);
-
-  if (indices_fit_32_bits(a, src_size, first_dim, region_stride))
-    launch<T, uint32_t>(a, src_size, region_stride, first_dim);
-  else
-    launch<T, uint64_t>(a, src_size, region_stride, first_dim);
-  return 0;
-
-Error:
-  return 1;
+  if (indices_fit_32_bits(a, src_size, first_dim, a.region_bytes / sizeof(T)))
+    return launch<T, uint32_t>(a, first_dim);
+  return launch<T, uint64_t>(a, first_dim);
 }
 
 extern "C" int

--- a/src/gpu/transpose.cu
+++ b/src/gpu/transpose.cu
@@ -1,40 +1,55 @@
+#include "defs.limits.h"
 #include "gpu/transpose.h"
-#include <assert.h>
+#include "util/prelude.h"
 #include <stdint.h>
+#include <type_traits>
 
 // Tiling the source per block measures faster than one element per thread.
 template<typename T>
 constexpr int ELEMENTS_PER_BLOCK = (1 << 12) / (int)sizeof(T);
 
+// Riding along in the launch parameters puts the shape and strides in the
+// constant bank, so the kernel no longer loads one of each from global memory
+// per dimension per element.
+template<typename Index>
+struct scatter_layout
+{
+  typedef typename std::make_signed<Index>::type stride_type;
+
+  Index shape[MAX_RANK];
+  stride_type strides[MAX_RANK];
+  int rank;
+  int first_dim; // dimensions before this one never move the destination
+};
+
 // Transpose data kernel - v0
-template<typename T>
+template<typename T, typename Index>
 __global__ void __launch_bounds__(256, 4)
   transpose_v0_k(T* d_dst,
                  const T* d_src,
-                 uint64_t src_size,
-                 uint64_t i_offset,
-                 uint64_t epoch_elements,
-                 uint64_t region_stride,
-                 uint8_t rank,
-                 const uint64_t* shape,
-                 const int64_t* strides)
+                 Index src_size,
+                 Index i_offset,
+                 Index region_stride,
+                 scatter_layout<Index> layout)
 {
-  const uint64_t block_offset = (uint64_t)blockIdx.x * ELEMENTS_PER_BLOCK<T>;
-  const uint64_t left = src_size - block_offset;
+  const Index block_offset = (Index)blockIdx.x * ELEMENTS_PER_BLOCK<T>;
+  const Index left = src_size - block_offset;
   const int elements =
-    left < ELEMENTS_PER_BLOCK<T> ? (int)left : ELEMENTS_PER_BLOCK<T>;
+    left < (Index)ELEMENTS_PER_BLOCK<T> ? (int)left : ELEMENTS_PER_BLOCK<T>;
 
   for (int i = threadIdx.x; i < elements; i += blockDim.x) {
-    uint64_t rest = i_offset + block_offset + i;
-    uint64_t out_offset = (rest / epoch_elements) * region_stride;
+    Index rest = i_offset + block_offset + (Index)i;
+    Index out_offset = 0;
 
-    for (int d = rank - 1; d >= 0; --d) {
-      const uint64_t coord = rest % shape[d];
-      rest /= shape[d];
-      out_offset += coord * strides[d];
+    for (int d = layout.rank - 1; d >= layout.first_dim; --d) {
+      const Index coord = rest % layout.shape[d];
+      rest /= layout.shape[d];
+      out_offset += coord * (Index)layout.strides[d];
     }
 
-    d_dst[out_offset] = d_src[block_offset + i];
+    // What the decomposition left over counts whole epochs, and each epoch
+    // lands in the next region of the destination.
+    d_dst[out_offset + rest * region_stride] = d_src[block_offset + i];
   }
 }
 
@@ -47,40 +62,133 @@ struct transpose_args
   uint64_t epoch_elements;
   uint64_t region_bytes;
   uint8_t rank;
-  const uint64_t* d_shape;
-  const int64_t* d_strides;
+  const uint64_t* shape;
+  const int64_t* strides;
   CUstream stream;
 };
 
-template<typename T>
-static void
-transpose_launch(const struct transpose_args& a)
+// The trailing dimensions multiply out to one epoch, so dividing the element
+// index by them leaves the epoch number — no separate division by
+// epoch_elements, and no iterations for the dimensions in front. Returns the
+// dimension the decomposition can stop at, or -1 when the shape does not
+// factor that way or a skipped dimension would have moved the destination.
+static int
+first_decomposed_dim(const struct transpose_args& a)
 {
-  const uint64_t src_size = a.src_bytes / sizeof(T);
-  if (src_size == 0)
-    return;
+  uint64_t product = 1;
+  int first = a.rank;
 
-  assert(a.d_src_beg % sizeof(T) == 0);
-  assert(a.region_bytes % sizeof(T) == 0);
-  assert(a.epoch_elements > 0);
+  while (product != a.epoch_elements) {
+    if (first == 0)
+      return -1;
+    const uint64_t n = a.shape[first - 1];
+    if (n == 0 || n > a.epoch_elements / product)
+      return -1;
+    product *= n;
+    --first;
+  }
+
+  for (int d = 0; d < first; ++d) {
+    if (a.strides[d] != 0 && a.shape[d] != 1)
+      return -1;
+  }
+  return first;
+}
+
+static int
+add_within_32_bits(uint64_t* total, uint64_t count, uint64_t step)
+{
+  if (count != 0 && step > (UINT32_MAX - *total) / count)
+    return 0;
+  *total += count * step;
+  return 1;
+}
+
+// 32-bit indexing takes the per-element divisions off the 64-bit division
+// subroutine, so use it whenever every index the kernel forms fits.
+static int
+indices_fit_32_bits(const struct transpose_args& a,
+                    uint64_t src_size,
+                    int first_dim,
+                    uint64_t region_stride)
+{
+  const uint64_t last = a.i_offset + src_size - 1;
+  if (last < a.i_offset || last > UINT32_MAX)
+    return 0;
+
+  uint64_t max_offset = 0;
+  if (!add_within_32_bits(&max_offset, last / a.epoch_elements, region_stride))
+    return 0;
+
+  for (int d = first_dim; d < a.rank; ++d) {
+    if (a.shape[d] > UINT32_MAX || a.strides[d] < 0)
+      return 0;
+    if (!add_within_32_bits(
+          &max_offset, a.shape[d] - 1, (uint64_t)a.strides[d]))
+      return 0;
+  }
+  return 1;
+}
+
+template<typename T, typename Index>
+static void
+launch(const struct transpose_args& a,
+       uint64_t src_size,
+       uint64_t region_stride,
+       int first_dim)
+{
+  scatter_layout<Index> layout = {};
+  layout.rank = a.rank;
+  layout.first_dim = first_dim;
+  for (int d = first_dim; d < a.rank; ++d) {
+    layout.shape[d] = (Index)a.shape[d];
+    layout.strides[d] =
+      (typename scatter_layout<Index>::stride_type)a.strides[d];
+  }
 
   const int block_size = 256;
   const unsigned grid_size =
     (unsigned)((src_size + ELEMENTS_PER_BLOCK<T> - 1) / ELEMENTS_PER_BLOCK<T>);
 
-  transpose_v0_k<T><<<grid_size, block_size, 0, (cudaStream_t)a.stream>>>(
-    (T*)a.d_dst_beg,
-    (T*)a.d_src_beg,
-    src_size,
-    a.i_offset,
-    a.epoch_elements,
-    a.region_bytes / sizeof(T),
-    a.rank,
-    a.d_shape,
-    a.d_strides);
+  transpose_v0_k<T, Index>
+    <<<grid_size, block_size, 0, (cudaStream_t)a.stream>>>(
+      (T*)a.d_dst_beg,
+      (const T*)a.d_src_beg,
+      (Index)src_size,
+      (Index)a.i_offset,
+      (Index)region_stride,
+      layout);
 }
 
-extern "C" void
+template<typename T>
+static int
+transpose_launch(const struct transpose_args& a)
+{
+  const uint64_t src_size = a.src_bytes / sizeof(T);
+  if (src_size == 0)
+    return 0;
+
+  // Every declaration comes before the checks: a goto may not jump past one.
+  const int first_dim = first_decomposed_dim(a);
+  const uint64_t region_stride = a.region_bytes / sizeof(T);
+
+  CHECK(Error, a.d_src_beg % sizeof(T) == 0);
+  CHECK(Error, a.region_bytes % sizeof(T) == 0);
+  CHECK(Error, a.epoch_elements > 0);
+  CHECK(Error, a.rank <= MAX_RANK);
+  CHECK(Error, first_dim >= 0);
+
+  if (indices_fit_32_bits(a, src_size, first_dim, region_stride))
+    launch<T, uint32_t>(a, src_size, region_stride, first_dim);
+  else
+    launch<T, uint64_t>(a, src_size, region_stride, first_dim);
+  return 0;
+
+Error:
+  return 1;
+}
+
+extern "C" int
 transpose(CUdeviceptr d_dst_beg,
           CUdeviceptr d_src_beg,
           uint64_t src_bytes,
@@ -89,29 +197,25 @@ transpose(CUdeviceptr d_dst_beg,
           uint64_t epoch_elements,
           uint64_t region_bytes,
           uint8_t rank,
-          const uint64_t* d_shape,
-          const int64_t* d_strides,
+          const uint64_t* shape,
+          const int64_t* strides,
           CUstream stream)
 {
   const struct transpose_args a = { d_dst_beg, d_src_beg,      src_bytes,
                                     i_offset,  epoch_elements, region_bytes,
-                                    rank,      d_shape,        d_strides,
+                                    rank,      shape,          strides,
                                     stream };
   switch (bpe) {
     case 1:
-      transpose_launch<uint8_t>(a);
-      break;
+      return transpose_launch<uint8_t>(a);
     case 2:
-      transpose_launch<uint16_t>(a);
-      break;
+      return transpose_launch<uint16_t>(a);
     case 4:
-      transpose_launch<uint32_t>(a);
-      break;
+      return transpose_launch<uint32_t>(a);
     case 8:
-      transpose_launch<uint64_t>(a);
-      break;
+      return transpose_launch<uint64_t>(a);
     default:
-      assert(!"transpose: unsupported bpe");
-      break;
+      log_error("transpose: unsupported bpe %u", (unsigned)bpe);
+      return 1;
   }
 }

--- a/src/gpu/transpose.h
+++ b/src/gpu/transpose.h
@@ -13,14 +13,13 @@ extern "C"
   // i_offset counts from the start of the epoch d_dst_beg points at, not from
   // the start of the stream.
   //
-  // shape and strides are host arrays; they travel to the device in the launch
-  // parameters. The trailing dimensions must multiply out to epoch_elements,
-  // and each dimension in front of those must have either a zero stride or an
-  // extent of one — that is what lets the kernel treat the leftover of the
-  // index decomposition as the epoch number. A shape that does not meet this
-  // returns non-zero without launching.
+  // shape and strides are host arrays. Some run of trailing extents must
+  // multiply out to epoch_elements, and every dimension in front of that run
+  // must have a zero stride or a single position.
   //
-  // Returns 0 on success, non-zero on error.
+  // Returns 0 once the scatter is queued, or when there is nothing to scatter.
+  // Non-zero means nothing was queued. What the device reports while running
+  // surfaces on the stream instead.
   int transpose(CUdeviceptr d_dst_beg,
                 CUdeviceptr d_src_beg,
                 uint64_t src_bytes,

--- a/src/gpu/transpose.h
+++ b/src/gpu/transpose.h
@@ -12,17 +12,26 @@ extern "C"
 
   // i_offset counts from the start of the epoch d_dst_beg points at, not from
   // the start of the stream.
-  void transpose(CUdeviceptr d_dst_beg,
-                 CUdeviceptr d_src_beg,
-                 uint64_t src_bytes,
-                 uint8_t bpe,
-                 uint64_t i_offset,
-                 uint64_t epoch_elements,
-                 uint64_t region_bytes,
-                 uint8_t rank,
-                 const uint64_t* d_shape,
-                 const int64_t* d_strides,
-                 CUstream stream);
+  //
+  // shape and strides are host arrays; they travel to the device in the launch
+  // parameters. The trailing dimensions must multiply out to epoch_elements,
+  // and each dimension in front of those must have either a zero stride or an
+  // extent of one — that is what lets the kernel treat the leftover of the
+  // index decomposition as the epoch number. A shape that does not meet this
+  // returns non-zero without launching.
+  //
+  // Returns 0 on success, non-zero on error.
+  int transpose(CUdeviceptr d_dst_beg,
+                CUdeviceptr d_src_beg,
+                uint64_t src_bytes,
+                uint8_t bpe,
+                uint64_t i_offset,
+                uint64_t epoch_elements,
+                uint64_t region_bytes,
+                uint8_t rank,
+                const uint64_t* shape,
+                const int64_t* strides,
+                CUstream stream);
 #ifdef __cplusplus
 }
 #endif

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -25,8 +25,8 @@ struct array_descriptor_gpu
   struct stream_context ctx;
   struct computed_stream_layouts cl; // owned, freed on destroy
 
-  // Whole-struct swapped on bind/unbind. st.lod owns plan, layouts[],
-  // CSRs, append accumulator device memory, and LOD LUTs — but
+  // Whole-struct swapped on bind/unbind. st.lod owns plan, layouts[], CSRs,
+  // append accumulator device memory, and LOD LUTs — but
   // NOT d_linear/d_morton/timing, which are shared and owned by the engine.
   // st.agg owns per-LOD layouts, shard_state, and the per-array tail buffers.
   struct engine_array_state st;

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -26,7 +26,7 @@ struct array_descriptor_gpu
   struct computed_stream_layouts cl; // owned, freed on destroy
 
   // Whole-struct swapped on bind/unbind. st.lod owns plan, layouts[],
-  // layout_gpu[], CSRs, append accumulator device memory, and LOD LUTs — but
+  // CSRs, append accumulator device memory, and LOD LUTs — but
   // NOT d_linear/d_morton/timing, which are shared and owned by the engine.
   // st.agg owns per-LOD layouts, shard_state, and the per-array tail buffers.
   struct engine_array_state st;

--- a/src/stream.gpu.h
+++ b/src/stream.gpu.h
@@ -6,12 +6,6 @@
 
 struct tile_stream_layout;
 
-struct tile_stream_layout_gpu
-{
-  uint64_t* d_lifted_shape;  // device copy (allocated once)
-  int64_t* d_lifted_strides; // device copy (allocated once)
-};
-
 struct tile_stream_memory_info
 {
   size_t device_bytes;      // total GPU memory

--- a/tests/experiments/index.ops.cuda.c
+++ b/tests/experiments/index.ops.cuda.c
@@ -159,7 +159,7 @@ test_transpose_u16_basic(void)
   printf("%30s", "Transposed strides: ");
   println_vi32(rank, transposed_strides);
 
-  CUdeviceptr d_src = 0, d_dst = 0, d_shape = 0, d_strides = 0;
+  CUdeviceptr d_src = 0, d_dst = 0;
   uint16_t *src = 0, *actual = 0, *expected = 0;
 
   const int n = transposed_strides[0] * shape[0];
@@ -189,7 +189,7 @@ test_transpose_u16_basic(void)
   CUstream stream = 0;
   CU(Fail, cuMemcpyHtoDAsync(d_src, src, n * sizeof(uint16_t), stream));
 
-  // Convert shape and strides to uint64_t/int64_t for the API
+  // Convert shape and strides to the widths the API takes
   uint64_t shape64[MAX_RANK] = { 0 };
   int64_t strides64[MAX_RANK] = { 0 };
   for (int i = 0; i < rank; ++i) {
@@ -197,24 +197,19 @@ test_transpose_u16_basic(void)
     strides64[i] = transposed_strides[i];
   }
 
-  // Copy shape and strides to device
-  CU(Fail, cuMemAlloc(&d_shape, rank * sizeof(uint64_t)));
-  CU(Fail, cuMemAlloc(&d_strides, rank * sizeof(int64_t)));
-  CU(Fail, cuMemcpyHtoD(d_shape, shape64, rank * sizeof(uint64_t)));
-  CU(Fail, cuMemcpyHtoD(d_strides, strides64, rank * sizeof(int64_t)));
-
   // Call the CUDA transpose kernel
-  transpose(d_dst,
-            d_src,
-            n * sizeof(uint16_t),
-            sizeof(uint16_t),
-            0, // i_offset (start at input index 0)
-            n, // one epoch holds the whole array
-            0, // so there is no second region to step to
-            rank,
-            (const uint64_t*)d_shape,
-            (const int64_t*)d_strides,
-            stream);
+  CHECK(Fail,
+        transpose(d_dst,
+                  d_src,
+                  n * sizeof(uint16_t),
+                  sizeof(uint16_t),
+                  0, // i_offset (start at input index 0)
+                  n, // one epoch holds the whole array
+                  0, // so there is no second region to step to
+                  rank,
+                  shape64,
+                  strides64,
+                  stream) == 0);
 
   // Copy results back to host
   CU(Fail, cuMemcpyDtoHAsync(actual, d_dst, n * sizeof(uint16_t), stream));
@@ -252,8 +247,6 @@ test_transpose_u16_basic(void)
   }
 
 Finalize:
-  cuMemFree(d_shape);
-  cuMemFree(d_strides);
   cuMemFree(d_src);
   cuMemFree(d_dst);
   free(src);
@@ -279,7 +272,7 @@ test_transpose_u16_with_offset(void)
 
   setup_transpose_strides(rank, shape, p, transposed_shape, transposed_strides);
 
-  CUdeviceptr d_src = 0, d_dst = 0, d_shape = 0, d_strides = 0;
+  CUdeviceptr d_src = 0, d_dst = 0;
   uint16_t *src = 0, *actual = 0, *expected = 0;
 
   const int n = transposed_strides[0] * shape[0];
@@ -332,7 +325,7 @@ test_transpose_u16_with_offset(void)
   // Copy source to device
   CU(Fail, cuMemcpyHtoDAsync(d_src, src, count * sizeof(uint16_t), stream));
 
-  // Convert shape and strides to uint64_t/int64_t for the API
+  // Convert shape and strides to the widths the API takes
   uint64_t shape64[MAX_RANK] = { 0 };
   int64_t strides64[MAX_RANK] = { 0 };
   for (int i = 0; i < rank; ++i) {
@@ -340,24 +333,19 @@ test_transpose_u16_with_offset(void)
     strides64[i] = transposed_strides[i];
   }
 
-  // Copy shape and strides to device
-  CU(Fail, cuMemAlloc(&d_shape, rank * sizeof(uint64_t)));
-  CU(Fail, cuMemAlloc(&d_strides, rank * sizeof(int64_t)));
-  CU(Fail, cuMemcpyHtoD(d_shape, shape64, rank * sizeof(uint64_t)));
-  CU(Fail, cuMemcpyHtoD(d_strides, strides64, rank * sizeof(int64_t)));
-
   // Call the CUDA transpose kernel with offset
-  transpose(d_dst,
-            d_src,
-            count * sizeof(uint16_t),
-            sizeof(uint16_t),
-            i_offset,
-            n, // one epoch holds the whole array
-            0, // so there is no second region to step to
-            rank,
-            (const uint64_t*)d_shape,
-            (const int64_t*)d_strides,
-            stream);
+  CHECK(Fail,
+        transpose(d_dst,
+                  d_src,
+                  count * sizeof(uint16_t),
+                  sizeof(uint16_t),
+                  i_offset,
+                  n, // one epoch holds the whole array
+                  0, // so there is no second region to step to
+                  rank,
+                  shape64,
+                  strides64,
+                  stream) == 0);
 
   // Copy results back to host
   CU(Fail, cuMemcpyDtoHAsync(actual, d_dst, n * sizeof(uint16_t), stream));
@@ -387,8 +375,6 @@ test_transpose_u16_with_offset(void)
   }
 
 Finalize:
-  cuMemFree(d_shape);
-  cuMemFree(d_strides);
   cuMemFree(d_src);
   cuMemFree(d_dst);
   free(src);

--- a/tests/index.ops.util.c
+++ b/tests/index.ops.util.c
@@ -132,6 +132,7 @@ random_vu64(int count, uint64_t max)
 
 void
 build_lifted_layout(int rank,
+                    uint8_t n_append,
                     const uint64_t* dim_sizes,
                     const uint64_t* chunk_sizes,
                     const uint8_t* storage_order,
@@ -163,12 +164,16 @@ build_lifted_layout(int rank,
                          (int64_t)chunk_stride,
                          lifted_strides);
 
-  *out_chunks_per_epoch = (uint64_t)lifted_strides[0] / chunk_stride;
-  lifted_strides[0] = 0; // collapse epoch dim
+  uint64_t chunks_per_epoch = 1;
+  for (int i = n_append; i < rank; ++i)
+    chunks_per_epoch *= chunk_count[i];
+  for (int d = 0; d < n_append; ++d)
+    lifted_strides[2 * d] = 0; // an append dim's chunk position never moves
 
+  *out_chunks_per_epoch = chunks_per_epoch;
   *out_chunk_elements = chunk_elements;
   *out_chunk_stride = chunk_stride;
-  *out_epoch_elements = *out_chunks_per_epoch * chunk_elements;
+  *out_epoch_elements = chunks_per_epoch * chunk_elements;
 }
 
 uint64_t

--- a/tests/index.ops.util.h
+++ b/tests/index.ops.util.h
@@ -63,10 +63,11 @@ cpu_perm(uint64_t i,
          const int64_t* strides);
 
 // Build lifted shape and strides for a chunk decomposition (no codec
-// alignment). The epoch dimension (dim 0) stride is set to 0 so all epochs
-// collapse. storage_order may be NULL for identity order.
+// alignment). The chunk stride of each of the first n_append dimensions is set
+// to 0 so all epochs collapse. storage_order may be NULL for identity order.
 void
 build_lifted_layout(int rank,
+                    uint8_t n_append,
                     const uint64_t* dim_sizes,
                     const uint64_t* chunk_sizes,
                     const uint8_t* storage_order,

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -10,31 +10,6 @@
 
 // ingest_init / ingest_destroy from stream_ingest.h
 
-static int
-upload_layout_gpu(struct tile_stream_layout_gpu* gpu,
-                  uint8_t lifted_rank,
-                  const uint64_t* lifted_shape,
-                  const int64_t* lifted_strides)
-{
-  size_t sb = lifted_rank * sizeof(uint64_t);
-  size_t stb = lifted_rank * sizeof(int64_t);
-  CU(Fail, cuMemAlloc((CUdeviceptr*)&gpu->d_lifted_shape, sb));
-  CU(Fail, cuMemAlloc((CUdeviceptr*)&gpu->d_lifted_strides, stb));
-  CU(Fail, cuMemcpyHtoD((CUdeviceptr)gpu->d_lifted_shape, lifted_shape, sb));
-  CU(Fail,
-     cuMemcpyHtoD((CUdeviceptr)gpu->d_lifted_strides, lifted_strides, stb));
-  return 0;
-Fail:
-  return 1;
-}
-
-static void
-destroy_layout_gpu(struct tile_stream_layout_gpu* gpu)
-{
-  cu_mem_free((CUdeviceptr)gpu->d_lifted_shape);
-  cu_mem_free((CUdeviceptr)gpu->d_lifted_strides);
-}
-
 static struct gpu_pool_view
 as_view(CUdeviceptr d)
 {
@@ -60,6 +35,7 @@ test_ingest_incremental(void)
   uint64_t chunk_elements, chunk_stride, chunks_per_epoch, epoch_elements;
 
   build_lifted_layout(rank,
+                      1,
                       dim_sizes,
                       chunk_sizes,
                       NULL,
@@ -78,7 +54,6 @@ test_ingest_incremental(void)
   struct staging_state stage = { 0 };
   struct gpu_ordering ord = { 0 };
   struct tile_stream_layout layout = { 0 };
-  struct tile_stream_layout_gpu layout_gpu = { 0 };
   CUstream h2d = 0, compute = 0;
   CUdeviceptr d_pool = 0;
   void* h_pool = NULL;
@@ -93,7 +68,8 @@ test_ingest_incremental(void)
   CHECK(Fail, ingest_init(&stage, half, &ord, compute) == 0);
 
   CU(Fail, cuMemAlloc(&d_pool, pool_bytes));
-  CU(Fail, cuMemsetD8(d_pool, 0, pool_bytes));
+  // On the scatter's stream, so the clear cannot land after it.
+  CU(Fail, cuMemsetD8Async(d_pool, 0, pool_bytes, compute));
 
   layout.lifted_rank = lifted_rank;
   memcpy(layout.lifted_shape, lifted_shape, lifted_rank * sizeof(uint64_t));
@@ -102,9 +78,6 @@ test_ingest_incremental(void)
   layout.chunk_stride = chunk_stride;
   layout.chunks_per_epoch = chunks_per_epoch;
   layout.epoch_elements = epoch_elements;
-  CHECK(Fail,
-        upload_layout_gpu(
-          &layout_gpu, lifted_rank, lifted_shape, lifted_strides) == 0);
 
   h_src = (uint16_t*)malloc(src_bytes);
   CHECK(Fail, h_src);
@@ -121,14 +94,8 @@ test_ingest_incremental(void)
     memcpy(gpu_pool_at(&stage.h_pool, stage.current, 0).p, h_src, half);
     stage.bytes_written = half;
     CHECK(Fail,
-          ingest_dispatch_scatter(&stage,
-                                  &layout,
-                                  &layout_gpu,
-                                  dst,
-                                  0,
-                                  bytes_per_element,
-                                  h2d,
-                                  compute) == 0);
+          ingest_dispatch_scatter(
+            &stage, &layout, dst, 0, bytes_per_element, h2d, compute) == 0);
 
     struct gpu_pool_view h_in;
     CHECK(Fail,
@@ -139,7 +106,6 @@ test_ingest_incremental(void)
     CHECK(Fail,
           ingest_dispatch_scatter(&stage,
                                   &layout,
-                                  &layout_gpu,
                                   dst,
                                   epoch_elements / 2,
                                   bytes_per_element,
@@ -189,7 +155,6 @@ Fail:
   free(h_pool);
   ingest_destroy(&stage);
   gpu_ordering_destroy(&ord);
-  destroy_layout_gpu(&layout_gpu);
   cu_mem_free(d_pool);
   cu_stream_destroy(h2d);
   cu_stream_destroy(compute);
@@ -215,6 +180,7 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   uint64_t chunk_elements, chunk_stride, chunks_per_epoch, epoch_elements;
 
   build_lifted_layout(rank,
+                      1,
                       dim_sizes,
                       chunk_sizes,
                       NULL,
@@ -238,7 +204,6 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   struct staging_state stage = { 0 };
   struct gpu_ordering ord = { 0 };
   struct tile_stream_layout layout = { 0 };
-  struct tile_stream_layout_gpu layout_gpu = { 0 };
   CUstream h2d = 0, compute = 0;
   CUdeviceptr d_pool = 0;
   void* h_pool = NULL;
@@ -253,7 +218,8 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   CHECK(Fail, ingest_init(&stage, src_bytes, &ord, compute) == 0);
 
   CU(Fail, cuMemAlloc(&d_pool, pool_bytes));
-  CU(Fail, cuMemsetD8(d_pool, 0, pool_bytes));
+  // On the scatter's stream, so the clear cannot land after it.
+  CU(Fail, cuMemsetD8Async(d_pool, 0, pool_bytes, compute));
 
   layout.lifted_rank = lifted_rank;
   memcpy(layout.lifted_shape, lifted_shape, lifted_rank * sizeof(uint64_t));
@@ -262,9 +228,6 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   layout.chunk_stride = chunk_stride;
   layout.chunks_per_epoch = chunks_per_epoch;
   layout.epoch_elements = epoch_elements;
-  CHECK(Fail,
-        upload_layout_gpu(
-          &layout_gpu, lifted_rank, lifted_shape, lifted_strides) == 0);
 
   h_src = (uint16_t*)malloc(src_bytes);
   CHECK(Fail, h_src);
@@ -277,7 +240,6 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   CHECK(Fail,
         ingest_dispatch_scatter(&stage,
                                 &layout,
-                                &layout_gpu,
                                 (struct scatter_destination){
                                   .first_epoch = as_view(d_pool),
                                   .epoch_bytes = epoch_bytes,
@@ -328,7 +290,6 @@ Fail:
   free(h_pool);
   ingest_destroy(&stage);
   gpu_ordering_destroy(&ord);
-  destroy_layout_gpu(&layout_gpu);
   cu_mem_free(d_pool);
   cu_stream_destroy(h2d);
   cu_stream_destroy(compute);

--- a/tests/test_transpose.c
+++ b/tests/test_transpose.c
@@ -24,6 +24,7 @@ fill_elements(uint8_t* dst, uint64_t n, uint8_t bpe)
 static int
 run_transpose_test(const char* name,
                    int rank,
+                   uint8_t n_append,
                    const uint64_t* dim_sizes,
                    const uint64_t* chunk_sizes,
                    const uint8_t* storage_order,
@@ -43,6 +44,7 @@ run_transpose_test(const char* name,
   uint64_t chunk_elements, chunk_stride, chunks_per_epoch, epoch_elements;
 
   build_lifted_layout(rank,
+                      n_append,
                       dim_sizes,
                       chunk_sizes,
                       storage_order,
@@ -73,7 +75,7 @@ run_transpose_test(const char* name,
 
   void* h_src = NULL;
   void* h_dst = NULL;
-  CUdeviceptr d_src = 0, d_dst = 0, d_shape = 0, d_strides = 0;
+  CUdeviceptr d_src = 0, d_dst = 0;
   CUstream stream = 0;
   int ok = 0;
 
@@ -85,26 +87,23 @@ run_transpose_test(const char* name,
   CU(Fail, cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuMemAlloc(&d_src, src_bytes));
   CU(Fail, cuMemAlloc(&d_dst, dst_bytes));
-  CU(Fail, cuMemsetD8(d_dst, 0, dst_bytes));
-  CU(Fail, cuMemAlloc(&d_shape, lifted_rank * sizeof(uint64_t)));
-  CU(Fail, cuMemAlloc(&d_strides, lifted_rank * sizeof(int64_t)));
+  // On the kernel's own stream, so the scatter cannot start before the source
+  // lands or race the clear.
+  CU(Fail, cuMemsetD8Async(d_dst, 0, dst_bytes, stream));
+  CU(Fail, cuMemcpyHtoDAsync(d_src, h_src, src_bytes, stream));
 
-  CU(Fail, cuMemcpyHtoD(d_src, h_src, src_bytes));
-  CU(Fail, cuMemcpyHtoD(d_shape, lifted_shape, lifted_rank * sizeof(uint64_t)));
-  CU(Fail,
-     cuMemcpyHtoD(d_strides, lifted_strides, lifted_rank * sizeof(int64_t)));
-
-  transpose(d_dst,
-            d_src,
-            src_bytes,
-            bpe,
-            in_epoch_offset,
-            epoch_elements,
-            region_elements * bpe,
-            lifted_rank,
-            (const uint64_t*)d_shape,
-            (const int64_t*)d_strides,
-            stream);
+  CHECK(Fail,
+        transpose(d_dst,
+                  d_src,
+                  src_bytes,
+                  bpe,
+                  in_epoch_offset,
+                  epoch_elements,
+                  region_elements * bpe,
+                  lifted_rank,
+                  lifted_shape,
+                  lifted_strides,
+                  stream) == 0);
   CU(Fail, cuStreamSynchronize(stream));
 
   CU(Fail, cuMemcpyDtoH(h_dst, d_dst, dst_bytes));
@@ -142,8 +141,6 @@ Fail:
   free(h_dst);
   cuMemFree(d_src);
   cuMemFree(d_dst);
-  cuMemFree(d_shape);
-  cuMemFree(d_strides);
   cuStreamDestroy(stream);
 
   if (ok) {
@@ -161,7 +158,7 @@ test_transpose_2d(void)
   uint64_t dim_sizes[] = { 4, 6 };
   uint64_t chunk_sizes[] = { 2, 3 };
   return run_transpose_test(
-    "test_transpose_2d", 2, dim_sizes, chunk_sizes, NULL, 2, 1, 0);
+    "test_transpose_2d", 2, 1, dim_sizes, chunk_sizes, NULL, 2, 1, 0);
 }
 
 static int
@@ -171,7 +168,7 @@ test_transpose_3d(void)
   uint64_t dim_sizes[] = { 4, 4, 6 };
   uint64_t chunk_sizes[] = { 2, 2, 3 };
   return run_transpose_test(
-    "test_transpose_3d", 3, dim_sizes, chunk_sizes, NULL, 2, 1, 0);
+    "test_transpose_3d", 3, 1, dim_sizes, chunk_sizes, NULL, 2, 1, 0);
 }
 
 static int
@@ -181,7 +178,7 @@ test_transpose_identity(void)
   uint64_t dim_sizes[] = { 6, 4 };
   uint64_t chunk_sizes[] = { 6, 4 };
   return run_transpose_test(
-    "test_transpose_identity", 2, dim_sizes, chunk_sizes, NULL, 2, 1, 0);
+    "test_transpose_identity", 2, 1, dim_sizes, chunk_sizes, NULL, 2, 1, 0);
 }
 
 static int
@@ -191,7 +188,7 @@ test_transpose_bpe4(void)
   uint64_t dim_sizes[] = { 4, 4, 6 };
   uint64_t chunk_sizes[] = { 2, 2, 3 };
   return run_transpose_test(
-    "test_transpose_bpe4", 3, dim_sizes, chunk_sizes, NULL, 4, 1, 0);
+    "test_transpose_bpe4", 3, 1, dim_sizes, chunk_sizes, NULL, 4, 1, 0);
 }
 
 static int
@@ -204,6 +201,7 @@ test_transpose_3d_storage_order(void)
   uint8_t storage_order[] = { 0, 2, 1 };
   return run_transpose_test("test_transpose_3d_storage_order",
                             3,
+                            1,
                             dim_sizes,
                             chunk_sizes,
                             storage_order,
@@ -222,6 +220,7 @@ test_transpose_4d_storage_order(void)
   uint8_t storage_order[] = { 0, 3, 1, 2 };
   return run_transpose_test("test_transpose_4d_storage_order",
                             4,
+                            1,
                             dim_sizes,
                             chunk_sizes,
                             storage_order,
@@ -243,6 +242,7 @@ test_transpose_many_epochs(void)
     for (uint64_t from = 0; from < 2; ++from)
       err |= run_transpose_test("test_transpose_many_epochs",
                                 3,
+                                1,
                                 dim_sizes,
                                 chunk_sizes,
                                 NULL,
@@ -258,7 +258,63 @@ test_transpose_bpe8(void)
   uint64_t dim_sizes[] = { 4, 4, 6 };
   uint64_t chunk_sizes[] = { 2, 2, 3 };
   return run_transpose_test(
-    "test_transpose_bpe8", 3, dim_sizes, chunk_sizes, NULL, 8, 1, 0);
+    "test_transpose_bpe8", 3, 1, dim_sizes, chunk_sizes, NULL, 8, 1, 0);
+}
+
+// Two append dimensions collapse, so the decomposition has to stop short of a
+// dimension sitting in the middle of the shape rather than at the front.
+static int
+test_transpose_two_append_dims(void)
+{
+  uint64_t dim_sizes[] = { 4, 3, 64, 96 };
+  uint64_t chunk_sizes[] = { 1, 1, 16, 24 };
+  return run_transpose_test("test_transpose_two_append_dims",
+                            4,
+                            2,
+                            dim_sizes,
+                            chunk_sizes,
+                            NULL,
+                            2,
+                            2,
+                            0);
+}
+
+// A shape whose trailing dimensions cannot make up an epoch is refused, rather
+// than scattered somewhere wrong.
+static int
+test_transpose_rejects_mismatched_epoch(void)
+{
+  log_info("=== test_transpose_rejects_mismatched_epoch ===");
+
+  const uint64_t shape[] = { 2, 4, 6 };
+  const int64_t strides[] = { 0, 6, 1 };
+  CUdeviceptr d_src = 0, d_dst = 0;
+  CUstream stream = 0;
+  int ok = 0;
+
+  CU(Fail, cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+  CU(Fail, cuMemAlloc(&d_src, 48 * sizeof(uint16_t)));
+  CU(Fail, cuMemAlloc(&d_dst, 48 * sizeof(uint16_t)));
+
+  // 25 is not a product of any run of trailing extents.
+  ok = transpose(d_dst,
+                 d_src,
+                 48 * sizeof(uint16_t),
+                 2,
+                 0,
+                 25,
+                 24 * sizeof(uint16_t),
+                 3,
+                 shape,
+                 strides,
+                 stream) != 0;
+
+Fail:
+  cuMemFree(d_src);
+  cuMemFree(d_dst);
+  cuStreamDestroy(stream);
+  log_info("  %s", ok ? "PASS" : "FAIL");
+  return ok ? 0 : 1;
 }
 
 RUN_GPU_TESTS({ "transpose_2d", test_transpose_2d },
@@ -268,4 +324,7 @@ RUN_GPU_TESTS({ "transpose_2d", test_transpose_2d },
               { "transpose_3d_storage_order", test_transpose_3d_storage_order },
               { "transpose_4d_storage_order", test_transpose_4d_storage_order },
               { "transpose_bpe8", test_transpose_bpe8 },
-              { "transpose_many_epochs", test_transpose_many_epochs }, )
+              { "transpose_many_epochs", test_transpose_many_epochs },
+              { "transpose_two_append_dims", test_transpose_two_append_dims },
+              { "transpose_rejects_mismatched_epoch",
+                test_transpose_rejects_mismatched_epoch }, )

--- a/tests/test_transpose.c
+++ b/tests/test_transpose.c
@@ -2,6 +2,7 @@
 #include "gpu/transpose.h"
 #include "index.ops.util.h"
 #include "util/prelude.h"
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -15,63 +16,54 @@ fill_elements(uint8_t* dst, uint64_t n, uint8_t bpe)
       dst[i * bpe + b] = (uint8_t)((i * 131 + b * 17 + 1) & 0xFF);
 }
 
-// Run transpose kernel and verify against CPU ravel() reference.
-// dim_sizes/chunk_sizes: per-dimension sizes.
-// bpe: bytes per element.
-// n_epochs: epochs worth of source to hand the kernel in one call.
-// in_epoch_offset: how far into its epoch the first element sits.
+// One scatter to run and check against the CPU reference. An omitted offset
+// starts at the first epoch; detail is extra geometry to log.
+struct scatter_case
+{
+  const char* name;
+  const char* detail;
+  uint8_t lifted_rank;
+  const uint64_t* lifted_shape;
+  const int64_t* lifted_strides;
+  uint64_t epoch_elements;
+  uint64_t region_elements;
+  uint8_t bpe;
+  uint64_t src_elements;
+  uint64_t in_epoch_offset;
+};
+
 // Returns 0 on success.
 static int
-run_transpose_test(const char* name,
-                   int rank,
-                   uint8_t n_append,
-                   const uint64_t* dim_sizes,
-                   const uint64_t* chunk_sizes,
-                   const uint8_t* storage_order,
-                   uint8_t bpe,
-                   uint32_t n_epochs,
-                   uint64_t in_epoch_offset)
+scatter_and_verify(struct scatter_case c)
 {
-  log_info("=== %s (bpe=%u epochs=%u from=%lu) ===",
-           name,
-           bpe,
-           n_epochs,
-           (unsigned long)in_epoch_offset);
+  const char* name = c.name;
+  const uint8_t lifted_rank = c.lifted_rank;
+  const uint64_t* lifted_shape = c.lifted_shape;
+  const int64_t* lifted_strides = c.lifted_strides;
+  const uint64_t epoch_elements = c.epoch_elements;
+  const uint64_t region_elements = c.region_elements;
+  const uint8_t bpe = c.bpe;
+  const uint64_t src_elements = c.src_elements;
+  const uint64_t in_epoch_offset = c.in_epoch_offset;
+  // Every epoch the call reaches, counting the one it starts partway into.
+  const uint64_t regions =
+    ceildiv(in_epoch_offset + src_elements, epoch_elements);
 
-  uint8_t lifted_rank;
-  uint64_t lifted_shape[MAX_RANK];
-  int64_t lifted_strides[MAX_RANK];
-  uint64_t chunk_elements, chunk_stride, chunks_per_epoch, epoch_elements;
-
-  build_lifted_layout(rank,
-                      n_append,
-                      dim_sizes,
-                      chunk_sizes,
-                      storage_order,
-                      &lifted_rank,
-                      lifted_shape,
-                      lifted_strides,
-                      &chunk_elements,
-                      &chunk_stride,
-                      &chunks_per_epoch,
-                      &epoch_elements);
-  const uint64_t region_elements =
-    chunks_per_epoch * chunk_stride + TEST_REGION_PAD_ELEMENTS;
-  const uint64_t src_elements = n_epochs * epoch_elements;
   const size_t src_bytes = src_elements * bpe;
-  // A start partway into an epoch pushes the last elements into one more region
-  // than the epochs they cover.
-  const uint32_t regions = n_epochs + 1;
   const size_t dst_bytes = regions * region_elements * bpe;
 
-  log_info("  rank=%d lifted_rank=%d chunk_elements=%lu chunk_stride=%lu "
-           "chunks_per_epoch=%lu epoch_elements=%lu",
-           rank,
+  log_info("=== %s (bpe=%u elements=%lu regions=%lu from=%lu) ===",
+           name,
+           bpe,
+           (unsigned long)src_elements,
+           (unsigned long)regions,
+           (unsigned long)in_epoch_offset);
+  if (c.detail)
+    log_info("  %s", c.detail);
+  log_info("  lifted_rank=%d epoch_elements=%lu region_elements=%lu",
            lifted_rank,
-           (unsigned long)chunk_elements,
-           (unsigned long)chunk_stride,
-           (unsigned long)chunks_per_epoch,
-           (unsigned long)epoch_elements);
+           (unsigned long)epoch_elements,
+           (unsigned long)region_elements);
 
   void* h_src = NULL;
   void* h_dst = NULL;
@@ -149,6 +141,62 @@ Fail:
   }
   log_error("  FAIL");
   return 1;
+}
+
+// dim_sizes/chunk_sizes: per-dimension sizes.
+// n_append: leading dimensions whose chunk position never moves.
+// n_epochs: epochs worth of source to hand the kernel in one call.
+static int
+run_transpose_test(const char* name,
+                   int rank,
+                   uint8_t n_append,
+                   const uint64_t* dim_sizes,
+                   const uint64_t* chunk_sizes,
+                   const uint8_t* storage_order,
+                   uint8_t bpe,
+                   uint32_t n_epochs,
+                   uint64_t in_epoch_offset)
+{
+  uint8_t lifted_rank;
+  uint64_t lifted_shape[MAX_RANK];
+  int64_t lifted_strides[MAX_RANK];
+  uint64_t chunk_elements, chunk_stride, chunks_per_epoch, epoch_elements;
+
+  build_lifted_layout(rank,
+                      n_append,
+                      dim_sizes,
+                      chunk_sizes,
+                      storage_order,
+                      &lifted_rank,
+                      lifted_shape,
+                      lifted_strides,
+                      &chunk_elements,
+                      &chunk_stride,
+                      &chunks_per_epoch,
+                      &epoch_elements);
+
+  char detail[128];
+  snprintf(detail,
+           sizeof(detail),
+           "rank=%d chunk_elements=%lu chunk_stride=%lu chunks_per_epoch=%lu",
+           rank,
+           (unsigned long)chunk_elements,
+           (unsigned long)chunk_stride,
+           (unsigned long)chunks_per_epoch);
+
+  return scatter_and_verify((struct scatter_case){
+    .name = name,
+    .detail = detail,
+    .lifted_rank = lifted_rank,
+    .lifted_shape = lifted_shape,
+    .lifted_strides = lifted_strides,
+    .epoch_elements = epoch_elements,
+    .region_elements =
+      chunks_per_epoch * chunk_stride + TEST_REGION_PAD_ELEMENTS,
+    .bpe = bpe,
+    .src_elements = n_epochs * epoch_elements,
+    .in_epoch_offset = in_epoch_offset,
+  });
 }
 
 static int
@@ -279,15 +327,17 @@ test_transpose_two_append_dims(void)
                             0);
 }
 
-// A shape whose trailing dimensions cannot make up an epoch is refused, rather
-// than scattered somewhere wrong.
+// A layout the kernel cannot scatter is refused, rather than scattered
+// somewhere wrong.
 static int
-test_transpose_rejects_mismatched_epoch(void)
+expect_rejected(const char* what,
+                uint8_t rank,
+                const uint64_t* shape,
+                const int64_t* strides,
+                uint64_t epoch_elements)
 {
-  log_info("=== test_transpose_rejects_mismatched_epoch ===");
+  log_info("=== rejects %s ===", what);
 
-  const uint64_t shape[] = { 2, 4, 6 };
-  const int64_t strides[] = { 0, 6, 1 };
   CUdeviceptr d_src = 0, d_dst = 0;
   CUstream stream = 0;
   int ok = 0;
@@ -296,15 +346,14 @@ test_transpose_rejects_mismatched_epoch(void)
   CU(Fail, cuMemAlloc(&d_src, 48 * sizeof(uint16_t)));
   CU(Fail, cuMemAlloc(&d_dst, 48 * sizeof(uint16_t)));
 
-  // 25 is not a product of any run of trailing extents.
   ok = transpose(d_dst,
                  d_src,
                  48 * sizeof(uint16_t),
                  2,
                  0,
-                 25,
+                 epoch_elements,
                  24 * sizeof(uint16_t),
-                 3,
+                 rank,
                  shape,
                  strides,
                  stream) != 0;
@@ -317,6 +366,92 @@ Fail:
   return ok ? 0 : 1;
 }
 
+static int
+test_transpose_rejects_bad_layouts(void)
+{
+  const uint64_t shape[] = { 2, 4, 6 };
+  int err = 0;
+
+  // No run of trailing extents multiplies out to 25.
+  {
+    const int64_t strides[] = { 0, 6, 1 };
+    err |= expect_rejected("an epoch no run of extents can make",
+                           countof(shape),
+                           shape,
+                           strides,
+                           25);
+  }
+  // The trailing extents make up the epoch, but the skipped dimension has both
+  // a stride and more than one position, so it reaches the destination.
+  {
+    const int64_t strides[] = { 5, 6, 1 };
+    err |= expect_rejected("a skipped dimension that moves the destination",
+                           countof(shape),
+                           shape,
+                           strides,
+                           24);
+  }
+  return err;
+}
+
+// The only cases that reach the wide kernel, one per route into it. An offset
+// past UINT32_MAX is the route left out, since it needs a 4 GiB destination.
+static int
+test_transpose_wide_index(void)
+{
+  const uint64_t huge = 1ull << 33;
+  const uint64_t wide_shape[] = { 1, huge, 4, 6 };
+  const int64_t no_stride[] = { 0, 0, 6, 1 };
+  const uint64_t wide_epoch = huge * 24;
+  const uint64_t region_elements = 24 + TEST_REGION_PAD_ELEMENTS;
+  int err = 0;
+
+  // An element index past UINT32_MAX, straddling an epoch boundary so the epoch
+  // step runs at full width too.
+  err |= scatter_and_verify((struct scatter_case){
+    .name = "wide_index",
+    .lifted_rank = 4,
+    .lifted_shape = wide_shape,
+    .lifted_strides = no_stride,
+    .epoch_elements = wide_epoch,
+    .region_elements = region_elements,
+    .bpe = 2,
+    .src_elements = 24,
+    .in_epoch_offset = wide_epoch - 12,
+  });
+
+  // The same extent, reached from index 0 so the extent picks the kernel.
+  err |= scatter_and_verify((struct scatter_case){
+    .name = "wide_extent",
+    .lifted_rank = 4,
+    .lifted_shape = wide_shape,
+    .lifted_strides = no_stride,
+    .epoch_elements = wide_epoch,
+    .region_elements = region_elements,
+    .bpe = 2,
+    .src_elements = 24,
+  });
+
+  // A backward stride, which no 32-bit index can carry. The epoch step puts
+  // every offset back above zero.
+  {
+    const uint64_t shape[] = { 1, 4, 6 };
+    const int64_t strides[] = { 0, -6, 1 };
+    err |= scatter_and_verify((struct scatter_case){
+      .name = "backward_stride",
+      .lifted_rank = 3,
+      .lifted_shape = shape,
+      .lifted_strides = strides,
+      .epoch_elements = 24,
+      .region_elements = 30,
+      .bpe = 2,
+      .src_elements = 24,
+      .in_epoch_offset = 24,
+    });
+  }
+  return err;
+}
+
 RUN_GPU_TESTS({ "transpose_2d", test_transpose_2d },
               { "transpose_3d", test_transpose_3d },
               { "transpose_identity", test_transpose_identity },
@@ -326,5 +461,6 @@ RUN_GPU_TESTS({ "transpose_2d", test_transpose_2d },
               { "transpose_bpe8", test_transpose_bpe8 },
               { "transpose_many_epochs", test_transpose_many_epochs },
               { "transpose_two_append_dims", test_transpose_two_append_dims },
-              { "transpose_rejects_mismatched_epoch",
-                test_transpose_rejects_mismatched_epoch }, )
+              { "transpose_wide_index", test_transpose_wide_index },
+              { "transpose_rejects_bad_layouts",
+                test_transpose_rejects_bad_layouts }, )

--- a/tests/test_transpose_cpu.c
+++ b/tests/test_transpose_cpu.c
@@ -26,6 +26,7 @@ run_test(const char* name,
   uint64_t chunk_elements, chunk_stride, chunks_per_epoch, epoch_elements;
 
   build_lifted_layout(rank,
+                      1,
                       dim_sizes,
                       chunk_sizes,
                       storage_order,
@@ -175,6 +176,7 @@ run_offset_test(const char* name,
   uint64_t chunk_elements, chunk_stride, chunks_per_epoch, epoch_elements;
 
   build_lifted_layout(rank,
+                      1,
                       dim_sizes,
                       chunk_sizes,
                       NULL,


### PR DESCRIPTION
The scatter kernel spent most of its per-element work on integer division,
and read the shape and strides from global memory once per dimension per
element.

Three changes. The host now finds the run of trailing extents that makes up
one epoch, so dividing an element index by them leaves the epoch number.
That drops the separate division by epoch_elements along with the iterations
for the dimensions in front, whose coordinates cannot reach the destination.
The shape and strides travel by value in the launch parameters instead of
through device copies, which retires struct tile_stream_layout_gpu and its
per-level allocations. A 32-bit index instantiation runs whenever every index
the kernel forms provably fits, which inlines the per-element divisions.

The scatter now returns a status, because it can refuse a layout it cannot
place and it reports a launch the driver turns away.

test_transpose and test_ingest staged their input with legacy-stream calls
while launching on non-blocking streams. The shape and stride uploads were
the only thing ordering the two, so removing them exposed the race and the
kernel read its source before the copy landed. Both tests now stage on the
stream their kernel runs on. New cases cover two append dimensions, the wide
index kernel, and the layouts the scatter refuses.

Closes #190
