### PR TITLE
small comment fixes

### DIFF
--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -290,7 +290,8 @@ json_stage_metric(struct json_writer* jw,
   double out_gibs = gb_per_s(sm->output_bytes, (double)sm->ms);
   jw_key(jw, name);
   jw_object_begin(jw);
-  // Which timeline this belongs to. Times may be summed only within one owner.
+  // The measurement belongs to this timeline. Times may be summed only within
+  // one owner.
   jw_key(jw, "owner");
   jw_string(jw, metric_owner_name(sm->owner));
   jw_key(jw, "total_ms");

--- a/bench/bench_report.h
+++ b/bench/bench_report.h
@@ -19,7 +19,7 @@ struct sink_stats
   uint64_t total_chunks; // all LOD levels, per epoch
 };
 
-// What the run was expected to take, and what it took.
+// Both the estimated and the measured memory use are recorded here.
 struct bench_memory
 {
   uint64_t estimate_total_bytes;  // device bytes on GPU, heap bytes on CPU
@@ -39,7 +39,7 @@ print_memory_report(const struct bench_memory* mem);
 void
 print_metric_row(const struct stream_metric* m);
 
-// How long individual appends took.
+// The time taken per append is printed here.
 void
 print_append_latency(const struct stream_metrics* m);
 

--- a/scripts/sweep/columnar.py
+++ b/scripts/sweep/columnar.py
@@ -80,7 +80,7 @@ def encode_rows(rows: list[dict], table: StringTable) -> dict:
 
 
 def decode_runs(block: dict, strings: list[str]) -> list[dict]:
-    """What the pages do on load."""
+    """A block is unpacked this way in the pages on load."""
     runs: list[dict] = [{} for _ in range(block["count"])]
     for key, column in block["columns"].items():
         text = column["text"] if isinstance(column, dict) else None

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -65,7 +65,7 @@ SITE_FILES = {
 EXPLORER_OMITS = ("id", "io_write_sizes")
 EXPLORER_VERSION = 5
 
-# What the explorer's sweep list keeps from each summarized sweep.
+# These are the fields kept in the explorer's sweep list for each summarized sweep.
 EXPLORER_INDEX_KEYS = ("filename", "machine", "member", "commit", "day", "date", "host", "gpu",
                        "driver", "cpus", "build")
 

--- a/scripts/sweep/summary.py
+++ b/scripts/sweep/summary.py
@@ -54,7 +54,7 @@ def parse_filename(path: Path) -> tuple[str | None, str | None, str | None]:
 
 
 def machine_identity(path: Path, machine: dict) -> tuple[str, str]:
-    """What this one sweep calls itself, and the commit it ran at.
+    """The sweep's own name and the commit it ran at are returned.
 
     The file name wins: renaming a results file is how a sweep gets reassigned
     after the fact. `machine.name` is what sweep.py --machine recorded, and the

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -327,7 +327,7 @@ BUILD_CACHE_KEYS = {
 
 
 def build_info(build_dir: Path) -> dict:
-    """How build_dir was last configured.
+    """The build directory's last configuration is returned.
 
     Read from the build directory rather than the environment the sweep runs
     in, so it describes the binaries rather than the machine. It describes the

--- a/src/gpu/flush.handoff.h
+++ b/src/gpu/flush.handoff.h
@@ -35,7 +35,7 @@ struct flush_handoff
 {
   int fc;                                    // flush slot index
   uint32_t n_epochs;                         // epochs in batch
-  uint32_t active_levels_mask;               // which levels active
+  uint32_t active_levels_mask;               // active levels
   const uint32_t* batch_active_masks;        // borrowed [K] per-epoch masks
   uint32_t per_lod_n_active[LOD_MAX_LEVELS]; // owned, for delivery sizing
   uint8_t nlod;

--- a/src/gpu/lod.cu
+++ b/src/gpu/lod.cu
@@ -632,7 +632,7 @@ lod_gather_lut(CUdeviceptr d_dst,
   return 1;
 }
 
-// Type trait: is this a floating-point type (including __half)?
+// This type trait is true for floating-point types, including __half.
 template<typename T>
 struct is_fp
 {

--- a/src/gpu/stream.ingest.h
+++ b/src/gpu/stream.ingest.h
@@ -38,7 +38,7 @@ ingest_collect_scatter_timing(struct staging_state* stage,
 void
 ingest_collect_h2d_timing(struct staging_state* stage, struct stream_metric* m);
 
-// Where one dispatch's data goes in the chunk pool.
+// One dispatch's data is written to this region of the chunk pool.
 struct scatter_destination
 {
   struct gpu_pool_view first_epoch; // region for the epoch holding the first

--- a/src/lod/lod_plan.c
+++ b/src/lod/lod_plan.c
@@ -87,7 +87,7 @@ lod_spans_at(const struct lod_spans* s, uint64_t i)
   };
 }
 
-// Are all LOD dims already at 1 chunk or fewer?
+// The result is true when every LOD dim is already at 1 chunk or fewer.
 // Stop generating levels when every dim fits in a single chunk.
 static int
 all_chunks_le_one(int lod_ndim,
@@ -168,7 +168,7 @@ level_dims_fill_fixed(struct level_dims* ld, int ndim)
   }
 }
 
-// Is any LOD dim at ≤1 chunk?
+// The result is true when any LOD dim is at ≤1 chunk.
 static int
 any_chunks_le_one(int lod_ndim,
                   const uint64_t* lod_shape,

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -9,9 +9,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// Which resource's timeline a measurement belongs to. Times may be added
-// together only within one owner. Named by role, not by thread, because the
-// drain does not always run on the same one.
+// An owner is the resource whose timeline a measurement belongs to. Times may
+// be added together only within one owner. Named by role, not by thread,
+// because the drain does not always run on the same one.
 enum metric_owner
 {
   METRIC_OWNER_NONE = 0,
@@ -76,9 +76,9 @@ struct stream_metrics
   // handed to the device rather than continuously.
   uint64_t peak_pending_bytes;
 
-  // How long individual appends took, as counts per time bucket. A caller
-  // asking whether it can keep up needs the slow tail, not the average, and
-  // there are far too many appends to keep every one.
+  // The time taken per append is counted in time buckets. A caller asking
+  // whether it can keep up needs the slow tail, not the average, and there are
+  // far too many appends to keep every one.
   uint64_t append_ms_buckets[APPEND_LATENCY_BUCKETS];
   uint64_t append_count;
 
@@ -126,7 +126,7 @@ struct tile_stream_status
   int flush_pending;
 };
 
-// Why tile_stream_{gpu,cpu}_advise_layout returned non-zero.
+// These are the reasons tile_stream_{gpu,cpu}_advise_layout returns non-zero.
 enum advise_layout_reason
 {
   ADVISE_OK = 0,

--- a/src/zarr/shard_delivery.c
+++ b/src/zarr/shard_delivery.c
@@ -202,9 +202,9 @@ write_footer(struct active_shard* sh,
   return err;
 }
 
-// How far along the append dim the shards reach, not how many chunks they
-// hold: a flush that closes a half-full shard leaves its remaining slots empty
-// and the next generation still starts after them.
+// The shards' reach along the append dim is recorded, not the number of chunks
+// they hold: a flush that closes a half-full shard leaves its remaining slots
+// empty and the next generation still starts after them.
 static void
 record_finalized(struct shard_state* ss, struct shard_sink* sink)
 {

--- a/src/zarr/shard_delivery.h
+++ b/src/zarr/shard_delivery.h
@@ -70,8 +70,8 @@ shard_state_destroy(struct shard_state* ss);
 size_t
 shard_state_heap_bytes(const struct level_layout_info* li);
 
-// How far along the append dim a reader can safely see. Waits for the last
-// finalize's writes to retire, which have normally landed already.
+// A reader can safely see up to this append-dim extent. The last finalize's
+// writes are waited on, and they have normally landed already.
 uint64_t
 shard_state_readable_append_chunks(struct shard_state* ss,
                                    struct shard_sink* sink);

--- a/tests/experiments/index.ops.c
+++ b/tests/experiments/index.ops.c
@@ -35,8 +35,8 @@ vadd(int rank,
     for (int d = rank - 1; d > 0; --d) {
       const int e = shape[d];
       rest /= e;
-      // Q: Over the next n elements, where will there be a carry from d to d-1?
-      // A: Every input_stride*shape[d] elements starting at first_carry.
+      // Over the next n elements, a carry from d to d-1 lands every
+      // input_stride*shape[d] elements starting at first_carry.
       const int next_input_stride = input_stride * shape[d];
       // correct for carry from d to d-1
       const uint64_t correction = strides[d - 1] - shape[d] * strides[d];

--- a/tests/index.ops.util.h
+++ b/tests/index.ops.util.h
@@ -85,8 +85,8 @@ test_level_layout(struct tile_stream_layout* out,
 // than an epoch's worth of elements.
 #define TEST_REGION_PAD_ELEMENTS 3
 
-// Where a scatter should put the element sitting this many elements past the
-// start of the first epoch's region.
+// A scatter should use this offset for the element sitting this many elements
+// past the start of the first epoch's region.
 uint64_t
 expected_scatter_offset(uint8_t lifted_rank,
                         const uint64_t* lifted_shape,

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -43,9 +43,9 @@ pump_data_bpe(struct writer* w,
               fill_fn fill,
               size_t bpe);
 
-// Fill one block once and reuse it for every append. block_elements is how much
-// is handed over per append; 0 uses a default. Pass one frame's worth to see
-// what a caller feeding frames would see.
+// Fill one block once and reuse it for every append. block_elements is the
+// amount handed over per append; 0 uses a default. Pass one frame's worth to
+// match a caller feeding frames.
 int
 pump_data_prefill_blocked(struct writer* w,
                           size_t total_elements,

--- a/tests/test_shape_after_flush_cpu.c
+++ b/tests/test_shape_after_flush_cpu.c
@@ -1,4 +1,4 @@
-// What the shape says after a flush, on the CPU backend.
+// The shape after a flush is checked here, on the CPU backend.
 //
 // #175: a failed flush leaves shards on disk that a reader cannot see unless
 // the shape is written.

--- a/tests/test_shape_after_flush_gpu.c
+++ b/tests/test_shape_after_flush_gpu.c
@@ -1,7 +1,7 @@
-// What the shape says after a flush, on the GPU backend (#193). A flush pads
-// the chunk the cursor stopped in and closes its shard, so it finalizes the
-// stream: anything appended afterwards would land at append positions the
-// caller never asked for. Mirrors tests/test_shape_after_flush_cpu.c.
+// The shape after a flush is checked here, on the GPU backend (#193). A flush
+// pads the chunk the cursor stopped in and closes its shard, so it finalizes
+// the stream: anything appended afterwards would land at append positions the
+// caller never asked for. This mirrors tests/test_shape_after_flush_cpu.c.
 
 #include "stream.gpu.h"
 #include "test_shard_sink.h"


### PR DESCRIPTION
A comment phrased as a question, rewritten as a complete sentence.
Twenty-two of them, across the stream types, the GPU ingest and reduction
paths, the level planner, shard delivery, the benchmark report, four
sweep scripts, and five tests.

Only two ended in a question mark. The rest are a clause standing where
a subject belongs: "How long individual appends took", "Which resource's
timeline a measurement belongs to", "What the run was expected to take".
Each now has a subject and a verb, in the passive or with a copula,
since a queue, a file or a shard does not act.

Comments only, no code changes. The io queue has the same defect in
three files, left to #216, which rewrites them.
