### PR TITLE
Report errors from work a flush queued

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -598,8 +598,8 @@ The caller interacts with the pipeline through a `struct writer` vtable:
 - **`flush(self)`** — finalize the stream. Writes out everything appended,
   including the chunk the cursor stopped partway through, and then stops taking
   input: a later `append` consumes nothing and reports `finished`. Idempotent.
-  Returns once those writes have landed, so the failure of any of them is
-  reported here.
+  Returns once those writes have landed, so a write that failed is reported
+  here.
 
 - **`close(self)`** — publishes the append extent and lets the sink write its
   own metadata. This is where the array becomes readable. Idempotent, and

--- a/docs/design.md
+++ b/docs/design.md
@@ -598,13 +598,13 @@ The caller interacts with the pipeline through a `struct writer` vtable:
 - **`flush(self)`** — finalize the stream. Writes out everything appended,
   including the chunk the cursor stopped partway through, and then stops taking
   input: a later `append` consumes nothing and reports `finished`. Idempotent.
-  Returns once the writes are queued, not once they have landed.
+  Returns once those writes have landed, so the failure of any of them is
+  reported here.
 
-- **`close(self)`** — waits for those writes to land, publishes the append
-  extent, and lets the sink write its own metadata. This is where a caller
-  learns its data reached storage and where the array becomes readable.
-  Idempotent, and destroy runs it if the caller did not — so the sink has to
-  outlive the stream.
+- **`close(self)`** — publishes the append extent and lets the sink write its
+  own metadata. This is where the array becomes readable. Idempotent, and
+  destroy runs it if the caller did not — so the sink has to outlive the
+  stream.
 
   Finalizing is what makes that last partial chunk readable — it is padded out
   and its shard is closed. Taking more input afterwards would have to start past

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -104,8 +104,8 @@ an optional `close(self)`, each returning a `writer_result`. Free functions
 `writer_append()` / `writer_flush()` / `writer_close()` dispatch through it.
 `flush` finalizes: it writes out everything appended so far and then stops
 taking input, so it is the last call on a stream rather than a mid-stream sync.
-It returns once the writes are queued; `writer_close()` waits for them, publishes
-the extent, and reports whether the data reached storage.
+It returns once those writes have landed; `writer_close()` publishes the extent
+and reports whether the array is readable.
 
 **Two-phase init.** `compute_stream_layouts()` does all pure-CPU layout math
 (lifted shape, strides, chunk geometry), then the GPU path uploads to device

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -104,8 +104,8 @@ an optional `close(self)`, each returning a `writer_result`. Free functions
 `writer_append()` / `writer_flush()` / `writer_close()` dispatch through it.
 `flush` finalizes: it writes out everything appended so far and then stops
 taking input, so it is the last call on a stream rather than a mid-stream sync.
-It returns once those writes have landed; `writer_close()` publishes the extent
-and reports whether the array is readable.
+It returns once those writes have landed. `writer_close()` then publishes the
+extent and reports whether the array is readable.
 
 **Two-phase init.** `compute_stream_layouts()` does all pure-CPU layout math
 (lifted shape, strides, chunk geometry), then the GPU path uploads to device

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -245,9 +245,10 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
   if (v->layout->epoch_elements == 0)
     return writer_ok();
 
-  // Every exit runs the drain: queued IO points into buffers destroy frees.
-  // Finalizing shards and writing the array shape both claim the output is
-  // complete, so they are skipped once anything above them failed.
+  // Finalizing a shard claims it is complete, so finalize is skipped once
+  // anything above it failed. A flush that bails that way skips the drain below
+  // too, and leaves the IO it already queued to the drain in close, which
+  // destroy runs when the caller does not.
   int failed = 0;
 
   // Flush partial epoch into the batch.

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -331,10 +331,8 @@ Fail:
   failed = 1;
 
 Done:
-  // Finalizing only queues the truncate and close of each partial shard, and a
-  // flush that bailed partway still has writes of its own outstanding.
-  // Returning without waiting for either would report a shard whose size on
-  // disk is wrong, or free buffers the IO worker is still reading.
+  // Writes queued anywhere above can still fail, and destroy frees the buffers
+  // they read.
   if (shard_sink_drain(v->sink))
     failed = 1;
 

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -246,9 +246,7 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
     return writer_ok();
 
   // Finalizing a shard claims it is complete, so finalize is skipped once
-  // anything above it failed. A flush that bails that way skips the drain below
-  // too, and leaves the IO it already queued to the drain in close, which
-  // destroy runs when the caller does not.
+  // anything above it failed.
   int failed = 0;
 
   // Flush partial epoch into the batch.
@@ -322,11 +320,6 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
               finalize_shards(&v->shard[lv], v->sink, v->shard_alignment) == 0);
     }
 
-    // Finalizing only queues the truncate and close of each partial shard.
-    // Returning without waiting would report success for a shard whose size on
-    // disk is wrong.
-    CHECK(Fail, shard_sink_drain(v->sink) == 0);
-
     float emit_ms = (float)(platform_toc(&emit_clk) * 1000.0);
     if (v->metrics)
       accumulate_metric_ms(&v->metrics->sink, emit_ms, 0, 0);
@@ -338,6 +331,13 @@ Fail:
   failed = 1;
 
 Done:
+  // Finalizing only queues the truncate and close of each partial shard, and a
+  // flush that bailed partway still has writes of its own outstanding.
+  // Returning without waiting for either would report a shard whose size on
+  // disk is wrong, or free buffers the IO worker is still reading.
+  if (shard_sink_drain(v->sink))
+    failed = 1;
+
   return failed ? writer_error() : writer_ok();
 }
 

--- a/src/cpu/stream.body.c
+++ b/src/cpu/stream.body.c
@@ -321,6 +321,11 @@ cpu_stream_flush_body(struct cpu_stream_view* v)
               finalize_shards(&v->shard[lv], v->sink, v->shard_alignment) == 0);
     }
 
+    // Finalizing only queues the truncate and close of each partial shard.
+    // Returning without waiting would report success for a shard whose size on
+    // disk is wrong.
+    CHECK(Fail, shard_sink_drain(v->sink) == 0);
+
     float emit_ms = (float)(platform_toc(&emit_clk) * 1000.0);
     if (v->metrics)
       accumulate_metric_ms(&v->metrics->sink, emit_ms, 0, 0);

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -781,9 +781,9 @@ cpu_close_final(struct writer* self)
 {
   struct tile_stream_cpu* s =
     container_of(self, struct tile_stream_cpu, writer);
-  // Only a close after a flush has work to do. Before a flush the extent is
-  // not final, and the writes appends queued are waited out by the close that
-  // destroy runs after its auto-flush.
+  // Only a close after a flush has work to do: before one the extent is not
+  // final, and destroy's auto-flush is followed by a close that waits out
+  // whatever the appends queued.
   if (s->closed || !s->flushed)
     return s->close_failed ? writer_error() : writer_ok();
   struct cpu_stream_view v = make_view(s);

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -781,9 +781,8 @@ cpu_close_final(struct writer* self)
 {
   struct tile_stream_cpu* s =
     container_of(self, struct tile_stream_cpu, writer);
-  // Only a close after a flush has work to do: before one the extent is not
-  // final, and destroy's auto-flush is followed by a close that waits out
-  // whatever the appends queued.
+  // Before a flush the extent is not final, so there is nothing to publish.
+  // Destroy flushes before it closes, so appends never lose their queued IO.
   if (s->closed || !s->flushed)
     return s->close_failed ? writer_error() : writer_ok();
   struct cpu_stream_view v = make_view(s);

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -781,8 +781,9 @@ cpu_close_final(struct writer* self)
 {
   struct tile_stream_cpu* s =
     container_of(self, struct tile_stream_cpu, writer);
-  // Nothing is queued until a flush runs, and close only completes what a
-  // flush queued.
+  // Only a close after a flush has work to do. Before a flush the extent is
+  // not final, and the writes appends queued are waited out by the close that
+  // destroy runs after its auto-flush.
   if (s->closed || !s->flushed)
     return s->close_failed ? writer_error() : writer_ok();
   struct cpu_stream_view v = make_view(s);

--- a/src/cpu/stream.internal.h
+++ b/src/cpu/stream.internal.h
@@ -70,7 +70,7 @@ struct tile_stream_cpu
   int pool_fully_covered;       // 1 if scatter overwrites every pool position
   int flushed;      // 1 once finalized; no further input is taken
   int flush_failed; // outcome of that finalize, re-reported by later calls
-  int closed;       // 1 once the queued writes have been waited out
+  int closed;       // 1 once close drained and, on success, published
   int close_failed; // outcome of that close, re-reported by later calls
 
   // Batch accumulation state (K = cl.epochs_per_batch).

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -382,6 +382,12 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
       ctx->append_failed = 1;
     else
       r = finalize_all_levels(e, ctx);
+
+    // Finalizing only queues the truncate and close of each partial shard.
+    // Returning without waiting would report success for a shard whose size on
+    // disk is wrong.
+    if (shard_sink_drain(ctx->sink))
+      r = writer_error();
   }
 
   collect_ingest_timing(e);

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -483,8 +483,9 @@ tile_stream_gpu_close_final(struct writer* self)
 {
   struct tile_stream_gpu* s =
     container_of(self, struct tile_stream_gpu, writer);
-  // Nothing is queued until a flush runs, and close only completes what a
-  // flush queued.
+  // Only a close after a flush has work to do. Before a flush the extent is
+  // not final, and the writes appends queued are waited out by the close that
+  // destroy runs after its auto-flush.
   if (s->closed || !s->flushed)
     return s->close_failed ? writer_error() : writer_ok();
   const int pushed = cu_ctx_push(s->engine.cuda);

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -382,13 +382,14 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
       ctx->append_failed = 1;
     else
       r = finalize_all_levels(e, ctx);
-
-    // Finalizing only queues the truncate and close of each partial shard.
-    // Returning without waiting would report success for a shard whose size on
-    // disk is wrong.
-    if (shard_sink_drain(ctx->sink))
-      r = writer_error();
   }
+
+  // Finalizing only queues the truncate and close of each partial shard, and a
+  // flush that bailed partway still has writes of its own outstanding.
+  // Returning without waiting for either would report a shard whose size on
+  // disk is wrong, or free buffers the IO worker is still reading.
+  if (shard_sink_drain(ctx->sink))
+    r = writer_error();
 
   collect_ingest_timing(e);
 
@@ -483,9 +484,9 @@ tile_stream_gpu_close_final(struct writer* self)
 {
   struct tile_stream_gpu* s =
     container_of(self, struct tile_stream_gpu, writer);
-  // Only a close after a flush has work to do. Before a flush the extent is
-  // not final, and the writes appends queued are waited out by the close that
-  // destroy runs after its auto-flush.
+  // Only a close after a flush has work to do: before one the extent is not
+  // final, and destroy's auto-flush is followed by a close that waits out
+  // whatever the appends queued.
   if (s->closed || !s->flushed)
     return s->close_failed ? writer_error() : writer_ok();
   const int pushed = cu_ctx_push(s->engine.cuda);

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -384,10 +384,8 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
       r = finalize_all_levels(e, ctx);
   }
 
-  // Finalizing only queues the truncate and close of each partial shard, and a
-  // flush that bailed partway still has writes of its own outstanding.
-  // Returning without waiting for either would report a shard whose size on
-  // disk is wrong, or free buffers the IO worker is still reading.
+  // Writes queued anywhere above can still fail, and destroy frees the buffers
+  // they read.
   if (shard_sink_drain(ctx->sink))
     r = writer_error();
 
@@ -484,9 +482,8 @@ tile_stream_gpu_close_final(struct writer* self)
 {
   struct tile_stream_gpu* s =
     container_of(self, struct tile_stream_gpu, writer);
-  // Only a close after a flush has work to do: before one the extent is not
-  // final, and destroy's auto-flush is followed by a close that waits out
-  // whatever the appends queued.
+  // Before a flush the extent is not final, so there is nothing to publish.
+  // Destroy flushes before it closes, so appends never lose their queued IO.
   if (s->closed || !s->flushed)
     return s->close_failed ? writer_error() : writer_ok();
   const int pushed = cu_ctx_push(s->engine.cuda);

--- a/src/gpu/stream.internal.h
+++ b/src/gpu/stream.internal.h
@@ -11,7 +11,7 @@ struct tile_stream_gpu
   struct engine_array_state ar;
   int flushed;      // 1 once finalized; no further input is taken
   int flush_failed; // outcome of that finalize, re-reported by later calls
-  int closed;       // 1 once the queued writes have been waited out
+  int closed;       // 1 once close drained and, on success, published
   int close_failed; // outcome of that close, re-reported by later calls
 };
 

--- a/src/multiarray/multiarray.h
+++ b/src/multiarray/multiarray.h
@@ -31,9 +31,9 @@ struct multiarray_writer
                                             int array_index,
                                             struct slice data);
   // Finalizes every array: writes out what each one holds and stops taking
-  // input. Returns once the writes are queued; `close` waits for them.
+  // input. Returns once those writes have landed.
   struct multiarray_writer_result (*flush)(struct multiarray_writer* self);
-  // Waits for those writes to land and publishes each array's append extent.
-  // Idempotent; destroy runs it if the caller did not.
+  // Publishes each array's append extent. Idempotent; destroy runs it if the
+  // caller did not.
   struct multiarray_writer_result (*close)(struct multiarray_writer* self);
 };

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -48,7 +48,7 @@ struct array_descriptor
   size_t shard_alignment; // from sink; 0 = no alignment
   int pool_fully_covered; // 1 if scatter overwrites every pool position
   int flushed;            // 1 once finalized; no further input is taken
-  int closed;             // 1 once this array's writes have been waited out
+  int closed;             // 1 once close drained and, on success, published
   int close_failed;       // outcome of that close, re-reported by later calls
 };
 

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -32,7 +32,7 @@ struct array_descriptor_gpu
   struct engine_array_state st;
 
   int flushed;      // 1 once finalized; no further input is taken
-  int closed;       // 1 once this array's writes have been waited out
+  int closed;       // 1 once close drained and, on success, published
   int close_failed; // outcome of that close, re-reported by later calls
 };
 

--- a/src/writer.h
+++ b/src/writer.h
@@ -32,10 +32,9 @@ struct writer
   struct writer_result (*append)(struct writer* self, struct slice data);
   // Finalizes the stream: writes out everything appended so far, including the
   // chunk the append cursor stopped partway through, and stops taking input.
-  // Idempotent. A later append consumes nothing and reports `finished`.
-  //
-  // Returns once those writes have landed, so the failure of any of them is
-  // reported here.
+  // Idempotent. A later append consumes nothing and reports `finished`. It
+  // returns once those writes have landed, so a write that failed is reported
+  // here.
   //
   // Finalizing is what makes the partial chunk readable: it is padded out and
   // its shard is closed. Taking more input afterwards would have to start past

--- a/src/writer.h
+++ b/src/writer.h
@@ -34,8 +34,8 @@ struct writer
   // chunk the append cursor stopped partway through, and stops taking input.
   // Idempotent. A later append consumes nothing and reports `finished`.
   //
-  // Returns once those writes are queued, not once they have landed; `close`
-  // waits for them.
+  // Returns once those writes have landed, so the failure of any of them is
+  // reported here.
   //
   // Finalizing is what makes the partial chunk readable: it is padded out and
   // its shard is closed. Taking more input afterwards would have to start past
@@ -43,12 +43,11 @@ struct writer
   // later data at append positions the caller never asked for.
   struct writer_result (*flush)(struct writer* self);
 
-  // Optional: waits for the writes `flush` queued to land, publishes the append
-  // extent, and lets the sink write its own metadata. Returns whether all of
-  // that succeeded, so this is where a caller learns its data reached storage,
-  // and where the array becomes readable. Idempotent, and destroying the stream
-  // runs it if the caller did not — so the sink has to outlive the stream.
-  // NULL when a writer has nothing to wait for.
+  // Optional: publishes the append extent and lets the sink write its own
+  // metadata. Returns whether that succeeded, so this is where the array
+  // becomes readable. Idempotent, and destroying the stream runs it if the
+  // caller did not — so the sink has to outlive the stream. NULL when a writer
+  // has nothing to publish.
   struct writer_result (*close)(struct writer* self);
 };
 

--- a/src/zarr/io_backend.fs.c
+++ b/src/zarr/io_backend.fs.c
@@ -26,6 +26,7 @@ struct io_backend_fs
   _Atomic uint64_t files_open_peak;
 
   _Atomic int fail_next_noop;
+  _Atomic int fail_next_truncate;
   _Atomic int block_next_noop;
   _Atomic int* block_gate;
   _Atomic int stopped;
@@ -141,6 +142,12 @@ io_backend_fs_inject_failure(struct io_backend_fs* b)
 }
 
 void
+io_backend_fs_inject_failing_truncate(struct io_backend_fs* b)
+{
+  atomic_store(&b->fail_next_truncate, 1);
+}
+
+void
 io_backend_fs_inject_block(struct io_backend_fs* b, _Atomic int* gate)
 {
   b->block_gate = gate;
@@ -225,7 +232,9 @@ fs_execute(void* ctx,
         record_failure(b, out, "io_backend_fs: pwrite failed");
       break;
     case IO_OP_TRUNCATE:
-      if (platform_ftruncate(fd, req->logical_size))
+      if (atomic_exchange(&b->fail_next_truncate, 0))
+        record_failure(b, out, "io_backend_fs: injected truncate failure");
+      else if (platform_ftruncate(fd, req->logical_size))
         record_failure(b, out, "io_backend_fs: ftruncate failed");
       break;
     case IO_OP_CLOSE:

--- a/src/zarr/io_backend.fs.h
+++ b/src/zarr/io_backend.fs.h
@@ -29,12 +29,17 @@ io_backend_fs_files_opened(const struct io_backend_fs* b);
 uint64_t
 io_backend_fs_files_open_peak(const struct io_backend_fs* b);
 
-// These test hooks are one-shot. Each applies to the next IO_OP_NOOP, the
-// one op with no file and no payload.
+// These test hooks are one-shot. Failure and block apply to the next
+// IO_OP_NOOP, the one op with no file and no payload.
 void
 io_backend_fs_inject_failure(struct io_backend_fs* b);
 void
 io_backend_fs_inject_block(struct io_backend_fs* b, _Atomic int* gate);
+
+// One-shot, applies to the next IO_OP_TRUNCATE: it fails where every other
+// failure does, on the worker, so only a caller that waits can see it.
+void
+io_backend_fs_inject_failing_truncate(struct io_backend_fs* b);
 
 // Release a blocked request, for a queue torn down with no flush in front of
 // it.

--- a/src/zarr/io_backend.fs.h
+++ b/src/zarr/io_backend.fs.h
@@ -30,9 +30,9 @@ uint64_t
 io_backend_fs_files_open_peak(const struct io_backend_fs* b);
 
 // These test hooks are one-shot, each applying to the next op of its kind:
-// IO_OP_NOOP (the one op with no file and no payload) for failure and block,
-// IO_OP_TRUNCATE for the failing truncate. All three fail on the worker, where
-// every real failure happens, so only a caller that waits can see them.
+// IO_OP_NOOP for failure and block, IO_OP_TRUNCATE for the failing truncate.
+// All three fail on the worker, where every real failure happens, so only a
+// caller that waits can see them.
 void
 io_backend_fs_inject_failure(struct io_backend_fs* b);
 void

--- a/src/zarr/io_backend.fs.h
+++ b/src/zarr/io_backend.fs.h
@@ -29,15 +29,14 @@ io_backend_fs_files_opened(const struct io_backend_fs* b);
 uint64_t
 io_backend_fs_files_open_peak(const struct io_backend_fs* b);
 
-// These test hooks are one-shot. Failure and block apply to the next
-// IO_OP_NOOP, the one op with no file and no payload.
+// These test hooks are one-shot, each applying to the next op of its kind:
+// IO_OP_NOOP (the one op with no file and no payload) for failure and block,
+// IO_OP_TRUNCATE for the failing truncate. All three fail on the worker, where
+// every real failure happens, so only a caller that waits can see them.
 void
 io_backend_fs_inject_failure(struct io_backend_fs* b);
 void
 io_backend_fs_inject_block(struct io_backend_fs* b, _Atomic int* gate);
-
-// One-shot, applies to the next IO_OP_TRUNCATE: it fails where every other
-// failure does, on the worker, so only a caller that waits can see it.
 void
 io_backend_fs_inject_failing_truncate(struct io_backend_fs* b);
 

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -24,8 +24,6 @@ struct shard_pool_fs
   int unbuffered;
   struct strbuf root; // owned
   _Atomic int io_error;
-  // Test hook: one-shot, fail the next truncate.
-  _Atomic int fail_next_truncate;
 };
 
 // --- Writer slot for a single shard file ---
@@ -35,9 +33,7 @@ struct fs_slot
   struct shard_writer base;
   struct io_file_token token; // zero generation means no file is open here
   struct io_queue* queue;
-  size_t alignment;      // 0 = normal malloc, >0 = page-aligned allocation
-  _Atomic int* io_error; // points to shard_pool_fs.io_error
-  _Atomic int* fail_next_truncate; // points to shard_pool_fs.fail_next_truncate
+  size_t alignment; // 0 = normal malloc, >0 = page-aligned allocation
 };
 
 static int
@@ -121,13 +117,6 @@ fs_slot_truncate(struct shard_writer* self, uint64_t logical_size)
   struct fs_slot* w = (struct fs_slot*)self;
   if (w->token.generation == 0)
     return 0;
-
-  // Test hook: fail synchronously and mark the pool errored, so a footer write
-  // already queued by the caller outlives the flush that bails on the error.
-  if (w->fail_next_truncate && atomic_exchange(w->fail_next_truncate, 0)) {
-    atomic_store(w->io_error, 1);
-    return 1;
-  }
 
   return io_queue_post(w->queue,
                        (struct io_request){
@@ -293,7 +282,7 @@ int
 shard_pool_fs_inject_failing_truncate(struct shard_pool* self)
 {
   struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
-  atomic_store(&p->fail_next_truncate, 1);
+  io_backend_fs_inject_failing_truncate(p->backend);
   return 0;
 }
 
@@ -354,8 +343,6 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
     s->base.finalize = fs_slot_finalize;
     s->queue = p->queue;
     s->alignment = page_size;
-    s->io_error = &p->io_error;
-    s->fail_next_truncate = &p->fail_next_truncate;
   }
 
   return &p->base;

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -278,12 +278,11 @@ shard_pool_fs_inject_failing_job(struct shard_pool* self)
   return io_queue_post(p->queue, (struct io_request){ .op = IO_OP_NOOP });
 }
 
-int
+void
 shard_pool_fs_inject_failing_truncate(struct shard_pool* self)
 {
   struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
   io_backend_fs_inject_failing_truncate(p->backend);
-  return 0;
 }
 
 void

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -24,8 +24,8 @@ shard_pool_fs_inject_failing_job(struct shard_pool* pool);
 int
 shard_pool_fs_inject_blocking_job(struct shard_pool* pool, _Atomic int* gate);
 
-// Test helper: one-shot, fail the next truncate so a flush errors with IO
-// still queued. Exercises the destroy-time drain that guards those buffers.
+// Test helper: one-shot, fail the next truncate on the IO worker. Returns 0
+// on success.
 int
 shard_pool_fs_inject_failing_truncate(struct shard_pool* pool);
 

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -24,9 +24,8 @@ shard_pool_fs_inject_failing_job(struct shard_pool* pool);
 int
 shard_pool_fs_inject_blocking_job(struct shard_pool* pool, _Atomic int* gate);
 
-// Test helper: one-shot, fail the next truncate on the IO worker. Returns 0
-// on success.
-int
+// Test helper: one-shot, fail the next truncate on the IO worker.
+void
 shard_pool_fs_inject_failing_truncate(struct shard_pool* pool);
 
 // Test helper: mark the pool errored so later deliveries fail and stay queued.

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -236,7 +236,7 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
 
   // The truncate fails only once the worker runs it, which is after the flush
   // has queued it — so only a flush that waits can see it.
-  CHECK(Cleanup, shard_pool_fs_inject_failing_truncate(pool) == 0);
+  shard_pool_fs_inject_failing_truncate(pool);
 
   {
     struct writer_result r = writer_flush(tile_stream_gpu_writer(s));

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -1,6 +1,6 @@
-// Regression test: writer_flush() on the GPU stream must drain sink IO
-// before returning, so flush is a commit point: when it returns, all
-// queued pwrite_ref jobs are durable, and any that failed are reported (#218).
+// Regression test: a flush on the GPU stream drains sink IO before returning,
+// so when it returns every queued write is durable and any that failed is
+// reported (#218).
 
 #include "gpu/prelude.cuda.h"
 #include "platform/platform.h"
@@ -166,9 +166,8 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
 {
   log_info("=== test_flush_reports_queued_truncate_failure ===");
 
-  // One epoch into a 2-per-shard append dim leaves a partial shard, so flush
-  // queues a footer write then a truncate — and the injected hook fails the
-  // truncate on the IO worker.
+  // One epoch into a 2-per-shard append dim leaves a partial shard, so the
+  // flush has a truncate to queue.
   struct dimension dims[3] = {
     { .size = 0,
       .chunk_size = 1,
@@ -234,8 +233,7 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
     CHECK(Cleanup, r.error == 0);
   }
 
-  // The truncate fails only once the worker runs it, which is after the flush
-  // has queued it — so only a flush that waits can see it.
+  // The truncate fails on the worker, so only a flush that waits can see it.
   shard_pool_fs_inject_failing_truncate(pool);
 
   {

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -1,6 +1,6 @@
 // Regression test: writer_flush() on the GPU stream must drain sink IO
 // before returning, so flush is a commit point: when it returns, all
-// queued pwrite_ref jobs are durable.
+// queued pwrite_ref jobs are durable, and any that failed are reported (#218).
 
 #include "gpu/prelude.cuda.h"
 #include "platform/platform.h"
@@ -155,6 +155,103 @@ Cleanup:
   free(src);
   tile_stream_gpu_destroy(s);
   test_thread_join(thr);
+  zarr_array_destroy(arr);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return rc;
+}
+
+static int
+test_flush_reports_queued_truncate_failure(const char* tmpdir)
+{
+  log_info("=== test_flush_reports_queued_truncate_failure ===");
+
+  // One epoch into a 2-per-shard append dim leaves a partial shard, so flush
+  // queues a footer write then a truncate — and the injected hook fails the
+  // truncate on the IO worker.
+  struct dimension dims[3] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 2,
+      .name = "t",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  const size_t epoch_elements = 8 * 8;
+
+  struct store* store = NULL;
+  struct shard_pool* pool = NULL;
+  struct zarr_array* arr = NULL;
+  struct tile_stream_gpu* s = NULL;
+  uint16_t* src = NULL;
+  int rc = 1;
+
+  store = store_fs_create(tmpdir, 1);
+  CHECK(Cleanup, store);
+  CHECK(Cleanup, store->mkdirs(store, ".") == 0);
+  CHECK(Cleanup, store->mkdirs(store, "0") == 0);
+
+  pool = store->create_pool(store, 8);
+  CHECK(Cleanup, pool);
+
+  struct zarr_array_config acfg = {
+    .data_type = dtype_u16,
+    .fill_value = 0,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  arr = zarr_array_create_with_pool(store, pool, 0, "0", &acfg);
+  CHECK(Cleanup, arr);
+
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = epoch_elements * sizeof(uint16_t),
+    .epochs_per_batch = 1,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .metadata_update_interval_s = 3600.0f,
+  };
+  s = tile_stream_gpu_create(&cfg, zarr_array_as_shard_sink(arr));
+  CHECK(Cleanup, s);
+
+  src = (uint16_t*)calloc(epoch_elements, sizeof(uint16_t));
+  CHECK(Cleanup, src);
+
+  {
+    struct slice input = { .beg = src, .end = src + epoch_elements };
+    struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
+    CHECK(Cleanup, r.error == 0);
+  }
+
+  // The truncate fails only once the worker runs it, which is after the flush
+  // has queued it — so only a flush that waits can see it.
+  CHECK(Cleanup, shard_pool_fs_inject_failing_truncate(pool) == 0);
+
+  {
+    struct writer_result r = writer_flush(tile_stream_gpu_writer(s));
+    if (!r.error) {
+      log_error("flush missed the failure of the truncate it queued");
+      goto Cleanup;
+    }
+  }
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  free(src);
+  tile_stream_gpu_destroy(s);
   zarr_array_destroy(arr);
   shard_pool_destroy(pool);
   store_destroy(store);
@@ -320,6 +417,13 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/flush_drain", tmpdir);
     test_mkdir(sub);
     ecode |= test_flush_waits_for_sink_io(sub);
+  }
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/flush_truncate_error", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_flush_reports_queued_truncate_failure(sub);
   }
 
   {

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -1,12 +1,7 @@
 // Regression test (#218): a flush has to report the failures of the work it
-// queued. Finalizing a partial shard posts a truncate and a close; a flush that
-// returned without waiting for them reported success for a shard whose size on
-// disk is wrong.
-//
-// The failed flush is torn down here as well, so ASAN sees destroy free the
-// buffers the IO queue was reading from. That is the shape of #147 but not a
-// reproduction of it: the truncate fails on the IO worker, so the flush only
-// learns of it by draining, and destroy has nothing left to race.
+// queued. Finalizing a partial shard posts a truncate and a close, and a flush
+// that returned without waiting reported success for a shard whose size on disk
+// is wrong.
 
 #include "platform/platform.h"
 #include "store.h"
@@ -28,9 +23,8 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
 {
   log_info("=== test_flush_reports_queued_truncate_failure (cpu) ===");
 
-  // One epoch into a 2-per-shard append dim leaves a partial shard, so flush
-  // queues a footer write then a truncate — and the injected hook fails the
-  // truncate on the IO worker.
+  // One epoch into a 2-per-shard append dim leaves a partial shard, so the
+  // flush has a truncate to queue.
   struct dimension dims[3] = {
     { .size = 0,
       .chunk_size = 1,
@@ -95,8 +89,7 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
     CHECK(Cleanup, r.error == 0);
   }
 
-  // The truncate fails only once the worker runs it, which is after the flush
-  // has queued it — so only a flush that waits can see it.
+  // The truncate fails on the worker, so only a flush that waits can see it.
   shard_pool_fs_inject_failing_truncate(pool);
 
   {
@@ -106,11 +99,6 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
       goto Cleanup;
     }
   }
-
-  // Destroy frees the footer buffers the queued IO read, so this is the
-  // teardown ASAN watches.
-  tile_stream_cpu_destroy(s);
-  s = NULL;
 
   rc = 0;
   log_info("  PASS");

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -3,8 +3,10 @@
 // returned without waiting for them reported success for a shard whose size on
 // disk is wrong.
 //
-// Also covers #147: the flush frees nothing the IO worker still reads, so
-// destroy after a failed flush is not a use-after-free (ASAN catches it).
+// The failed flush is torn down here as well, so ASAN sees destroy free the
+// buffers the IO queue was reading from. That is the shape of #147 but not a
+// reproduction of it: the truncate fails on the IO worker, so the flush only
+// learns of it by draining, and destroy has nothing left to race.
 
 #include "platform/platform.h"
 #include "store.h"
@@ -105,8 +107,8 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
     }
   }
 
-  // Destroy frees the footer buffers, which the queued IO reads — under ASAN
-  // this catches a flush that left any of it outstanding.
+  // Destroy frees the footer buffers the queued IO read, so this is the
+  // teardown ASAN watches.
   tile_stream_cpu_destroy(s);
   s = NULL;
 

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -1,6 +1,10 @@
-// Regression test (#147): a flush that errors with footer IO still queued must
-// drain the sink before returning, or destroy frees buffers the IO worker still
-// reads (use-after-free; ASAN catches it).
+// Regression test (#218): a flush has to report the failures of the work it
+// queued. Finalizing a partial shard posts a truncate and a close; a flush that
+// returned without waiting for them reported success for a shard whose size on
+// disk is wrong.
+//
+// Also covers #147: the flush frees nothing the IO worker still reads, so
+// destroy after a failed flush is not a use-after-free (ASAN catches it).
 
 #include "platform/platform.h"
 #include "store.h"
@@ -18,13 +22,13 @@
 #include <stdlib.h>
 
 static int
-test_destroy_drains_after_flush_error(const char* tmpdir)
+test_flush_reports_queued_truncate_failure(const char* tmpdir)
 {
-  log_info("=== test_destroy_drains_after_flush_error (cpu) ===");
+  log_info("=== test_flush_reports_queued_truncate_failure (cpu) ===");
 
   // One epoch into a 2-per-shard append dim leaves a partial shard, so flush
-  // queues a footer write then truncates — and the injected hook fails
-  // truncate.
+  // queues a footer write then a truncate — and the injected hook fails the
+  // truncate on the IO worker.
   struct dimension dims[3] = {
     { .size = 0,
       .chunk_size = 1,
@@ -89,19 +93,20 @@ test_destroy_drains_after_flush_error(const char* tmpdir)
     CHECK(Cleanup, r.error == 0);
   }
 
-  // Fail the next truncate so flush errors with a footer write still queued.
+  // The truncate fails only once the worker runs it, which is after the flush
+  // has queued it — so only a flush that waits can see it.
   CHECK(Cleanup, shard_pool_fs_inject_failing_truncate(pool) == 0);
 
   {
     struct writer_result r = writer_flush(tile_stream_cpu_writer(s));
     if (!r.error) {
-      log_error("flush unexpectedly succeeded — fault hook not in effect");
+      log_error("flush missed the failure of the truncate it queued");
       goto Cleanup;
     }
   }
 
-  // Destroy frees the footer buffers; the errored flush must have drained the
-  // queued IO, or this reads freed heap under ASAN.
+  // Destroy frees the footer buffers, which the queued IO reads — under ASAN
+  // this catches a flush that left any of it outstanding.
   tile_stream_cpu_destroy(s);
   s = NULL;
 
@@ -132,7 +137,7 @@ main(int ac, char* av[])
     char sub[4200];
     snprintf(sub, sizeof(sub), "%s/flush_error_drain_cpu", tmpdir);
     test_mkdir(sub);
-    ecode |= test_destroy_drains_after_flush_error(sub);
+    ecode |= test_flush_reports_queued_truncate_failure(sub);
   }
 
   test_tmpdir_remove(tmpdir);

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -97,7 +97,7 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
 
   // The truncate fails only once the worker runs it, which is after the flush
   // has queued it — so only a flush that waits can see it.
-  CHECK(Cleanup, shard_pool_fs_inject_failing_truncate(pool) == 0);
+  shard_pool_fs_inject_failing_truncate(pool);
 
   {
     struct writer_result r = writer_flush(tile_stream_cpu_writer(s));

--- a/tests/test_shape_after_flush_cpu.c
+++ b/tests/test_shape_after_flush_cpu.c
@@ -119,8 +119,8 @@ run_shape_case(const struct shape_case* c)
   }
 
   struct writer_result fr = writer_flush(w);
-  // flush queues the writes; the extent is published once they have landed.
-  // Closing runs even after a failed flush, which is what #175 is about.
+  // The extent is published at close, not at flush. Closing runs even after a
+  // failed flush, which is what #175 is about.
   struct writer_result cr = writer_close(w);
   if (!fr.error)
     fr = cr;

--- a/tests/test_shape_after_flush_gpu.c
+++ b/tests/test_shape_after_flush_gpu.c
@@ -73,7 +73,7 @@ run_shape_case(const struct shape_case* c)
   }
 
   CHECK(Fail, writer_flush(w).error == 0);
-  // flush queues the writes; the extent is published once they have landed.
+  // The extent is published at close, not at flush.
   CHECK(Fail, writer_close(w).error == 0);
   log_info("  updates=%d shape0=%llu",
            sink.update_append_count,

--- a/tests/test_sink_flush_error.c
+++ b/tests/test_sink_flush_error.c
@@ -99,8 +99,7 @@ test_cpu_flush_error_propagates(void)
   struct writer_result ar = writer_append(w, sl);
   CHECK(Fail, ar.error == 0);
 
-  // flush only queues the writes; the sink's own flush runs in close, so that
-  // is where its error surfaces.
+  // The sink's own flush runs in close, so that is where its error surfaces.
   CHECK(Fail, writer_flush(w).error == 0);
   CHECK(Fail, sink.flush_called == 0);
   CHECK(Fail, writer_close(w).error != 0);


### PR DESCRIPTION
Closes #218.

A flush finalized its partial shards and returned without waiting, so a
truncate or close that failed afterwards was invisible to it. The flush
reported success, and record_finalized published a fence and an append
extent for a shard whose size on disk is wrong.

Both flush bodies now drain the sink before returning, on every path, and
report what it found. A flush blocks until the shards it closed are on
disk. It already waited on both io fences before finalizing, so the wait
added here covers the truncate and close of partial shards, plus anything
a flush that failed partway left queued.

The failing-truncate test hook no longer fires on the caller's thread. It
moved to io_backend_fs, where it fails on the IO worker like every other
failure, so only a caller that waits can see it.

test_flush_error_drain_cpu and a new case in test_flush_drain_gpu inject a
failing truncate and require the flush to report it. Taking the drain back
out makes both fail, with the error surfacing only at destroy.

The writer contract said a flush returns once its writes are queued. It
now returns once they have landed, and close is left with publishing the
append extent.
