### PR TITLE
Rebuild the GPU test image each run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,8 +184,18 @@ jobs:
     env:
       CUDA_VERSION: ${{ matrix.cuda.version }}
       CUDA_MAJOR: ${{ matrix.cuda.major }}
+      # One image and one set of containers per CUDA major. Without this both
+      # legs share the name, so whichever ran first decides what the other
+      # tests, and either one's cleanup tears down the other's containers.
+      COMPOSE_PROJECT_NAME: chucky-cuda${{ matrix.cuda.major }}
     steps:
       - uses: actions/checkout@v4
+
+      # `docker compose run` alone reuses whatever image the runner already has.
+      # The image carries the sources, so without this the job tests whatever
+      # commit the image was first built from.
+      - name: Build image (CUDA ${{ matrix.cuda.version }})
+        run: docker compose build test
 
       - name: Build and test (GPU, CUDA ${{ matrix.cuda.version }})
         run: docker compose run --rm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,16 +184,11 @@ jobs:
     env:
       CUDA_VERSION: ${{ matrix.cuda.version }}
       CUDA_MAJOR: ${{ matrix.cuda.major }}
-      # One image and one set of containers per CUDA major. Without this both
-      # legs share the name, so whichever ran first decides what the other
-      # tests, and either one's cleanup tears down the other's containers.
+      # One image and one set of containers per CUDA major version.
       COMPOSE_PROJECT_NAME: chucky-cuda${{ matrix.cuda.major }}
     steps:
       - uses: actions/checkout@v4
 
-      # `docker compose run` alone reuses whatever image the runner already has.
-      # The image carries the sources, so without this the job tests whatever
-      # commit the image was first built from.
       - name: Build image (CUDA ${{ matrix.cuda.version }})
         run: docker compose build test
 


### PR DESCRIPTION
`gpu-tests` runs `docker compose run --rm test`, which builds the image only when
the runner does not already have one. The image carries the sources — the
Dockerfile does `COPY . .` and builds inside — so on the self-hosted runner the
job has been testing whatever commit the image was first built from, not the
commit under test.

It has been that way since roughly 2026-04-26. The tell is on any recent PR: both
legs finish in about 44 seconds and run 45 tests, where the tree now registers 54,
and their list still holds `test_aggregate` and `test_flush_drain_multiarray_gpu`,
targets removed in #125 and #118.

Building the image explicitly fixes that. Both legs also shared one compose
project name, so they shared one image and one set of containers: the first leg
to run decided what the second tested, and either one's `docker compose down`
could tear down the other's minio. A per-major project name separates them.

Expect the first run here to be slow, and to fail if anything has broken on the
GPU path in the last three months. That is the point of the change.
