### PR TITLE
Fix platform_resident_memory failure handling

### DIFF
--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -38,7 +38,7 @@ print_memory_report(const struct bench_memory* mem)
 {
   char a[32], b[32];
   fputc('\n', stderr);
-  if (mem->host_peak_bytes) {
+  if (!mem->host_reading_failed) {
     format_bytes(a, sizeof(a), mem->host_baseline_bytes);
     format_bytes(b, sizeof(b), mem->host_peak_bytes);
     print_report("  Host memory:   %s at rest, %s peak", a, b);
@@ -334,6 +334,8 @@ print_bench_json_pass(const struct stream_metrics* m,
   jw_uint(&jw, mem->host_baseline_bytes);
   jw_key(&jw, "memory_host_peak_bytes");
   jw_uint(&jw, mem->host_peak_bytes);
+  jw_key(&jw, "memory_host_reading_failed");
+  jw_bool(&jw, mem->host_reading_failed);
   jw_key(&jw, "memory_device_used_bytes");
   jw_uint(&jw, mem->device_used_bytes);
   jw_key(&jw, "memory_measured_bytes");

--- a/bench/bench_report.h
+++ b/bench/bench_report.h
@@ -25,9 +25,10 @@ struct bench_memory
   uint64_t estimate_pinned_bytes; // pinned host bytes on GPU, 0 on CPU
   uint64_t host_baseline_bytes;   // resident before the stream was created
   uint64_t host_peak_bytes;       // most resident memory held during the run
-  uint64_t device_used_bytes;     // GPU: free device memory the stream took
-  // Which of the two above the estimate can be held against: device memory on
-  // the GPU, the host difference on the CPU. 0 when that reading failed.
+  // A reading of 0 is valid, so it cannot signal failure.
+  int host_reading_failed;
+  uint64_t device_used_bytes; // GPU: free device memory the stream took
+  // Device memory on GPU, the host difference on CPU. 0 if unavailable.
   uint64_t measured_bytes;
 };
 

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -473,8 +473,10 @@ run_bench(const struct bench_config* cfg)
     .estimate_total_bytes = est_total_bytes,
     .estimate_pinned_bytes = est_pinned_bytes,
   };
-  if (platform_resident_memory(&mem_used.host_baseline_bytes) != 0)
+  if (platform_resident_memory(&mem_used.host_baseline_bytes) != 0) {
     log_warn("  host memory reading unavailable");
+    mem_used.host_reading_failed = 1;
+  }
   const size_t device_free_at_rest =
     cfg->backend == BENCH_GPU ? bench_gpu_free_memory() : 0;
 
@@ -537,15 +539,19 @@ run_bench(const struct bench_config* cfg)
   float flush_s = platform_toc(&flush_clock);
   float wall_s = platform_toc(&clock);
 
-  if (platform_peak_resident_memory(&mem_used.host_peak_bytes) != 0)
+  if (platform_peak_resident_memory(&mem_used.host_peak_bytes) != 0) {
     log_warn("  host peak memory reading unavailable");
+    mem_used.host_reading_failed = 1;
+  }
+  // A 0 baseline is the page counter not started yet, not an empty process.
+  const int baseline_is_usable = mem_used.host_baseline_bytes > 0;
   if (cfg->backend == BENCH_GPU) {
     // 0 means the reading failed, not that the device ran out.
     const size_t device_free_now = bench_gpu_free_memory();
     if (device_free_now > 0 && device_free_at_rest > device_free_now)
       mem_used.device_used_bytes = device_free_at_rest - device_free_now;
     mem_used.measured_bytes = mem_used.device_used_bytes;
-  } else if (mem_used.host_baseline_bytes &&
+  } else if (baseline_is_usable &&
              mem_used.host_peak_bytes > mem_used.host_baseline_bytes) {
     mem_used.measured_bytes =
       mem_used.host_peak_bytes - mem_used.host_baseline_bytes;

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -472,8 +472,9 @@ run_bench(const struct bench_config* cfg)
   struct bench_memory mem_used = {
     .estimate_total_bytes = est_total_bytes,
     .estimate_pinned_bytes = est_pinned_bytes,
-    .host_baseline_bytes = platform_resident_memory(),
   };
+  if (platform_resident_memory(&mem_used.host_baseline_bytes) != 0)
+    log_warn("  host memory reading unavailable");
   const size_t device_free_at_rest =
     cfg->backend == BENCH_GPU ? bench_gpu_free_memory() : 0;
 
@@ -536,7 +537,8 @@ run_bench(const struct bench_config* cfg)
   float flush_s = platform_toc(&flush_clock);
   float wall_s = platform_toc(&clock);
 
-  mem_used.host_peak_bytes = platform_peak_resident_memory();
+  if (platform_peak_resident_memory(&mem_used.host_peak_bytes) != 0)
+    log_warn("  host peak memory reading unavailable");
   if (cfg->backend == BENCH_GPU) {
     // 0 means the reading failed, not that the device ran out.
     const size_t device_free_now = bench_gpu_free_memory();

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -176,6 +176,7 @@ Each run records memory as an estimate and a measurement:
 | `memory_estimate_pinned_bytes` | pinned host bytes on GPU, 0 on CPU |
 | `memory_host_baseline_bytes` | resident memory before the stream was created |
 | `memory_host_peak_bytes` | most resident memory the process held during the run |
+| `memory_host_reading_failed` | true when either host reading was unavailable, since 0 is also a valid reading |
 | `memory_device_used_bytes` | device memory the stream took, 0 on CPU |
 | `memory_measured_bytes` | the figure to hold the estimate against: device memory on GPU, the host difference on CPU |
 

--- a/scripts/sweep/models.py
+++ b/scripts/sweep/models.py
@@ -37,6 +37,7 @@ class RunResult(BaseModel, extra="allow"):
     memory_estimate_pinned_bytes: int | None = None
     memory_host_baseline_bytes: int | None = None
     memory_host_peak_bytes: int | None = None
+    memory_host_reading_failed: bool | None = None
     memory_device_used_bytes: int | None = None
     memory_measured_bytes: int | None = None
     s3_endpoint: str | None = None

--- a/src/platform/platform.darwin.c
+++ b/src/platform/platform.darwin.c
@@ -48,24 +48,26 @@ task_memory(mach_task_basic_info_data_t* info)
          KERN_SUCCESS;
 }
 
-uint64_t
-platform_resident_memory(void)
+int
+platform_resident_memory(uint64_t* bytes)
 {
   mach_task_basic_info_data_t info;
   if (!task_memory(&info))
-    return 0;
-  return (uint64_t)info.resident_size;
+    return 1;
+  *bytes = (uint64_t)info.resident_size;
+  return 0;
 }
 
 // Both readings come from one call, so they are in bytes and count the same
 // pages.
-uint64_t
-platform_peak_resident_memory(void)
+int
+platform_peak_resident_memory(uint64_t* bytes)
 {
   mach_task_basic_info_data_t info;
   if (!task_memory(&info))
-    return 0;
-  return (uint64_t)info.resident_size_max;
+    return 1;
+  *bytes = (uint64_t)info.resident_size_max;
+  return 0;
 }
 
 void*

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -29,17 +29,12 @@ platform_aligned_free(void* ptr);
 size_t
 platform_available_memory(void);
 
-// Physical memory this process holds right now. Writes the size in bytes and
-// returns 0; returns non-zero, leaving bytes untouched, if the reading is
-// unavailable. A successful reading can still be 0: Linux batches the page
-// counters, so a process a few tens of milliseconds old reports nothing
-// resident however many pages it has touched.
+// Physical memory this process holds now. Returns non-zero if unavailable.
+// A reading of 0 is valid: Linux batches the page counters.
 int
 platform_resident_memory(uint64_t* bytes);
 
-// Most physical memory this process has held at any point. Same reporting as
-// platform_resident_memory. Never goes down, so it can be read once at the end
-// of a run.
+// Most physical memory this process has held at any point. Never goes down.
 int
 platform_peak_resident_memory(uint64_t* bytes);
 

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -29,14 +29,19 @@ platform_aligned_free(void* ptr);
 size_t
 platform_available_memory(void);
 
-// Physical memory this process holds right now, in bytes, or 0 on failure.
-uint64_t
-platform_resident_memory(void);
+// Physical memory this process holds right now. Writes the size in bytes and
+// returns 0; returns non-zero, leaving bytes untouched, if the reading is
+// unavailable. A successful reading can still be 0: Linux batches the page
+// counters, so a process a few tens of milliseconds old reports nothing
+// resident however many pages it has touched.
+int
+platform_resident_memory(uint64_t* bytes);
 
-// Most physical memory this process has held at any point, in bytes, or 0 on
-// failure. Never goes down, so it can be read once at the end of a run.
-uint64_t
-platform_peak_resident_memory(void);
+// Most physical memory this process has held at any point. Same reporting as
+// platform_resident_memory. Never goes down, so it can be read once at the end
+// of a run.
+int
+platform_peak_resident_memory(uint64_t* bytes);
 
 // Monotonic clock for timing. Returns elapsed seconds since last call.
 struct platform_clock

--- a/src/platform/platform.posix.c
+++ b/src/platform/platform.posix.c
@@ -39,27 +39,29 @@ platform_available_memory(void)
   return 0;
 }
 
-uint64_t
-platform_resident_memory(void)
+int
+platform_resident_memory(uint64_t* bytes)
 {
   FILE* f = fopen("/proc/self/statm", "r");
   if (!f)
-    return 0;
+    return 1;
   unsigned long long total_pages = 0, resident_pages = 0;
   int fields = fscanf(f, "%llu %llu", &total_pages, &resident_pages);
   fclose(f);
   if (fields != 2)
-    return 0;
-  return (uint64_t)resident_pages * (uint64_t)platform_page_alignment();
+    return 1;
+  *bytes = (uint64_t)resident_pages * (uint64_t)platform_page_alignment();
+  return 0;
 }
 
-uint64_t
-platform_peak_resident_memory(void)
+int
+platform_peak_resident_memory(uint64_t* bytes)
 {
   struct rusage ru;
-  if (getrusage(RUSAGE_SELF, &ru) != 0 || ru.ru_maxrss <= 0)
-    return 0;
-  return (uint64_t)ru.ru_maxrss * 1024; // kilobytes on Linux
+  if (getrusage(RUSAGE_SELF, &ru) != 0 || ru.ru_maxrss < 0)
+    return 1;
+  *bytes = (uint64_t)ru.ru_maxrss * 1024; // kilobytes on Linux
+  return 0;
 }
 
 void*

--- a/src/platform/platform.win32.c
+++ b/src/platform/platform.win32.c
@@ -56,22 +56,24 @@ process_memory(PROCESS_MEMORY_COUNTERS* pmc)
   return GetProcessMemoryInfo(GetCurrentProcess(), pmc, sizeof(*pmc));
 }
 
-uint64_t
-platform_resident_memory(void)
+int
+platform_resident_memory(uint64_t* bytes)
 {
   PROCESS_MEMORY_COUNTERS pmc;
   if (!process_memory(&pmc))
-    return 0;
-  return (uint64_t)pmc.WorkingSetSize;
+    return 1;
+  *bytes = (uint64_t)pmc.WorkingSetSize;
+  return 0;
 }
 
-uint64_t
-platform_peak_resident_memory(void)
+int
+platform_peak_resident_memory(uint64_t* bytes)
 {
   PROCESS_MEMORY_COUNTERS pmc;
   if (!process_memory(&pmc))
-    return 0;
-  return (uint64_t)pmc.PeakWorkingSetSize;
+    return 1;
+  *bytes = (uint64_t)pmc.PeakWorkingSetSize;
+  return 0;
 }
 
 void

--- a/tests/test_platform_memory.c
+++ b/tests/test_platform_memory.c
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 
+// Big enough that faulting it in overflows the kernel's batched page counters.
 #define BLOCK_BYTES (64u << 20)
 
 // Anything short of the whole block would still catch a kilobyte-reported-as-
@@ -20,22 +21,6 @@ touch_block(char* block)
   const size_t page = platform_page_alignment();
   for (size_t i = 0; i < BLOCK_BYTES; i += page)
     pages[i] = 1;
-}
-
-// Linux batches the page counters behind /proc/self/statm, so a process a few
-// tens of milliseconds old reads nothing resident however many pages it has
-// touched. Only elapsed time clears it. The two tests that compare readings
-// need the counter running before they start.
-static void
-wait_for_the_page_counter(void)
-{
-  for (int i = 0; i < 200; ++i) {
-    uint64_t bytes = 0;
-    if (platform_resident_memory(&bytes) != 0 || bytes > 0)
-      return;
-    platform_sleep_ns(1000000);
-  }
-  log_warn("resident memory still reads 0 after 200 ms");
 }
 
 static int
@@ -111,7 +96,6 @@ int
 main(void)
 {
   int failed = 0;
-  wait_for_the_page_counter();
   failed += test_resident_memory_is_plausible();
   failed += test_resident_memory_follows_a_touched_block();
   failed += test_peak_covers_memory_already_released();

--- a/tests/test_platform_memory.c
+++ b/tests/test_platform_memory.c
@@ -22,12 +22,28 @@ touch_block(char* block)
     pages[i] = 1;
 }
 
+// Linux batches the page counters behind /proc/self/statm, so a process a few
+// tens of milliseconds old reads nothing resident however many pages it has
+// touched. Only elapsed time clears it. The two tests that compare readings
+// need the counter running before they start.
+static void
+wait_for_the_page_counter(void)
+{
+  for (int i = 0; i < 200; ++i) {
+    uint64_t bytes = 0;
+    if (platform_resident_memory(&bytes) != 0 || bytes > 0)
+      return;
+    platform_sleep_ns(1000000);
+  }
+  log_warn("resident memory still reads 0 after 200 ms");
+}
+
 static int
 test_resident_memory_is_plausible(void)
 {
   log_info("=== test_resident_memory_is_plausible ===");
-  uint64_t resident = platform_resident_memory();
-  CHECK(Fail, resident > 0); // 0 is how the reading reports failure
+  uint64_t resident = 0;
+  CHECK(Fail, platform_resident_memory(&resident) == 0);
   CHECK(Fail, resident < ((uint64_t)1 << 40));
   return 0;
 Fail:
@@ -40,12 +56,14 @@ test_resident_memory_follows_a_touched_block(void)
   // Must run before any other test here allocates a block: an allocator that
   // keeps the freed pages leaves the next baseline already inflated.
   log_info("=== test_resident_memory_follows_a_touched_block ===");
-  uint64_t before = platform_resident_memory();
+  uint64_t before = 0, during = 0;
+  int reads_failed = platform_resident_memory(&before);
   char* block = (char*)malloc(BLOCK_BYTES);
   CHECK(Fail, block != NULL);
   touch_block(block);
-  uint64_t during = platform_resident_memory();
+  reads_failed |= platform_resident_memory(&during);
   free(block);
+  CHECK(Fail, reads_failed == 0);
   CHECK(Fail, during >= before + HALF_BLOCK);
   return 0;
 Fail:
@@ -56,18 +74,21 @@ static int
 test_peak_covers_memory_already_released(void)
 {
   log_info("=== test_peak_covers_memory_already_released ===");
-  uint64_t resident_before = platform_resident_memory();
-  uint64_t peak_before = platform_peak_resident_memory();
-  CHECK(Fail, peak_before > 0);
+  uint64_t resident_before = 0, peak_before = 0;
+  int reads_failed = platform_resident_memory(&resident_before);
+  reads_failed |= platform_peak_resident_memory(&peak_before);
 
   char* block = (char*)malloc(BLOCK_BYTES);
   CHECK(Fail, block != NULL);
   touch_block(block);
-  uint64_t resident_during = platform_resident_memory();
-  uint64_t peak_during = platform_peak_resident_memory();
+  uint64_t resident_during = 0, peak_during = 0;
+  reads_failed |= platform_resident_memory(&resident_during);
+  reads_failed |= platform_peak_resident_memory(&peak_during);
   free(block);
 
-  uint64_t peak = platform_peak_resident_memory();
+  uint64_t peak = 0;
+  reads_failed |= platform_peak_resident_memory(&peak);
+  CHECK(Fail, reads_failed == 0);
   log_info("  resident %llu -> %llu, peak %llu -> %llu -> %llu, block %u",
            (unsigned long long)resident_before,
            (unsigned long long)resident_during,
@@ -90,6 +111,7 @@ int
 main(void)
 {
   int failed = 0;
+  wait_for_the_page_counter();
   failed += test_resident_memory_is_plausible();
   failed += test_resident_memory_follows_a_touched_block();
   failed += test_peak_covers_memory_already_released();


### PR DESCRIPTION
`platform_resident_memory` returned 0 both when the read failed and when
the kernel reported no resident pages. `test_resident_memory_is_plausible`
asserted `resident > 0` to check the read worked, and on Linux 6.8 a young
process reads 0 until enough pages push a batch through the kernel's
per-CPU counters, so the test raced process startup.

Both readings now write through an out-parameter and return 0 on success,
so a caller can tell a failed read from a real zero. The test checks the
status instead of the value. The benchmark carries the same distinction
into its console report and its results file, which gains a
`memory_host_reading_failed` field.

Closes #209.
