### PR TITLE
Collapse the three one-shot io fault flags into one

### DIFF
--- a/tests/test_io_faults.c
+++ b/tests/test_io_faults.c
@@ -18,9 +18,11 @@ faults_execute(void* ctx,
 {
   struct io_faults* f = (struct io_faults*)ctx;
 
+  uint16_t armed = atomic_load(&f->armed);
   uint8_t fault = IO_FAULT_NONE;
-  if (req->op == atomic_load(&f->fault_op))
-    fault = atomic_exchange(&f->fault, IO_FAULT_NONE);
+  if ((armed >> 8) == req->op &&
+      atomic_compare_exchange_strong(&f->armed, &armed, (uint16_t)0))
+    fault = (uint8_t)(armed & 0xff);
 
   if (fault == IO_FAULT_FAIL) {
     log_error("io_faults: injected failure of io op %u", (unsigned)req->op);
@@ -171,13 +173,10 @@ Fail:
 
 // --- Injection ---
 
-// The op is stored first so a request already running cannot claim the fault
-// against whichever op was armed before it.
 static void
-arm(struct io_faults* f, uint8_t op, uint8_t fault)
+arm_fault(struct io_faults* f, uint8_t op, uint8_t fault)
 {
-  atomic_store(&f->fault_op, op);
-  atomic_store(&f->fault, fault);
+  atomic_store(&f->armed, (uint16_t)(((uint16_t)op << 8) | fault));
 }
 
 static int
@@ -189,7 +188,7 @@ post_noop(struct io_faults* f)
 int
 io_faults_inject_failing_job(struct io_faults* f)
 {
-  arm(f, IO_OP_NOOP, IO_FAULT_FAIL);
+  arm_fault(f, IO_OP_NOOP, IO_FAULT_FAIL);
   return post_noop(f);
 }
 
@@ -197,12 +196,12 @@ int
 io_faults_inject_blocking_job(struct io_faults* f, _Atomic int* gate)
 {
   f->block_gate = gate;
-  arm(f, IO_OP_NOOP, IO_FAULT_BLOCK);
+  arm_fault(f, IO_OP_NOOP, IO_FAULT_BLOCK);
   return post_noop(f);
 }
 
 void
 io_faults_fail_next_truncate(struct io_faults* f)
 {
-  arm(f, IO_OP_TRUNCATE, IO_FAULT_FAIL);
+  arm_fault(f, IO_OP_TRUNCATE, IO_FAULT_FAIL);
 }

--- a/tests/test_io_faults.c
+++ b/tests/test_io_faults.c
@@ -18,8 +18,12 @@ faults_execute(void* ctx,
 {
   struct io_faults* f = (struct io_faults*)ctx;
 
-  if (req->op == IO_OP_TRUNCATE && atomic_exchange(&f->fail_next_truncate, 0)) {
-    log_error("io_faults: injected truncate failure");
+  uint8_t fault = IO_FAULT_NONE;
+  if (req->op == atomic_load(&f->fault_op))
+    fault = atomic_exchange(&f->fault, IO_FAULT_NONE);
+
+  if (fault == IO_FAULT_FAIL) {
+    log_error("io_faults: injected failure of io op %u", (unsigned)req->op);
     shard_pool_fs_set_error(f->pool);
     out->seq = seq;
     out->nbytes = 0;
@@ -27,22 +31,12 @@ faults_execute(void* ctx,
     return IO_DONE;
   }
 
-  if (req->op != IO_OP_NOOP)
-    return f->inner.execute(f->inner.ctx, req, seq, out);
-
-  out->seq = seq;
-  if (atomic_exchange(&f->fail_next_noop, 0)) {
-    log_error("io_faults: injected test failure");
-    shard_pool_fs_set_error(f->pool);
-    out->nbytes = 0;
-    out->status = IO_FAILED;
-    return IO_DONE;
-  }
-  if (atomic_exchange(&f->block_next_noop, 0)) {
+  if (fault == IO_FAULT_BLOCK) {
     while (atomic_load(f->block_gate) == 0)
       platform_sleep_ns(1000000LL);
   }
-  return IO_DONE;
+
+  return f->inner.execute(f->inner.ctx, req, seq, out);
 }
 
 static struct io_backend
@@ -177,6 +171,15 @@ Fail:
 
 // --- Injection ---
 
+// The op is stored first so a request already running cannot claim the fault
+// against whichever op was armed before it.
+static void
+arm(struct io_faults* f, uint8_t op, uint8_t fault)
+{
+  atomic_store(&f->fault_op, op);
+  atomic_store(&f->fault, fault);
+}
+
 static int
 post_noop(struct io_faults* f)
 {
@@ -186,7 +189,7 @@ post_noop(struct io_faults* f)
 int
 io_faults_inject_failing_job(struct io_faults* f)
 {
-  atomic_store(&f->fail_next_noop, 1);
+  arm(f, IO_OP_NOOP, IO_FAULT_FAIL);
   return post_noop(f);
 }
 
@@ -194,12 +197,12 @@ int
 io_faults_inject_blocking_job(struct io_faults* f, _Atomic int* gate)
 {
   f->block_gate = gate;
-  atomic_store(&f->block_next_noop, 1);
+  arm(f, IO_OP_NOOP, IO_FAULT_BLOCK);
   return post_noop(f);
 }
 
 void
 io_faults_fail_next_truncate(struct io_faults* f)
 {
-  atomic_store(&f->fail_next_truncate, 1);
+  arm(f, IO_OP_TRUNCATE, IO_FAULT_FAIL);
 }

--- a/tests/test_io_faults.h
+++ b/tests/test_io_faults.h
@@ -1,5 +1,5 @@
-// This backend is for tests only: every request goes to the filesystem backend
-// behind it, except that one armed operation is made to fail or to block first.
+// This backend is for tests only. Every request goes to the filesystem backend
+// behind it. One armed request can be held at a gate first, or made to fail.
 #pragma once
 
 #include "zarr/io_backend.h"
@@ -25,10 +25,9 @@ struct io_faults
   struct io_queue* queue;
   struct shard_pool* pool;
 
-  // One fault is armed at a time, and the first request whose op matches
-  // clears it.
-  _Atomic uint8_t fault_op; // enum io_op
-  _Atomic uint8_t fault;    // enum io_fault
+  // One fault is armed at a time. The op is in the high byte and the fault in
+  // the low, so that a request reads both as one value.
+  _Atomic uint16_t armed;
   _Atomic int* block_gate;
 
   struct io_scheduling io; // zero fields take the pool's own defaults

--- a/tests/test_io_faults.h
+++ b/tests/test_io_faults.h
@@ -1,6 +1,5 @@
 // This backend is for tests only: every request goes to the filesystem backend
-// behind it, except IO_OP_NOOP, which can be made to fail or to block, and
-// IO_OP_TRUNCATE, which can be made to fail.
+// behind it, except that one armed operation is made to fail or to block first.
 #pragma once
 
 #include "zarr/io_backend.h"
@@ -13,17 +12,23 @@ struct io_queue;
 struct shard_pool;
 struct store;
 
+enum io_fault
+{
+  IO_FAULT_NONE = 0,
+  IO_FAULT_FAIL,  // report the request failed and mark the pool errored
+  IO_FAULT_BLOCK, // hold the request until the gate opens
+};
+
 struct io_faults
 {
   struct io_backend inner;
   struct io_queue* queue;
   struct shard_pool* pool;
 
-  // The flags are one-shot. Two apply to the next IO_OP_NOOP, the third to the
-  // next IO_OP_TRUNCATE.
-  _Atomic int fail_next_noop;
-  _Atomic int block_next_noop;
-  _Atomic int fail_next_truncate;
+  // One fault is armed at a time, and the first request whose op matches
+  // clears it.
+  _Atomic uint8_t fault_op; // enum io_op
+  _Atomic uint8_t fault;    // enum io_fault
   _Atomic int* block_gate;
 
   struct io_scheduling io; // zero fields take the pool's own defaults


### PR DESCRIPTION
The test fault backend kept one one-shot flag for every operation and
effect it could inject: fail_next_noop, block_next_noop, and
fail_next_truncate. Failing a fourth operation would have meant a fourth
flag, and the header comment had to say which operation each flag applied
to.

One armed fault replaces all three. It holds the operation to act on and
the effect to apply, packed into one word so a request reads both
together. The injection functions keep their names and signatures, so
every test arms the same fault at the same point.

The wrapper no longer special-cases IO_OP_NOOP. The filesystem backend
behind it already completes a noop, so any request the fault does not
claim goes straight through.

Closes #231
