### PR TITLE
Move the filesystem fault hooks into tests

### DIFF
--- a/src/zarr/io_backend.fs.c
+++ b/src/zarr/io_backend.fs.c
@@ -24,11 +24,6 @@ struct io_backend_fs
   _Atomic uint64_t files_opened;
   _Atomic uint64_t files_open_now;
   _Atomic uint64_t files_open_peak;
-
-  _Atomic int fail_next_noop;
-  _Atomic int block_next_noop;
-  _Atomic int* block_gate;
-  _Atomic int stopped;
 };
 
 static int
@@ -134,25 +129,6 @@ io_backend_fs_files_open_peak(const struct io_backend_fs* b)
   return atomic_load(&b->files_open_peak);
 }
 
-void
-io_backend_fs_inject_failure(struct io_backend_fs* b)
-{
-  atomic_store(&b->fail_next_noop, 1);
-}
-
-void
-io_backend_fs_inject_block(struct io_backend_fs* b, _Atomic int* gate)
-{
-  b->block_gate = gate;
-  atomic_store(&b->block_next_noop, 1);
-}
-
-void
-io_backend_fs_stop(struct io_backend_fs* b)
-{
-  atomic_store(&b->stopped, 1);
-}
-
 static int
 resolve(struct io_backend_fs* b, struct io_file_token file, platform_fd* fd)
 {
@@ -201,17 +177,8 @@ fs_execute(void* ctx,
   struct io_backend_fs* b = (struct io_backend_fs*)ctx;
   out->seq = seq;
 
-  if (req->op == IO_OP_NOOP) {
-    if (atomic_exchange(&b->fail_next_noop, 0)) {
-      record_failure(b, out, "io_backend_fs: injected test failure");
-      return IO_DONE;
-    }
-    if (atomic_exchange(&b->block_next_noop, 0)) {
-      while (atomic_load(b->block_gate) == 0 && !atomic_load(&b->stopped))
-        platform_sleep_ns(1000000LL);
-    }
+  if (req->op == IO_OP_NOOP)
     return IO_DONE;
-  }
 
   platform_fd fd = PLATFORM_FD_INVALID;
   if (!resolve(b, req->file, &fd)) {

--- a/src/zarr/io_backend.fs.h
+++ b/src/zarr/io_backend.fs.h
@@ -28,15 +28,3 @@ io_backend_fs_files_opened(const struct io_backend_fs* b);
 
 uint64_t
 io_backend_fs_files_open_peak(const struct io_backend_fs* b);
-
-// These test hooks are one-shot. Each applies to the next IO_OP_NOOP, the
-// one op with no file and no payload.
-void
-io_backend_fs_inject_failure(struct io_backend_fs* b);
-void
-io_backend_fs_inject_block(struct io_backend_fs* b, _Atomic int* gate);
-
-// Release a blocked request, for a queue torn down with no flush in front of
-// it.
-void
-io_backend_fs_stop(struct io_backend_fs* b);

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -264,8 +264,6 @@ pool_fs_destroy(struct shard_pool* self)
 {
   struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
 
-  io_backend_fs_stop(p->backend);
-
   // Finalize any open slots
   for (uint64_t i = 0; i < p->nslots; ++i) {
     if (p->slots[i].token.generation != 0)
@@ -279,14 +277,6 @@ pool_fs_destroy(struct shard_pool* self)
   free(p->slots);
   strbuf_free(&p->root);
   free(p);
-}
-
-int
-shard_pool_fs_inject_failing_job(struct shard_pool* self)
-{
-  struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
-  io_backend_fs_inject_failure(p->backend);
-  return io_queue_post(p->queue, (struct io_request){ .op = IO_OP_NOOP });
 }
 
 int
@@ -304,16 +294,11 @@ shard_pool_fs_set_error(struct shard_pool* self)
   atomic_store(&p->io_error, 1);
 }
 
-int
-shard_pool_fs_inject_blocking_job(struct shard_pool* self, _Atomic int* gate)
-{
-  struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
-  io_backend_fs_inject_block(p->backend, gate);
-  return io_queue_post(p->queue, (struct io_request){ .op = IO_OP_NOOP });
-}
-
 struct shard_pool*
-shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
+shard_pool_fs_create_wrapped(const char* root,
+                             uint64_t nslots,
+                             int unbuffered,
+                             struct shard_pool_fs_wrapper wrapper)
 {
   CHECK(Fail, root);
   CHECK(Fail, nslots > 0);
@@ -338,8 +323,11 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
   p->backend = io_backend_fs_create(&p->io_error);
   CHECK(Fail_alloc, p->backend);
 
-  p->queue = io_queue_create(io_backend_fs_as_backend(p->backend),
-                             (struct io_queue_limits){ 0 });
+  struct io_backend backend = io_backend_fs_as_backend(p->backend);
+  if (wrapper.wrap)
+    backend = wrapper.wrap(wrapper.ctx, backend);
+
+  p->queue = io_queue_create(backend, (struct io_queue_limits){ 0 });
   CHECK(Fail_backend, p->queue);
 
   p->slots = (struct fs_slot*)calloc((size_t)nslots, sizeof(struct fs_slot));
@@ -358,6 +346,9 @@ shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
     s->fail_next_truncate = &p->fail_next_truncate;
   }
 
+  if (wrapper.queue)
+    *wrapper.queue = p->queue;
+
   return &p->base;
 
 Fail_queue:
@@ -369,4 +360,11 @@ Fail_alloc:
   free(p);
 Fail:
   return NULL;
+}
+
+struct shard_pool*
+shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered)
+{
+  return shard_pool_fs_create_wrapped(
+    root, nslots, unbuffered, (struct shard_pool_fs_wrapper){ 0 });
 }

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -2,9 +2,12 @@
 // Uses io_queue for async pwrite with sequence-number fencing.
 #pragma once
 
+#include "zarr/io_backend.h"
 #include "zarr/shard_pool.h"
 
 #include <stdint.h>
+
+struct io_queue;
 
 // Create a filesystem shard pool with nslots writer slots.
 // root: filesystem root path (keys are relative to this).
@@ -13,16 +16,24 @@
 struct shard_pool*
 shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered);
 
-// Test helper: enqueue a job that unconditionally marks the pool as errored
-// when it runs. Lets tests exercise the flush/has_error propagation path
-// without depending on filesystem behavior. Returns 0 on successful enqueue.
-int
-shard_pool_fs_inject_failing_job(struct shard_pool* pool);
+// How a test puts a backend of its own in front of the filesystem one, to make
+// requests fail or block. Every field may be left null.
+struct shard_pool_fs_wrapper
+{
+  void* ctx;
+  // Given the backend the pool built, return the one the queue should call.
+  struct io_backend (*wrap)(void* ctx, struct io_backend inner);
+  // Set to the queue the pool built, so a test can post requests of its own.
+  struct io_queue** queue;
+};
 
-// Test helper: enqueue a job that spins until *gate becomes non-zero.
-// Caller owns gate. Returns 0 on successful enqueue.
-int
-shard_pool_fs_inject_blocking_job(struct shard_pool* pool, _Atomic int* gate);
+// Create a filesystem shard pool with a wrapper between its queue and its
+// filesystem backend. shard_pool_fs_create passes an empty wrapper.
+struct shard_pool*
+shard_pool_fs_create_wrapped(const char* root,
+                             uint64_t nslots,
+                             int unbuffered,
+                             struct shard_pool_fs_wrapper wrapper);
 
 // Test helper: one-shot, fail the next truncate so a flush errors with IO
 // still queued. Exercises the destroy-time drain that guards those buffers.

--- a/src/zarr/shard_pool_fs.h
+++ b/src/zarr/shard_pool_fs.h
@@ -16,19 +16,18 @@ struct io_queue;
 struct shard_pool*
 shard_pool_fs_create(const char* root, uint64_t nslots, int unbuffered);
 
-// How a test puts a backend of its own in front of the filesystem one, to make
+// A test's own backend can be called in place of the filesystem one, to make
 // requests fail or block. Every field may be left null.
 struct shard_pool_fs_wrapper
 {
   void* ctx;
-  // Given the backend the pool built, return the one the queue should call.
+  // The pool's backend is the argument, and the queue calls the result.
   struct io_backend (*wrap)(void* ctx, struct io_backend inner);
-  // Set to the queue the pool built, so a test can post requests of its own.
-  struct io_queue** queue;
+  struct io_queue** queue; // receives the queue the pool built
 };
 
-// Create a filesystem shard pool with a wrapper between its queue and its
-// filesystem backend. shard_pool_fs_create passes an empty wrapper.
+// Create a filesystem shard pool with the wrapper between its queue and its
+// filesystem backend.
 struct shard_pool*
 shard_pool_fs_create_wrapped(const char* root,
                              uint64_t nslots,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,13 @@ target_link_libraries(morton_util PUBLIC lod_plan index_ops)
 add_test_lib(test_io_backend_fake test_io_backend_fake.c test_io_backend_fake.h)
 target_link_libraries(test_io_backend_fake PUBLIC io_queue platform)
 
+# Filesystem io that can be made to fail or block, for the drain tests
+add_test_lib(test_io_faults test_io_faults.c test_io_faults.h)
+target_link_libraries(
+    test_io_faults
+    PUBLIC shard_pool_fs store_fs io_queue platform strbuf chucky_log
+)
+
 # Shared test shard sink (multi-shard-safe)
 add_test_lib(test_shard_sink test_shard_sink.c test_shard_sink.h)
 target_link_libraries(test_shard_sink PUBLIC writer)
@@ -164,7 +171,7 @@ add_test_exe(test_json_writer test_json_writer.c zarr_metadata ngff_metadata str
 add_test_exe(test_io_queue    test_io_queue.c    io_queue test_io_backend_fake test_platform chucky_log)
 # A worker left held would hang rather than fail; bound it.
 set_tests_properties(test-test_io_queue PROPERTIES TIMEOUT 60)
-add_test_exe(test_store_fs    test_store_fs.c    store_fs store_api zarr_group platform test_platform chucky_log)
+add_test_exe(test_store_fs    test_store_fs.c    store_fs store_api zarr_group platform test_platform chucky_log test_io_faults)
 add_test_exe(test_zarr_attribute test_zarr_attribute.c zarr_array zarr_group store_fs store_api stream_cpu writer test_platform chucky_log)
 add_test_exe(test_ngff_attribute test_ngff_attribute.c ngff_multiscale store_fs store_api test_platform chucky_log)
 add_test_exe(test_hcs_attribute test_hcs_attribute.c hcs store_fs store_api test_platform chucky_log)
@@ -183,12 +190,12 @@ add_gpu_test_exe(test_zarr_fs_sink   test_zarr_fs_sink.c   LINKS CUDA::cuda_driv
 if(CHUCKY_ENABLE_GPU)
     set_tests_properties(test-test_zarr_fs_sink PROPERTIES TIMEOUT 120)
 endif()
-add_gpu_test_exe(test_destroy_drain  test_destroy_drain.c  LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
-add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
-add_gpu_test_exe(test_destroy_midstream test_destroy_midstream.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log)
-add_test_exe(test_flush_drain_cpu test_flush_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
+add_gpu_test_exe(test_destroy_drain  test_destroy_drain.c  LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log test_io_faults)
+add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log test_io_faults)
+add_gpu_test_exe(test_destroy_midstream test_destroy_midstream.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log test_io_faults)
+add_test_exe(test_flush_drain_cpu test_flush_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log test_io_faults)
 add_test_exe(test_flush_error_drain_cpu test_flush_error_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
-add_test_exe(test_pending_bytes_fs test_pending_bytes_fs.c shard_pool_fs platform writer test_platform chucky_log)
+add_test_exe(test_pending_bytes_fs test_pending_bytes_fs.c shard_pool_fs platform writer test_platform chucky_log test_io_faults)
 # A worker left held would hang rather than fail; bound it.
 set_tests_properties(test-test_pending_bytes_fs PROPERTIES TIMEOUT 60)
 add_test_exe(test_shape_after_flush_cpu test_shape_after_flush_cpu.c stream_cpu test_shard_sink writer chucky_log)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -172,6 +172,8 @@ add_test_exe(test_io_queue    test_io_queue.c    io_queue test_io_backend_fake t
 # A worker left held would hang rather than fail; bound it.
 set_tests_properties(test-test_io_queue PROPERTIES TIMEOUT 60)
 add_test_exe(test_store_fs    test_store_fs.c    store_fs store_api zarr_group platform test_platform chucky_log test_io_faults)
+# A worker left held would hang rather than fail; bound it.
+set_tests_properties(test-test_store_fs PROPERTIES TIMEOUT 60)
 add_test_exe(test_zarr_attribute test_zarr_attribute.c zarr_array zarr_group store_fs store_api stream_cpu writer test_platform chucky_log)
 add_test_exe(test_ngff_attribute test_ngff_attribute.c ngff_multiscale store_fs store_api test_platform chucky_log)
 add_test_exe(test_hcs_attribute test_hcs_attribute.c hcs store_fs store_api test_platform chucky_log)
@@ -194,6 +196,15 @@ add_gpu_test_exe(test_destroy_drain  test_destroy_drain.c  LINKS CUDA::cuda_driv
 add_gpu_test_exe(test_flush_drain_gpu test_flush_drain_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log test_io_faults)
 add_gpu_test_exe(test_destroy_midstream test_destroy_midstream.c LINKS CUDA::cuda_driver CUDA::cudart_static stream zarr_array store_fs store_api shard_pool_fs platform test_platform Zstd::Zstd chucky_log test_io_faults)
 add_test_exe(test_flush_drain_cpu test_flush_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log test_io_faults)
+# A worker left held would hang rather than fail; bound them.
+set_tests_properties(test-test_flush_drain_cpu PROPERTIES TIMEOUT 60)
+if(CHUCKY_ENABLE_GPU)
+    set_tests_properties(
+        test-test_destroy_drain test-test_flush_drain_gpu
+        test-test_destroy_midstream
+        PROPERTIES TIMEOUT 120
+    )
+endif()
 add_test_exe(test_flush_error_drain_cpu test_flush_error_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log)
 add_test_exe(test_pending_bytes_fs test_pending_bytes_fs.c shard_pool_fs platform writer test_platform chucky_log test_io_faults)
 # A worker left held would hang rather than fail; bound it.

--- a/tests/test_destroy_drain.c
+++ b/tests/test_destroy_drain.c
@@ -5,12 +5,12 @@
 #include "platform/platform.h"
 #include "store.h"
 #include "stream.gpu.h"
+#include "test_io_faults.h"
 #include "test_platform.h"
 #include "util/prelude.h"
 #include "writer.h"
 #include "zarr.h"
 #include "zarr/shard_pool.h"
-#include "zarr/shard_pool_fs.h"
 #include "zarr/zarr_array.h"
 
 #include <stdatomic.h>
@@ -62,6 +62,7 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
   const size_t total_elements = 12 * 8 * 12;
 
   struct store* store = NULL;
+  struct io_faults faults;
   struct shard_pool* pool = NULL;
   struct zarr_array* arr = NULL;
   struct tile_stream_gpu* s = NULL;
@@ -71,7 +72,7 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
   _Atomic int gate;
   atomic_store(&gate, 0);
 
-  store = store_fs_create(tmpdir, 1);
+  store = io_faults_store_create(&faults, tmpdir, 1);
   CHECK(Cleanup, store);
   CHECK(Cleanup, store->mkdirs(store, ".") == 0);
   CHECK(Cleanup, store->mkdirs(store, "0") == 0);
@@ -110,7 +111,7 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
 
   // Gate sits at seq=1 in the io_queue ahead of any pwrite jobs the
   // destroy auto-flush will queue behind it.
-  CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
 
   struct destroy_args da = { .s = s };
   atomic_store(&da.done, 0);
@@ -145,6 +146,7 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
   log_info("  PASS");
 
 Cleanup:
+  atomic_store(&gate, 1);
   free(src);
   tile_stream_gpu_destroy(s);
   test_thread_join(thr);

--- a/tests/test_destroy_midstream.c
+++ b/tests/test_destroy_midstream.c
@@ -7,6 +7,7 @@
 #include "platform/platform.h"
 #include "store.h"
 #include "stream.gpu.h"
+#include "test_io_faults.h"
 #include "test_platform.h"
 #include "util/prelude.h"
 #include "writer.h"
@@ -268,6 +269,7 @@ test_destroy_blocks_on_gated_sink(const char* tmpdir)
   const size_t append_elements = 2 * epoch_elements; // one full batch at K=2
 
   struct store* store = NULL;
+  struct io_faults faults;
   struct shard_pool* pool = NULL;
   struct zarr_array* arr = NULL;
   struct tile_stream_gpu* s = NULL;
@@ -277,7 +279,7 @@ test_destroy_blocks_on_gated_sink(const char* tmpdir)
   _Atomic int gate;
   atomic_store(&gate, 0);
 
-  store = store_fs_create(tmpdir, 0);
+  store = io_faults_store_create(&faults, tmpdir, 0);
   CHECK(Cleanup, store);
   CHECK(Cleanup, store->mkdirs(store, ".") == 0);
   CHECK(Cleanup, store->mkdirs(store, "0") == 0);
@@ -315,7 +317,7 @@ test_destroy_blocks_on_gated_sink(const char* tmpdir)
     CHECK(Cleanup, r.error == 0);
   }
 
-  CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
 
   struct destroy_args da = { .s = s };
   atomic_store(&da.done, 0);
@@ -347,6 +349,7 @@ test_destroy_blocks_on_gated_sink(const char* tmpdir)
   log_info("  PASS");
 
 Cleanup:
+  atomic_store(&gate, 1);
   free(src);
   tile_stream_gpu_destroy(s);
   test_thread_join(thr);

--- a/tests/test_flush_drain_cpu.c
+++ b/tests/test_flush_drain_cpu.c
@@ -6,11 +6,11 @@
 #include "platform/platform.h"
 #include "store.h"
 #include "stream.cpu.h"
+#include "test_io_faults.h"
 #include "test_platform.h"
 #include "util/prelude.h"
 #include "writer.h"
 #include "zarr/shard_pool.h"
-#include "zarr/shard_pool_fs.h"
 #include "zarr/zarr_array.h"
 
 #include <stdatomic.h>
@@ -67,6 +67,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
   const size_t epoch_elements = 8 * 8;
 
   struct store* store = NULL;
+  struct io_faults faults;
   struct shard_pool* pool = NULL;
   struct zarr_array* arr = NULL;
   struct tile_stream_cpu* s = NULL;
@@ -76,7 +77,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
   _Atomic int gate;
   atomic_store(&gate, 0);
 
-  store = store_fs_create(tmpdir, /*unbuffered=*/1);
+  store = io_faults_store_create(&faults, tmpdir, /*unbuffered=*/1);
   CHECK(Cleanup, store);
   CHECK(Cleanup, store->mkdirs(store, ".") == 0);
   CHECK(Cleanup, store->mkdirs(store, "0") == 0);
@@ -116,7 +117,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
 
   // Gate sits in the io_queue ahead of the footer jobs the flush will queue
   // behind it.
-  CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
 
   struct flush_args fa = { .w = tile_stream_cpu_writer(s) };
   atomic_store(&fa.done, 0);
@@ -155,6 +156,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
   log_info("  PASS");
 
 Cleanup:
+  atomic_store(&gate, 1);
   free(src);
   tile_stream_cpu_destroy(s);
   test_thread_join(thr);

--- a/tests/test_flush_drain_cpu.c
+++ b/tests/test_flush_drain_cpu.c
@@ -158,8 +158,8 @@ test_flush_waits_for_sink_io(const char* tmpdir)
 Cleanup:
   atomic_store(&gate, 1);
   free(src);
-  tile_stream_cpu_destroy(s);
   test_thread_join(thr);
+  tile_stream_cpu_destroy(s);
   zarr_array_destroy(arr);
   shard_pool_destroy(pool);
   store_destroy(store);

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -6,12 +6,12 @@
 #include "platform/platform.h"
 #include "store.h"
 #include "stream.gpu.h"
+#include "test_io_faults.h"
 #include "test_platform.h"
 #include "util/prelude.h"
 #include "writer.h"
 #include "zarr.h"
 #include "zarr/shard_pool.h"
-#include "zarr/shard_pool_fs.h"
 #include "zarr/zarr_array.h"
 
 #include <stdatomic.h>
@@ -65,6 +65,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
   const size_t total_elements = 12 * 8 * 12;
 
   struct store* store = NULL;
+  struct io_faults faults;
   struct shard_pool* pool = NULL;
   struct zarr_array* arr = NULL;
   struct tile_stream_gpu* s = NULL;
@@ -74,7 +75,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
   _Atomic int gate;
   atomic_store(&gate, 0);
 
-  store = store_fs_create(tmpdir, 1);
+  store = io_faults_store_create(&faults, tmpdir, 1);
   CHECK(Cleanup, store);
   CHECK(Cleanup, store->mkdirs(store, ".") == 0);
   CHECK(Cleanup, store->mkdirs(store, "0") == 0);
@@ -113,7 +114,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
 
   // Gate sits at seq=1 in the io_queue ahead of any pwrite jobs the
   // flush will queue behind it.
-  CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
 
   struct flush_args fa = { .w = tile_stream_gpu_writer(s) };
   atomic_store(&fa.done, 0);
@@ -152,6 +153,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
   log_info("  PASS");
 
 Cleanup:
+  atomic_store(&gate, 1);
   free(src);
   tile_stream_gpu_destroy(s);
   test_thread_join(thr);

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -155,8 +155,8 @@ test_flush_waits_for_sink_io(const char* tmpdir)
 Cleanup:
   atomic_store(&gate, 1);
   free(src);
-  tile_stream_gpu_destroy(s);
   test_thread_join(thr);
+  tile_stream_gpu_destroy(s);
   zarr_array_destroy(arr);
   shard_pool_destroy(pool);
   store_destroy(store);
@@ -290,8 +290,8 @@ test_writes_from_a_foreign_context(const char* tmpdir, CUdevice dev)
 
 Cleanup:
   free(src);
-  tile_stream_gpu_destroy(s);
   test_thread_join(thr);
+  tile_stream_gpu_destroy(s);
   zarr_array_destroy(arr);
   shard_pool_destroy(pool);
   store_destroy(store);

--- a/tests/test_io_faults.c
+++ b/tests/test_io_faults.c
@@ -1,0 +1,175 @@
+#include "test_io_faults.h"
+#include "platform/platform.h"
+#include "util/prelude.h"
+#include "util/strbuf.h"
+#include "zarr/io_queue.h"
+#include "zarr/shard_pool_fs.h"
+#include "zarr/store.h"
+#include "zarr/store_fs.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static int
+faults_execute(void* ctx,
+               const struct io_request* req,
+               uint64_t seq,
+               struct io_completion* out)
+{
+  struct io_faults* f = (struct io_faults*)ctx;
+
+  if (req->op != IO_OP_NOOP)
+    return f->inner.execute(f->inner.ctx, req, seq, out);
+
+  out->seq = seq;
+  if (atomic_exchange(&f->fail_next_noop, 0)) {
+    log_error("io_faults: injected test failure");
+    shard_pool_fs_set_error(f->pool);
+    out->nbytes = 0;
+    out->status = IO_FAILED;
+    return IO_DONE;
+  }
+  if (atomic_exchange(&f->block_next_noop, 0)) {
+    while (atomic_load(f->block_gate) == 0)
+      platform_sleep_ns(1000000LL);
+  }
+  return IO_DONE;
+}
+
+static struct io_backend
+faults_wrap(void* ctx, struct io_backend inner)
+{
+  struct io_faults* f = (struct io_faults*)ctx;
+  f->inner = inner;
+  return (struct io_backend){ .ctx = f, .execute = faults_execute };
+}
+
+static struct shard_pool*
+pool_create(struct io_faults* f,
+            const char* root,
+            uint64_t nslots,
+            int unbuffered)
+{
+  f->pool = shard_pool_fs_create_wrapped(root,
+                                         nslots,
+                                         unbuffered,
+                                         (struct shard_pool_fs_wrapper){
+                                           .ctx = f,
+                                           .wrap = faults_wrap,
+                                           .queue = &f->queue,
+                                         });
+  return f->pool;
+}
+
+struct shard_pool*
+io_faults_pool_create(struct io_faults* f,
+                      const char* root,
+                      uint64_t nslots,
+                      int unbuffered)
+{
+  memset(f, 0, sizeof(*f));
+  return pool_create(f, root, nslots, unbuffered);
+}
+
+// --- Store ---
+
+struct faults_store
+{
+  struct store base;
+  struct store* inner; // owned
+  struct io_faults* faults;
+  struct strbuf root; // owned
+  int unbuffered;
+};
+
+static int
+faults_store_put(struct store* self,
+                 const char* key,
+                 const void* data,
+                 size_t len)
+{
+  struct faults_store* s = container_of(self, struct faults_store, base);
+  return s->inner->put(s->inner, key, data, len);
+}
+
+static int
+faults_store_mkdirs(struct store* self, const char* key)
+{
+  struct faults_store* s = container_of(self, struct faults_store, base);
+  return s->inner->mkdirs(s->inner, key);
+}
+
+static int
+faults_store_has_existing_data(struct store* self)
+{
+  struct faults_store* s = container_of(self, struct faults_store, base);
+  return s->inner->has_existing_data(s->inner);
+}
+
+static struct shard_pool*
+faults_store_create_pool(struct store* self, uint64_t nslots)
+{
+  struct faults_store* s = container_of(self, struct faults_store, base);
+  return pool_create(s->faults, strbuf_cstr(&s->root), nslots, s->unbuffered);
+}
+
+static void
+faults_store_destroy(struct store* self)
+{
+  struct faults_store* s = container_of(self, struct faults_store, base);
+  s->inner->destroy(s->inner);
+  strbuf_free(&s->root);
+  free(s);
+}
+
+struct store*
+io_faults_store_create(struct io_faults* f, const char* root, int unbuffered)
+{
+  memset(f, 0, sizeof(*f));
+
+  struct faults_store* s = (struct faults_store*)calloc(1, sizeof(*s));
+  CHECK(Fail, s);
+
+  s->base.put = faults_store_put;
+  s->base.mkdirs = faults_store_mkdirs;
+  s->base.create_pool = faults_store_create_pool;
+  s->base.has_existing_data = faults_store_has_existing_data;
+  s->base.destroy = faults_store_destroy;
+  s->faults = f;
+  s->unbuffered = unbuffered;
+  CHECK(Fail_alloc, strbuf_set(&s->root, root) == 0);
+
+  s->inner = store_fs_create(root, unbuffered);
+  CHECK(Fail_alloc, s->inner);
+
+  return &s->base;
+
+Fail_alloc:
+  strbuf_free(&s->root);
+  free(s);
+Fail:
+  return NULL;
+}
+
+// --- Injection ---
+
+static int
+post_noop(struct io_faults* f)
+{
+  return io_queue_post(f->queue, (struct io_request){ .op = IO_OP_NOOP });
+}
+
+int
+io_faults_inject_failing_job(struct io_faults* f)
+{
+  atomic_store(&f->fail_next_noop, 1);
+  return post_noop(f);
+}
+
+int
+io_faults_inject_blocking_job(struct io_faults* f, _Atomic int* gate)
+{
+  f->block_gate = gate;
+  atomic_store(&f->block_next_noop, 1);
+  return post_noop(f);
+}

--- a/tests/test_io_faults.c
+++ b/tests/test_io_faults.c
@@ -110,7 +110,12 @@ static struct shard_pool*
 faults_store_create_pool(struct store* self, uint64_t nslots)
 {
   struct faults_store* s = container_of(self, struct faults_store, base);
+  // A second pool would leave the first pool's queue calling the wrong
+  // backend.
+  CHECK(Fail, !s->faults->pool);
   return pool_create(s->faults, strbuf_cstr(&s->root), nslots, s->unbuffered);
+Fail:
+  return NULL;
 }
 
 static void

--- a/tests/test_io_faults.h
+++ b/tests/test_io_faults.h
@@ -17,8 +17,7 @@ struct io_faults
   struct io_queue* queue;
   struct shard_pool* pool;
 
-  // Both flags are one-shot and apply to the next IO_OP_NOOP, the one op with
-  // no file and no payload.
+  // Both flags are one-shot and apply to the next IO_OP_NOOP.
   _Atomic int fail_next_noop;
   _Atomic int block_next_noop;
   _Atomic int* block_gate;
@@ -31,8 +30,8 @@ io_faults_pool_create(struct io_faults* f,
                       uint64_t nslots,
                       int unbuffered);
 
-// Create a filesystem store whose pools can be made to fail or block. Only the
-// pool opened last is reached by the calls below.
+// Create a filesystem store whose pool can be made to fail or block. Only one
+// pool can be built from it, even after that pool is destroyed.
 struct store*
 io_faults_store_create(struct io_faults* f, const char* root, int unbuffered);
 

--- a/tests/test_io_faults.h
+++ b/tests/test_io_faults.h
@@ -1,0 +1,48 @@
+// This backend is for tests only: every request goes to the filesystem backend
+// behind it, except IO_OP_NOOP, which can be made to fail or to block.
+#pragma once
+
+#include "zarr/io_backend.h"
+
+#include <stdatomic.h>
+#include <stdint.h>
+
+struct io_queue;
+struct shard_pool;
+struct store;
+
+struct io_faults
+{
+  struct io_backend inner;
+  struct io_queue* queue;
+  struct shard_pool* pool;
+
+  // Both flags are one-shot and apply to the next IO_OP_NOOP, the one op with
+  // no file and no payload.
+  _Atomic int fail_next_noop;
+  _Atomic int block_next_noop;
+  _Atomic int* block_gate;
+};
+
+// Create a filesystem shard pool whose io can be made to fail or block.
+struct shard_pool*
+io_faults_pool_create(struct io_faults* f,
+                      const char* root,
+                      uint64_t nslots,
+                      int unbuffered);
+
+// Create a filesystem store whose pools can be made to fail or block. Only the
+// pool opened last is reached by the calls below.
+struct store*
+io_faults_store_create(struct io_faults* f, const char* root, int unbuffered);
+
+// Queue a job that marks the pool errored when it runs. Returns 0 on a
+// successful enqueue.
+int
+io_faults_inject_failing_job(struct io_faults* f);
+
+// Queue a job that spins until *gate is non-zero. The caller owns the gate and
+// must open it before tearing the pool down. Returns 0 on a successful
+// enqueue.
+int
+io_faults_inject_blocking_job(struct io_faults* f, _Atomic int* gate);

--- a/tests/test_pending_bytes_fs.c
+++ b/tests/test_pending_bytes_fs.c
@@ -2,11 +2,11 @@
 // the io queue, and tests/test_io_queue.c covers it there. This checks that the
 // pool passes the figure through, over both write paths.
 
+#include "test_io_faults.h"
 #include "test_platform.h"
 #include "util/prelude.h"
 #include "writer.h"
 #include "zarr/shard_pool.h"
-#include "zarr/shard_pool_fs.h"
 
 #include <stdatomic.h>
 #include <stdint.h>
@@ -25,12 +25,13 @@ test_counts_every_write(const char* tmpdir, int direct)
   log_info("=== test_counts_every_write (%s) ===", label);
 
   struct shard_pool* pool = NULL;
+  struct io_faults faults;
   uint8_t* src = NULL;
   int rc = 1;
   _Atomic int gate;
   atomic_store(&gate, 0);
 
-  pool = shard_pool_fs_create(tmpdir, /*nslots=*/1, /*unbuffered=*/0);
+  pool = io_faults_pool_create(&faults, tmpdir, /*nslots=*/1, /*unbuffered=*/0);
   CHECK(Cleanup, pool);
   CHECK(Cleanup, shard_pool_pending_bytes(pool) == 0);
 
@@ -44,7 +45,7 @@ test_counts_every_write(const char* tmpdir, int direct)
   src = (uint8_t*)calloc(1, WRITE_BYTES);
   CHECK(Cleanup, src);
 
-  CHECK(Cleanup, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
 
   for (int i = 0; i < BATCH_WRITES; ++i) {
     uint64_t offset = (uint64_t)i * WRITE_BYTES;

--- a/tests/test_store_fs.c
+++ b/tests/test_store_fs.c
@@ -1,12 +1,12 @@
 #include "platform/platform.h"
 #include "store.h"
+#include "test_io_faults.h"
 #include "test_platform.h"
 #include "util/prelude.h"
 #include "zarr.h"
 #include "zarr/io_backend.fs.h"
 #include "zarr/io_queue.h"
 #include "zarr/shard_pool.h"
-#include "zarr/shard_pool_fs.h"
 #include "zarr/store.h"
 #include "zarr/store_fs.h"
 
@@ -285,7 +285,8 @@ static int
 test_shard_pool_io_stats(void)
 {
   log_info("=== test_shard_pool_io_stats ===");
-  struct store* s = store_fs_create(tmpdir, 0);
+  struct io_faults faults;
+  struct store* s = io_faults_store_create(&faults, tmpdir, 0);
   CHECK(Fail, s);
   CHECK(Fail2, s->mkdirs(s, "stats") == 0);
 
@@ -294,7 +295,7 @@ test_shard_pool_io_stats(void)
   CHECK(Fail2, pool);
 
   atomic_int gate = 0;
-  CHECK(Fail3, shard_pool_fs_inject_blocking_job(pool, &gate) == 0);
+  CHECK(Fail3, io_faults_inject_blocking_job(&faults, &gate) == 0);
 
   for (int i = 0; i < 6; ++i) {
     char key[256];
@@ -348,11 +349,12 @@ test_shard_pool_error_propagation(void)
   // Use a buffered pool — the error path under test is filesystem-independent,
   // driven by a test-only failing-job injector rather than by O_DIRECT
   // alignment enforcement (which varies across filesystems).
-  struct shard_pool* pool = shard_pool_fs_create(tmpdir, 1, 0);
+  struct io_faults faults;
+  struct shard_pool* pool = io_faults_pool_create(&faults, tmpdir, 1, 0);
   CHECK(Fail, pool);
 
   // Inject a job that deliberately reports a write failure.
-  CHECK(Fail2, shard_pool_fs_inject_failing_job(pool) == 0);
+  CHECK(Fail2, io_faults_inject_failing_job(&faults) == 0);
 
   // Flush waits for all async IO and returns the error flag.
   int flush_err = pool->flush(pool);


### PR DESCRIPTION
Three functions in src/zarr/io_backend.fs.h existed only for tests:
io_backend_fs_inject_failure, io_backend_fs_inject_block and
io_backend_fs_stop. They are gone, along with the two one-shot flags, the
gate pointer, the stopped flag and the polling loop, and pool_fs_destroy
no longer calls stop on every teardown.

In their place, shard_pool_fs_create_wrapped puts a backend of the
caller's own between the pool's queue and its filesystem backend, and
reports the queue it built. shard_pool_fs_create passes an empty wrapper,
so the shipping path is unchanged.

The fault state now lives in tests/test_io_faults.c, which passes every
request through to the filesystem except IO_OP_NOOP, and fails or blocks
on that one. It also carries a filesystem store, since most of these
tests reach the pool through store->create_pool. The six test files keep
the same shape; each now opens its gate in cleanup, because nothing
releases a blocked job at teardown any more.

Closes #219.
