### PR TITLE
Count pending bytes inside the io queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 target
 build
-build-cpu
+build-*
 result
 .ninja_log
 .clangd

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -105,7 +105,7 @@ print_bench_report(const struct stream_metrics* metrics,
                    float wall_s,
                    float init_s,
                    float flush_s,
-                   size_t flush_pending_bytes)
+                   uint64_t flush_pending_bytes)
 {
   const size_t chunk_bytes = layout->chunk_stride * dtype_bpe(dtype);
   const size_t num_epochs =
@@ -182,7 +182,7 @@ print_bench_report(const struct stream_metrics* metrics,
                    (unsigned long long)metrics->lod_samples_lost);
     print_append_latency(metrics);
     char pbuf[32];
-    format_bytes(pbuf, sizeof(pbuf), (uint64_t)metrics->peak_pending_bytes);
+    format_bytes(pbuf, sizeof(pbuf), metrics->peak_pending_bytes);
     print_report("  peak pending:    %s", pbuf);
   }
 

--- a/bench/bench_report.h
+++ b/bench/bench_report.h
@@ -44,7 +44,7 @@ print_bench_report(const struct stream_metrics* metrics,
                    float wall_s,
                    float init_s,
                    float flush_s,
-                   size_t flush_pending_bytes);
+                   uint64_t flush_pending_bytes);
 
 // Emit the pass-case JSON report to stdout. sink_metric may be NULL (no sink
 // block is written in that case).

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -510,7 +510,7 @@ run_bench(const struct bench_config* cfg)
                                   dtype_bpe(dtype),
                                   cfg->append_elements) == 0);
 
-  size_t pending_bytes = bench_zarr_pending_bytes(&zarr);
+  uint64_t pending_bytes = bench_zarr_pending_bytes(&zarr);
 
   struct platform_clock flush_clock = { 0 };
   platform_toc(&flush_clock);
@@ -1066,7 +1066,7 @@ run_bench_two_streams(const struct bench_config* cfg)
       print_metric_row(&m[k].backpressure);
       print_append_latency(&m[k]);
       char pbuf[32];
-      format_bytes(pbuf, sizeof(pbuf), (uint64_t)m[k].peak_pending_bytes);
+      format_bytes(pbuf, sizeof(pbuf), m[k].peak_pending_bytes);
       print_report("  peak pending:    %s", pbuf);
     }
   }

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -53,7 +53,7 @@ struct bench_config
   int json_output;            // print JSON to stdout after run
   uint64_t io_bw_mbps;        // 0 = no bandwidth cap (MiB/s)
   uint64_t io_latency_us;     // 0 = no fixed per-job latency
-  size_t backpressure_bytes;  // 0 = disabled; >0 = stall when pending > N
+  uint64_t backpressure_bytes; // 0 = disabled; >0 = stall when pending > N
   int max_threads;            // 0 = OpenMP default (omp_get_max_threads)
 };
 

--- a/bench/bench_zarr.c
+++ b/bench/bench_zarr.c
@@ -179,7 +179,7 @@ bench_zarr_flush(struct bench_zarr_handle* z)
   return err;
 }
 
-size_t
+uint64_t
 bench_zarr_pending_bytes(struct bench_zarr_handle* z)
 {
   if (z->ms)

--- a/bench/bench_zarr.h
+++ b/bench/bench_zarr.h
@@ -54,7 +54,7 @@ int
 bench_zarr_flush(struct bench_zarr_handle* z);
 
 // Return number of bytes queued but not yet written.
-size_t
+uint64_t
 bench_zarr_pending_bytes(struct bench_zarr_handle* z);
 
 // Close and free resources. Safe to call on a zero-initialized handle.

--- a/bench/sink_metering.c
+++ b/bench/sink_metering.c
@@ -96,7 +96,7 @@ metering_has_error(const struct shard_sink* self)
   return ms->inner->has_error(ms->inner);
 }
 
-static size_t
+static uint64_t
 metering_pending_bytes(const struct shard_sink* self)
 {
   const struct metering_sink* ms = (const struct metering_sink*)self;

--- a/bench/sink_throttled.c
+++ b/bench/sink_throttled.c
@@ -17,7 +17,6 @@ struct throttled_job
   uint64_t nbytes;
   uint64_t latency_ns;
   uint64_t bytes_per_sec;
-  _Atomic int64_t* pending_bytes;
   _Atomic uint64_t* total_bytes;
 };
 
@@ -30,7 +29,6 @@ throttled_fn(void* arg)
     ns += (int64_t)((j->nbytes * 1000000000ull) / j->bytes_per_sec);
   if (ns > 0)
     platform_sleep_ns(ns);
-  atomic_fetch_sub(j->pending_bytes, (int64_t)j->nbytes);
   atomic_fetch_add(j->total_bytes, j->nbytes);
 }
 
@@ -42,11 +40,8 @@ throttled_post(struct throttled_shard_sink* s, size_t nbytes)
   j->nbytes = nbytes;
   j->latency_ns = s->latency_ns;
   j->bytes_per_sec = s->bytes_per_sec;
-  j->pending_bytes = &s->pending_bytes;
   j->total_bytes = &s->total_bytes;
-  atomic_fetch_add(&s->pending_bytes, (int64_t)nbytes);
-  if (io_queue_post(s->queue, throttled_fn, j, free)) {
-    atomic_fetch_sub(&s->pending_bytes, (int64_t)nbytes);
+  if (io_queue_post_bytes(s->queue, throttled_fn, j, free, nbytes)) {
     free(j);
     goto Error;
   }
@@ -124,8 +119,7 @@ throttled_shard_pending_bytes(const struct shard_sink* self)
 {
   const struct throttled_shard_sink* s =
     (const struct throttled_shard_sink*)self;
-  int64_t pending = atomic_load(&s->pending_bytes);
-  return pending > 0 ? (size_t)pending : 0;
+  return (size_t)io_queue_pending_bytes(s->queue);
 }
 
 int

--- a/bench/sink_throttled.c
+++ b/bench/sink_throttled.c
@@ -17,7 +17,7 @@ struct throttled_job
   uint64_t nbytes;
   uint64_t latency_ns;
   uint64_t bytes_per_sec;
-  _Atomic uint64_t* retired_bytes;
+  _Atomic int64_t* pending_bytes;
   _Atomic uint64_t* total_bytes;
 };
 
@@ -30,7 +30,7 @@ throttled_fn(void* arg)
     ns += (int64_t)((j->nbytes * 1000000000ull) / j->bytes_per_sec);
   if (ns > 0)
     platform_sleep_ns(ns);
-  atomic_fetch_add(j->retired_bytes, j->nbytes);
+  atomic_fetch_sub(j->pending_bytes, (int64_t)j->nbytes);
   atomic_fetch_add(j->total_bytes, j->nbytes);
 }
 
@@ -42,11 +42,11 @@ throttled_post(struct throttled_shard_sink* s, size_t nbytes)
   j->nbytes = nbytes;
   j->latency_ns = s->latency_ns;
   j->bytes_per_sec = s->bytes_per_sec;
-  j->retired_bytes = &s->retired_bytes;
+  j->pending_bytes = &s->pending_bytes;
   j->total_bytes = &s->total_bytes;
-  atomic_fetch_add(&s->queued_bytes, nbytes);
+  atomic_fetch_add(&s->pending_bytes, (int64_t)nbytes);
   if (io_queue_post(s->queue, throttled_fn, j, free)) {
-    atomic_fetch_sub(&s->queued_bytes, nbytes);
+    atomic_fetch_sub(&s->pending_bytes, (int64_t)nbytes);
     free(j);
     goto Error;
   }
@@ -124,11 +124,8 @@ throttled_shard_pending_bytes(const struct shard_sink* self)
 {
   const struct throttled_shard_sink* s =
     (const struct throttled_shard_sink*)self;
-  uint64_t retired = atomic_load(&s->retired_bytes);
-  uint64_t queued = atomic_load(&s->queued_bytes);
-  if (queued <= retired)
-    return 0;
-  return (size_t)(queued - retired);
+  int64_t pending = atomic_load(&s->pending_bytes);
+  return pending > 0 ? (size_t)pending : 0;
 }
 
 int

--- a/bench/sink_throttled.c
+++ b/bench/sink_throttled.c
@@ -44,11 +44,12 @@ throttled_post(struct throttled_shard_sink* s, size_t nbytes)
   j->bytes_per_sec = s->bytes_per_sec;
   j->retired_bytes = &s->retired_bytes;
   j->total_bytes = &s->total_bytes;
+  atomic_fetch_add(&s->queued_bytes, nbytes);
   if (io_queue_post(s->queue, throttled_fn, j, free)) {
+    atomic_fetch_sub(&s->queued_bytes, nbytes);
     free(j);
     goto Error;
   }
-  atomic_fetch_add(&s->queued_bytes, nbytes);
   return 0;
 
 Error:

--- a/bench/sink_throttled.c
+++ b/bench/sink_throttled.c
@@ -114,12 +114,12 @@ throttled_shard_has_error(const struct shard_sink* self)
   return 0;
 }
 
-static size_t
+static uint64_t
 throttled_shard_pending_bytes(const struct shard_sink* self)
 {
   const struct throttled_shard_sink* s =
     (const struct throttled_shard_sink*)self;
-  return (size_t)io_queue_pending_bytes(s->queue);
+  return io_queue_pending_bytes(s->queue);
 }
 
 int

--- a/bench/sink_throttled.h
+++ b/bench/sink_throttled.h
@@ -18,9 +18,9 @@ struct throttled_shard_sink
   struct shard_sink base;
   struct throttled_shard_writer writer; // single shared writer
   struct io_queue* queue;               // owned
-  _Atomic uint64_t total_bytes; // reporting
-  uint64_t latency_ns;          // fixed per-job cost
-  uint64_t bytes_per_sec;       // 0 = no bandwidth cap
+  _Atomic uint64_t total_bytes;         // reporting
+  uint64_t latency_ns;                  // fixed per-job cost
+  uint64_t bytes_per_sec;               // 0 = no bandwidth cap
 };
 
 // Initialize a throttled sink. Returns 0 on success.

--- a/bench/sink_throttled.h
+++ b/bench/sink_throttled.h
@@ -18,8 +18,7 @@ struct throttled_shard_sink
   struct shard_sink base;
   struct throttled_shard_writer writer; // single shared writer
   struct io_queue* queue;               // owned
-  // Delivery thread adds before queueing, worker subtracts once the job runs,
-  // producer reads.
+  // Delivery thread adds, worker subtracts, producer reads.
   _Atomic int64_t pending_bytes;
   _Atomic uint64_t total_bytes; // reporting
   uint64_t latency_ns;          // fixed per-job cost

--- a/bench/sink_throttled.h
+++ b/bench/sink_throttled.h
@@ -18,8 +18,6 @@ struct throttled_shard_sink
   struct shard_sink base;
   struct throttled_shard_writer writer; // single shared writer
   struct io_queue* queue;               // owned
-  // Delivery thread adds, worker subtracts, producer reads.
-  _Atomic int64_t pending_bytes;
   _Atomic uint64_t total_bytes; // reporting
   uint64_t latency_ns;          // fixed per-job cost
   uint64_t bytes_per_sec;       // 0 = no bandwidth cap

--- a/bench/sink_throttled.h
+++ b/bench/sink_throttled.h
@@ -19,7 +19,7 @@ struct throttled_shard_sink
   struct throttled_shard_writer writer; // single shared writer
   struct io_queue* queue;               // owned
   // Delivery thread adds before queueing, worker subtracts once the job runs,
-  // producer reads. Signed so a slip reads as a small negative, not a wrap.
+  // producer reads.
   _Atomic int64_t pending_bytes;
   _Atomic uint64_t total_bytes; // reporting
   uint64_t latency_ns;          // fixed per-job cost

--- a/bench/sink_throttled.h
+++ b/bench/sink_throttled.h
@@ -18,11 +18,12 @@ struct throttled_shard_sink
   struct shard_sink base;
   struct throttled_shard_writer writer; // single shared writer
   struct io_queue* queue;               // owned
-  _Atomic uint64_t queued_bytes;        // delivery thread posts, producer reads
-  _Atomic uint64_t retired_bytes;       // worker, atomic
-  _Atomic uint64_t total_bytes;         // reporting
-  uint64_t latency_ns;                  // fixed per-job cost
-  uint64_t bytes_per_sec;               // 0 = no bandwidth cap
+  // Delivery thread adds before queueing, worker subtracts once the job runs,
+  // producer reads. Signed so a slip reads as a small negative, not a wrap.
+  _Atomic int64_t pending_bytes;
+  _Atomic uint64_t total_bytes; // reporting
+  uint64_t latency_ns;          // fixed per-job cost
+  uint64_t bytes_per_sec;       // 0 = no bandwidth cap
 };
 
 // Initialize a throttled sink. Returns 0 on success.

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -169,7 +169,7 @@ dispatch_target_bytes(const struct stream_engine* e,
 static void
 apply_backpressure(struct stream_engine* e, struct stream_context* ctx)
 {
-  size_t pend = shard_sink_pending_bytes(ctx->sink);
+  uint64_t pend = shard_sink_pending_bytes(ctx->sink);
   if (pend > e->metrics.peak_pending_bytes)
     e->metrics.peak_pending_bytes = pend;
   if (ctx->config.backpressure_bytes == 0 ||
@@ -195,9 +195,9 @@ apply_backpressure(struct stream_engine* e, struct stream_context* ctx)
   accumulate_metric_ms(
     &e->metrics.backpressure, (float)((bp_clk.last_ns - start_ns) / 1e6), 0, 0);
   if (!drained)
-    log_warn("backpressure timeout after %.1fs (pending %zu bytes)",
+    log_warn("backpressure timeout after %.1fs (pending %llu bytes)",
              timeout_s,
-             shard_sink_pending_bytes(ctx->sink));
+             (unsigned long long)shard_sink_pending_bytes(ctx->sink));
 }
 
 // --- Shared append body ---

--- a/src/ngff.h
+++ b/src/ngff.h
@@ -82,7 +82,7 @@ int
 ngff_multiscale_has_error(const struct ngff_multiscale* ms);
 
 // Returns number of bytes queued but not yet written.
-size_t
+uint64_t
 ngff_multiscale_pending_bytes(const struct ngff_multiscale* ms);
 
 // Buffer a custom attribute on the multiscale's OME group (sibling of the

--- a/src/ngff/ngff_multiscale.c
+++ b/src/ngff/ngff_multiscale.c
@@ -162,7 +162,7 @@ ngff_multiscale_has_error_fn(const struct shard_sink* self)
   return ms->pool->has_error(ms->pool);
 }
 
-static size_t
+static uint64_t
 ngff_multiscale_pending_bytes_fn(const struct shard_sink* self)
 {
   const struct ngff_multiscale* ms =
@@ -411,7 +411,7 @@ ngff_multiscale_has_error(const struct ngff_multiscale* ms)
   return ms ? ms->pool->has_error(ms->pool) : 0;
 }
 
-size_t
+uint64_t
 ngff_multiscale_pending_bytes(const struct ngff_multiscale* ms)
 {
   return ms ? ms->pool->pending_bytes(ms->pool) : 0;

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -74,7 +74,7 @@ struct stream_metrics
   float max_append_ms; // longest single append
   // High-water mark of bytes awaiting write, read once per staging buffer
   // handed to the device rather than continuously.
-  size_t peak_pending_bytes;
+  uint64_t peak_pending_bytes;
 
   // How long individual appends took, as counts per time bucket. A caller
   // asking whether it can keep up needs the slow tail, not the average, and
@@ -104,10 +104,10 @@ struct tile_stream_configuration
   uint64_t
     target_batch_bytes; // target uncompressed bytes per batch (default 512 MiB)
   float metadata_update_interval_s;
-  size_t backpressure_bytes; // 0 = disabled; >0 = stall after handing a
-                             // staging buffer to the device when
-                             // sink->pending_bytes exceeds this watermark
-  int max_threads;           // 0 = OpenMP default
+  uint64_t backpressure_bytes; // 0 = disabled; >0 = stall after handing a
+                               // staging buffer to the device when the sink
+                               // reports more pending than this
+  int max_threads;             // 0 = OpenMP default
 };
 
 struct tile_stream_status

--- a/src/writer.c
+++ b/src/writer.c
@@ -86,7 +86,7 @@ writer_finished_at(const void* beg, const void* end)
   return r;
 }
 
-size_t
+uint64_t
 shard_sink_pending_bytes(const struct shard_sink* s)
 {
   return (s && s->pending_bytes) ? s->pending_bytes(s) : 0;
@@ -127,7 +127,7 @@ shard_sink_drain(struct shard_sink* s)
   return shard_sink_drain_wait(s, ev);
 }
 
-size_t
+uint64_t
 shard_pool_pending_bytes(const struct shard_pool* p)
 {
   return (p && p->pending_bytes) ? p->pending_bytes(p) : 0;

--- a/src/writer.h
+++ b/src/writer.h
@@ -102,14 +102,14 @@ struct shard_sink
 
   // Returns an upper bound on bytes accepted but not yet written; a 0 is not
   // proof that nothing is outstanding. NULL = treated as 0.
-  size_t (*pending_bytes)(const struct shard_sink* self);
+  uint64_t (*pending_bytes)(const struct shard_sink* self);
 
   // Required write alignment in bytes (e.g. page size for O_DIRECT).
   // NULL or returns 0 = no alignment constraint.
   size_t (*required_shard_alignment)(const struct shard_sink* self);
 };
 
-size_t
+uint64_t
 shard_sink_pending_bytes(const struct shard_sink* s);
 
 size_t

--- a/src/writer.h
+++ b/src/writer.h
@@ -100,8 +100,8 @@ struct shard_sink
   // Returns non-zero if any async IO has failed. NULL = no async IO.
   int (*has_error)(const struct shard_sink* self);
 
-  // Returns an upper bound on the bytes accepted but not yet written, so a 0 is
-  // not proof that nothing is outstanding. NULL = treated as 0.
+  // Returns an upper bound on bytes accepted but not yet written; a 0 is not
+  // proof that nothing is outstanding. NULL = treated as 0.
   size_t (*pending_bytes)(const struct shard_sink* self);
 
   // Required write alignment in bytes (e.g. page size for O_DIRECT).

--- a/src/writer.h
+++ b/src/writer.h
@@ -100,7 +100,8 @@ struct shard_sink
   // Returns non-zero if any async IO has failed. NULL = no async IO.
   int (*has_error)(const struct shard_sink* self);
 
-  // Returns bytes queued but not yet retired on this sink. NULL = treated as 0.
+  // Returns an upper bound on the bytes accepted but not yet written, so a 0 is
+  // not proof that nothing is outstanding. NULL = treated as 0.
   size_t (*pending_bytes)(const struct shard_sink* self);
 
   // Required write alignment in bytes (e.g. page size for O_DIRECT).

--- a/src/zarr.h
+++ b/src/zarr.h
@@ -48,7 +48,7 @@ int
 zarr_array_has_error(const struct zarr_array* a);
 
 // Returns number of bytes queued but not yet written.
-size_t
+uint64_t
 zarr_array_pending_bytes(const struct zarr_array* a);
 
 // Access live dimensions (reflects append-dimension updates).

--- a/src/zarr/io_queue.h
+++ b/src/zarr/io_queue.h
@@ -21,6 +21,20 @@ io_queue_post(struct io_queue* q,
               void* ctx,
               void (*ctx_free)(void*));
 
+// Post a job that carries nbytes of outstanding work. The queue raises its
+// pending count as it takes the job, so a reader can never see less work than
+// the queue is holding.
+int
+io_queue_post_bytes(struct io_queue* q,
+                    void (*fn)(void*),
+                    void* ctx,
+                    void (*ctx_free)(void*),
+                    uint64_t nbytes);
+
+// Bytes posted through io_queue_post_bytes whose jobs have not finished.
+uint64_t
+io_queue_pending_bytes(const struct io_queue* q);
+
 // Record an event capturing the current sequence number.
 struct io_event
 io_queue_record(struct io_queue* q);

--- a/src/zarr/io_queue.posix.c
+++ b/src/zarr/io_queue.posix.c
@@ -11,6 +11,7 @@ struct io_job
   void* ctx;
   void (*ctx_free)(void*);
   uint64_t seq;
+  uint64_t nbytes;
 };
 
 struct io_queue
@@ -25,8 +26,9 @@ struct io_queue
   uint64_t head;     // next write position (post)
   uint64_t tail;     // next read position (worker)
 
-  uint64_t next_seq;    // incremented on post
-  uint64_t retired_seq; // updated after each job completes
+  uint64_t next_seq;      // incremented on post
+  uint64_t retired_seq;   // updated after each job completes
+  uint64_t pending_bytes; // raised as a job is taken, lowered as it completes
 
   int shutdown;
   int started;
@@ -59,6 +61,7 @@ worker_thread(void* arg)
 
     pthread_mutex_lock(&q->mutex);
     q->retired_seq = job.seq;
+    q->pending_bytes -= job.nbytes;
     pthread_cond_broadcast(&q->cond_retired);
     pthread_mutex_unlock(&q->mutex);
   }
@@ -148,6 +151,16 @@ io_queue_post(struct io_queue* q,
               void* ctx,
               void (*ctx_free)(void*))
 {
+  return io_queue_post_bytes(q, fn, ctx, ctx_free, 0);
+}
+
+int
+io_queue_post_bytes(struct io_queue* q,
+                    void (*fn)(void*),
+                    void* ctx,
+                    void (*ctx_free)(void*),
+                    uint64_t nbytes)
+{
   pthread_mutex_lock(&q->mutex);
 
   if (q->head - q->tail == q->ring_cap) {
@@ -163,12 +176,24 @@ io_queue_post(struct io_queue* q,
     .ctx = ctx,
     .ctx_free = ctx_free,
     .seq = q->next_seq,
+    .nbytes = nbytes,
   };
   q->head++;
+  q->pending_bytes += nbytes;
 
   pthread_cond_signal(&q->cond_not_empty);
   pthread_mutex_unlock(&q->mutex);
   return 0;
+}
+
+uint64_t
+io_queue_pending_bytes(const struct io_queue* q)
+{
+  struct io_queue* mq = (struct io_queue*)q;
+  pthread_mutex_lock(&mq->mutex);
+  uint64_t pending = mq->pending_bytes;
+  pthread_mutex_unlock(&mq->mutex);
+  return pending;
 }
 
 struct io_event

--- a/src/zarr/io_queue.posix.c
+++ b/src/zarr/io_queue.posix.c
@@ -28,7 +28,7 @@ struct io_queue
 
   uint64_t next_seq;      // incremented on post
   uint64_t retired_seq;   // updated after each job completes
-  uint64_t pending_bytes; // raised as a job is taken, lowered as it completes
+  uint64_t pending_bytes; // raised on post, lowered when the job finishes
 
   int shutdown;
   int started;

--- a/src/zarr/io_queue.win32.c
+++ b/src/zarr/io_queue.win32.c
@@ -30,7 +30,7 @@ struct io_queue
 
   uint64_t next_seq;      // incremented on post
   uint64_t retired_seq;   // updated after each job completes
-  uint64_t pending_bytes; // raised as a job is taken, lowered as it completes
+  uint64_t pending_bytes; // raised on post, lowered when the job finishes
 
   int shutdown;
   int started;

--- a/src/zarr/io_queue.win32.c
+++ b/src/zarr/io_queue.win32.c
@@ -13,6 +13,7 @@ struct io_job
   void* ctx;
   void (*ctx_free)(void*);
   uint64_t seq;
+  uint64_t nbytes;
 };
 
 struct io_queue
@@ -27,8 +28,9 @@ struct io_queue
   uint64_t head;     // next write position (post)
   uint64_t tail;     // next read position (worker)
 
-  uint64_t next_seq;    // incremented on post
-  uint64_t retired_seq; // updated after each job completes
+  uint64_t next_seq;      // incremented on post
+  uint64_t retired_seq;   // updated after each job completes
+  uint64_t pending_bytes; // raised as a job is taken, lowered as it completes
 
   int shutdown;
   int started;
@@ -61,6 +63,7 @@ worker_thread(LPVOID arg)
 
     AcquireSRWLockExclusive(&q->srw);
     q->retired_seq = job.seq;
+    q->pending_bytes -= job.nbytes;
     WakeAllConditionVariable(&q->cond_retired);
     ReleaseSRWLockExclusive(&q->srw);
   }
@@ -148,6 +151,16 @@ io_queue_post(struct io_queue* q,
               void* ctx,
               void (*ctx_free)(void*))
 {
+  return io_queue_post_bytes(q, fn, ctx, ctx_free, 0);
+}
+
+int
+io_queue_post_bytes(struct io_queue* q,
+                    void (*fn)(void*),
+                    void* ctx,
+                    void (*ctx_free)(void*),
+                    uint64_t nbytes)
+{
   AcquireSRWLockExclusive(&q->srw);
 
   if (q->head - q->tail == q->ring_cap) {
@@ -163,12 +176,24 @@ io_queue_post(struct io_queue* q,
     .ctx = ctx,
     .ctx_free = ctx_free,
     .seq = q->next_seq,
+    .nbytes = nbytes,
   };
   q->head++;
+  q->pending_bytes += nbytes;
 
   WakeConditionVariable(&q->cond_not_empty);
   ReleaseSRWLockExclusive(&q->srw);
   return 0;
+}
+
+uint64_t
+io_queue_pending_bytes(const struct io_queue* q)
+{
+  struct io_queue* mq = (struct io_queue*)q;
+  AcquireSRWLockExclusive(&mq->srw);
+  uint64_t pending = mq->pending_bytes;
+  ReleaseSRWLockExclusive(&mq->srw);
+  return pending;
 }
 
 struct io_event

--- a/src/zarr/shard_pool.h
+++ b/src/zarr/shard_pool.h
@@ -28,10 +28,9 @@ struct shard_pool
   // Returns non-zero if any I/O has failed.
   int (*has_error)(const struct shard_pool* self);
 
-  // Returns an upper bound on the bytes accepted but not yet written; a write
-  // counts from the moment it is accepted, before it reaches the queue. Never
-  // reads below the true figure, because a caller deciding whether to slow down
-  // can tolerate too high but not too low.
+  // Bytes accepted but not yet written. A write counts from the moment it is
+  // accepted until it lands, so the figure can read high but never low — a
+  // caller deciding whether to slow down can tolerate too high, not too low.
   size_t (*pending_bytes)(const struct shard_pool* self);
 
   // Required write alignment in bytes (e.g. page size for O_DIRECT).

--- a/src/zarr/shard_pool.h
+++ b/src/zarr/shard_pool.h
@@ -28,7 +28,11 @@ struct shard_pool
   // Returns non-zero if any I/O has failed.
   int (*has_error)(const struct shard_pool* self);
 
-  // Returns number of bytes queued but not yet written.
+  // Returns an upper bound on the bytes accepted but not yet written. A write
+  // counts from the moment it is accepted, so the figure may include one that
+  // has not reached the queue yet. Overcounting is safe for a caller deciding
+  // whether to slow down; undercounting is not, which is why this never reads
+  // below the true figure.
   size_t (*pending_bytes)(const struct shard_pool* self);
 
   // Required write alignment in bytes (e.g. page size for O_DIRECT).

--- a/src/zarr/shard_pool.h
+++ b/src/zarr/shard_pool.h
@@ -31,7 +31,7 @@ struct shard_pool
   // Bytes accepted but not yet written. A write counts from the moment it is
   // accepted until it lands, so the figure can read high but never low — a
   // caller deciding whether to slow down can tolerate too high, not too low.
-  size_t (*pending_bytes)(const struct shard_pool* self);
+  uint64_t (*pending_bytes)(const struct shard_pool* self);
 
   // Required write alignment in bytes (e.g. page size for O_DIRECT).
   // NULL = no alignment constraint.
@@ -40,7 +40,7 @@ struct shard_pool
   void (*destroy)(struct shard_pool* self);
 };
 
-size_t
+uint64_t
 shard_pool_pending_bytes(const struct shard_pool* p);
 
 size_t

--- a/src/zarr/shard_pool.h
+++ b/src/zarr/shard_pool.h
@@ -28,11 +28,10 @@ struct shard_pool
   // Returns non-zero if any I/O has failed.
   int (*has_error)(const struct shard_pool* self);
 
-  // Returns an upper bound on the bytes accepted but not yet written. A write
-  // counts from the moment it is accepted, so the figure may include one that
-  // has not reached the queue yet. Overcounting is safe for a caller deciding
-  // whether to slow down; undercounting is not, which is why this never reads
-  // below the true figure.
+  // Returns an upper bound on the bytes accepted but not yet written; a write
+  // counts from the moment it is accepted, before it reaches the queue. Never
+  // reads below the true figure, because a caller deciding whether to slow down
+  // can tolerate too high but not too low.
   size_t (*pending_bytes)(const struct shard_pool* self);
 
   // Required write alignment in bytes (e.g. page size for O_DIRECT).

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -21,14 +21,9 @@ struct shard_pool_fs
   uint64_t nslots;
   int unbuffered;
   struct strbuf root; // owned
-  // Writes land on whichever thread runs sink delivery while the producer
-  // samples pending_bytes for backpressure.
-  _Atomic int64_t pending_bytes;
   _Atomic int io_error;
   // Test hook: one-shot, fail the next truncate.
   _Atomic int fail_next_truncate;
-  // Test hook: park a writer partway through queueing a write.
-  _Atomic int pause_mid_write;
 };
 
 // --- Writer slot for a single shard file ---
@@ -39,46 +34,17 @@ struct fs_slot
   platform_fd fd;
   struct io_queue* queue;
   size_t alignment; // 0 = normal malloc, >0 = page-aligned allocation
-  _Atomic int64_t* pending_bytes;  // points to shard_pool_fs.pending_bytes
   _Atomic int* io_error;           // points to shard_pool_fs.io_error
   _Atomic int* fail_next_truncate; // points to shard_pool_fs.fail_next_truncate
-  _Atomic int* pause_mid_write;    // points to shard_pool_fs.pause_mid_write
 };
-
-static void
-fs_slot_pause_mid_write(const struct fs_slot* w)
-{
-  while (w->pause_mid_write && atomic_load(w->pause_mid_write))
-    platform_sleep_ns(100000);
-}
-
-// Count before the handoff: the worker can finish the write the moment it is
-// posted, and a late count reads below the work outstanding.
-static int
-fs_slot_post_write(struct fs_slot* w,
-                   size_t nbytes,
-                   void (*fn)(void*),
-                   void* job,
-                   void (*job_free)(void*))
-{
-  atomic_fetch_add(w->pending_bytes, (int64_t)nbytes);
-  fs_slot_pause_mid_write(w);
-  if (io_queue_post(w->queue, fn, job, job_free) == 0)
-    return 0;
-
-  atomic_fetch_sub(w->pending_bytes, (int64_t)nbytes);
-  job_free(job);
-  return 1;
-}
 
 struct pwrite_job
 {
   platform_fd fd;
   uint64_t offset;
   size_t nbytes;
-  size_t data_off;                // byte offset from start of struct to data
-  _Atomic int64_t* pending_bytes; // decremented by io worker after pwrite
-  _Atomic int* io_error;          // set on write failure
+  size_t data_off;       // byte offset from start of struct to data
+  _Atomic int* io_error; // set on write failure
   uint8_t data[]; // used when data_off == sizeof(struct pwrite_job)
 };
 
@@ -91,7 +57,6 @@ pwrite_fn(void* arg)
     log_error("shard_pool_fs pwrite failed");
     atomic_store(j->io_error, 1);
   }
-  atomic_fetch_sub(j->pending_bytes, (int64_t)j->nbytes);
 }
 
 static int
@@ -127,10 +92,12 @@ fs_slot_write(struct shard_writer* self,
     j->fd = w->fd;
     j->offset = offset;
     j->nbytes = nbytes;
-    j->pending_bytes = w->pending_bytes;
     j->io_error = w->io_error;
     memcpy((char*)j + j->data_off, beg, nbytes);
-    CHECK(Error, fs_slot_post_write(w, nbytes, pwrite_fn, j, job_free) == 0);
+    if (io_queue_post_bytes(w->queue, pwrite_fn, j, job_free, nbytes)) {
+      job_free(j);
+      goto Error;
+    }
   } else {
     CHECK(Error, platform_pwrite(w->fd, beg, nbytes, offset) == 0);
   }
@@ -146,9 +113,8 @@ struct pwrite_ref_job
   platform_fd fd;
   uint64_t offset;
   size_t nbytes;
-  const void* data;               // NOT owned — points into pinned memory
-  _Atomic int64_t* pending_bytes; // decremented by io worker after pwrite
-  _Atomic int* io_error;          // set on write failure
+  const void* data;      // NOT owned — points into pinned memory
+  _Atomic int* io_error; // set on write failure
 };
 
 static void
@@ -159,7 +125,6 @@ pwrite_ref_fn(void* arg)
     log_error("shard_pool_fs pwrite_ref failed");
     atomic_store(j->io_error, 1);
   }
-  atomic_fetch_sub(j->pending_bytes, (int64_t)j->nbytes);
 }
 
 static int
@@ -181,9 +146,11 @@ fs_slot_write_direct(struct shard_writer* self,
     j->offset = offset;
     j->nbytes = nbytes;
     j->data = beg;
-    j->pending_bytes = w->pending_bytes;
     j->io_error = w->io_error;
-    CHECK(Error, fs_slot_post_write(w, nbytes, pwrite_ref_fn, j, free) == 0);
+    if (io_queue_post_bytes(w->queue, pwrite_ref_fn, j, free, nbytes)) {
+      free(j);
+      goto Error;
+    }
   } else {
     CHECK(Error, platform_pwrite(w->fd, beg, nbytes, offset) == 0);
   }
@@ -359,8 +326,7 @@ pool_fs_pending_bytes(const struct shard_pool* self)
 {
   const struct shard_pool_fs* p =
     container_of(self, struct shard_pool_fs, base);
-  int64_t pending = atomic_load(&p->pending_bytes);
-  return pending > 0 ? (size_t)pending : 0;
+  return (size_t)io_queue_pending_bytes(p->queue);
 }
 
 static size_t
@@ -421,13 +387,6 @@ shard_pool_fs_set_error(struct shard_pool* self)
 {
   struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
   atomic_store(&p->io_error, 1);
-}
-
-void
-shard_pool_fs_pause_mid_write(struct shard_pool* self, int paused)
-{
-  struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
-  atomic_store(&p->pause_mid_write, paused);
 }
 
 struct gate_ctx
@@ -501,10 +460,8 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
     s->fd = PLATFORM_FD_INVALID;
     s->queue = p->queue;
     s->alignment = page_size;
-    s->pending_bytes = &p->pending_bytes;
     s->io_error = &p->io_error;
     s->fail_next_truncate = &p->fail_next_truncate;
-    s->pause_mid_write = &p->pause_mid_write;
   }
 
   return &p->base;

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -33,8 +33,8 @@ struct fs_slot
   struct shard_writer base;
   platform_fd fd;
   struct io_queue* queue;
-  size_t alignment; // 0 = normal malloc, >0 = page-aligned allocation
-  _Atomic int* io_error;           // points to shard_pool_fs.io_error
+  size_t alignment;      // 0 = normal malloc, >0 = page-aligned allocation
+  _Atomic int* io_error; // points to shard_pool_fs.io_error
   _Atomic int* fail_next_truncate; // points to shard_pool_fs.fail_next_truncate
 };
 
@@ -45,7 +45,7 @@ struct pwrite_job
   size_t nbytes;
   size_t data_off;       // byte offset from start of struct to data
   _Atomic int* io_error; // set on write failure
-  uint8_t data[]; // used when data_off == sizeof(struct pwrite_job)
+  uint8_t data[];        // used when data_off == sizeof(struct pwrite_job)
 };
 
 static void

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -22,9 +22,9 @@ struct shard_pool_fs
   int unbuffered;
   struct strbuf root; // owned
   // Writes land on whichever thread runs sink delivery while the producer
-  // samples pending_bytes for backpressure.
-  _Atomic uint64_t queued_bytes;
-  _Atomic uint64_t retired_bytes;
+  // samples pending_bytes for backpressure. Signed, so a slip in the
+  // bookkeeping reads as a small negative instead of wrapping.
+  _Atomic int64_t pending_bytes;
   _Atomic int io_error;
   // Test hook: one-shot, fail the next truncate.
   _Atomic int fail_next_truncate;
@@ -40,8 +40,7 @@ struct fs_slot
   platform_fd fd;
   struct io_queue* queue;
   size_t alignment; // 0 = normal malloc, >0 = page-aligned allocation
-  _Atomic uint64_t* retired_bytes; // points to shard_pool_fs.retired_bytes
-  _Atomic uint64_t* queued_bytes;  // points to shard_pool_fs.queued_bytes
+  _Atomic int64_t* pending_bytes;  // points to shard_pool_fs.pending_bytes
   _Atomic int* io_error;           // points to shard_pool_fs.io_error
   _Atomic int* fail_next_truncate; // points to shard_pool_fs.fail_next_truncate
   _Atomic int* pause_mid_write;    // points to shard_pool_fs.pause_mid_write
@@ -59,9 +58,9 @@ struct pwrite_job
   platform_fd fd;
   uint64_t offset;
   size_t nbytes;
-  size_t data_off;                 // byte offset from start of struct to data
-  _Atomic uint64_t* retired_bytes; // written by io worker after pwrite
-  _Atomic int* io_error;           // set on write failure
+  size_t data_off;                // byte offset from start of struct to data
+  _Atomic int64_t* pending_bytes; // decremented by io worker after pwrite
+  _Atomic int* io_error;          // set on write failure
   uint8_t data[]; // used when data_off == sizeof(struct pwrite_job)
 };
 
@@ -74,7 +73,7 @@ pwrite_fn(void* arg)
     log_error("shard_pool_fs pwrite failed");
     atomic_store(j->io_error, 1);
   }
-  atomic_fetch_add(j->retired_bytes, j->nbytes);
+  atomic_fetch_sub(j->pending_bytes, (int64_t)j->nbytes);
 }
 
 static int
@@ -110,13 +109,13 @@ fs_slot_write(struct shard_writer* self,
     j->fd = w->fd;
     j->offset = offset;
     j->nbytes = nbytes;
-    j->retired_bytes = w->retired_bytes;
+    j->pending_bytes = w->pending_bytes;
     j->io_error = w->io_error;
     memcpy((char*)j + j->data_off, beg, nbytes);
-    atomic_fetch_add(w->queued_bytes, nbytes);
+    atomic_fetch_add(w->pending_bytes, (int64_t)nbytes);
     fs_slot_pause_mid_write(w);
     if (io_queue_post(w->queue, pwrite_fn, j, job_free)) {
-      atomic_fetch_sub(w->queued_bytes, nbytes);
+      atomic_fetch_sub(w->pending_bytes, (int64_t)nbytes);
       job_free(j);
       goto Error;
     }
@@ -135,9 +134,9 @@ struct pwrite_ref_job
   platform_fd fd;
   uint64_t offset;
   size_t nbytes;
-  const void* data;                // NOT owned — points into pinned memory
-  _Atomic uint64_t* retired_bytes; // written by io worker after pwrite
-  _Atomic int* io_error;           // set on write failure
+  const void* data;               // NOT owned — points into pinned memory
+  _Atomic int64_t* pending_bytes; // decremented by io worker after pwrite
+  _Atomic int* io_error;          // set on write failure
 };
 
 static void
@@ -148,7 +147,7 @@ pwrite_ref_fn(void* arg)
     log_error("shard_pool_fs pwrite_ref failed");
     atomic_store(j->io_error, 1);
   }
-  atomic_fetch_add(j->retired_bytes, j->nbytes);
+  atomic_fetch_sub(j->pending_bytes, (int64_t)j->nbytes);
 }
 
 static int
@@ -170,12 +169,12 @@ fs_slot_write_direct(struct shard_writer* self,
     j->offset = offset;
     j->nbytes = nbytes;
     j->data = beg;
-    j->retired_bytes = w->retired_bytes;
+    j->pending_bytes = w->pending_bytes;
     j->io_error = w->io_error;
-    atomic_fetch_add(w->queued_bytes, nbytes);
+    atomic_fetch_add(w->pending_bytes, (int64_t)nbytes);
     fs_slot_pause_mid_write(w);
     if (io_queue_post(w->queue, pwrite_ref_fn, j, free)) {
-      atomic_fetch_sub(w->queued_bytes, nbytes);
+      atomic_fetch_sub(w->pending_bytes, (int64_t)nbytes);
       free(j);
       goto Error;
     }
@@ -354,11 +353,8 @@ pool_fs_pending_bytes(const struct shard_pool* self)
 {
   const struct shard_pool_fs* p =
     container_of(self, struct shard_pool_fs, base);
-  // Load retired first: a write is counted in queued_bytes before it is
-  // handed to the worker, so this order cannot see a retire whose queue
-  // was missed, and the difference cannot go negative.
-  uint64_t retired = atomic_load(&p->retired_bytes);
-  return atomic_load(&p->queued_bytes) - retired;
+  int64_t pending = atomic_load(&p->pending_bytes);
+  return pending > 0 ? (size_t)pending : 0;
 }
 
 static size_t
@@ -499,8 +495,7 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
     s->fd = PLATFORM_FD_INVALID;
     s->queue = p->queue;
     s->alignment = page_size;
-    s->retired_bytes = &p->retired_bytes;
-    s->queued_bytes = &p->queued_bytes;
+    s->pending_bytes = &p->pending_bytes;
     s->io_error = &p->io_error;
     s->fail_next_truncate = &p->fail_next_truncate;
     s->pause_mid_write = &p->pause_mid_write;

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -28,6 +28,8 @@ struct shard_pool_fs
   _Atomic int io_error;
   // Test hook: one-shot, fail the next truncate.
   _Atomic int fail_next_truncate;
+  // Test hook: park a writer partway through queueing a write.
+  _Atomic int pause_mid_write;
 };
 
 // --- Writer slot for a single shard file ---
@@ -42,7 +44,15 @@ struct fs_slot
   _Atomic uint64_t* queued_bytes;  // points to shard_pool_fs.queued_bytes
   _Atomic int* io_error;           // points to shard_pool_fs.io_error
   _Atomic int* fail_next_truncate; // points to shard_pool_fs.fail_next_truncate
+  _Atomic int* pause_mid_write;    // points to shard_pool_fs.pause_mid_write
 };
+
+static void
+fs_slot_pause_mid_write(const struct fs_slot* w)
+{
+  while (w->pause_mid_write && atomic_load(w->pause_mid_write))
+    platform_sleep_ns(100000);
+}
 
 struct pwrite_job
 {
@@ -103,11 +113,13 @@ fs_slot_write(struct shard_writer* self,
     j->retired_bytes = w->retired_bytes;
     j->io_error = w->io_error;
     memcpy((char*)j + j->data_off, beg, nbytes);
+    atomic_fetch_add(w->queued_bytes, nbytes);
+    fs_slot_pause_mid_write(w);
     if (io_queue_post(w->queue, pwrite_fn, j, job_free)) {
+      atomic_fetch_sub(w->queued_bytes, nbytes);
       job_free(j);
       goto Error;
     }
-    atomic_fetch_add(w->queued_bytes, nbytes);
   } else {
     CHECK(Error, platform_pwrite(w->fd, beg, nbytes, offset) == 0);
   }
@@ -160,11 +172,13 @@ fs_slot_write_direct(struct shard_writer* self,
     j->data = beg;
     j->retired_bytes = w->retired_bytes;
     j->io_error = w->io_error;
+    atomic_fetch_add(w->queued_bytes, nbytes);
+    fs_slot_pause_mid_write(w);
     if (io_queue_post(w->queue, pwrite_ref_fn, j, free)) {
+      atomic_fetch_sub(w->queued_bytes, nbytes);
       free(j);
       goto Error;
     }
-    atomic_fetch_add(w->queued_bytes, nbytes);
   } else {
     CHECK(Error, platform_pwrite(w->fd, beg, nbytes, offset) == 0);
   }
@@ -340,7 +354,11 @@ pool_fs_pending_bytes(const struct shard_pool* self)
 {
   const struct shard_pool_fs* p =
     container_of(self, struct shard_pool_fs, base);
-  return atomic_load(&p->queued_bytes) - atomic_load(&p->retired_bytes);
+  // Load retired first: a write is counted in queued_bytes before it is
+  // handed to the worker, so this order cannot see a retire whose queue
+  // was missed, and the difference cannot go negative.
+  uint64_t retired = atomic_load(&p->retired_bytes);
+  return atomic_load(&p->queued_bytes) - retired;
 }
 
 static size_t
@@ -401,6 +419,13 @@ shard_pool_fs_set_error(struct shard_pool* self)
 {
   struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
   atomic_store(&p->io_error, 1);
+}
+
+void
+shard_pool_fs_pause_mid_write(struct shard_pool* self, int paused)
+{
+  struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
+  atomic_store(&p->pause_mid_write, paused);
 }
 
 struct gate_ctx
@@ -478,6 +503,7 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
     s->queued_bytes = &p->queued_bytes;
     s->io_error = &p->io_error;
     s->fail_next_truncate = &p->fail_next_truncate;
+    s->pause_mid_write = &p->pause_mid_write;
   }
 
   return &p->base;

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -52,8 +52,8 @@ fs_slot_pause_mid_write(const struct fs_slot* w)
     platform_sleep_ns(100000);
 }
 
-// Counting before the handoff is what keeps pending_bytes from dropping below
-// the work outstanding: the worker can finish a write the moment it is posted.
+// Count before the handoff: the worker can finish the write the moment it is
+// posted, and a late count reads below the work outstanding.
 static int
 fs_slot_post_write(struct fs_slot* w,
                    size_t nbytes,

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -321,12 +321,12 @@ pool_fs_has_error(const struct shard_pool* self)
   return atomic_load(&p->io_error);
 }
 
-static size_t
+static uint64_t
 pool_fs_pending_bytes(const struct shard_pool* self)
 {
   const struct shard_pool_fs* p =
     container_of(self, struct shard_pool_fs, base);
-  return (size_t)io_queue_pending_bytes(p->queue);
+  return io_queue_pending_bytes(p->queue);
 }
 
 static size_t

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -22,8 +22,7 @@ struct shard_pool_fs
   int unbuffered;
   struct strbuf root; // owned
   // Writes land on whichever thread runs sink delivery while the producer
-  // samples pending_bytes for backpressure. Signed, so a slip in the
-  // bookkeeping reads as a small negative instead of wrapping.
+  // samples pending_bytes for backpressure.
   _Atomic int64_t pending_bytes;
   _Atomic int io_error;
   // Test hook: one-shot, fail the next truncate.
@@ -51,6 +50,25 @@ fs_slot_pause_mid_write(const struct fs_slot* w)
 {
   while (w->pause_mid_write && atomic_load(w->pause_mid_write))
     platform_sleep_ns(100000);
+}
+
+// Counting before the handoff is what keeps pending_bytes from dropping below
+// the work outstanding: the worker can finish a write the moment it is posted.
+static int
+fs_slot_post_write(struct fs_slot* w,
+                   size_t nbytes,
+                   void (*fn)(void*),
+                   void* job,
+                   void (*job_free)(void*))
+{
+  atomic_fetch_add(w->pending_bytes, (int64_t)nbytes);
+  fs_slot_pause_mid_write(w);
+  if (io_queue_post(w->queue, fn, job, job_free) == 0)
+    return 0;
+
+  atomic_fetch_sub(w->pending_bytes, (int64_t)nbytes);
+  job_free(job);
+  return 1;
 }
 
 struct pwrite_job
@@ -112,13 +130,7 @@ fs_slot_write(struct shard_writer* self,
     j->pending_bytes = w->pending_bytes;
     j->io_error = w->io_error;
     memcpy((char*)j + j->data_off, beg, nbytes);
-    atomic_fetch_add(w->pending_bytes, (int64_t)nbytes);
-    fs_slot_pause_mid_write(w);
-    if (io_queue_post(w->queue, pwrite_fn, j, job_free)) {
-      atomic_fetch_sub(w->pending_bytes, (int64_t)nbytes);
-      job_free(j);
-      goto Error;
-    }
+    CHECK(Error, fs_slot_post_write(w, nbytes, pwrite_fn, j, job_free) == 0);
   } else {
     CHECK(Error, platform_pwrite(w->fd, beg, nbytes, offset) == 0);
   }
@@ -171,13 +183,7 @@ fs_slot_write_direct(struct shard_writer* self,
     j->data = beg;
     j->pending_bytes = w->pending_bytes;
     j->io_error = w->io_error;
-    atomic_fetch_add(w->pending_bytes, (int64_t)nbytes);
-    fs_slot_pause_mid_write(w);
-    if (io_queue_post(w->queue, pwrite_ref_fn, j, free)) {
-      atomic_fetch_sub(w->pending_bytes, (int64_t)nbytes);
-      free(j);
-      goto Error;
-    }
+    CHECK(Error, fs_slot_post_write(w, nbytes, pwrite_ref_fn, j, free) == 0);
   } else {
     CHECK(Error, platform_pwrite(w->fd, beg, nbytes, offset) == 0);
   }

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -35,6 +35,6 @@ shard_pool_fs_set_error(struct shard_pool* pool);
 
 // Test helper: park writers partway through queueing a write, between counting
 // the bytes and handing the job to the worker. Lets a test read pending_bytes
-// at the one point where the two counters disagree.
+// at the one point where the count and the queued work disagree.
 void
 shard_pool_fs_pause_mid_write(struct shard_pool* pool, int paused);

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -34,7 +34,7 @@ void
 shard_pool_fs_set_error(struct shard_pool* pool);
 
 // Test helper: park writers between counting the bytes and handing the job to
-// the worker. A parked writer polls a flag that lives in the pool, so clear the
-// pause and let the writer finish before destroying the pool.
+// the worker. A parked writer polls a flag in the pool, so clear the pause and
+// let the writer finish before destroying it.
 void
 shard_pool_fs_pause_mid_write(struct shard_pool* pool, int paused);

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -32,9 +32,3 @@ shard_pool_fs_inject_failing_truncate(struct shard_pool* pool);
 // Test helper: mark the pool errored so later deliveries fail and stay queued.
 void
 shard_pool_fs_set_error(struct shard_pool* pool);
-
-// Test helper: park writers between counting the bytes and handing the job to
-// the worker. A parked writer polls a flag in the pool, so clear the pause and
-// let the writer finish before destroying it.
-void
-shard_pool_fs_pause_mid_write(struct shard_pool* pool, int paused);

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -33,10 +33,8 @@ shard_pool_fs_inject_failing_truncate(struct shard_pool* pool);
 void
 shard_pool_fs_set_error(struct shard_pool* pool);
 
-// Test helper: park writers partway through queueing a write, between counting
-// the bytes and handing the job to the worker. Lets a test read pending_bytes
-// at the one point where the count and the queued work disagree. A parked
-// writer polls a flag that lives in the pool, so clear the pause and let the
-// writer finish before destroying the pool.
+// Test helper: park writers between counting the bytes and handing the job to
+// the worker. A parked writer polls a flag that lives in the pool, so clear the
+// pause and let the writer finish before destroying the pool.
 void
 shard_pool_fs_pause_mid_write(struct shard_pool* pool, int paused);

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -32,3 +32,9 @@ shard_pool_fs_inject_failing_truncate(struct shard_pool* pool);
 // Test helper: mark the pool errored so later deliveries fail and stay queued.
 void
 shard_pool_fs_set_error(struct shard_pool* pool);
+
+// Test helper: park writers partway through queueing a write, between counting
+// the bytes and handing the job to the worker. Lets a test read pending_bytes
+// at the one point where the two counters disagree.
+void
+shard_pool_fs_pause_mid_write(struct shard_pool* pool, int paused);

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -35,6 +35,8 @@ shard_pool_fs_set_error(struct shard_pool* pool);
 
 // Test helper: park writers partway through queueing a write, between counting
 // the bytes and handing the job to the worker. Lets a test read pending_bytes
-// at the one point where the count and the queued work disagree.
+// at the one point where the count and the queued work disagree. A parked
+// writer polls a flag that lives in the pool, so clear the pause and let the
+// writer finish before destroying the pool.
 void
 shard_pool_fs_pause_mid_write(struct shard_pool* pool, int paused);

--- a/src/zarr/shard_pool_s3.c
+++ b/src/zarr/shard_pool_s3.c
@@ -167,7 +167,7 @@ pool_s3_has_error(const struct shard_pool* self)
   return p->finalize_err;
 }
 
-static size_t
+static uint64_t
 pool_s3_pending_bytes(const struct shard_pool* self)
 {
   (void)self;

--- a/src/zarr/zarr_array.c
+++ b/src/zarr/zarr_array.c
@@ -155,7 +155,7 @@ zarr_array_has_error_fn(const struct shard_sink* self)
   return a->pool->has_error(a->pool);
 }
 
-static size_t
+static uint64_t
 zarr_array_pending_bytes_fn(const struct shard_sink* self)
 {
   const struct zarr_array* a = container_of(self, struct zarr_array, base);
@@ -333,7 +333,7 @@ zarr_array_has_error(const struct zarr_array* a)
   return a ? a->pool->has_error(a->pool) : 0;
 }
 
-size_t
+uint64_t
 zarr_array_pending_bytes(const struct zarr_array* a)
 {
   return a ? a->pool->pending_bytes(a->pool) : 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -158,6 +158,8 @@ add_gpu_test_exe(test_compress        test_compress.c        LINKS CUDA::cuda_dr
 
 add_test_exe(test_json_writer test_json_writer.c zarr_metadata ngff_metadata strbuf chucky_log)
 add_test_exe(test_io_queue    test_io_queue.c    io_queue chucky_log)
+# A worker left held would hang rather than fail; bound it.
+set_tests_properties(test-test_io_queue PROPERTIES TIMEOUT 60)
 add_test_exe(test_store_fs    test_store_fs.c    store_fs store_api zarr_group platform test_platform chucky_log)
 add_test_exe(test_zarr_attribute test_zarr_attribute.c zarr_array zarr_group store_fs store_api stream_cpu writer test_platform chucky_log)
 add_test_exe(test_ngff_attribute test_ngff_attribute.c ngff_multiscale store_fs store_api test_platform chucky_log)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,9 +144,9 @@ set_tests_properties(test-test_zarr_readback PROPERTIES SKIP_RETURN_CODE 77)
 add_gpu_test_exe(test_cross_validate test_cross_validate.c LINKS CUDA::cuda_driver CUDA::cudart_static stream stream_cpu writer test_data test_shard_verify)
 
 # Test platform utilities
-add_test_lib(test_platform test_platform.h)
+add_test_lib(test_platform test_platform.h test_platform.common.c)
 add_platform_sources(test_platform)
-target_link_libraries(test_platform PUBLIC Threads::Threads)
+target_link_libraries(test_platform PUBLIC Threads::Threads platform)
 
 # Shared test data generation library
 add_test_lib(test_data test_data.c test_data.h)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -182,6 +182,7 @@ add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_dr
 add_gpu_test_exe(test_destroy_midstream test_destroy_midstream.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
 add_test_exe(test_flush_drain_cpu test_flush_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
 add_test_exe(test_flush_error_drain_cpu test_flush_error_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
+add_test_exe(test_pending_bytes_fs test_pending_bytes_fs.c shard_pool_fs platform writer test_platform chucky_log)
 add_test_exe(test_shape_after_flush_cpu test_shape_after_flush_cpu.c stream_cpu test_shard_sink writer chucky_log)
 add_gpu_test_exe(test_shape_after_flush_gpu test_shape_after_flush_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink writer chucky_log)
 add_gpu_test_exe(test_multiarray_flush_mock  test_multiarray_flush_mock.c  LINKS CUDA::cuda_driver CUDA::cudart_static multiarray_gpu stream writer chucky_log)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,6 +183,8 @@ add_gpu_test_exe(test_destroy_midstream test_destroy_midstream.c LINKS CUDA::cud
 add_test_exe(test_flush_drain_cpu test_flush_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
 add_test_exe(test_flush_error_drain_cpu test_flush_error_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
 add_test_exe(test_pending_bytes_fs test_pending_bytes_fs.c shard_pool_fs platform writer test_platform chucky_log)
+# A writer left parked would hang rather than fail; bound it.
+set_tests_properties(test-test_pending_bytes_fs PROPERTIES TIMEOUT 60)
 add_test_exe(test_shape_after_flush_cpu test_shape_after_flush_cpu.c stream_cpu test_shard_sink writer chucky_log)
 add_gpu_test_exe(test_shape_after_flush_gpu test_shape_after_flush_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink writer chucky_log)
 add_gpu_test_exe(test_multiarray_flush_mock  test_multiarray_flush_mock.c  LINKS CUDA::cuda_driver CUDA::cudart_static multiarray_gpu stream writer chucky_log)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,7 +183,7 @@ add_gpu_test_exe(test_destroy_midstream test_destroy_midstream.c LINKS CUDA::cud
 add_test_exe(test_flush_drain_cpu test_flush_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
 add_test_exe(test_flush_error_drain_cpu test_flush_error_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
 add_test_exe(test_pending_bytes_fs test_pending_bytes_fs.c shard_pool_fs platform writer test_platform chucky_log)
-# A writer left parked would hang rather than fail; bound it.
+# A worker left held would hang rather than fail; bound it.
 set_tests_properties(test-test_pending_bytes_fs PROPERTIES TIMEOUT 60)
 add_test_exe(test_shape_after_flush_cpu test_shape_after_flush_cpu.c stream_cpu test_shard_sink writer chucky_log)
 add_gpu_test_exe(test_shape_after_flush_gpu test_shape_after_flush_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink writer chucky_log)

--- a/tests/test_counting_sink.c
+++ b/tests/test_counting_sink.c
@@ -96,7 +96,7 @@ counting_has_error(const struct shard_sink* self)
   return cs->inner->has_error(cs->inner);
 }
 
-static size_t
+static uint64_t
 counting_pending_bytes(const struct shard_sink* self)
 {
   const struct counting_sink* cs = (const struct counting_sink*)self;

--- a/tests/test_destroy_drain.c
+++ b/tests/test_destroy_drain.c
@@ -22,7 +22,6 @@
 
 #define DRAIN_OBSERVE_MS 200
 #define POST_RELEASE_TIMEOUT_MS 5000
-#define POLL_STEP_MS 10
 
 struct destroy_args
 {
@@ -36,17 +35,6 @@ destroy_thread_fn(void* arg)
   struct destroy_args* da = (struct destroy_args*)arg;
   tile_stream_gpu_destroy(da->s);
   atomic_store(&da->done, 1);
-}
-
-static int
-wait_for_done(_Atomic int* done, int timeout_ms)
-{
-  int waited_ms = 0;
-  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
-    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
-    waited_ms += POLL_STEP_MS;
-  }
-  return atomic_load(done) != 0 ? 0 : -1;
 }
 
 static int
@@ -134,7 +122,7 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
 
   atomic_store(&gate, 1);
 
-  if (wait_for_done(&da.done, POST_RELEASE_TIMEOUT_MS)) {
+  if (test_wait_flag(&da.done, POST_RELEASE_TIMEOUT_MS)) {
     log_error("destroy did not finish within %d ms after gate release",
               POST_RELEASE_TIMEOUT_MS);
     goto Cleanup;

--- a/tests/test_destroy_midstream.c
+++ b/tests/test_destroy_midstream.c
@@ -25,7 +25,6 @@
 
 #define DRAIN_OBSERVE_MS 200
 #define POST_RELEASE_TIMEOUT_MS 10000
-#define POLL_STEP_MS 10
 
 struct destroy_args
 {
@@ -39,17 +38,6 @@ destroy_thread_fn(void* arg)
   struct destroy_args* da = (struct destroy_args*)arg;
   tile_stream_gpu_destroy(da->s);
   atomic_store(&da->done, 1);
-}
-
-static int
-wait_for_done(_Atomic int* done, int timeout_ms)
-{
-  int waited_ms = 0;
-  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
-    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
-    waited_ms += POLL_STEP_MS;
-  }
-  return atomic_load(done) != 0 ? 0 : -1;
 }
 
 // Append 1.5 batches (slot kicked, delivery in flight, partial batch
@@ -230,7 +218,7 @@ test_destroy_runs_out_queued_delivery(const char* tmpdir)
   CHECK(Cleanup, test_thread_start(&thr, destroy_thread_fn, &da) == 0);
   s = NULL;
 
-  if (wait_for_done(&da.done, POST_RELEASE_TIMEOUT_MS)) {
+  if (test_wait_flag(&da.done, POST_RELEASE_TIMEOUT_MS)) {
     log_error("destroy hung with a delivery job still queued");
     goto Cleanup;
   }
@@ -339,7 +327,7 @@ test_destroy_blocks_on_gated_sink(const char* tmpdir)
 
   atomic_store(&gate, 1);
 
-  if (wait_for_done(&da.done, POST_RELEASE_TIMEOUT_MS)) {
+  if (test_wait_flag(&da.done, POST_RELEASE_TIMEOUT_MS)) {
     log_error("destroy did not finish within %d ms after gate release",
               POST_RELEASE_TIMEOUT_MS);
     goto Cleanup;

--- a/tests/test_flush_drain_cpu.c
+++ b/tests/test_flush_drain_cpu.c
@@ -20,7 +20,6 @@
 
 #define DRAIN_OBSERVE_MS 200
 #define POST_RELEASE_TIMEOUT_MS 5000
-#define POLL_STEP_MS 10
 
 struct flush_args
 {
@@ -38,17 +37,6 @@ flush_thread_fn(void* arg)
     r = writer_close(fa->w);
   fa->error = r.error;
   atomic_store(&fa->done, 1);
-}
-
-static int
-wait_for_done(_Atomic int* done, int timeout_ms)
-{
-  int waited_ms = 0;
-  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
-    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
-    waited_ms += POLL_STEP_MS;
-  }
-  return atomic_load(done) != 0 ? 0 : -1;
 }
 
 static int
@@ -139,7 +127,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
 
   atomic_store(&gate, 1);
 
-  if (wait_for_done(&fa.done, POST_RELEASE_TIMEOUT_MS)) {
+  if (test_wait_flag(&fa.done, POST_RELEASE_TIMEOUT_MS)) {
     log_error("flush did not finish within %d ms after gate release",
               POST_RELEASE_TIMEOUT_MS);
     goto Cleanup;

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -23,7 +23,6 @@
 
 #define DRAIN_OBSERVE_MS 200
 #define POST_RELEASE_TIMEOUT_MS 5000
-#define POLL_STEP_MS 10
 
 struct flush_args
 {
@@ -39,17 +38,6 @@ flush_thread_fn(void* arg)
   struct writer_result r = writer_flush(fa->w);
   fa->error = r.error;
   atomic_store(&fa->done, 1);
-}
-
-static int
-wait_for_done(_Atomic int* done, int timeout_ms)
-{
-  int waited_ms = 0;
-  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
-    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
-    waited_ms += POLL_STEP_MS;
-  }
-  return atomic_load(done) != 0 ? 0 : -1;
 }
 
 static int
@@ -136,7 +124,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
 
   atomic_store(&gate, 1);
 
-  if (wait_for_done(&fa.done, POST_RELEASE_TIMEOUT_MS)) {
+  if (test_wait_flag(&fa.done, POST_RELEASE_TIMEOUT_MS)) {
     log_error("flush did not finish within %d ms after gate release",
               POST_RELEASE_TIMEOUT_MS);
     goto Cleanup;

--- a/tests/test_io_queue.c
+++ b/tests/test_io_queue.c
@@ -169,9 +169,8 @@ Fail:
 
 // --- test: pending bytes ---
 
-// Regression test for #201. The count rises inside the same lock that hands the
-// job to the worker, so a reader can never see fewer bytes than the queue holds
-// — not even for the instant between taking a job and counting it.
+// #201: the reported figure has to account for every job the queue holds. The
+// old split counter, raised after the post, could report fewer.
 
 static void
 wait_for_gate(void* arg)

--- a/tests/test_io_queue.c
+++ b/tests/test_io_queue.c
@@ -167,6 +167,60 @@ Fail:
   return 1;
 }
 
+// --- test: pending bytes ---
+
+// Regression test for #201. The count rises inside the same lock that hands the
+// job to the worker, so a reader can never see fewer bytes than the queue holds
+// — not even for the instant between taking a job and counting it.
+
+static void
+wait_for_gate(void* arg)
+{
+  atomic_int* gate = (atomic_int*)arg;
+  while (atomic_load(gate) == 0)
+    ;
+}
+
+static int
+test_pending_bytes(void)
+{
+  struct io_queue* q = io_queue_create();
+  CHECK(Fail, q);
+
+  CHECK(Fail2, io_queue_pending_bytes(q) == 0);
+
+  // Hold the worker on the first job so the rest stay queued.
+  atomic_int gate = 0;
+  CHECK(Fail2, io_queue_post(q, wait_for_gate, (void*)&gate, NULL) == 0);
+
+  uint64_t posted = 0;
+  for (int i = 1; i <= 8; ++i) {
+    uint64_t nbytes = (uint64_t)i * 1024;
+    CHECK(Fail3, io_queue_post_bytes(q, noop_fn, NULL, NULL, nbytes) == 0);
+    posted += nbytes;
+    CHECK(Fail3, io_queue_pending_bytes(q) == posted);
+  }
+
+  atomic_store(&gate, 1);
+  io_event_wait(q, io_queue_record(q));
+  CHECK(Fail2, io_queue_pending_bytes(q) == 0);
+
+  // A job posted without a byte count leaves the figure alone.
+  CHECK(Fail2, io_queue_post(q, noop_fn, NULL, NULL) == 0);
+  io_event_wait(q, io_queue_record(q));
+  CHECK(Fail2, io_queue_pending_bytes(q) == 0);
+
+  io_queue_destroy(q);
+  return 0;
+
+Fail3:
+  atomic_store(&gate, 1);
+Fail2:
+  io_queue_destroy(q);
+Fail:
+  return 1;
+}
+
 // --- main ---
 
 int
@@ -183,6 +237,7 @@ main(void)
     { "ctx_free", test_ctx_free },
     { "destroy_drains", test_destroy_drains },
     { "empty_queue_event", test_empty_queue_event },
+    { "pending_bytes", test_pending_bytes },
   };
   for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
     int r = tests[i].fn();

--- a/tests/test_pending_bytes_fs.c
+++ b/tests/test_pending_bytes_fs.c
@@ -1,7 +1,6 @@
-// The pool reports the bytes its queued writes are still carrying. The count
-// itself lives in the io queue, which raises it inside the lock that hands a job
-// to the worker; tests/test_io_queue.c covers that. This checks the pool passes
-// the figure through, over both write paths.
+// The pool reports the bytes its queued writes still carry. The count lives in
+// the io queue, and tests/test_io_queue.c covers it there. This checks that the
+// pool passes the figure through, over both write paths.
 
 #include "test_platform.h"
 #include "util/prelude.h"
@@ -38,9 +37,9 @@ test_counts_every_write(const char* tmpdir, int direct)
   struct shard_writer* w = pool->open(pool, 0, "shard");
   CHECK(Cleanup, w);
 
-  int (*write)(struct shard_writer*, uint64_t, const void*, const void*) =
+  int (*post_write)(struct shard_writer*, uint64_t, const void*, const void*) =
     direct ? w->write_direct : w->write;
-  CHECK(Cleanup, write);
+  CHECK(Cleanup, post_write);
 
   src = (uint8_t*)calloc(1, WRITE_BYTES);
   CHECK(Cleanup, src);
@@ -49,7 +48,7 @@ test_counts_every_write(const char* tmpdir, int direct)
 
   for (int i = 0; i < BATCH_WRITES; ++i) {
     uint64_t offset = (uint64_t)i * WRITE_BYTES;
-    CHECK(Cleanup, write(w, offset, src, src + WRITE_BYTES) == 0);
+    CHECK(Cleanup, post_write(w, offset, src, src + WRITE_BYTES) == 0);
     CHECK(Cleanup,
           shard_pool_pending_bytes(pool) == (size_t)(i + 1) * WRITE_BYTES);
   }

--- a/tests/test_pending_bytes_fs.c
+++ b/tests/test_pending_bytes_fs.c
@@ -1,12 +1,7 @@
-// Regression test for #201: pending_bytes must never report less than the work
-// outstanding.
-//
-// The pool adds a write to its pending count, then hands the job to the io
-// worker, which subtracts once the write lands. Hand off before counting and the
-// worker can subtract a write nobody has added yet, driving the count negative.
-//
-// That window is a few nanoseconds wide, so waiting for a thread to lose the
-// race does not work. The pool has a test hook that parks a writer inside it.
+// The pool reports the bytes its queued writes are still carrying. The count
+// itself lives in the io queue, which raises it inside the lock that hands a job
+// to the worker; tests/test_io_queue.c covers that. This checks the pool passes
+// the figure through, over both write paths.
 
 #include "test_platform.h"
 #include "util/prelude.h"
@@ -21,110 +16,14 @@
 
 #define WRITE_BYTES 4096
 #define BATCH_WRITES 8
-#define PARK_TIMEOUT_MS 2000
 
-typedef int (*write_fn)(struct shard_writer*,
-                        uint64_t,
-                        const void*,
-                        const void*);
-
-struct one_write_args
-{
-  struct shard_writer* w;
-  write_fn write;
-  const uint8_t* src;
-  int error;
-};
-
-static void
-one_write_fn(void* arg)
-{
-  struct one_write_args* oa = (struct one_write_args*)arg;
-  oa->error = oa->write(oa->w, 0, oa->src, oa->src + WRITE_BYTES);
-}
-
+// With the worker held, every queued write must show up in the figure, and it
+// must fall back to zero once they land.
 static int
-has_pending(void* ctx)
-{
-  return shard_pool_pending_bytes((struct shard_pool*)ctx) != 0;
-}
-
-// A parked writer must report exactly the write it is queueing. Equality
-// matters: counting after the handoff drives the count negative, which clamps to
-// 0, and a check for "not too high" would accept that.
-static int
-test_parked_writer(const char* tmpdir, int direct)
+test_counts_every_write(const char* tmpdir, int direct)
 {
   const char* label = direct ? "zero-copy" : "copy";
-  log_info("=== test_parked_writer (%s) ===", label);
-
-  struct shard_pool* pool = NULL;
-  uint8_t* src = NULL;
-  test_thread* thr = NULL;
-  int rc = 1;
-  struct one_write_args oa = { 0 };
-
-  pool = shard_pool_fs_create(tmpdir, /*nslots=*/1, /*unbuffered=*/0);
-  CHECK(Cleanup, pool);
-
-  struct shard_writer* w = pool->open(pool, 0, "shard");
-  CHECK(Cleanup, w);
-
-  oa.w = w;
-  oa.write = direct ? w->write_direct : w->write;
-  CHECK(Cleanup, oa.write);
-
-  src = (uint8_t*)calloc(1, WRITE_BYTES);
-  CHECK(Cleanup, src);
-  oa.src = src;
-
-  shard_pool_fs_pause_mid_write(pool, 1);
-  CHECK(Cleanup, test_thread_start(&thr, one_write_fn, &oa) == 0);
-
-  // Wait for the writer to reach the window rather than guess how long that
-  // takes. A build that counts after the handoff never reports the write, so
-  // this waits out the timeout and the check below fails, as it should.
-  test_wait_until(has_pending, pool, PARK_TIMEOUT_MS);
-
-  // Settle anything already queued. A build that hands off before counting has a
-  // write in flight whose worker drives the count too low; a correct build has
-  // posted nothing and this returns at once.
-  pool->wait_fence(pool, pool->record_fence(pool));
-
-  size_t parked = shard_pool_pending_bytes(pool);
-  log_info("  pending while parked: %llu bytes (queueing %d)",
-           (unsigned long long)parked,
-           WRITE_BYTES);
-  CHECK(Cleanup, parked == (size_t)WRITE_BYTES);
-
-  shard_pool_fs_pause_mid_write(pool, 0);
-  CHECK(Cleanup, test_thread_join(thr) == 0);
-  thr = NULL;
-  CHECK(Cleanup, oa.error == 0);
-
-  CHECK(Cleanup, pool->flush(pool) == 0);
-  CHECK(Cleanup, shard_pool_pending_bytes(pool) == 0);
-
-  rc = 0;
-  log_info("  PASS");
-
-Cleanup:
-  if (pool)
-    shard_pool_fs_pause_mid_write(pool, 0);
-  test_thread_join(thr);
-  shard_pool_destroy(pool);
-  free(src);
-  if (rc)
-    log_error("  FAIL");
-  return rc;
-}
-
-// With the worker held, the count must equal every queued write, and fall back
-// to zero once they land.
-static int
-test_counts_every_write(const char* tmpdir)
-{
-  log_info("=== test_counts_every_write ===");
+  log_info("=== test_counts_every_write (%s) ===", label);
 
   struct shard_pool* pool = NULL;
   uint8_t* src = NULL;
@@ -134,9 +33,14 @@ test_counts_every_write(const char* tmpdir)
 
   pool = shard_pool_fs_create(tmpdir, /*nslots=*/1, /*unbuffered=*/0);
   CHECK(Cleanup, pool);
+  CHECK(Cleanup, shard_pool_pending_bytes(pool) == 0);
 
   struct shard_writer* w = pool->open(pool, 0, "shard");
   CHECK(Cleanup, w);
+
+  int (*write)(struct shard_writer*, uint64_t, const void*, const void*) =
+    direct ? w->write_direct : w->write;
+  CHECK(Cleanup, write);
 
   src = (uint8_t*)calloc(1, WRITE_BYTES);
   CHECK(Cleanup, src);
@@ -145,13 +49,13 @@ test_counts_every_write(const char* tmpdir)
 
   for (int i = 0; i < BATCH_WRITES; ++i) {
     uint64_t offset = (uint64_t)i * WRITE_BYTES;
-    CHECK(Cleanup, w->write(w, offset, src, src + WRITE_BYTES) == 0);
+    CHECK(Cleanup, write(w, offset, src, src + WRITE_BYTES) == 0);
+    CHECK(Cleanup,
+          shard_pool_pending_bytes(pool) == (size_t)(i + 1) * WRITE_BYTES);
   }
 
-  size_t pending = shard_pool_pending_bytes(pool);
   log_info("  pending with worker held: %llu bytes",
-           (unsigned long long)pending);
-  CHECK(Cleanup, pending == (size_t)BATCH_WRITES * WRITE_BYTES);
+           (unsigned long long)shard_pool_pending_bytes(pool));
 
   atomic_store(&gate, 1);
   CHECK(Cleanup, pool->flush(pool) == 0);
@@ -185,19 +89,13 @@ main(int ac, char* av[])
     char sub[4200];
     snprintf(sub, sizeof(sub), "%s/copy", tmpdir);
     test_mkdir(sub);
-    ecode |= test_parked_writer(sub, 0);
+    ecode |= test_counts_every_write(sub, 0);
   }
   {
     char sub[4200];
     snprintf(sub, sizeof(sub), "%s/zero-copy", tmpdir);
     test_mkdir(sub);
-    ecode |= test_parked_writer(sub, 1);
-  }
-  {
-    char sub[4200];
-    snprintf(sub, sizeof(sub), "%s/counts", tmpdir);
-    test_mkdir(sub);
-    ecode |= test_counts_every_write(sub);
+    ecode |= test_counts_every_write(sub, 1);
   }
 
   test_tmpdir_remove(tmpdir);

--- a/tests/test_pending_bytes_fs.c
+++ b/tests/test_pending_bytes_fs.c
@@ -27,6 +27,7 @@
 #define BATCH_WRITES 8
 #define WORKER_SETTLE_MS 200
 #define POLL_STEP_MS 5
+#define PARK_TIMEOUT_MS 2000
 #define JOIN_TIMEOUT_MS 5000
 
 struct one_write_args
@@ -43,9 +44,10 @@ one_write_fn(void* arg)
 {
   struct one_write_args* oa = (struct one_write_args*)arg;
   const uint8_t* beg = oa->src;
-  oa->error = oa->direct
-                ? oa->w->write_direct(oa->w, 0, beg, beg + WRITE_BYTES)
-                : oa->w->write(oa->w, 0, beg, beg + WRITE_BYTES);
+  if (oa->direct)
+    oa->error = oa->w->write_direct(oa->w, 0, beg, beg + WRITE_BYTES);
+  else
+    oa->error = oa->w->write(oa->w, 0, beg, beg + WRITE_BYTES);
   atomic_store(&oa->done, 1);
 }
 
@@ -58,6 +60,19 @@ wait_for_done(_Atomic int* done, int timeout_ms)
     waited_ms += POLL_STEP_MS;
   }
   return atomic_load(done) != 0 ? 0 : -1;
+}
+
+// Wait for the writer to reach the window instead of guessing how long it takes
+// to get there. A build that counts after the handoff never reports the write,
+// so this waits out the timeout and the caller's check fails, as it should.
+static void
+wait_for_pending(struct shard_pool* pool, int timeout_ms)
+{
+  int waited_ms = 0;
+  while (shard_pool_pending_bytes(pool) == 0 && waited_ms < timeout_ms) {
+    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
+    waited_ms += POLL_STEP_MS;
+  }
 }
 
 // A writer parked in the window must leave pending_bytes reporting exactly the
@@ -92,6 +107,8 @@ test_parked_writer(const char* tmpdir, const char* label, int direct)
   oa.direct = direct;
   atomic_store(&oa.done, 0);
   CHECK(Cleanup, test_thread_start(&thr, one_write_fn, &oa) == 0);
+
+  wait_for_pending(pool, PARK_TIMEOUT_MS);
 
   // Long enough for the worker to have retired the write, if this build handed
   // it over before counting it.
@@ -186,9 +203,10 @@ main(int ac, char* av[])
   (void)ac;
   (void)av;
 
-  int ecode = 0;
+  int ecode = 1;
   char tmpdir[4096];
   CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  ecode = 0;
   log_info("temp dir: %s", tmpdir);
 
   {

--- a/tests/test_pending_bytes_fs.c
+++ b/tests/test_pending_bytes_fs.c
@@ -8,7 +8,6 @@
 // That window is a few nanoseconds wide, so waiting for a thread to lose the
 // race does not work. The pool has a test hook that parks a writer inside it.
 
-#include "platform/platform.h"
 #include "test_platform.h"
 #include "util/prelude.h"
 #include "writer.h"
@@ -22,7 +21,6 @@
 
 #define WRITE_BYTES 4096
 #define BATCH_WRITES 8
-#define POLL_STEP_MS 10
 #define PARK_TIMEOUT_MS 2000
 
 typedef int (*write_fn)(struct shard_writer*,
@@ -45,17 +43,10 @@ one_write_fn(void* arg)
   oa->error = oa->write(oa->w, 0, oa->src, oa->src + WRITE_BYTES);
 }
 
-// Wait for the writer to reach the window rather than guess how long that takes.
-// A build that counts after the handoff never reports the write, so this waits
-// out the timeout and the caller's check fails, as it should.
-static void
-wait_for_pending(struct shard_pool* pool, int timeout_ms)
+static int
+has_pending(void* ctx)
 {
-  int waited_ms = 0;
-  while (shard_pool_pending_bytes(pool) == 0 && waited_ms < timeout_ms) {
-    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
-    waited_ms += POLL_STEP_MS;
-  }
+  return shard_pool_pending_bytes((struct shard_pool*)ctx) != 0;
 }
 
 // A parked writer must report exactly the write it is queueing. Equality
@@ -90,7 +81,10 @@ test_parked_writer(const char* tmpdir, int direct)
   shard_pool_fs_pause_mid_write(pool, 1);
   CHECK(Cleanup, test_thread_start(&thr, one_write_fn, &oa) == 0);
 
-  wait_for_pending(pool, PARK_TIMEOUT_MS);
+  // Wait for the writer to reach the window rather than guess how long that
+  // takes. A build that counts after the handoff never reports the write, so
+  // this waits out the timeout and the check below fails, as it should.
+  test_wait_until(has_pending, pool, PARK_TIMEOUT_MS);
 
   // Settle anything already queued. A build that hands off before counting has a
   // write in flight whose worker drives the count too low; a correct build has

--- a/tests/test_pending_bytes_fs.c
+++ b/tests/test_pending_bytes_fs.c
@@ -1,15 +1,12 @@
 // Regression test for #201: pending_bytes must never report less than the work
 // outstanding.
 //
-// The pool adds a write to its pending count and hands the job to the io
-// worker, which subtracts once the write lands. Between those two steps the
-// count and the queued work disagree, and the order decides which way: count
-// first and pending_bytes reads high by that write, hand off first and the
+// The pool adds a write to its pending count, then hands the job to the io
+// worker, which subtracts once the write lands. Hand off before counting and the
 // worker can subtract a write nobody has added yet, driving the count negative.
 //
-// The window is a few nanoseconds wide, so waiting for a real thread to lose
-// the race does not work. The pool has a test hook that parks a writer in the
-// window instead, which makes both orders show their result every run.
+// That window is a few nanoseconds wide, so waiting for a thread to lose the
+// race does not work. The pool has a test hook that parks a writer inside it.
 
 #include "platform/platform.h"
 #include "test_platform.h"
@@ -48,9 +45,9 @@ one_write_fn(void* arg)
   oa->error = oa->write(oa->w, 0, oa->src, oa->src + WRITE_BYTES);
 }
 
-// Wait for the writer to reach the window instead of guessing how long it takes
-// to get there. A build that counts after the handoff never reports the write,
-// so this waits out the timeout and the caller's check fails, as it should.
+// Wait for the writer to reach the window rather than guess how long that takes.
+// A build that counts after the handoff never reports the write, so this waits
+// out the timeout and the caller's check fails, as it should.
 static void
 wait_for_pending(struct shard_pool* pool, int timeout_ms)
 {
@@ -61,10 +58,9 @@ wait_for_pending(struct shard_pool* pool, int timeout_ms)
   }
 }
 
-// A writer parked in the window must leave pending_bytes reporting exactly the
-// write it is queueing. Equality matters: counting after the handoff drives the
-// count negative, and pending_bytes clamps that to 0, which an upper-bound
-// check would accept.
+// A parked writer must report exactly the write it is queueing. Equality
+// matters: counting after the handoff drives the count negative, which clamps to
+// 0, and a check for "not too high" would accept that.
 static int
 test_parked_writer(const char* tmpdir, int direct)
 {
@@ -96,9 +92,9 @@ test_parked_writer(const char* tmpdir, int direct)
 
   wait_for_pending(pool, PARK_TIMEOUT_MS);
 
-  // Settle any write already queued. A build that hands off before counting has
-  // one in flight here, and its worker drives the count below what is
-  // outstanding; a correct build has posted nothing and this returns at once.
+  // Settle anything already queued. A build that hands off before counting has a
+  // write in flight whose worker drives the count too low; a correct build has
+  // posted nothing and this returns at once.
   pool->wait_fence(pool, pool->record_fence(pool));
 
   size_t parked = shard_pool_pending_bytes(pool);
@@ -129,8 +125,8 @@ Cleanup:
   return rc;
 }
 
-// With the worker held, pending_bytes must account for every queued write, and
-// must fall back to zero once they land.
+// With the worker held, the count must equal every queued write, and fall back
+// to zero once they land.
 static int
 test_counts_every_write(const char* tmpdir)
 {

--- a/tests/test_pending_bytes_fs.c
+++ b/tests/test_pending_bytes_fs.c
@@ -1,11 +1,11 @@
-// Regression test for #201: pending_bytes must never report more bytes than
-// were queued.
+// Regression test for #201: pending_bytes must never report less than the work
+// outstanding.
 //
 // The pool adds a write to its pending count and hands the job to the io
 // worker, which subtracts once the write lands. Between those two steps the
 // count and the queued work disagree, and the order decides which way: count
 // first and pending_bytes reads high by that write, hand off first and the
-// worker can subtract a write nobody has added yet, leaving the count negative.
+// worker can subtract a write nobody has added yet, driving the count negative.
 //
 // The window is a few nanoseconds wide, so waiting for a real thread to lose
 // the race does not work. The pool has a test hook that parks a writer in the
@@ -25,17 +25,19 @@
 
 #define WRITE_BYTES 4096
 #define BATCH_WRITES 8
-#define WORKER_SETTLE_MS 200
-#define POLL_STEP_MS 5
+#define POLL_STEP_MS 10
 #define PARK_TIMEOUT_MS 2000
-#define JOIN_TIMEOUT_MS 5000
+
+typedef int (*write_fn)(struct shard_writer*,
+                        uint64_t,
+                        const void*,
+                        const void*);
 
 struct one_write_args
 {
   struct shard_writer* w;
+  write_fn write;
   const uint8_t* src;
-  int direct;
-  _Atomic int done;
   int error;
 };
 
@@ -43,23 +45,7 @@ static void
 one_write_fn(void* arg)
 {
   struct one_write_args* oa = (struct one_write_args*)arg;
-  const uint8_t* beg = oa->src;
-  if (oa->direct)
-    oa->error = oa->w->write_direct(oa->w, 0, beg, beg + WRITE_BYTES);
-  else
-    oa->error = oa->w->write(oa->w, 0, beg, beg + WRITE_BYTES);
-  atomic_store(&oa->done, 1);
-}
-
-static int
-wait_for_done(_Atomic int* done, int timeout_ms)
-{
-  int waited_ms = 0;
-  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
-    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
-    waited_ms += POLL_STEP_MS;
-  }
-  return atomic_load(done) != 0 ? 0 : -1;
+  oa->error = oa->write(oa->w, 0, oa->src, oa->src + WRITE_BYTES);
 }
 
 // Wait for the writer to reach the window instead of guessing how long it takes
@@ -77,11 +63,12 @@ wait_for_pending(struct shard_pool* pool, int timeout_ms)
 
 // A writer parked in the window must leave pending_bytes reporting exactly the
 // write it is queueing. Equality matters: counting after the handoff drives the
-// count negative, and the clamp in pending_bytes would report that as 0, which
-// an upper-bound check would accept.
+// count negative, and pending_bytes clamps that to 0, which an upper-bound
+// check would accept.
 static int
-test_parked_writer(const char* tmpdir, const char* label, int direct)
+test_parked_writer(const char* tmpdir, int direct)
 {
+  const char* label = direct ? "zero-copy" : "copy";
   log_info("=== test_parked_writer (%s) ===", label);
 
   struct shard_pool* pool = NULL;
@@ -95,38 +82,37 @@ test_parked_writer(const char* tmpdir, const char* label, int direct)
 
   struct shard_writer* w = pool->open(pool, 0, "shard");
   CHECK(Cleanup, w);
-  CHECK(Cleanup, !direct || w->write_direct);
+
+  oa.w = w;
+  oa.write = direct ? w->write_direct : w->write;
+  CHECK(Cleanup, oa.write);
 
   src = (uint8_t*)calloc(1, WRITE_BYTES);
   CHECK(Cleanup, src);
+  oa.src = src;
 
   shard_pool_fs_pause_mid_write(pool, 1);
-
-  oa.w = w;
-  oa.src = src;
-  oa.direct = direct;
-  atomic_store(&oa.done, 0);
   CHECK(Cleanup, test_thread_start(&thr, one_write_fn, &oa) == 0);
 
   wait_for_pending(pool, PARK_TIMEOUT_MS);
 
-  // Long enough for the worker to have retired the write, if this build handed
-  // it over before counting it.
-  platform_sleep_ns((int64_t)WORKER_SETTLE_MS * 1000000LL);
+  // Settle any write already queued. A build that hands off before counting has
+  // one in flight here, and its worker drives the count below what is
+  // outstanding; a correct build has posted nothing and this returns at once.
+  pool->wait_fence(pool, pool->record_fence(pool));
 
   size_t parked = shard_pool_pending_bytes(pool);
   log_info("  pending while parked: %llu bytes (queueing %d)",
            (unsigned long long)parked,
            WRITE_BYTES);
+  CHECK(Cleanup, parked == (size_t)WRITE_BYTES);
 
   shard_pool_fs_pause_mid_write(pool, 0);
-  CHECK(Cleanup, wait_for_done(&oa.done, JOIN_TIMEOUT_MS) == 0);
-  test_thread_join(thr);
+  CHECK(Cleanup, test_thread_join(thr) == 0);
   thr = NULL;
   CHECK(Cleanup, oa.error == 0);
 
   CHECK(Cleanup, pool->flush(pool) == 0);
-  CHECK(Cleanup, parked == (size_t)WRITE_BYTES);
   CHECK(Cleanup, shard_pool_pending_bytes(pool) == 0);
 
   rc = 0;
@@ -136,10 +122,8 @@ Cleanup:
   if (pool)
     shard_pool_fs_pause_mid_write(pool, 0);
   test_thread_join(thr);
-  if (pool)
-    pool->flush(pool);
-  free(src);
   shard_pool_destroy(pool);
+  free(src);
   if (rc)
     log_error("  FAIL");
   return rc;
@@ -188,10 +172,8 @@ test_counts_every_write(const char* tmpdir)
 
 Cleanup:
   atomic_store(&gate, 1);
-  if (pool)
-    pool->flush(pool);
-  free(src);
   shard_pool_destroy(pool);
+  free(src);
   if (rc)
     log_error("  FAIL");
   return rc;
@@ -213,13 +195,13 @@ main(int ac, char* av[])
     char sub[4200];
     snprintf(sub, sizeof(sub), "%s/copy", tmpdir);
     test_mkdir(sub);
-    ecode |= test_parked_writer(sub, "copy", 0);
+    ecode |= test_parked_writer(sub, 0);
   }
   {
     char sub[4200];
-    snprintf(sub, sizeof(sub), "%s/direct", tmpdir);
+    snprintf(sub, sizeof(sub), "%s/zero-copy", tmpdir);
     test_mkdir(sub);
-    ecode |= test_parked_writer(sub, "zero-copy", 1);
+    ecode |= test_parked_writer(sub, 1);
   }
   {
     char sub[4200];

--- a/tests/test_pending_bytes_fs.c
+++ b/tests/test_pending_bytes_fs.c
@@ -50,7 +50,7 @@ test_counts_every_write(const char* tmpdir, int direct)
     uint64_t offset = (uint64_t)i * WRITE_BYTES;
     CHECK(Cleanup, post_write(w, offset, src, src + WRITE_BYTES) == 0);
     CHECK(Cleanup,
-          shard_pool_pending_bytes(pool) == (size_t)(i + 1) * WRITE_BYTES);
+          shard_pool_pending_bytes(pool) == (uint64_t)(i + 1) * WRITE_BYTES);
   }
 
   log_info("  pending with worker held: %llu bytes",

--- a/tests/test_pending_bytes_fs.c
+++ b/tests/test_pending_bytes_fs.c
@@ -1,11 +1,11 @@
 // Regression test for #201: pending_bytes must never report more bytes than
 // were queued.
 //
-// The pool counts a write in queued_bytes and hands the job to the io worker.
-// Between those two steps the counters disagree, and the order decides which
-// way: count first and pending_bytes reads high by that write, hand off first
-// and the worker can retire a write nobody has counted yet, so the unsigned
-// difference wraps to about 2^64.
+// The pool adds a write to its pending count and hands the job to the io
+// worker, which subtracts once the write lands. Between those two steps the
+// count and the queued work disagree, and the order decides which way: count
+// first and pending_bytes reads high by that write, hand off first and the
+// worker can subtract a write nobody has added yet, leaving the count negative.
 //
 // The window is a few nanoseconds wide, so waiting for a real thread to lose
 // the race does not work. The pool has a test hook that parks a writer in the
@@ -60,8 +60,10 @@ wait_for_done(_Atomic int* done, int timeout_ms)
   return atomic_load(done) != 0 ? 0 : -1;
 }
 
-// A writer parked in the window must never leave pending_bytes above the bytes
-// it is queueing.
+// A writer parked in the window must leave pending_bytes reporting exactly the
+// write it is queueing. Equality matters: counting after the handoff drives the
+// count negative, and the clamp in pending_bytes would report that as 0, which
+// an upper-bound check would accept.
 static int
 test_parked_writer(const char* tmpdir, const char* label, int direct)
 {
@@ -107,7 +109,7 @@ test_parked_writer(const char* tmpdir, const char* label, int direct)
   CHECK(Cleanup, oa.error == 0);
 
   CHECK(Cleanup, pool->flush(pool) == 0);
-  CHECK(Cleanup, parked <= (size_t)WRITE_BYTES);
+  CHECK(Cleanup, parked == (size_t)WRITE_BYTES);
   CHECK(Cleanup, shard_pool_pending_bytes(pool) == 0);
 
   rc = 0;

--- a/tests/test_pending_bytes_fs.c
+++ b/tests/test_pending_bytes_fs.c
@@ -1,0 +1,215 @@
+// Regression test for #201: pending_bytes must never report more bytes than
+// were queued.
+//
+// The pool counts a write in queued_bytes and hands the job to the io worker.
+// Between those two steps the counters disagree, and the order decides which
+// way: count first and pending_bytes reads high by that write, hand off first
+// and the worker can retire a write nobody has counted yet, so the unsigned
+// difference wraps to about 2^64.
+//
+// The window is a few nanoseconds wide, so waiting for a real thread to lose
+// the race does not work. The pool has a test hook that parks a writer in the
+// window instead, which makes both orders show their result every run.
+
+#include "platform/platform.h"
+#include "test_platform.h"
+#include "util/prelude.h"
+#include "writer.h"
+#include "zarr/shard_pool.h"
+#include "zarr/shard_pool_fs.h"
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define WRITE_BYTES 4096
+#define BATCH_WRITES 8
+#define WORKER_SETTLE_MS 200
+#define POLL_STEP_MS 5
+#define JOIN_TIMEOUT_MS 5000
+
+struct one_write_args
+{
+  struct shard_writer* w;
+  const uint8_t* src;
+  int direct;
+  _Atomic int done;
+  int error;
+};
+
+static void
+one_write_fn(void* arg)
+{
+  struct one_write_args* oa = (struct one_write_args*)arg;
+  const uint8_t* beg = oa->src;
+  oa->error = oa->direct
+                ? oa->w->write_direct(oa->w, 0, beg, beg + WRITE_BYTES)
+                : oa->w->write(oa->w, 0, beg, beg + WRITE_BYTES);
+  atomic_store(&oa->done, 1);
+}
+
+static int
+wait_for_done(_Atomic int* done, int timeout_ms)
+{
+  int waited_ms = 0;
+  while (atomic_load(done) == 0 && waited_ms < timeout_ms) {
+    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
+    waited_ms += POLL_STEP_MS;
+  }
+  return atomic_load(done) != 0 ? 0 : -1;
+}
+
+// A writer parked in the window must never leave pending_bytes above the bytes
+// it is queueing.
+static int
+test_parked_writer(const char* tmpdir, const char* label, int direct)
+{
+  log_info("=== test_parked_writer (%s) ===", label);
+
+  struct shard_pool* pool = NULL;
+  uint8_t* src = NULL;
+  test_thread* thr = NULL;
+  int rc = 1;
+  struct one_write_args oa = { 0 };
+
+  pool = shard_pool_fs_create(tmpdir, /*nslots=*/1, /*unbuffered=*/0);
+  CHECK(Cleanup, pool);
+
+  struct shard_writer* w = pool->open(pool, 0, "shard");
+  CHECK(Cleanup, w);
+  CHECK(Cleanup, !direct || w->write_direct);
+
+  src = (uint8_t*)calloc(1, WRITE_BYTES);
+  CHECK(Cleanup, src);
+
+  shard_pool_fs_pause_mid_write(pool, 1);
+
+  oa.w = w;
+  oa.src = src;
+  oa.direct = direct;
+  atomic_store(&oa.done, 0);
+  CHECK(Cleanup, test_thread_start(&thr, one_write_fn, &oa) == 0);
+
+  // Long enough for the worker to have retired the write, if this build handed
+  // it over before counting it.
+  platform_sleep_ns((int64_t)WORKER_SETTLE_MS * 1000000LL);
+
+  size_t parked = shard_pool_pending_bytes(pool);
+  log_info("  pending while parked: %llu bytes (queueing %d)",
+           (unsigned long long)parked,
+           WRITE_BYTES);
+
+  shard_pool_fs_pause_mid_write(pool, 0);
+  CHECK(Cleanup, wait_for_done(&oa.done, JOIN_TIMEOUT_MS) == 0);
+  test_thread_join(thr);
+  thr = NULL;
+  CHECK(Cleanup, oa.error == 0);
+
+  CHECK(Cleanup, pool->flush(pool) == 0);
+  CHECK(Cleanup, parked <= (size_t)WRITE_BYTES);
+  CHECK(Cleanup, shard_pool_pending_bytes(pool) == 0);
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  if (pool)
+    shard_pool_fs_pause_mid_write(pool, 0);
+  test_thread_join(thr);
+  if (pool)
+    pool->flush(pool);
+  free(src);
+  shard_pool_destroy(pool);
+  if (rc)
+    log_error("  FAIL");
+  return rc;
+}
+
+// With the worker held, pending_bytes must account for every queued write, and
+// must fall back to zero once they land.
+static int
+test_counts_every_write(const char* tmpdir)
+{
+  log_info("=== test_counts_every_write ===");
+
+  struct shard_pool* pool = NULL;
+  uint8_t* src = NULL;
+  int rc = 1;
+  _Atomic int gate;
+  atomic_store(&gate, 0);
+
+  pool = shard_pool_fs_create(tmpdir, /*nslots=*/1, /*unbuffered=*/0);
+  CHECK(Cleanup, pool);
+
+  struct shard_writer* w = pool->open(pool, 0, "shard");
+  CHECK(Cleanup, w);
+
+  src = (uint8_t*)calloc(1, WRITE_BYTES);
+  CHECK(Cleanup, src);
+
+  CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+
+  for (int i = 0; i < BATCH_WRITES; ++i) {
+    uint64_t offset = (uint64_t)i * WRITE_BYTES;
+    CHECK(Cleanup, w->write(w, offset, src, src + WRITE_BYTES) == 0);
+  }
+
+  size_t pending = shard_pool_pending_bytes(pool);
+  log_info("  pending with worker held: %llu bytes",
+           (unsigned long long)pending);
+  CHECK(Cleanup, pending == (size_t)BATCH_WRITES * WRITE_BYTES);
+
+  atomic_store(&gate, 1);
+  CHECK(Cleanup, pool->flush(pool) == 0);
+  CHECK(Cleanup, shard_pool_pending_bytes(pool) == 0);
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  atomic_store(&gate, 1);
+  if (pool)
+    pool->flush(pool);
+  free(src);
+  shard_pool_destroy(pool);
+  if (rc)
+    log_error("  FAIL");
+  return rc;
+}
+
+int
+main(int ac, char* av[])
+{
+  (void)ac;
+  (void)av;
+
+  int ecode = 0;
+  char tmpdir[4096];
+  CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  log_info("temp dir: %s", tmpdir);
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/copy", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_parked_writer(sub, "copy", 0);
+  }
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/direct", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_parked_writer(sub, "zero-copy", 1);
+  }
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/counts", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_counts_every_write(sub);
+  }
+
+  test_tmpdir_remove(tmpdir);
+
+Fail:
+  return ecode;
+}

--- a/tests/test_platform.common.c
+++ b/tests/test_platform.common.c
@@ -1,0 +1,30 @@
+#include "test_platform.h"
+
+#include "platform/platform.h"
+
+#define POLL_STEP_MS 10
+
+int
+test_wait_until(int (*ready)(void*), void* ctx, int timeout_ms)
+{
+  int waited_ms = 0;
+  while (!ready(ctx)) {
+    if (waited_ms >= timeout_ms)
+      return -1;
+    platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
+    waited_ms += POLL_STEP_MS;
+  }
+  return 0;
+}
+
+static int
+flag_is_set(void* ctx)
+{
+  return atomic_load((_Atomic int*)ctx) != 0;
+}
+
+int
+test_wait_flag(_Atomic int* flag, int timeout_ms)
+{
+  return test_wait_until(flag_is_set, (void*)flag, timeout_ms);
+}

--- a/tests/test_platform.common.c
+++ b/tests/test_platform.common.c
@@ -5,26 +5,14 @@
 #define POLL_STEP_MS 10
 
 int
-test_wait_until(int (*ready)(void*), void* ctx, int timeout_ms)
+test_wait_flag(_Atomic int* flag, int timeout_ms)
 {
   int waited_ms = 0;
-  while (!ready(ctx)) {
+  while (atomic_load(flag) == 0) {
     if (waited_ms >= timeout_ms)
       return -1;
     platform_sleep_ns((int64_t)POLL_STEP_MS * 1000000LL);
     waited_ms += POLL_STEP_MS;
   }
   return 0;
-}
-
-static int
-flag_is_set(void* ctx)
-{
-  return atomic_load((_Atomic int*)ctx) != 0;
-}
-
-int
-test_wait_flag(_Atomic int* flag, int timeout_ms)
-{
-  return test_wait_until(flag_is_set, (void*)flag, timeout_ms);
 }

--- a/tests/test_platform.h
+++ b/tests/test_platform.h
@@ -36,11 +36,6 @@ test_thread_start(test_thread** out, void (*fn)(void*), void* arg);
 int
 test_thread_join(test_thread* t);
 
-// Poll until ready(ctx) returns non-zero. Returns 0 once it does, -1 if
-// timeout_ms elapsed first.
-int
-test_wait_until(int (*ready)(void*), void* ctx, int timeout_ms);
-
 // Poll until *flag is non-zero. Returns 0 once it is, -1 if timeout_ms elapsed
 // first.
 int

--- a/tests/test_platform.h
+++ b/tests/test_platform.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdatomic.h>
 #include <stddef.h>
 
 #ifdef _WIN32
@@ -34,3 +35,13 @@ test_thread_start(test_thread** out, void (*fn)(void*), void* arg);
 // Wait for the thread to finish and free resources. Returns 0 on success.
 int
 test_thread_join(test_thread* t);
+
+// Poll until ready(ctx) returns non-zero. Returns 0 once it does, -1 if
+// timeout_ms elapsed first.
+int
+test_wait_until(int (*ready)(void*), void* ctx, int timeout_ms);
+
+// Poll until *flag is non-zero. Returns 0 once it is, -1 if timeout_ms elapsed
+// first.
+int
+test_wait_flag(_Atomic int* flag, int timeout_ms);


### PR DESCRIPTION
shard_pool_fs reports the bytes its queued writes are still carrying: an
upper bound, since a write counts from the moment it is accepted, so the
figure can read high but never low. It used to be a subtraction of two
counters, one raised by the thread queueing a write and one by the worker
that finished it. Two separate reads are not a consistent snapshot, and
the result was unsigned, so it could wrap to a number near 2^64. The pool
also counted a write only after handing it to the worker, so the worker
could finish and lower the total before the raise landed.

The io queue keeps the count now. io_queue_post_bytes takes a byte count
and raises the total inside the same lock that puts the job in the queue;
the worker lowers it inside the same lock that marks the job finished. A
reader can never see less work than the queue holds, so no ordering rule
is left to break. io_queue_post is that call with a count of zero, leaving
jobs that carry no data unchanged.

shard_pool_fs and the throttled bench sink drop their own counters and read
the queue's instead. The shard_pool and shard_sink headers state the bound,
and pending_bytes is uint64_t rather than size_t throughout: both
interfaces, every implementation behind them, peak_pending_bytes, and
backpressure_bytes.

tests/test_io_queue.c covers the count directly. It blocks the worker,
checks the total after each post, then checks that it returns to zero once
the queue drains and that a job posted without a byte count never changes
it. The pool test checks that both write paths, copying and zero-copy,
report through. Tests now share one wait-for-flag helper instead of four
copies.

Closes #201.
