### PR TITLE
Bring the io plan up to date

### DIFF
--- a/dev/io-scheduler.md
+++ b/dev/io-scheduler.md
@@ -1,6 +1,7 @@
 # Filesystem write scheduling
 
-**Status.** Step 1 is done. Steps 2-5 are planned. Issue #178.
+**Status.** Steps 1 and 2 are done. Step 3 is being written, with two fixes
+spun out of step 2 alongside it. Steps 4 and 5 are planned. Issue #178.
 
 Only one write at a time is run by the filesystem sink: each queued job is a
 blocking `pwrite`, so however deep the backlog, only one request reaches the
@@ -25,30 +26,36 @@ drive. This file is the working plan for changing that.
 
 ## Current write path
 
-`io_queue` (`src/zarr/io_queue.h`) is a growable ring buffer of closures with
-one worker thread. Three kinds of job from `shard_pool_fs`: a copying write, a
-zero-copy write over borrowed pinned memory, and the truncate and close of a
-shard file at finalize.
+`io_queue` (`src/zarr/io_queue.h`) is a window of described requests
+(`src/zarr/io_request.h`) drained by one worker thread. Four operations: a
+write, whose payload is either copied or borrowed from pinned memory, and the
+truncate and close of a shard file at finalize, which are barriers, and a
+no-op used as a fence marker. Every open file carries a token, and a request
+naming a generation that has closed is refused.
 
-### Ordering guarantees from one worker
+### What holds the ordering
 
-Correctness, given jobs run in the order posted:
+After step 2 most of it no longer rests on the order the worker happens to run
+things in:
 
-- In `pool_fs_open`, `fs_slot_finalize` is called: a close is *queued*, the
-  slot marked free at once, the next file opened, no wait on that close. With
-  one in-order worker the close cannot be run ahead of the writes before it,
-  and the new descriptor cannot be the old one, still open — neither true once
-  completions are unordered.
-- The shard footer is written at `data_cursor`, after the data writes;
-  truncate and close are last, after every write to that file.
+- A write cannot reach a recycled descriptor. `pool_fs_open` still queues a
+  close, frees the slot at once and opens the next file without waiting, but
+  the new file gets a new generation, and the old one's late requests are
+  refused rather than applied.
+- Truncate and close cannot pass the writes ahead of them on their own file,
+  because they are barriers. Writes carry their own offsets, so among
+  themselves they need no order at all.
 - In `pool_fs_flush` a sequence number is recorded and waited on, meaning
-  "everything posted so far has finished".
+  "everything posted so far has finished". Retirement walks a cursor over
+  finished slots, so this holds however the completions arrive.
 - In `shard_delivery.c`, a shard's footer buffer is fenced against reuse while
   its zero-copy write is queued, and footer, truncate, and close are fenced
   before the array's shape is allowed to name that data.
-- In `io_event_wait` the wait is abandoned as soon as shutdown is set, so a
-  fence taken at the same time as a destroy is allowed to return before its
-  writes are done — covered only by the worker join in `io_queue_destroy`.
+
+One thing still rests on the worker. In `io_event_wait` the wait is abandoned as
+soon as shutdown is set, so a fence taken at the same time as a destroy may
+return before its writes are done — covered only by the worker join in
+`io_queue_destroy`.
 
 ### Pools shared across levels and fields
 
@@ -56,8 +63,9 @@ One pool — one queue, one worker — per `store->create_pool` call. One for al
 levels of a multiscale array, each level given a disjoint range of slots, so
 every shard and level is put through a single worker. Worse for a plate: one
 pool sized for a *single* field of view, handed to every field, so slot indices
-are shared — safe only because fields are written one at a time and their opens
-and closes are kept apart by the single worker. Untested.
+are shared and two fields open at once write into each other's files. That is
+#211, and its fix changes how slots are allocated. Untested either way: no test
+in the tree writes array data through a plate field sink.
 
 ## Cost of one write at a time
 
@@ -81,14 +89,16 @@ Every data write is already 2-48 MiB — nothing to combine, nothing to split.
 The only small writes are shard footers at 4-8 KiB, one per file, about 2.6 ms
 across a whole run.
 
-Full measurements in issue #178, including between-node variation: no single
-number is safe to quote.
+Full measurements are in #178, including between-node variation: no single
+number is safe to quote. The program that produced them is not in the
+repository and is not being added, so everything measured from here on is
+measured through the sweep, on the real write path.
 
 ## Plan
 
-Five changes, each a pull request off `main`, opened after the previous
-merge. Not stacked: with squash merges, every child would be rebased onto a
-commit its history does not contain.
+Five steps, each of them one or more pull requests off `main`, opened after the
+previous merge. Not stacked: with squash merges, every child
+would be rebased onto a commit its history does not contain.
 
 ### 1. Write-path measurements
 
@@ -133,38 +143,59 @@ it, because `cpu_stream_flush_body` checks for an error before it finalizes the
 shards and never looks again. That gap is #218. The fault hooks still compiled
 into the shipping backend are #219.
 
+Both rewrite `io_backend.fs.c` and `shard_pool_fs.c`, so they have to be taken
+in order, #218 first. #218 does not delete the truncate hook; it moves the
+failure onto the worker, which is the point of the fix. So #219 has three hooks
+to carry out of shipping code, not the two its description assumes.
+
 ### 3. More queue depth
 
-Raise the worker count, schedule ready files round-robin, and add pre-sizing so
-queue depth per file can be raised above one. Add the selecting flags and
-record them in the results file: `--io-writes-in-flight`,
-`--io-writes-in-flight-per-file`, `--io-workers`, `--io-backend`. Sweep writes
-in flight from 1 to 32.
+Issue #213. Raise the worker count, schedule ready files round-robin, add the
+flags that select it — `--io-writes-in-flight`, `--io-writes-in-flight-per-file`,
+`--io-workers`, `--io-backend` — and record them in the results file. The byte
+ceiling gets its number here, from step 1's `io_queued_bytes_peak`.
 
-Two things step 2 left for this step, both harmless while one worker runs
-everything in order and neither harmless afterwards.
+Four pieces around it, each its own pull request, in this order.
 
-Dispatch picks the next request by scanning the window from the tail, and the
-readiness test for each candidate scans the window again. That is quadratic in
-the size of the window, under the queue's lock. It costs nothing today: the
-filesystem backend finishes every request inside `execute`, so nothing is ever
-running while the worker scans, the oldest slot is always the next one to run,
-and the scan stops on its first step. The moment a backend answers
-`IO_SUBMITTED`, or a second worker starts, the front of the window fills with
-running requests and every dispatch walks past all of them. At the default
-ceiling of 1024 requests that is around half a million comparisons per dispatch
-while holding the lock the producer needs to post. The fix is to stop scanning:
-the file token already carries a dense index, so the queue's open-file table can
-be indexed rather than searched, and each file can carry the sequence number of
-its oldest request and of its first waiting barrier. Readiness is then one
-comparison.
-
-The same change should merge the queue's open-file table with the one in
-`io_queue_stats.c`. They have the same shape and the same key, and they are
+**Index the open-file table.** Left by step 2, harmless while one worker runs
+everything in order and not harmless afterwards, so it goes first. Dispatch
+picks the next request by scanning the window from the tail, and the readiness
+test for each candidate scans the window again. That is quadratic in the size of
+the window, under the queue's lock. It costs nothing today: the filesystem
+backend finishes every request inside `execute`, so nothing is ever running
+while the worker scans, the oldest slot is always the next one to run, and the
+scan stops on its first step. The moment a backend answers `IO_SUBMITTED`, or a
+second worker starts, the front of the window fills with running requests and
+every dispatch walks past all of them. At the default ceiling of 1024 requests
+that is around half a million comparisons per dispatch while holding the lock
+the producer needs to post. The fix is to stop scanning: the file token already
+carries a dense index, so the queue's open-file table can be indexed rather than
+searched, and each file can carry the sequence number of its oldest request and
+of its first waiting barrier. Readiness is then one comparison. The same change
+merges that table with the one in `io_queue_stats.c`: same shape, same key,
 updated from adjacent lines under the same lock, so every post and every retire
 walks two lists instead of one.
 
-*Done when:* the reef-l40 XFS matrix is green.
+**Give the sweep a queue depth.** Nothing in `scripts/sweep` can say how deep to
+go. A run's id is built from the scenario, codec, fill, backend, dtype, chunk
+size and sink, so a sweep from 1 to 32 writes 32 runs under one id and keeps the
+last. The S3 tier already shows the shape: an optional field on the run spec, a
+suffix on the id, a column in the results file. Add that, a tier that sweeps the
+scenarios holding more than one shard file, a schema version with its migration
+and its line in `scripts/sweep/README.md`, and a report that reads depth as an
+axis rather than as unrelated runs.
+
+**Pre-size shard files.** `ftruncate` at open, trimmed back at finalize, so a
+write lands inside the file instead of extending it. Taken after the workers,
+because queue depth per file above one buys nothing without it and it buys
+nothing on its own. `smallepoch_single` is the only scenario that can measure
+it, and Windows does not get it at all — see step 5.
+
+**Publish what it was worth.** A sweep at the depths above, its results file its
+own pull request, as with earlier sweeps. Step 4 is decided on this: a ring is
+worth writing only if the depth it buys is not already reached here.
+
+*Done when:* the reef-l40 XFS matrix is green and the sweep is published.
 
 ### 4. io_uring on Linux
 
@@ -173,17 +204,16 @@ threads when a ring is not allowed by the kernel or the container. At chucky's
 write sizes the ceiling is reached by one ring alone, and by blocking writes
 too, so evidence is needed first.
 
-The backend interface step 2 built is general enough to hold a ring, but three
-things are worth settling before the first one is written. A backend has no way
-to say "not now", which a full submission queue needs; the alternatives today
-are to block a worker or to fail the request. The queue never calls into the
-backend at teardown, so a backend with its own thread has nowhere to stop it.
-And the request handed to `execute` is the worker's own copy, which dies when
-the call returns, so a backend that finishes later has to copy what it needs.
-
-A short write is also unowned. `platform_pwrite` loops internally, so it never
-reports one; a ring does. Retrying the remainder belongs in the backend, not in
-the queue.
+**Close four gaps in the backend interface**, as its own pull request before any
+ring is written. The interface step 2 built is general enough to hold one, but a
+backend has no way to say "not now", which a full submission queue needs; the
+alternatives today are to block a worker or to fail the request. The queue never
+calls into the backend at teardown, so a backend with a thread of its own has
+nowhere to stop it. The request handed to `execute` is the worker's own copy and
+dies when the call returns, so a backend that finishes later has to copy what it
+needs. And a short write is unowned: `platform_pwrite` loops internally so it
+never reports one, a ring does, and retrying the remainder belongs in the
+backend rather than in the queue.
 
 *Done when:* the XFS matrix is green, then an NFS matrix before it is made the
 default.
@@ -204,3 +234,24 @@ privileged, with old disk contents exposed.
   sizes, no space reserved so peak disk usage is unchanged, `fallocate`
   unsupported on the NFS mount. The cost: on a full disk, failure is at the
   write, not the open.
+- macOS keeps the thread backend. Neither step 4 nor step 5 touches it, and
+  nothing else is planned for it.
+- The S3 pool is out of scope. It writes on the calling thread through the AWS
+  client and never reaches `io_queue`, and the last L40 sweep put it at about
+  what a local write costs.
+- The queue-depth microbenchmark is not being added to the repository; its
+  numbers stay in #178.
+
+## Issues
+
+- #178, the epic.
+- #208, step 1, merged as `fee70ed`.
+- #212 and #216, step 2, merged as `54b03fa`.
+- #213, step 3. #214, step 4. #215, step 5.
+- #217, a fence waiter left holding a freed lock. Fixed inside #216.
+- #218, a flush misses the errors of the work it queued.
+- #219, the fault hooks compiled into the shipping backend.
+- #211, plate fields share pool slots. A different epic, and its fix changes how
+  slots are allocated.
+
+The pieces named in steps 3 and 4 above are not filed yet.

--- a/dev/io-scheduler.md
+++ b/dev/io-scheduler.md
@@ -113,40 +113,25 @@ only place pre-sizing can be measured.
 
 ### 2. Correctness at queue depth one
 
-- Described write requests instead of closures.
-- An opaque token on every open file, so no late write can be applied to a
-  recycled descriptor.
-- Request and byte credits reserved before a payload is allocated or copied.
-  The byte ceiling starts unlimited: there is no memory limit today to keep, and
-  step 3 picks a number from sweep data.
-- Truncate and close as barriers, run only once that file's writes are done.
-- Completions retired through a sliding window with a watermark, so the
-  meaning of `wait` is unchanged.
-- Defined behavior for partial, zero-byte, failed, and cancelled completions.
-- Still one worker.
+Done, merged as `54b03fa` (#216). Output is byte-identical and failure
+behavior is unchanged.
 
-Keep `bench/sink_throttled.c` working: a second `io_queue` where one write at a
-time is the point, bandwidth modeled by sleeping inside jobs.
+Requests are described rather than wrapped in closures, descriptors and their
+syscalls sit behind a backend interface, and every open file carries a token,
+so no late write reaches a recycled descriptor. Room is claimed before a
+payload is copied. A truncate or close is held behind the writes posted ahead
+of it on its own file. Retirement walks a tail cursor over finished slots, so
+the watermark follows from the structure rather than from the dispatch order,
+and a backend may report an outcome after `execute` has returned. Still one
+worker.
 
-Rewrite the injection tests against a fake backend able to complete out of
-order, and add cases for the orderings impossible today. Several are pinned to
-today's behavior and must be rewritten: jobs finishing in the order posted; an
-exact pending-byte total after every post; one blocking job holding up
-everything behind it — only possible with one worker.
+The byte ceiling ships unlimited. The mechanism is tested; step 3 picks the
+number from sweep data.
 
-One uncovered hazard above still needs a case: a fence at the same time as a
-destroy. The plate's shared pool slot moved to #211, whose fix changes how slots
-are allocated.
-
-The synchronous failing-truncate hook stays. A fake backend does not replace it.
-`cpu_stream_flush_body` checks for an error before it finalizes the shards and
-never drains afterwards, so a flush reports a truncate failure only when
-`finalize_shards` returns non-zero. Make the truncate asynchronous and the flush
-reports success, then publishes a fence and an append extent for a shard whose
-size is wrong. The fake backend covers the queue-level case instead: a failed
-truncate still lets the close run.
-
-*Done when:* output is byte-identical and failure behavior is unchanged.
+The synchronous failing-truncate hook stayed. A fake backend does not replace
+it, because `cpu_stream_flush_body` checks for an error before it finalizes the
+shards and never looks again. That gap is #218. The fault hooks still compiled
+into the shipping backend are #219.
 
 ### 3. More queue depth
 

--- a/dev/io-scheduler.md
+++ b/dev/io-scheduler.md
@@ -151,9 +151,9 @@ to carry out of shipping code, not the two its description assumes.
 ### 3. More queue depth
 
 Issue #213. Raise the worker count, schedule ready files round-robin, add the
-flags that select it — `--io-writes-in-flight`, `--io-writes-in-flight-per-file`,
-`--io-workers`, `--io-backend` — and record them in the results file. The byte
-ceiling gets its number here, from step 1's `io_queued_bytes_peak`.
+flags that select it — `--io-writes-in-flight`, `--io-workers`, `--io-backend`
+and `--io-writes-in-flight-per-file` — and record them in the results file. The
+byte ceiling gets its number here, from step 1's `io_queued_bytes_peak`.
 
 Four pieces around it, each its own pull request, in this order.
 

--- a/dev/io-scheduler.md
+++ b/dev/io-scheduler.md
@@ -33,18 +33,17 @@ truncate and close of a shard file at finalize, which are barriers, and a
 no-op used as a fence marker. Every open file carries a token, and a request
 naming a generation that has closed is refused.
 
-### What holds the ordering
+### Ordering guarantees
 
-After step 2 most of it no longer rests on the order the worker happens to run
-things in:
+After step 2 most of these no longer depend on the order the worker runs things
+in:
 
 - A write cannot reach a recycled descriptor. `pool_fs_open` still queues a
-  close, frees the slot at once and opens the next file without waiting, but
-  the new file gets a new generation, and the old one's late requests are
-  refused rather than applied.
+  close, frees the slot and opens the next file without waiting, but the new
+  file gets a new generation, and late requests naming the old one are refused.
 - Truncate and close cannot pass the writes ahead of them on their own file,
   because they are barriers. Writes carry their own offsets, so among
-  themselves they need no order at all.
+  themselves they need no order.
 - In `pool_fs_flush` a sequence number is recorded and waited on, meaning
   "everything posted so far has finished". Retirement walks a cursor over
   finished slots, so this holds however the completions arrive.
@@ -52,7 +51,7 @@ things in:
   its zero-copy write is queued, and footer, truncate, and close are fenced
   before the array's shape is allowed to name that data.
 
-One thing still rests on the worker. In `io_event_wait` the wait is abandoned as
+One case still rests on the worker. In `io_event_wait` the wait is abandoned as
 soon as shutdown is set, so a fence taken at the same time as a destroy may
 return before its writes are done — covered only by the worker join in
 `io_queue_destroy`.
@@ -145,8 +144,8 @@ into the shipping backend are #219.
 
 Both rewrite `io_backend.fs.c` and `shard_pool_fs.c`, so they have to be taken
 in order, #218 first. #218 does not delete the truncate hook; it moves the
-failure onto the worker, which is the point of the fix. So #219 has three hooks
-to carry out of shipping code, not the two its description assumes.
+failure onto the worker, which is the point of the fix. #219 therefore has one
+more hook to carry out of shipping code, not one fewer.
 
 ### 3. More queue depth
 
@@ -157,43 +156,37 @@ byte ceiling gets its number here, from step 1's `io_queued_bytes_peak`.
 
 Four pieces around it, each its own pull request, in this order.
 
-**Index the open-file table.** Left by step 2, harmless while one worker runs
-everything in order and not harmless afterwards, so it goes first. Dispatch
-picks the next request by scanning the window from the tail, and the readiness
-test for each candidate scans the window again. That is quadratic in the size of
-the window, under the queue's lock. It costs nothing today: the filesystem
-backend finishes every request inside `execute`, so nothing is ever running
-while the worker scans, the oldest slot is always the next one to run, and the
-scan stops on its first step. The moment a backend answers `IO_SUBMITTED`, or a
-second worker starts, the front of the window fills with running requests and
-every dispatch walks past all of them. At the default ceiling of 1024 requests
-that is around half a million comparisons per dispatch while holding the lock
-the producer needs to post. The fix is to stop scanning: the file token already
-carries a dense index, so the queue's open-file table can be indexed rather than
-searched, and each file can carry the sequence number of its oldest request and
-of its first waiting barrier. Readiness is then one comparison. The same change
-merges that table with the one in `io_queue_stats.c`: same shape, same key,
-updated from adjacent lines under the same lock, so every post and every retire
-walks two lists instead of one.
+**Index the open-file table** (#225). Dispatch picks the next request by
+scanning the window from the tail, and the readiness test for each candidate
+scans it again — quadratic, under the queue's lock. It is free today because the
+filesystem backend finishes every request inside `execute`, so the oldest slot
+is always next and the scan stops on its first step. With a second worker, or a
+backend that answers `IO_SUBMITTED`, the front of the window fills with running
+requests and every dispatch walks past them: around half a million comparisons
+at the default ceiling of 1024, while holding the lock the producer needs to
+post. The file token already carries a dense index, so the table can be indexed
+rather than searched, and each file can carry the sequence number of its oldest
+request and of its first waiting barrier. The same change merges that table with
+the one in `io_queue_stats.c`, which has the same shape and the same key and is
+updated under the same lock.
 
-**Give the sweep a queue depth.** Nothing in `scripts/sweep` can say how deep to
-go. A run's id is built from the scenario, codec, fill, backend, dtype, chunk
-size and sink, so a sweep from 1 to 32 writes 32 runs under one id and keeps the
-last. The S3 tier already shows the shape: an optional field on the run spec, a
-suffix on the id, a column in the results file. Add that, a tier that sweeps the
-scenarios holding more than one shard file, a schema version with its migration
-and its line in `scripts/sweep/README.md`, and a report that reads depth as an
-axis rather than as unrelated runs.
+**Record a queue depth in the sweep** (#226). A run's id is built from the
+scenario, codec, fill, backend, dtype, chunk size and sink, so 32 runs that
+differ only in writes in flight share one id and the last one written wins. The
+S3 tier shows the shape: an optional field on the run spec, a suffix on the id,
+a column in the results file. Add a tier over the scenarios holding more than
+one shard file, a schema version and its migration, a line in
+`scripts/sweep/README.md`, and a report that reads depth as an axis.
 
-**Pre-size shard files.** `ftruncate` at open, trimmed back at finalize, so a
-write lands inside the file instead of extending it. Taken after the workers,
-because queue depth per file above one buys nothing without it and it buys
+**Pre-size shard files** (#227). `ftruncate` at open, trimmed back at finalize,
+so a write lands inside the file instead of extending it. Taken after the
+workers, because depth per file above one buys nothing without it and it buys
 nothing on its own. `smallepoch_single` is the only scenario that can measure
 it, and Windows does not get it at all — see step 5.
 
-**Publish what it was worth.** A sweep at the depths above, its results file its
-own pull request, as with earlier sweeps. Step 4 is decided on this: a ring is
-worth writing only if the depth it buys is not already reached here.
+**Publish the measurement** (#228). A sweep at those depths, its results file
+its own pull request, as with earlier sweeps. Step 4 depends on it: a ring is
+worth writing only if threads do not already reach the same depth.
 
 *Done when:* the reef-l40 XFS matrix is green and the sweep is published.
 
@@ -204,16 +197,16 @@ threads when a ring is not allowed by the kernel or the container. At chucky's
 write sizes the ceiling is reached by one ring alone, and by blocking writes
 too, so evidence is needed first.
 
-**Close four gaps in the backend interface**, as its own pull request before any
-ring is written. The interface step 2 built is general enough to hold one, but a
-backend has no way to say "not now", which a full submission queue needs; the
-alternatives today are to block a worker or to fail the request. The queue never
-calls into the backend at teardown, so a backend with a thread of its own has
-nowhere to stop it. The request handed to `execute` is the worker's own copy and
-dies when the call returns, so a backend that finishes later has to copy what it
-needs. And a short write is unowned: `platform_pwrite` loops internally so it
-never reports one, a ring does, and retrying the remainder belongs in the
-backend rather than in the queue.
+**Close four gaps in the backend interface** (#229), as its own pull request
+before any ring is written. The interface step 2 built is general enough to hold
+one, but a backend has no way to say "not now", which a full submission queue
+needs; the alternatives today are to block a worker or to fail the request. The
+queue never calls into the backend at teardown, so a backend with a thread of
+its own has nowhere to stop it. The request handed to `execute` is the worker's
+own copy and dies when the call returns, so a backend that finishes later has to
+copy what it needs. And a short write is unowned: `platform_pwrite` loops
+internally so it never reports one, a ring does, and retrying the remainder
+belongs in the backend rather than in the queue.
 
 *Done when:* the XFS matrix is green, then an NFS matrix before it is made the
 default.
@@ -247,11 +240,10 @@ privileged, with old disk contents exposed.
 - #178, the epic.
 - #208, step 1, merged as `fee70ed`.
 - #212 and #216, step 2, merged as `54b03fa`.
-- #213, step 3. #214, step 4. #215, step 5.
+- #213, step 3, with #225, #226, #227 and #228 around it.
+- #229, then #214, step 4. #215, step 5.
 - #217, a fence waiter left holding a freed lock. Fixed inside #216.
 - #218, a flush misses the errors of the work it queued.
 - #219, the fault hooks compiled into the shipping backend.
 - #211, plate fields share pool slots. A different epic, and its fix changes how
   slots are allocated.
-
-The pieces named in steps 3 and 4 above are not filed yet.


### PR DESCRIPTION
Step 2 of #178 is merged, so its section is now a record of what shipped
rather than a list of what to build, and the rest of the file has caught up
with it.

The current write path described a queue of closures and a list of orderings
that held only because one worker ran them in the order posted. Step 2 replaced
both, so that section now says what holds the ordering and which single case
still rests on the worker.

Step 3 and step 4 name the pieces that are not in #213 and #214, each now its
own issue: indexing the open-file table (#225), recording a queue depth in the
sweep (#226), pre-sizing (#227), publishing the measurement (#228), and closing
the gaps in the backend interface (#229). Nothing in scripts/sweep can express
a depth today, so the sweep #213 calls for cannot be recorded yet.

#218 and #219 rewrite the same two files and have to be taken in order. #218
keeps the truncate hook rather than deleting it, so #219 has one more hook to
move rather than one fewer.

Settled: macOS keeps threads, the S3 pool is out of scope, and the queue-depth
microbenchmark is not being added to the repository. An issue list at the end
points back at the board.
