### PR TITLE
Test timing metrics

### DIFF
--- a/src/gpu/stream.ingest.c
+++ b/src/gpu/stream.ingest.c
@@ -83,6 +83,9 @@ ingest_destroy(struct staging_state* stage)
     cu_event_destroy(stage->timing[i].t_start);
     cu_event_destroy(stage->timing[i].t_end);
   }
+  // Setup tears itself down before returning an error and the caller tears
+  // down again, so this has to be safe to run twice.
+  memset(stage, 0, sizeof(*stage));
 }
 
 void

--- a/src/gpu/stream.ingest.h
+++ b/src/gpu/stream.ingest.h
@@ -19,7 +19,9 @@ ingest_init(struct staging_state* stage,
             struct gpu_ordering* ord,
             CUstream compute);
 
-// Free staging buffers and events.
+// Free staging buffers and events. The caller synchronizes the streams first:
+// a copy still reading a staging buffer faults once it is freed. Safe to call
+// twice, and on a state whose setup failed.
 void
 ingest_destroy(struct staging_state* stage);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -200,5 +200,6 @@ add_test_exe(test_append_latency test_append_latency.c stream_config chucky_log)
 add_gpu_test_exe(test_lod         test_lod.c         LINKS CUDA::cuda_driver CUDA::cudart_static lod lod_plan index_ops morton_util)
 add_gpu_test_exe(test_lod_dtypes  test_lod_dtypes.cu LINKS CUDA::cuda_driver CUDA::cudart_static lod lod_plan)
 add_gpu_test_exe(test_multiscale  test_multiscale.c  LINKS CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd test_data test_shard_sink)
+add_gpu_test_exe(test_metrics     test_metrics.c     LINKS CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd test_shard_sink)
 
 add_subdirectory(experiments)

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -6,6 +6,7 @@
 
 #include "index.ops.util.h"
 #include "test_gpu_helpers.h"
+#include "test_metric_check.h"
 #include "test_runner.h"
 #include "test_shard_sink.h"
 
@@ -117,6 +118,7 @@ test_ctx_setup(struct test_ctx* c,
   c->metrics.d2h = mk_stream_metric("D2H", METRIC_OWNER_D2H);
   c->metrics.sink = mk_stream_metric("Sink", METRIC_OWNER_DRAIN);
   c->metrics.lod_gather = mk_stream_metric("LOD Gather", METRIC_OWNER_COMPUTE);
+  c->metrics.tail_gate = mk_stream_metric("TailGate", METRIC_OWNER_COMPRESS);
 
   memset(&c->lod, 0, sizeof(c->lod));
   memset(&c->lod_shared, 0, sizeof(c->lod_shared));
@@ -229,6 +231,15 @@ test_d2h_single_epoch_none(void)
   // Verify metrics (sink uses platform_toc, always fires)
   CHECK(Fail, c.metrics.sink.count == 1);
   CHECK(Fail, c.metrics.lod_gather.count == 0);
+
+  // Pass-through runs no codec, so a missing compress row is the truth here
+  // rather than a lost measurement. Everything else the drain times must
+  // arrive.
+  CHECK(Fail, c.metrics.compress.count == 0);
+  CHECK(Fail, metric_arrived(&c.metrics.aggregate, 1));
+  CHECK(Fail, metric_arrived(&c.metrics.d2h, 1));
+  // The gate is a wait, and a wait that never had to wait measures zero.
+  CHECK(Fail, c.metrics.tail_gate.count == 1);
 
   // Tile data correctness verified by test_compress_agg
 
@@ -436,6 +447,13 @@ test_d2h_zstd_single_epoch(void)
 
   CHECK(Fail, sink.finalize_count == 1);
   CHECK(Fail, sink.writers[0][0].size > 0);
+
+  // Every stage the drain times must report one measurement. A codec runs
+  // here, so compress has an interval to report as well.
+  CHECK(Fail, metric_arrived(&c.metrics.compress, 1));
+  CHECK(Fail, metric_arrived(&c.metrics.aggregate, 1));
+  CHECK(Fail, metric_arrived(&c.metrics.d2h, 1));
+  CHECK(Fail, c.metrics.tail_gate.count == 1);
 
   // Decompress and verify chunk data via the on-disk index.
   {
@@ -736,6 +754,13 @@ test_d2h_zstd_double_buffer(void)
   }
 
   CHECK(Fail, sink.finalize_count == 2);
+
+  // Four cycles, four measurements per stage. The timing events belong to the
+  // slot, not the cycle, so a slot reused on cycle 3 has to re-record them.
+  CHECK(Fail, metric_arrived(&c.metrics.compress, 4));
+  CHECK(Fail, metric_arrived(&c.metrics.aggregate, 4));
+  CHECK(Fail, metric_arrived(&c.metrics.d2h, 4));
+  CHECK(Fail, c.metrics.tail_gate.count == 4);
 
   {
     struct shard_state* ss = &c.ca.ar.shard[0];

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -1,6 +1,7 @@
 #include "gpu/flush.compress_agg.h"
 #include "gpu/flush.d2h_deliver.h"
 #include "gpu/schedule.h"
+#include "gpu/stream.engine.h"
 #include "platform/platform.h"
 #include "stream/config.h"
 
@@ -112,13 +113,7 @@ test_ctx_setup(struct test_ctx* c,
     (uint32_t*)calloc(c->cl.epochs_per_batch, sizeof(uint32_t));
   CHECK(Fail, c->batch_active_masks);
 
-  memset(&c->metrics, 0, sizeof(c->metrics));
-  c->metrics.compress = mk_stream_metric("Compress", METRIC_OWNER_COMPRESS);
-  c->metrics.aggregate = mk_stream_metric("Aggregate", METRIC_OWNER_COMPRESS);
-  c->metrics.d2h = mk_stream_metric("D2H", METRIC_OWNER_D2H);
-  c->metrics.sink = mk_stream_metric("Sink", METRIC_OWNER_DRAIN);
-  c->metrics.lod_gather = mk_stream_metric("LOD Gather", METRIC_OWNER_COMPUTE);
-  c->metrics.tail_gate = mk_stream_metric("TailGate", METRIC_OWNER_COMPRESS);
+  c->metrics = stream_engine_init_metrics(0);
 
   memset(&c->lod, 0, sizeof(c->lod));
   memset(&c->lod_shared, 0, sizeof(c->lod_shared));
@@ -228,18 +223,15 @@ test_d2h_single_epoch_none(void)
   CHECK(Fail, sink.open_count == 1);     // shard_inner_count=1
   CHECK(Fail, sink.finalize_count == 0); // tps_0=2, need 2 epochs
 
-  // Verify metrics (sink uses platform_toc, always fires)
-  CHECK(Fail, c.metrics.sink.count == 1);
-  CHECK(Fail, c.metrics.lod_gather.count == 0);
+  // Sink is host-clocked, so it fires without CUDA events.
+  CHECK(Fail, metric_arrived_timed(&c.metrics.sink, 1));
+  CHECK(Fail, metric_arrived(&c.metrics.lod_gather, 0));
 
-  // Pass-through runs no codec, so a missing compress row is the truth here
-  // rather than a lost measurement. Everything else the drain times must
-  // arrive.
-  CHECK(Fail, c.metrics.compress.count == 0);
-  CHECK(Fail, metric_arrived(&c.metrics.aggregate, 1));
-  CHECK(Fail, metric_arrived(&c.metrics.d2h, 1));
-  // The gate is a wait, and a wait that never had to wait measures zero.
-  CHECK(Fail, c.metrics.tail_gate.count == 1);
+  // Pass-through runs no codec, so a missing compress row is the truth here.
+  CHECK(Fail, metric_arrived(&c.metrics.compress, 0));
+  CHECK(Fail, metric_arrived_timed(&c.metrics.aggregate, 1));
+  CHECK(Fail, metric_arrived_timed(&c.metrics.d2h, 1));
+  CHECK(Fail, metric_arrived(&c.metrics.tail_gate, 1));
 
   // Tile data correctness verified by test_compress_agg
 
@@ -448,12 +440,10 @@ test_d2h_zstd_single_epoch(void)
   CHECK(Fail, sink.finalize_count == 1);
   CHECK(Fail, sink.writers[0][0].size > 0);
 
-  // Every stage the drain times must report one measurement. A codec runs
-  // here, so compress has an interval to report as well.
-  CHECK(Fail, metric_arrived(&c.metrics.compress, 1));
-  CHECK(Fail, metric_arrived(&c.metrics.aggregate, 1));
-  CHECK(Fail, metric_arrived(&c.metrics.d2h, 1));
-  CHECK(Fail, c.metrics.tail_gate.count == 1);
+  CHECK(Fail, metric_arrived_timed(&c.metrics.compress, 1));
+  CHECK(Fail, metric_arrived_timed(&c.metrics.aggregate, 1));
+  CHECK(Fail, metric_arrived_timed(&c.metrics.d2h, 1));
+  CHECK(Fail, metric_arrived(&c.metrics.tail_gate, 1));
 
   // Decompress and verify chunk data via the on-disk index.
   {
@@ -755,12 +745,13 @@ test_d2h_zstd_double_buffer(void)
 
   CHECK(Fail, sink.finalize_count == 2);
 
-  // Four cycles, four measurements per stage. The timing events belong to the
-  // slot, not the cycle, so a slot reused on cycle 3 has to re-record them.
-  CHECK(Fail, metric_arrived(&c.metrics.compress, 4));
-  CHECK(Fail, metric_arrived(&c.metrics.aggregate, 4));
-  CHECK(Fail, metric_arrived(&c.metrics.d2h, 4));
-  CHECK(Fail, c.metrics.tail_gate.count == 4);
+  // Counts only reach so far. These events are seeded at setup, so a cycle
+  // that skipped its record still reports a plausible interval; catching that
+  // needs the ordering check the ingest tests use.
+  CHECK(Fail, metric_arrived_timed(&c.metrics.compress, 4));
+  CHECK(Fail, metric_arrived_timed(&c.metrics.aggregate, 4));
+  CHECK(Fail, metric_arrived_timed(&c.metrics.d2h, 4));
+  CHECK(Fail, metric_arrived(&c.metrics.tail_gate, 4));
 
   {
     struct shard_state* ss = &c.ca.ar.shard[0];

--- a/tests/test_d2h_deliver.c
+++ b/tests/test_d2h_deliver.c
@@ -745,9 +745,8 @@ test_d2h_zstd_double_buffer(void)
 
   CHECK(Fail, sink.finalize_count == 2);
 
-  // Counts only reach so far. These events are seeded at setup, so a cycle
-  // that skipped its record still reports a plausible interval; catching that
-  // needs the ordering check the ingest tests use.
+  // These events are seeded at setup, so a cycle that skipped its record
+  // still reports a plausible interval. Counting alone cannot see that.
   CHECK(Fail, metric_arrived_timed(&c.metrics.compress, 4));
   CHECK(Fail, metric_arrived_timed(&c.metrics.aggregate, 4));
   CHECK(Fail, metric_arrived_timed(&c.metrics.d2h, 4));

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -18,30 +18,82 @@ as_view(CUdeviceptr d)
   return (struct gpu_pool_view){ .p = (void*)(uintptr_t)d };
 }
 
-// Both dispatch paths record the same two events and mark the same ring, and
-// nothing downstream notices when a mark goes missing: a metric that never
-// arrives keeps count 0, and the bench report drops the row. Call after both
-// streams are synchronized, once per dispatch count of 2 or fewer — the H2D
-// side has one entry per staging slot, of which there are two.
+// A timestamp for the dispatches' timing events to be ordered against. The
+// synchronize is the point of it: the events seeded when the staging state was
+// created must run first, or the marker lands before them and nothing below
+// can ever fail.
 static int
-check_ingest_timing(struct staging_state* stage, int dispatches)
+record_marker(CUevent* marker, CUstream compute, CUstream h2d)
+{
+  CU(Error, cuEventCreate(marker, CU_EVENT_DEFAULT));
+  CU(Error, cuStreamSynchronize(compute));
+  CU(Error, cuEventRecord(*marker, h2d));
+  return 0;
+
+Error:
+  return 1;
+}
+
+static int
+event_is_after(CUevent marker, CUevent e, const char* what, int which)
+{
+  float ms = 0;
+  CU(Error, cuEventElapsedTime(&ms, marker, e));
+  if (ms < 0.0f) {
+    log_error("  %s %d reported a stale event", what, which);
+    return 0;
+  }
+  return 1;
+
+Error:
+  return 0;
+}
+
+// Setup seeds these events and a reuse overwrites them in place, so a dispatch
+// that failed to record one still reports a measurement, taken from the stale
+// event. Counting cannot see that; ordering against a marker that predates the
+// dispatches can.
+static int
+timing_events_are_fresh(struct staging_state* stage, CUevent marker)
+{
+  int ok = 1;
+  for (int i = 0; i < (int)countof(stage->slot); ++i)
+    if (stage->slot[i].h2d_pending)
+      ok &= event_is_after(marker, stage->slot[i].t_h2d_start, "H2D slot", i);
+  for (int i = 0; i < SCATTER_TIMING_SLOTS; ++i)
+    if (stage->timing[i].pending)
+      ok &= event_is_after(marker, stage->timing[i].t_end, "Scatter entry", i);
+  return ok;
+}
+
+// Reports every broken stage rather than the first: a rerun costs a GPU.
+// `marker` must predate every dispatch, and both streams must be synchronized.
+static int
+check_ingest_timing(struct staging_state* stage,
+                    CUevent marker,
+                    int h2d_count,
+                    int scatter_count,
+                    uint64_t expected_lost)
 {
   struct stream_metric h2d = mk_stream_metric("H2D", METRIC_OWNER_H2D);
   struct stream_metric scatter =
     mk_stream_metric("Scatter", METRIC_OWNER_COMPUTE);
 
+  // Read before collecting, which clears the pending flags these key on.
+  int ok = timing_events_are_fresh(stage, marker);
+
   ingest_collect_h2d_timing(stage, &h2d);
   ingest_collect_scatter_timing(stage, &scatter);
 
-  if (!metric_arrived(&h2d, dispatches) ||
-      !metric_arrived(&scatter, dispatches))
-    return 1;
-  if (stage->scatter_samples_lost != 0) {
-    log_error("  scatter ring wrapped %llu times",
-              (unsigned long long)stage->scatter_samples_lost);
-    return 1;
+  ok &= metric_arrived_timed(&h2d, h2d_count);
+  ok &= metric_arrived_timed(&scatter, scatter_count);
+  if (stage->scatter_samples_lost != expected_lost) {
+    log_error("  scatter ring wrapped %llu times, expected %llu",
+              (unsigned long long)stage->scatter_samples_lost,
+              (unsigned long long)expected_lost);
+    ok = 0;
   }
-  return 0;
+  return ok;
 }
 
 // --- Tests ---
@@ -77,6 +129,7 @@ test_ingest_incremental(void)
   struct staging_state stage = { 0 };
   struct gpu_ordering ord = { 0 };
   CUstream h2d = 0, compute = 0;
+  CUevent marker = 0;
   CUdeviceptr d_pool = 0;
   void* h_pool = NULL;
   uint16_t* h_src = NULL;
@@ -88,6 +141,7 @@ test_ingest_incremental(void)
   gpu_ordering_register_stream(&ord, GPU_STREAM_H2D, h2d);
   gpu_ordering_register_stream(&ord, GPU_STREAM_COMPUTE, compute);
   CHECK(Fail, ingest_init(&stage, half, &ord, compute) == 0);
+  CHECK(Fail, record_marker(&marker, compute, h2d) == 0);
 
   CU(Fail, cuMemAlloc(&d_pool, pool_bytes));
   // On the scatter's stream, so the clear cannot land after it.
@@ -130,7 +184,7 @@ test_ingest_incremental(void)
   CU(Fail, cuStreamSynchronize(compute));
   CU(Fail, cuStreamSynchronize(h2d));
 
-  CHECK(Fail, check_ingest_timing(&stage, 2) == 0);
+  CHECK(Fail, check_ingest_timing(&stage, marker, 2, 2, 0));
 
   h_pool = calloc(1, pool_bytes);
   CHECK(Fail, h_pool);
@@ -167,10 +221,13 @@ test_ingest_incremental(void)
   ok = 1;
 
 Fail:
+  cu_stream_sync(compute);
+  cu_stream_sync(h2d);
   free(h_src);
   free(h_pool);
   ingest_destroy(&stage);
   gpu_ordering_destroy(&ord);
+  cu_event_destroy(marker);
   cu_mem_free(d_pool);
   cu_stream_destroy(h2d);
   cu_stream_destroy(compute);
@@ -214,6 +271,7 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   struct staging_state stage = { 0 };
   struct gpu_ordering ord = { 0 };
   CUstream h2d = 0, compute = 0;
+  CUevent marker = 0;
   CUdeviceptr d_pool = 0;
   void* h_pool = NULL;
   uint16_t* h_src = NULL;
@@ -225,6 +283,7 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   gpu_ordering_register_stream(&ord, GPU_STREAM_H2D, h2d);
   gpu_ordering_register_stream(&ord, GPU_STREAM_COMPUTE, compute);
   CHECK(Fail, ingest_init(&stage, src_bytes, &ord, compute) == 0);
+  CHECK(Fail, record_marker(&marker, compute, h2d) == 0);
 
   CU(Fail, cuMemAlloc(&d_pool, pool_bytes));
   // On the scatter's stream, so the clear cannot land after it.
@@ -254,7 +313,7 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   CU(Fail, cuStreamSynchronize(compute));
   CU(Fail, cuStreamSynchronize(h2d));
 
-  CHECK(Fail, check_ingest_timing(&stage, 1) == 0);
+  CHECK(Fail, check_ingest_timing(&stage, marker, 1, 1, 0));
 
   h_pool = calloc(1, pool_bytes);
   CHECK(Fail, h_pool);
@@ -289,10 +348,13 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   ok = 1;
 
 Fail:
+  cu_stream_sync(compute);
+  cu_stream_sync(h2d);
   free(h_src);
   free(h_pool);
   ingest_destroy(&stage);
   gpu_ordering_destroy(&ord);
+  cu_event_destroy(marker);
   cu_mem_free(d_pool);
   cu_stream_destroy(h2d);
   cu_stream_destroy(compute);
@@ -338,6 +400,7 @@ test_ingest_multiscale(void)
   struct staging_state stage = { 0 };
   struct gpu_ordering ord = { 0 };
   CUstream h2d = 0, compute = 0;
+  CUevent marker = 0;
   CUdeviceptr d_linear = 0;
   uint16_t* h_src = NULL;
   void* h_out = NULL;
@@ -349,6 +412,7 @@ test_ingest_multiscale(void)
   gpu_ordering_register_stream(&ord, GPU_STREAM_H2D, h2d);
   gpu_ordering_register_stream(&ord, GPU_STREAM_COMPUTE, compute);
   CHECK(Fail, ingest_init(&stage, src_bytes, &ord, compute) == 0);
+  CHECK(Fail, record_marker(&marker, compute, h2d) == 0);
 
   CU(Fail, cuMemAlloc(&d_linear, src_bytes));
   CU(Fail, cuMemsetD8(d_linear, 0, src_bytes));
@@ -373,7 +437,7 @@ test_ingest_multiscale(void)
   // The ring mark lives in each caller rather than the helper they share, so
   // it has to be repeated here. #191 left it out of this path, throwing away
   // every measurement and losing the report's Copy row. Nothing else noticed.
-  CHECK(Fail, check_ingest_timing(&stage, 1) == 0);
+  CHECK(Fail, check_ingest_timing(&stage, marker, 1, 1, 0));
 
   h_out = malloc(src_bytes);
   CHECK(Fail, h_out);
@@ -384,10 +448,13 @@ test_ingest_multiscale(void)
   ok = 1;
 
 Fail:
+  cu_stream_sync(compute);
+  cu_stream_sync(h2d);
   free(h_src);
   free(h_out);
   ingest_destroy(&stage);
   gpu_ordering_destroy(&ord);
+  cu_event_destroy(marker);
   cu_mem_free(d_linear);
   cu_stream_destroy(h2d);
   cu_stream_destroy(compute);
@@ -396,10 +463,9 @@ Fail:
   return ok ? 0 : 1;
 }
 
-// Dispatching more times than the ring holds without collecting overwrites the
-// oldest measurements. Those show up only in scatter_samples_lost, so a test
-// that asserts the counter is zero elsewhere needs this one to prove the
-// counter can be non-zero at all.
+// Overrunning the ring without collecting overwrites the oldest measurements,
+// and only the lost-sample counter records it. Every other test asserts that
+// counter is zero, so one has to drive it non-zero for those to mean anything.
 static int
 test_ingest_timing_ring_wraps(void)
 {
@@ -414,6 +480,7 @@ test_ingest_timing_ring_wraps(void)
   struct staging_state stage = { 0 };
   struct gpu_ordering ord = { 0 };
   CUstream h2d = 0, compute = 0;
+  CUevent before_all = 0, before_reuse = 0;
   CUdeviceptr d_linear = 0;
   int ok = 0;
 
@@ -423,6 +490,7 @@ test_ingest_timing_ring_wraps(void)
   gpu_ordering_register_stream(&ord, GPU_STREAM_H2D, h2d);
   gpu_ordering_register_stream(&ord, GPU_STREAM_COMPUTE, compute);
   CHECK(Fail, ingest_init(&stage, src_bytes, &ord, compute) == 0);
+  CHECK(Fail, record_marker(&before_all, compute, h2d) == 0);
 
   CU(Fail, cuMemAlloc(&d_linear, src_bytes));
 
@@ -431,6 +499,10 @@ test_ingest_timing_ring_wraps(void)
     CHECK(Fail,
           gpu_pool_host_acquire_produce(&stage.h_pool, stage.current, &h_in) ==
             0);
+    // The last two dispatches leave each staging slot's start event behind, so
+    // a marker here proves both were re-recorded. No other test reuses a slot.
+    if (i == dispatches - 2)
+      CHECK(Fail, record_marker(&before_reuse, compute, h2d) == 0);
     memset(h_in.p, i + 1, src_bytes);
     stage.bytes_written = src_bytes;
     CHECK(
@@ -443,20 +515,30 @@ test_ingest_timing_ring_wraps(void)
   CU(Fail, cuStreamSynchronize(compute));
   CU(Fail, cuStreamSynchronize(h2d));
 
-  CHECK(Fail, stage.scatter_samples_lost == (uint64_t)extra);
+  // Before the collect, which clears the flags this reads.
+  for (int i = 0; i < (int)countof(stage.slot); ++i)
+    CHECK(Fail,
+          event_is_after(
+            before_reuse, stage.slot[i].t_h2d_start, "reused H2D slot", i));
 
-  {
-    struct stream_metric scatter =
-      mk_stream_metric("Scatter", METRIC_OWNER_COMPUTE);
-    ingest_collect_scatter_timing(&stage, &scatter);
-    CHECK(Fail, metric_arrived(&scatter, SCATTER_TIMING_SLOTS));
-  }
+  // The ring keeps one entry per slot and H2D one per staging slot, so the
+  // surviving counts are the capacities rather than the dispatch count.
+  CHECK(Fail,
+        check_ingest_timing(&stage,
+                            before_all,
+                            (int)countof(stage.slot),
+                            SCATTER_TIMING_SLOTS,
+                            (uint64_t)extra));
 
   ok = 1;
 
 Fail:
+  cu_stream_sync(compute);
+  cu_stream_sync(h2d);
   ingest_destroy(&stage);
   gpu_ordering_destroy(&ord);
+  cu_event_destroy(before_all);
+  cu_event_destroy(before_reuse);
   cu_mem_free(d_linear);
   cu_stream_destroy(h2d);
   cu_stream_destroy(compute);

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -19,9 +19,8 @@ as_view(CUdeviceptr d)
 }
 
 // A timestamp for the dispatches' timing events to be ordered against. The
-// synchronize is the point of it: the events seeded when the staging state was
-// created must run first, or the marker lands before them and nothing below
-// can ever fail.
+// synchronize matters: events seeded when the staging state was created must
+// run first, or the marker lands before them and nothing below can fail.
 static int
 record_marker(CUevent* marker, CUstream compute, CUstream h2d)
 {
@@ -434,9 +433,7 @@ test_ingest_multiscale(void)
   CU(Fail, cuStreamSynchronize(compute));
   CU(Fail, cuStreamSynchronize(h2d));
 
-  // The ring mark lives in each caller rather than the helper they share, so
-  // it has to be repeated here. #191 left it out of this path, throwing away
-  // every measurement and losing the report's Copy row. Nothing else noticed.
+  // #191 lost this path's measurements and the report lost its Copy row.
   CHECK(Fail, check_ingest_timing(&stage, marker, 1, 1, 0));
 
   h_out = malloc(src_bytes);
@@ -463,9 +460,9 @@ Fail:
   return ok ? 0 : 1;
 }
 
-// Overrunning the ring without collecting overwrites the oldest measurements,
-// and only the lost-sample counter records it. Every other test asserts that
-// counter is zero, so one has to drive it non-zero for those to mean anything.
+// Overrunning the ring overwrites the oldest measurements, and only the
+// lost-sample counter records it. Other tests assert it is zero; this drives
+// it.
 static int
 test_ingest_timing_ring_wraps(void)
 {
@@ -521,8 +518,8 @@ test_ingest_timing_ring_wraps(void)
           event_is_after(
             before_reuse, stage.slot[i].t_h2d_start, "reused H2D slot", i));
 
-  // The ring keeps one entry per slot and H2D one per staging slot, so the
-  // surviving counts are the capacities rather than the dispatch count.
+  // Each side keeps one entry per slot, so the surviving counts are the
+  // capacities rather than the dispatch count.
   CHECK(Fail,
         check_ingest_timing(&stage,
                             before_all,

--- a/tests/test_ingest.c
+++ b/tests/test_ingest.c
@@ -1,8 +1,10 @@
 #include "gpu/prelude.cuda.h"
 #include "gpu/stream.ingest.h"
 #include "index.ops.util.h"
+#include "stream/config.h"
 #include "util/prelude.h"
 
+#include "test_metric_check.h"
 #include "test_runner.h"
 
 #include <stdlib.h>
@@ -14,6 +16,32 @@ static struct gpu_pool_view
 as_view(CUdeviceptr d)
 {
   return (struct gpu_pool_view){ .p = (void*)(uintptr_t)d };
+}
+
+// Both dispatch paths record the same two events and mark the same ring, and
+// nothing downstream notices when a mark goes missing: a metric that never
+// arrives keeps count 0, and the bench report drops the row. Call after both
+// streams are synchronized, once per dispatch count of 2 or fewer — the H2D
+// side has one entry per staging slot, of which there are two.
+static int
+check_ingest_timing(struct staging_state* stage, int dispatches)
+{
+  struct stream_metric h2d = mk_stream_metric("H2D", METRIC_OWNER_H2D);
+  struct stream_metric scatter =
+    mk_stream_metric("Scatter", METRIC_OWNER_COMPUTE);
+
+  ingest_collect_h2d_timing(stage, &h2d);
+  ingest_collect_scatter_timing(stage, &scatter);
+
+  if (!metric_arrived(&h2d, dispatches) ||
+      !metric_arrived(&scatter, dispatches))
+    return 1;
+  if (stage->scatter_samples_lost != 0) {
+    log_error("  scatter ring wrapped %llu times",
+              (unsigned long long)stage->scatter_samples_lost);
+    return 1;
+  }
+  return 0;
 }
 
 // --- Tests ---
@@ -115,6 +143,8 @@ test_ingest_incremental(void)
 
   CU(Fail, cuStreamSynchronize(compute));
   CU(Fail, cuStreamSynchronize(h2d));
+
+  CHECK(Fail, check_ingest_timing(&stage, 2) == 0);
 
   h_pool = calloc(1, pool_bytes);
   CHECK(Fail, h_pool);
@@ -253,6 +283,8 @@ run_epochs_from(uint32_t n_epochs, uint64_t first_element)
   CU(Fail, cuStreamSynchronize(compute));
   CU(Fail, cuStreamSynchronize(h2d));
 
+  CHECK(Fail, check_ingest_timing(&stage, 1) == 0);
+
   h_pool = calloc(1, pool_bytes);
   CHECK(Fail, h_pool);
   CU(Fail, cuMemcpyDtoH(h_pool, d_pool, pool_bytes));
@@ -367,6 +399,11 @@ test_ingest_multiscale(void)
   CU(Fail, cuStreamSynchronize(compute));
   CU(Fail, cuStreamSynchronize(h2d));
 
+  // The ring mark lives in each caller rather than the helper they share, so
+  // it has to be repeated here. #191 left it out of this path, throwing away
+  // every measurement and losing the report's Copy row. Nothing else noticed.
+  CHECK(Fail, check_ingest_timing(&stage, 1) == 0);
+
   h_out = malloc(src_bytes);
   CHECK(Fail, h_out);
   CU(Fail, cuMemcpyDtoH(h_out, d_linear, src_bytes));
@@ -388,10 +425,80 @@ Fail:
   return ok ? 0 : 1;
 }
 
+// Dispatching more times than the ring holds without collecting overwrites the
+// oldest measurements. Those show up only in scatter_samples_lost, so a test
+// that asserts the counter is zero elsewhere needs this one to prove the
+// counter can be non-zero at all.
+static int
+test_ingest_timing_ring_wraps(void)
+{
+  log_info("=== test_ingest_timing_ring_wraps ===");
+
+  const size_t bytes_per_element = 2;
+  const uint64_t epoch_elements = 48;
+  const size_t src_bytes = epoch_elements * bytes_per_element;
+  const int extra = 2;
+  const int dispatches = SCATTER_TIMING_SLOTS + extra;
+
+  struct staging_state stage = { 0 };
+  struct gpu_ordering ord = { 0 };
+  CUstream h2d = 0, compute = 0;
+  CUdeviceptr d_linear = 0;
+  int ok = 0;
+
+  CU(Fail, cuStreamCreate(&h2d, CU_STREAM_NON_BLOCKING));
+  CU(Fail, cuStreamCreate(&compute, CU_STREAM_NON_BLOCKING));
+  CHECK(Fail, gpu_ordering_init(&ord, compute) == 0);
+  gpu_ordering_register_stream(&ord, GPU_STREAM_H2D, h2d);
+  gpu_ordering_register_stream(&ord, GPU_STREAM_COMPUTE, compute);
+  CHECK(Fail, ingest_init(&stage, src_bytes, &ord, compute) == 0);
+
+  CU(Fail, cuMemAlloc(&d_linear, src_bytes));
+
+  for (int i = 0; i < dispatches; ++i) {
+    struct gpu_pool_view h_in;
+    CHECK(Fail,
+          gpu_pool_host_acquire_produce(&stage.h_pool, stage.current, &h_in) ==
+            0);
+    memset(h_in.p, i + 1, src_bytes);
+    stage.bytes_written = src_bytes;
+    CHECK(
+      Fail,
+      ingest_dispatch_multiscale(
+        &stage, d_linear, epoch_elements, 0, bytes_per_element, h2d, compute) ==
+        0);
+  }
+
+  CU(Fail, cuStreamSynchronize(compute));
+  CU(Fail, cuStreamSynchronize(h2d));
+
+  CHECK(Fail, stage.scatter_samples_lost == (uint64_t)extra);
+
+  {
+    struct stream_metric scatter =
+      mk_stream_metric("Scatter", METRIC_OWNER_COMPUTE);
+    ingest_collect_scatter_timing(&stage, &scatter);
+    CHECK(Fail, metric_arrived(&scatter, SCATTER_TIMING_SLOTS));
+  }
+
+  ok = 1;
+
+Fail:
+  ingest_destroy(&stage);
+  gpu_ordering_destroy(&ord);
+  cu_mem_free(d_linear);
+  cu_stream_destroy(h2d);
+  cu_stream_destroy(compute);
+
+  log_info("  %s", ok ? "PASS" : "FAIL");
+  return ok ? 0 : 1;
+}
+
 RUN_GPU_TESTS({ "ingest_single_epoch", test_ingest_single_epoch },
               { "ingest_incremental", test_ingest_incremental },
               { "ingest_many_epochs_one_dispatch",
                 test_ingest_many_epochs_one_dispatch },
               { "ingest_many_epochs_from_mid_epoch",
                 test_ingest_many_epochs_from_mid_epoch },
-              { "ingest_multiscale", test_ingest_multiscale }, )
+              { "ingest_multiscale", test_ingest_multiscale },
+              { "ingest_timing_ring_wraps", test_ingest_timing_ring_wraps }, )

--- a/tests/test_metric_check.h
+++ b/tests/test_metric_check.h
@@ -1,0 +1,50 @@
+#ifndef TEST_METRIC_CHECK_H
+#define TEST_METRIC_CHECK_H
+
+#include "log/log.h"
+#include "types.stream.h"
+
+// A stage whose measurements never arrive keeps count 0, and the bench report
+// drops a zero-count row instead of printing zeros. So a stage that was never
+// measured looks like a stage that was never run. Checking the count is what
+// tells the two apart.
+//
+// Only the count and a duration above zero are checked. A threshold on the
+// duration would be flaky on a shared machine, and the failure this guards
+// against is a measurement that never arrives at all.
+static inline int
+metric_arrived(const struct stream_metric* m, int expected_count)
+{
+  const char* name = m->name ? m->name : "(unnamed)";
+  if (m->count != expected_count) {
+    log_error(
+      "  %s: expected %d measurements, got %d", name, expected_count, m->count);
+    return 0;
+  }
+  if (expected_count > 0 && !(m->ms > 0.0f)) {
+    log_error(
+      "  %s: %d measurements totalling %g ms", name, m->count, (double)m->ms);
+    return 0;
+  }
+  return 1;
+}
+
+// The same check without pinning the number, for whole-stream runs where how
+// many measurements a stage takes depends on how the schedule split the work.
+static inline int
+metric_arrived_at_least_once(const struct stream_metric* m)
+{
+  const char* name = m->name ? m->name : "(unnamed)";
+  if (m->count <= 0) {
+    log_error("  %s: no measurement arrived", name);
+    return 0;
+  }
+  if (!(m->ms > 0.0f)) {
+    log_error(
+      "  %s: %d measurements totalling %g ms", name, m->count, (double)m->ms);
+    return 0;
+  }
+  return 1;
+}
+
+#endif // TEST_METRIC_CHECK_H

--- a/tests/test_metric_check.h
+++ b/tests/test_metric_check.h
@@ -4,47 +4,74 @@
 #include "log/log.h"
 #include "types.stream.h"
 
-// A stage whose measurements never arrive keeps count 0, and the bench report
-// drops a zero-count row instead of printing zeros. So a stage that was never
-// measured looks like a stage that was never run. Checking the count is what
-// tells the two apart.
+// A stage that was never measured keeps count 0, and the report drops a
+// zero-count row, so it reads as a stage that never ran. Count is the contract.
 //
-// Only the count and a duration above zero are checked. A threshold on the
-// duration would be flaky on a shared machine, and the failure this guards
-// against is a measurement that never arrives at all.
+// Hold an interval that brackets work to a positive duration. The smallest here
+// is 6 to 7 us against a timer resolving to about half of one. An interval that
+// brackets a wait is the exception: a wait that never waited is honestly zero.
+
 static inline int
 metric_arrived(const struct stream_metric* m, int expected_count)
 {
-  const char* name = m->name ? m->name : "(unnamed)";
   if (m->count != expected_count) {
-    log_error(
-      "  %s: expected %d measurements, got %d", name, expected_count, m->count);
+    log_error("  %s: expected %d measurements, got %d",
+              m->name,
+              expected_count,
+              m->count);
     return 0;
   }
-  if (expected_count > 0 && !(m->ms > 0.0f)) {
+  // A total hides one backwards interval among good ones. The fastest single
+  // measurement cannot: a negative is smaller than anything real.
+  if (m->count > 0 && m->best_ms < 0.0f) {
     log_error(
-      "  %s: %d measurements totalling %g ms", name, m->count, (double)m->ms);
+      "  %s: a measurement ran backwards, %g ms", m->name, (double)m->best_ms);
     return 0;
   }
   return 1;
 }
 
-// The same check without pinning the number, for whole-stream runs where how
-// many measurements a stage takes depends on how the schedule split the work.
+// Every one of the expected measurements took time the timer could resolve.
 static inline int
-metric_arrived_at_least_once(const struct stream_metric* m)
+metric_arrived_timed(const struct stream_metric* m, int expected_count)
 {
-  const char* name = m->name ? m->name : "(unnamed)";
-  if (m->count <= 0) {
-    log_error("  %s: no measurement arrived", name);
+  if (!metric_arrived(m, expected_count))
     return 0;
-  }
-  if (!(m->ms > 0.0f)) {
-    log_error(
-      "  %s: %d measurements totalling %g ms", name, m->count, (double)m->ms);
+  if (!(expected_count > 0 && m->best_ms > 0.0f)) {
+    log_error("  %s: a measurement took %g ms", m->name, (double)m->best_ms);
     return 0;
   }
   return 1;
+}
+
+// For whole-stream runs, where the schedule decides how many times a stage
+// ran. Holding each of an unknown number to the timer would buy a flake.
+static inline int
+metric_any_arrived_timed(const struct stream_metric* m)
+{
+  if (m->count <= 0) {
+    log_error("  %s: no measurement arrived", m->name);
+    return 0;
+  }
+  if (!(m->ms > 0.0f)) {
+    log_error("  %s: %d measurements totalling %g ms",
+              m->name,
+              m->count,
+              (double)m->ms);
+    return 0;
+  }
+  return 1;
+}
+
+// A ring that overwrote a measurement before anyone read it under-reports its
+// stage, and this counter is the only trace.
+static inline int
+no_samples_lost(const char* ring, uint64_t lost)
+{
+  if (lost == 0)
+    return 1;
+  log_error("  %s ring wrapped %llu times", ring, (unsigned long long)lost);
+  return 0;
 }
 
 #endif // TEST_METRIC_CHECK_H

--- a/tests/test_metrics.c
+++ b/tests/test_metrics.c
@@ -1,8 +1,6 @@
 // Every per-stage timing number the report prints comes from a pair of CUDA
 // events and a ring slot the caller has to mark. Drop the mark and the metric
-// keeps count 0, which the report prints as a missing row rather than a zero
-// (#191, #197). These tests run a whole stream and check that each stage the
-// run actually exercised reported at least one measurement.
+// keeps count 0, which the report prints as a missing row (#191, #197).
 #include "stream.gpu.h"
 #include "stream/layouts.h"
 #include "util/prelude.h"
@@ -12,8 +10,6 @@
 #include "test_shard_sink.h"
 
 #include <stdlib.h>
-
-#define EPOCHS 8
 
 static struct tile_stream_configuration
 make_config(struct dimension* dims, const char* downsample_names)
@@ -34,18 +30,21 @@ make_config(struct dimension* dims, const char* downsample_names)
   };
 }
 
-// Append EPOCHS epochs and flush, then hand back what the stream measured.
 static int
 run_stream(const char* downsample_names,
            struct stream_metrics* out,
            struct tile_stream_status* out_status)
 {
+  // Four batches at two epochs each. The schedule collects the LOD timing ring
+  // after every epoch, so it cannot wrap at any number of them.
+  const uint64_t epochs = 8;
+
   struct dimension dims[3];
   struct tile_stream_configuration config = make_config(dims, downsample_names);
 
   struct test_shard_sink sink;
   const int shards_per_level[] = { 32, 32, 32 };
-  test_sink_init_multi(&sink, 3, shards_per_level, 4 * 1024 * 1024);
+  test_sink_init_multi(&sink, 3, shards_per_level, 256 * 1024);
 
   struct tile_stream_gpu* s = NULL;
   uint16_t* src = NULL;
@@ -58,7 +57,7 @@ run_stream(const char* downsample_names,
 
   {
     const uint64_t elements =
-      EPOCHS * tile_stream_gpu_layout(s)->epoch_elements;
+      epochs * tile_stream_gpu_layout(s)->epoch_elements;
     src = (uint16_t*)malloc(elements * sizeof(uint16_t));
     CHECK(Fail, src);
     // Sequential values keep the codec from collapsing the payload to nothing.
@@ -81,123 +80,88 @@ Fail:
   return ok ? 0 : 1;
 }
 
-// Stages every run goes through, whatever the level geometry is.
+// Every stage is checked even after one has failed, so a run that lost several
+// reports them all: each rerun here costs a GPU allocation.
 static int
 check_shared_stages(const struct stream_metrics* m)
 {
-  return metric_arrived_at_least_once(&m->h2d) &&
-         metric_arrived_at_least_once(&m->scatter) &&
-         metric_arrived_at_least_once(&m->compress) &&
-         metric_arrived_at_least_once(&m->aggregate) &&
-         metric_arrived_at_least_once(&m->d2h) &&
-         metric_arrived_at_least_once(&m->sink) &&
-         // The gate is a wait, and a wait that never had to wait measures
-         // zero, so only its count says whether it was read.
-         m->tail_gate.count > 0;
+  int ok = 1;
+  ok &= metric_any_arrived_timed(&m->h2d);
+  ok &= metric_any_arrived_timed(&m->scatter);
+  ok &= metric_any_arrived_timed(&m->compress);
+  ok &= metric_any_arrived_timed(&m->aggregate);
+  ok &= metric_any_arrived_timed(&m->d2h);
+  ok &= metric_any_arrived_timed(&m->sink);
+  if (m->tail_gate.count <= 0) {
+    log_error("  %s: no measurement arrived", m->tail_gate.name);
+    ok = 0;
+  }
+  ok &= no_samples_lost("scatter", m->scatter_samples_lost);
+  // The LOD arm cannot fail while the schedule collects every epoch; it guards
+  // a change in that cadence rather than proving the collector kept up.
+  ok &= no_samples_lost("lod", m->lod_samples_lost);
+  return ok;
 }
 
+// The pyramid stages run only when there is a pyramid, and the fold only when
+// the append dimension is downsampled, so elsewhere their empty rows are the
+// truth.
 static int
-check_nothing_lost(const struct stream_metrics* m)
+run_case(const char* downsample_names, int expect_pyramid, int expect_fold)
 {
-  if (m->scatter_samples_lost != 0)
-    log_error("  scatter ring wrapped %llu times",
-              (unsigned long long)m->scatter_samples_lost);
-  if (m->lod_samples_lost != 0)
-    log_error("  lod ring wrapped %llu times",
-              (unsigned long long)m->lod_samples_lost);
-  return m->scatter_samples_lost == 0 && m->lod_samples_lost == 0;
+  struct stream_metrics m;
+  struct tile_stream_status st;
+  int ok = 0;
+
+  CHECK(Fail, run_stream(downsample_names, &m, &st) == 0);
+  CHECK(Fail, (st.nlod > 1) == expect_pyramid);
+  CHECK(Fail, st.append_downsample == expect_fold);
+
+  CHECK(Fail, check_shared_stages(&m));
+
+  if (expect_pyramid) {
+    CHECK(Fail, metric_any_arrived_timed(&m.lod_gather));
+    CHECK(Fail, metric_any_arrived_timed(&m.lod_reduce));
+    CHECK(Fail, metric_any_arrived_timed(&m.lod_morton_chunk));
+  } else {
+    CHECK(Fail, metric_arrived(&m.lod_gather, 0));
+    CHECK(Fail, metric_arrived(&m.lod_reduce, 0));
+    CHECK(Fail, metric_arrived(&m.lod_morton_chunk, 0));
+  }
+
+  if (expect_fold)
+    CHECK(Fail, metric_any_arrived_timed(&m.lod_append_fold));
+  else
+    CHECK(Fail, metric_arrived(&m.lod_append_fold, 0));
+
+  ok = 1;
+
+Fail:
+  log_info("  %s", ok ? "PASS" : "FAIL");
+  return ok ? 0 : 1;
 }
 
-// A single-level stream: the LOD stages never run, so their empty rows are
-// the truth rather than a lost measurement.
 static int
 test_metrics_single_level(void)
 {
   log_info("=== test_metrics_single_level ===");
-
-  struct stream_metrics m;
-  struct tile_stream_status st;
-  int ok = 0;
-
-  CHECK(Fail, run_stream(NULL, &m, &st) == 0);
-  CHECK(Fail, st.nlod == 1);
-
-  CHECK(Fail, check_shared_stages(&m));
-  CHECK(Fail, check_nothing_lost(&m));
-
-  CHECK(Fail, m.lod_gather.count == 0);
-  CHECK(Fail, m.lod_reduce.count == 0);
-  CHECK(Fail, m.lod_append_fold.count == 0);
-  CHECK(Fail, m.lod_morton_chunk.count == 0);
-
-  ok = 1;
-
-Fail:
-  log_info("  %s", ok ? "PASS" : "FAIL");
-  return ok ? 0 : 1;
+  return run_case(NULL, 0, 0);
 }
 
-// Downsampling the two bounded dimensions builds a pyramid without folding
-// along the append dimension. This is the path #191 broke: it takes the
-// device-to-device copy rather than the scatter, and the copy is what the
-// report calls Copy once multiscale is on.
+// #191 broke this path: with a pyramid the ingest takes the device-to-device
+// copy rather than the scatter, and that copy is the report's Copy row.
 static int
 test_metrics_multiscale(void)
 {
   log_info("=== test_metrics_multiscale ===");
-
-  struct stream_metrics m;
-  struct tile_stream_status st;
-  int ok = 0;
-
-  CHECK(Fail, run_stream("yx", &m, &st) == 0);
-  CHECK(Fail, st.nlod > 1);
-  CHECK(Fail, st.append_downsample == 0);
-
-  CHECK(Fail, check_shared_stages(&m));
-  CHECK(Fail, check_nothing_lost(&m));
-
-  CHECK(Fail, metric_arrived_at_least_once(&m.lod_gather));
-  CHECK(Fail, metric_arrived_at_least_once(&m.lod_reduce));
-  CHECK(Fail, metric_arrived_at_least_once(&m.lod_morton_chunk));
-  // The fold runs only when the append dimension is downsampled too.
-  CHECK(Fail, m.lod_append_fold.count == 0);
-
-  ok = 1;
-
-Fail:
-  log_info("  %s", ok ? "PASS" : "FAIL");
-  return ok ? 0 : 1;
+  return run_case("yx", 1, 0);
 }
 
-// Downsampling the append dimension as well adds the fold, the one LOD stage
-// the previous case cannot reach.
 static int
 test_metrics_append_downsample(void)
 {
   log_info("=== test_metrics_append_downsample ===");
-
-  struct stream_metrics m;
-  struct tile_stream_status st;
-  int ok = 0;
-
-  CHECK(Fail, run_stream("zyx", &m, &st) == 0);
-  CHECK(Fail, st.nlod > 1);
-  CHECK(Fail, st.append_downsample == 1);
-
-  CHECK(Fail, check_shared_stages(&m));
-  CHECK(Fail, check_nothing_lost(&m));
-
-  CHECK(Fail, metric_arrived_at_least_once(&m.lod_gather));
-  CHECK(Fail, metric_arrived_at_least_once(&m.lod_reduce));
-  CHECK(Fail, metric_arrived_at_least_once(&m.lod_morton_chunk));
-  CHECK(Fail, metric_arrived_at_least_once(&m.lod_append_fold));
-
-  ok = 1;
-
-Fail:
-  log_info("  %s", ok ? "PASS" : "FAIL");
-  return ok ? 0 : 1;
+  return run_case("zyx", 1, 1);
 }
 
 RUN_GPU_TESTS({ "metrics_single_level", test_metrics_single_level },

--- a/tests/test_metrics.c
+++ b/tests/test_metrics.c
@@ -1,0 +1,205 @@
+// Every per-stage timing number the report prints comes from a pair of CUDA
+// events and a ring slot the caller has to mark. Drop the mark and the metric
+// keeps count 0, which the report prints as a missing row rather than a zero
+// (#191, #197). These tests run a whole stream and check that each stage the
+// run actually exercised reported at least one measurement.
+#include "stream.gpu.h"
+#include "stream/layouts.h"
+#include "util/prelude.h"
+
+#include "test_metric_check.h"
+#include "test_runner.h"
+#include "test_shard_sink.h"
+
+#include <stdlib.h>
+
+#define EPOCHS 8
+
+static struct tile_stream_configuration
+make_config(struct dimension* dims, const char* downsample_names)
+{
+  const uint8_t rank = dims_create(dims, "zyx", (uint64_t[]){ 0, 8, 8 });
+  dims_set_chunk_sizes(dims, rank, (uint64_t[]){ 2, 2, 2 });
+  dims[0].chunks_per_shard = 2;
+  dims_set_shard_counts(dims, rank, (uint64_t[]){ 0, 1, 1 });
+  dims_set_downsample_by_name(dims, rank, downsample_names);
+
+  return (struct tile_stream_configuration){
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = rank,
+    .dimensions = dims,
+    .codec = { .id = CODEC_ZSTD },
+    .epochs_per_batch = 2,
+  };
+}
+
+// Append EPOCHS epochs and flush, then hand back what the stream measured.
+static int
+run_stream(const char* downsample_names,
+           struct stream_metrics* out,
+           struct tile_stream_status* out_status)
+{
+  struct dimension dims[3];
+  struct tile_stream_configuration config = make_config(dims, downsample_names);
+
+  struct test_shard_sink sink;
+  const int shards_per_level[] = { 32, 32, 32 };
+  test_sink_init_multi(&sink, 3, shards_per_level, 4 * 1024 * 1024);
+
+  struct tile_stream_gpu* s = NULL;
+  uint16_t* src = NULL;
+  int ok = 0;
+
+  s = tile_stream_gpu_create(&config, &sink.base);
+  CHECK(Fail, s);
+
+  *out_status = tile_stream_gpu_status(s);
+
+  {
+    const uint64_t elements =
+      EPOCHS * tile_stream_gpu_layout(s)->epoch_elements;
+    src = (uint16_t*)malloc(elements * sizeof(uint16_t));
+    CHECK(Fail, src);
+    // Sequential values keep the codec from collapsing the payload to nothing.
+    for (uint64_t i = 0; i < elements; ++i)
+      src[i] = (uint16_t)(i & 0xFFFF);
+
+    struct slice input = { .beg = src, .end = src + elements };
+    CHECK(Fail, writer_append(tile_stream_gpu_writer(s), input).error == 0);
+  }
+
+  CHECK(Fail, writer_flush(tile_stream_gpu_writer(s)).error == 0);
+
+  *out = tile_stream_gpu_get_metrics(s);
+  ok = 1;
+
+Fail:
+  free(src);
+  tile_stream_gpu_destroy(s);
+  test_sink_free(&sink);
+  return ok ? 0 : 1;
+}
+
+// Stages every run goes through, whatever the level geometry is.
+static int
+check_shared_stages(const struct stream_metrics* m)
+{
+  return metric_arrived_at_least_once(&m->h2d) &&
+         metric_arrived_at_least_once(&m->scatter) &&
+         metric_arrived_at_least_once(&m->compress) &&
+         metric_arrived_at_least_once(&m->aggregate) &&
+         metric_arrived_at_least_once(&m->d2h) &&
+         metric_arrived_at_least_once(&m->sink) &&
+         // The gate is a wait, and a wait that never had to wait measures
+         // zero, so only its count says whether it was read.
+         m->tail_gate.count > 0;
+}
+
+static int
+check_nothing_lost(const struct stream_metrics* m)
+{
+  if (m->scatter_samples_lost != 0)
+    log_error("  scatter ring wrapped %llu times",
+              (unsigned long long)m->scatter_samples_lost);
+  if (m->lod_samples_lost != 0)
+    log_error("  lod ring wrapped %llu times",
+              (unsigned long long)m->lod_samples_lost);
+  return m->scatter_samples_lost == 0 && m->lod_samples_lost == 0;
+}
+
+// A single-level stream: the LOD stages never run, so their empty rows are
+// the truth rather than a lost measurement.
+static int
+test_metrics_single_level(void)
+{
+  log_info("=== test_metrics_single_level ===");
+
+  struct stream_metrics m;
+  struct tile_stream_status st;
+  int ok = 0;
+
+  CHECK(Fail, run_stream(NULL, &m, &st) == 0);
+  CHECK(Fail, st.nlod == 1);
+
+  CHECK(Fail, check_shared_stages(&m));
+  CHECK(Fail, check_nothing_lost(&m));
+
+  CHECK(Fail, m.lod_gather.count == 0);
+  CHECK(Fail, m.lod_reduce.count == 0);
+  CHECK(Fail, m.lod_append_fold.count == 0);
+  CHECK(Fail, m.lod_morton_chunk.count == 0);
+
+  ok = 1;
+
+Fail:
+  log_info("  %s", ok ? "PASS" : "FAIL");
+  return ok ? 0 : 1;
+}
+
+// Downsampling the two bounded dimensions builds a pyramid without folding
+// along the append dimension. This is the path #191 broke: it takes the
+// device-to-device copy rather than the scatter, and the copy is what the
+// report calls Copy once multiscale is on.
+static int
+test_metrics_multiscale(void)
+{
+  log_info("=== test_metrics_multiscale ===");
+
+  struct stream_metrics m;
+  struct tile_stream_status st;
+  int ok = 0;
+
+  CHECK(Fail, run_stream("yx", &m, &st) == 0);
+  CHECK(Fail, st.nlod > 1);
+  CHECK(Fail, st.append_downsample == 0);
+
+  CHECK(Fail, check_shared_stages(&m));
+  CHECK(Fail, check_nothing_lost(&m));
+
+  CHECK(Fail, metric_arrived_at_least_once(&m.lod_gather));
+  CHECK(Fail, metric_arrived_at_least_once(&m.lod_reduce));
+  CHECK(Fail, metric_arrived_at_least_once(&m.lod_morton_chunk));
+  // The fold runs only when the append dimension is downsampled too.
+  CHECK(Fail, m.lod_append_fold.count == 0);
+
+  ok = 1;
+
+Fail:
+  log_info("  %s", ok ? "PASS" : "FAIL");
+  return ok ? 0 : 1;
+}
+
+// Downsampling the append dimension as well adds the fold, the one LOD stage
+// the previous case cannot reach.
+static int
+test_metrics_append_downsample(void)
+{
+  log_info("=== test_metrics_append_downsample ===");
+
+  struct stream_metrics m;
+  struct tile_stream_status st;
+  int ok = 0;
+
+  CHECK(Fail, run_stream("zyx", &m, &st) == 0);
+  CHECK(Fail, st.nlod > 1);
+  CHECK(Fail, st.append_downsample == 1);
+
+  CHECK(Fail, check_shared_stages(&m));
+  CHECK(Fail, check_nothing_lost(&m));
+
+  CHECK(Fail, metric_arrived_at_least_once(&m.lod_gather));
+  CHECK(Fail, metric_arrived_at_least_once(&m.lod_reduce));
+  CHECK(Fail, metric_arrived_at_least_once(&m.lod_morton_chunk));
+  CHECK(Fail, metric_arrived_at_least_once(&m.lod_append_fold));
+
+  ok = 1;
+
+Fail:
+  log_info("  %s", ok ? "PASS" : "FAIL");
+  return ok ? 0 : 1;
+}
+
+RUN_GPU_TESTS({ "metrics_single_level", test_metrics_single_level },
+              { "metrics_multiscale", test_metrics_multiscale },
+              { "metrics_append_downsample", test_metrics_append_downsample }, )


### PR DESCRIPTION
No test asserted that a metric derived from CUDA events ever arrives. A
dropped measurement leaves the count at zero, and the report drops a
zero-count row, so the stage vanishes instead of reading as zero. #191
lost every measurement from the multiscale ingest path that way and the
suite stayed green.

Each metric is now checked where it is produced. test_ingest covers the
H2D copy and the scatter on both dispatch paths. It orders their timing
events against a marker, so a stale event cannot pass as fresh, and
overruns the ring on purpose so the lost-sample counter reports a loss.
test_d2h_deliver covers compress, the tail gate, aggregate and D2H.
test_metrics is new and runs a whole stream in three geometries, the only
way to reach the four pyramid stages.

test_metric_check.h holds the shared checks: the count is the contract,
and an interval that brackets work must also show a positive duration.

ingest_destroy now clears the state it frees, so a failed setup followed
by the caller's teardown no longer frees the same handles twice.

Closes #197
