### PR TITLE
Close four gaps in the io queue backend interface

### DIFF
--- a/dev/io-scheduler.md
+++ b/dev/io-scheduler.md
@@ -394,14 +394,15 @@ too, so evidence is needed first.
 
 **Close four gaps in the backend interface** (#229), as its own pull request
 before any ring is written. The interface step 2 built is general enough to hold
-one, but a backend has no way to say "not now", which a full submission queue
-needs; the alternatives today are to block a worker or to fail the request. The
-queue never calls into the backend at teardown, so a backend with a thread of
-its own has nowhere to stop it. The request handed to `execute` is the worker's
-own copy and dies when the call returns, so a backend that finishes later has to
-copy what it needs. And a short write is unowned: `platform_pwrite` loops
-internally so it never reports one, a ring does, and retrying the remainder
-belongs in the backend rather than in the queue.
+one, and these four were what it was short of. A backend with no room now
+answers "not now" instead of blocking a worker or failing the request, and the
+queue offers that request again with its place in line kept. A backend can carry
+a stop, called once at teardown, so one running a thread of its own has
+somewhere to release it. The request handed to `execute` is the queue's own copy
+and outlives the call, so a backend that finishes later reads it where it lies
+rather than copying what it needs. And a short write is the backend's to finish:
+`platform_pwrite` loops internally so it never reports one, a ring does, and the
+part still to be done is handed back for retrying.
 
 *Done when:* the XFS matrix is green, then an NFS matrix before it is made the
 default. The file server's own numbers are above, so that matrix has a

--- a/src/zarr/io_backend.h
+++ b/src/zarr/io_backend.h
@@ -26,8 +26,8 @@ struct io_backend
   //
   // A write that comes back short is finished here rather than by the queue,
   // by retrying what io_write_remaining hands back. Reporting fewer bytes
-  // than were asked for says the backend gave up, and raising the error flag
-  // it was given is its own to do.
+  // than were asked for says the backend gave up; the queue does not read
+  // that as an error, so the backend raises the error flag it was given.
   int (*execute)(void* ctx,
                  const struct io_request* req,
                  uint64_t seq,
@@ -35,6 +35,6 @@ struct io_backend
 
   // Called once by io_queue_destroy, after the last request has finished and
   // every worker has stopped. A backend running a thread of its own stops it
-  // here. Optional, and a backend wrapping another must pass it along.
+  // here. This is optional, and a backend wrapping another passes it along.
   void (*stop)(void* ctx);
 };

--- a/src/zarr/io_backend.h
+++ b/src/zarr/io_backend.h
@@ -18,15 +18,12 @@ struct io_backend
 {
   void* ctx;
 
-  // A request taken but not finished is good until its outcome is reported.
-  // The completion is good only for the length of the call. Every request has
-  // to be taken eventually. A write that moved fewer bytes than asked is the
-  // backend's to finish, not the queue's. Neither the count nor the status is
-  // read, so a backend that gives up has to raise the error flag itself.
+  // A request is carried out here. Every request has to be taken eventually,
+  // and one taken but not finished stays good until its outcome is reported.
   int (*execute)(void* ctx,
                  const struct io_request* req,
                  uint64_t seq,
-                 struct io_completion* out);
+                 struct io_completion* out); // good only for this call
 
   // A backend's own thread is stopped here, after every request has finished.
   // This may be null.

--- a/src/zarr/io_backend.h
+++ b/src/zarr/io_backend.h
@@ -9,6 +9,7 @@ enum io_dispatch
 {
   IO_DONE = 0,  // finished; *out is filled in
   IO_SUBMITTED, // finished later, through io_queue_complete
+  IO_BUSY,      // not taken; the queue hands it over again
 };
 
 // Descriptors and syscalls live behind this; the queue owns admission,
@@ -16,8 +17,24 @@ enum io_dispatch
 struct io_backend
 {
   void* ctx;
+
+  // The request outlives the call, so a backend answering IO_SUBMITTED can
+  // keep reading it until it calls io_queue_complete; after that the queue
+  // may reuse the slot. A backend with no room for the request answers
+  // IO_BUSY, which keeps its place and its order, and one that answers
+  // IO_BUSY forever leaves the queue nothing to drain.
+  //
+  // A write that comes back short is finished here rather than by the queue,
+  // by retrying what io_write_remaining hands back. Reporting fewer bytes
+  // than were asked for says the backend gave up, and raising the error flag
+  // it was given is its own to do.
   int (*execute)(void* ctx,
                  const struct io_request* req,
                  uint64_t seq,
                  struct io_completion* out);
+
+  // Called once by io_queue_destroy, after the last request has finished and
+  // every worker has stopped. A backend running a thread of its own stops it
+  // here. Optional, and a backend wrapping another must pass it along.
+  void (*stop)(void* ctx);
 };

--- a/src/zarr/io_backend.h
+++ b/src/zarr/io_backend.h
@@ -18,11 +18,11 @@ struct io_backend
 {
   void* ctx;
 
-  // The request is good until its outcome is reported. The completion is good
-  // only for the length of the call. Every request has to be taken
-  // eventually. A write that moved fewer bytes than asked is the backend's to
-  // finish, not the queue's. The status is never read, so a backend that
-  // gives up has to raise the error flag it was created with.
+  // A request taken but not finished is good until its outcome is reported.
+  // The completion is good only for the length of the call. Every request has
+  // to be taken eventually. A write that moved fewer bytes than asked is the
+  // backend's to finish, not the queue's. The status is never read, so a
+  // backend that gives up has to raise the error flag it was created with.
   int (*execute)(void* ctx,
                  const struct io_request* req,
                  uint64_t seq,

--- a/src/zarr/io_backend.h
+++ b/src/zarr/io_backend.h
@@ -21,8 +21,9 @@ struct io_backend
   // The request outlives the call, so a backend answering IO_SUBMITTED can
   // keep reading it until it calls io_queue_complete; after that the queue
   // may reuse the slot. A backend with no room for the request answers
-  // IO_BUSY, which keeps its place and its order, and one that answers
-  // IO_BUSY forever leaves the queue nothing to drain.
+  // IO_BUSY, which keeps the request where it was in line. A backend that
+  // never takes a request keeps the queue from draining, so io_queue_destroy
+  // never returns.
   //
   // A write that comes back short is finished here rather than by the queue,
   // by retrying what io_write_remaining hands back. Reporting fewer bytes

--- a/src/zarr/io_backend.h
+++ b/src/zarr/io_backend.h
@@ -21,8 +21,8 @@ struct io_backend
   // A request taken but not finished is good until its outcome is reported.
   // The completion is good only for the length of the call. Every request has
   // to be taken eventually. A write that moved fewer bytes than asked is the
-  // backend's to finish, not the queue's. The status is never read, so a
-  // backend that gives up has to raise the error flag it was created with.
+  // backend's to finish, not the queue's. Neither the count nor the status is
+  // read, so a backend that gives up has to raise the error flag itself.
   int (*execute)(void* ctx,
                  const struct io_request* req,
                  uint64_t seq,

--- a/src/zarr/io_backend.h
+++ b/src/zarr/io_backend.h
@@ -9,7 +9,7 @@ enum io_dispatch
 {
   IO_DONE = 0,  // finished; *out is filled in
   IO_SUBMITTED, // finished later, through io_queue_complete
-  IO_BUSY,      // not taken; the queue hands it over again
+  IO_BUSY,      // not taken; handed over again
 };
 
 // Descriptors and syscalls live behind this; the queue owns admission,
@@ -18,26 +18,17 @@ struct io_backend
 {
   void* ctx;
 
-  // The request outlives the call, so a backend answering IO_SUBMITTED can
-  // keep reading it until it calls io_queue_complete; after that the queue
-  // may reuse the slot. The completion does not outlive the call, and is good
-  // only for as long as it runs. A backend with no room for the request
-  // answers IO_BUSY, which keeps the request where it was in line, and one
-  // that never takes a request keeps the queue from draining, so
-  // io_queue_destroy never returns.
-  //
-  // A write that comes back short is finished here rather than by the queue,
-  // by retrying what io_write_remaining hands back. Neither the count nor the
-  // status is read by the queue, so a backend that gives up raises the error
-  // flag it was given.
+  // The request is good until its outcome is reported. The completion is good
+  // only for the length of the call. Every request has to be taken
+  // eventually. A write that moved fewer bytes than asked is the backend's to
+  // finish, not the queue's. The status is never read, so a backend that
+  // gives up has to raise the error flag it was created with.
   int (*execute)(void* ctx,
                  const struct io_request* req,
                  uint64_t seq,
                  struct io_completion* out);
 
-  // Called once by io_queue_destroy, after the last request has finished and
-  // every worker has stopped, so work already handed over has to finish
-  // without being asked to. A backend running a thread of its own stops it
-  // here. This is optional, and a backend wrapping another passes it along.
+  // A backend's own thread is stopped here, after every request has finished.
+  // This may be null.
   void (*stop)(void* ctx);
 };

--- a/src/zarr/io_backend.h
+++ b/src/zarr/io_backend.h
@@ -20,22 +20,24 @@ struct io_backend
 
   // The request outlives the call, so a backend answering IO_SUBMITTED can
   // keep reading it until it calls io_queue_complete; after that the queue
-  // may reuse the slot. A backend with no room for the request answers
-  // IO_BUSY, which keeps the request where it was in line. A backend that
-  // never takes a request keeps the queue from draining, so io_queue_destroy
-  // never returns.
+  // may reuse the slot. The completion does not outlive the call, and is good
+  // only for as long as it runs. A backend with no room for the request
+  // answers IO_BUSY, which keeps the request where it was in line, and one
+  // that never takes a request keeps the queue from draining, so
+  // io_queue_destroy never returns.
   //
   // A write that comes back short is finished here rather than by the queue,
-  // by retrying what io_write_remaining hands back. Reporting fewer bytes
-  // than were asked for says the backend gave up; the queue does not read
-  // that as an error, so the backend raises the error flag it was given.
+  // by retrying what io_write_remaining hands back. Neither the count nor the
+  // status is read by the queue, so a backend that gives up raises the error
+  // flag it was given.
   int (*execute)(void* ctx,
                  const struct io_request* req,
                  uint64_t seq,
                  struct io_completion* out);
 
   // Called once by io_queue_destroy, after the last request has finished and
-  // every worker has stopped. A backend running a thread of its own stops it
+  // every worker has stopped, so work already handed over has to finish
+  // without being asked to. A backend running a thread of its own stops it
   // here. This is optional, and a backend wrapping another passes it along.
   void (*stop)(void* ctx);
 };

--- a/src/zarr/io_queue.c
+++ b/src/zarr/io_queue.c
@@ -389,7 +389,7 @@ Unlock:
 static void
 requeue_job(struct io_queue* q, uint64_t seq)
 {
-  int wait_for_a_retirement = 0;
+  int waited_for_a_retirement = 0;
 
   platform_mutex_lock(q->mutex);
 
@@ -412,13 +412,14 @@ requeue_job(struct io_queue* q, uint64_t seq)
 
   // Whatever the backend has no room for is work it already holds, so the
   // next request to finish is what frees it.
-  wait_for_a_retirement = q->in_flight > 0;
-  if (wait_for_a_retirement)
+  if (q->in_flight > 0) {
+    waited_for_a_retirement = 1;
     platform_cond_wait(q->cond_not_empty, q->mutex);
+  }
 
 Unlock:
   platform_mutex_unlock(q->mutex);
-  if (!wait_for_a_retirement)
+  if (!waited_for_a_retirement)
     platform_sleep_ns(BUSY_RETRY_NS);
 }
 
@@ -462,7 +463,7 @@ worker_thread(void* arg)
     const struct io_request* req = &slot->req;
     struct io_completion done = {
       .seq = seq,
-      .nbytes = slot->req.nbytes,
+      .nbytes = req->nbytes,
       .status = IO_OK,
     };
     platform_mutex_unlock(q->mutex);

--- a/src/zarr/io_queue.c
+++ b/src/zarr/io_queue.c
@@ -9,8 +9,8 @@
 
 #define DEFAULT_MAX_REQUESTS 1024u
 #define NO_SEQ 0u
-// A busy backend with nothing in flight has no finish coming to wake a
-// wait, so the request is offered again on a timer instead.
+// With nothing in flight there is nothing to wake a wait, so a refused
+// request is offered again on a timer.
 #define BUSY_RETRY_NS 100000LL
 
 enum io_job_state
@@ -383,10 +383,9 @@ Unlock:
     owned_free(owned);
 }
 
-// A refused request goes back where it was, keeping its sequence number and
-// its place on its file, so nothing is reordered. Zero is returned when it
-// cannot go back: a newer open of the same file index has taken that entry
-// over, and the list the request was reachable from went with it.
+// A refused request is put back where it was, with its sequence number and
+// its place on its file, so nothing is reordered. Zero is returned when a
+// newer open of the same file index has taken that entry over.
 static int
 requeue_job(struct io_queue* q, uint64_t seq, int64_t now)
 {
@@ -412,8 +411,7 @@ requeue_job(struct io_queue* q, uint64_t seq, int64_t now)
   }
   requeued = 1;
 
-  // Whatever the backend has no room for is work it already holds, so the
-  // next request to finish is what frees it.
+  // The backend is full until something already handed over finishes.
   if (q->in_flight > 0) {
     waited_for_a_retirement = 1;
     platform_cond_wait(q->cond_not_empty, q->mutex);
@@ -461,8 +459,7 @@ worker_thread(void* arg)
       if (is_barrier(&slot->req))
         f->barrier_running = 1;
     }
-    // The slot outlives the call, so a backend that finishes later can keep
-    // reading the request until it reports the outcome.
+    // The request has to outlive the call, so the slot is passed, not a copy.
     const struct io_request* req = &slot->req;
     struct io_completion done = {
       .seq = seq,
@@ -477,8 +474,8 @@ worker_thread(void* arg)
       retire_job(q, done, platform_monotonic_ns());
     } else if (dispatch == IO_BUSY) {
       const int64_t now = platform_monotonic_ns();
-      // A request that is on no list can never be picked up again, so it is
-      // finished here rather than left waiting to be.
+      // A request on no list can never be picked up again, so it is finished
+      // here instead.
       if (!requeue_job(q, seq, now)) {
         log_error("io_queue: a refused request named a file that was reopened");
         done.nbytes = 0;

--- a/src/zarr/io_queue.c
+++ b/src/zarr/io_queue.c
@@ -383,32 +383,34 @@ Unlock:
     owned_free(owned);
 }
 
-// A backend with no room for a request answers IO_BUSY and the request is
-// handed over again. It keeps its sequence number and its place on the file,
-// so nothing is reordered.
-static void
-requeue_job(struct io_queue* q, uint64_t seq)
+// A refused request goes back where it was, keeping its sequence number and
+// its place on its file, so nothing is reordered. Zero is returned when it
+// cannot go back: a newer open of the same file index has taken that entry
+// over, and the list the request was reachable from went with it.
+static int
+requeue_job(struct io_queue* q, uint64_t seq, int64_t now)
 {
+  int requeued = 0;
   int waited_for_a_retirement = 0;
 
   platform_mutex_lock(q->mutex);
 
   struct io_job* slot = job_at(q, seq);
   CHECK(Unlock, slot->seq == seq && slot->state == IO_JOB_RUNNING);
+  struct file_pending* f = file_find(q, slot->req.file);
+  CHECK_SILENT(Unlock, f || slot->req.file.generation == 0);
 
   slot->state = IO_JOB_WAITING;
-  slot->started_ns = 0;
   q->jobs_waiting++;
   q->in_flight--;
-  io_queue_counters_in_flight(
-    &q->counters, q->in_flight, platform_monotonic_ns());
+  io_queue_counters_in_flight(&q->counters, q->in_flight, now);
 
-  struct file_pending* f = file_find(q, slot->req.file);
   if (f) {
     f->in_flight--;
     if (is_barrier(&slot->req))
       f->barrier_running = 0;
   }
+  requeued = 1;
 
   // Whatever the backend has no room for is work it already holds, so the
   // next request to finish is what frees it.
@@ -419,8 +421,9 @@ requeue_job(struct io_queue* q, uint64_t seq)
 
 Unlock:
   platform_mutex_unlock(q->mutex);
-  if (!waited_for_a_retirement)
+  if (requeued && !waited_for_a_retirement)
     platform_sleep_ns(BUSY_RETRY_NS);
+  return requeued;
 }
 
 static void
@@ -470,10 +473,19 @@ worker_thread(void* arg)
 
     const int dispatch = q->backend.execute(q->backend.ctx, req, seq, &done);
 
-    if (dispatch == IO_DONE)
+    if (dispatch == IO_DONE) {
       retire_job(q, done, platform_monotonic_ns());
-    else if (dispatch == IO_BUSY)
-      requeue_job(q, seq);
+    } else if (dispatch == IO_BUSY) {
+      const int64_t now = platform_monotonic_ns();
+      // A request that is on no list can never be picked up again, so it is
+      // finished here rather than left waiting to be.
+      if (!requeue_job(q, seq, now)) {
+        log_error("io_queue: a refused request named a file that was reopened");
+        done.nbytes = 0;
+        done.status = IO_CANCELLED;
+        retire_job(q, done, now);
+      }
+    }
   }
 }
 

--- a/src/zarr/io_queue.c
+++ b/src/zarr/io_queue.c
@@ -383,9 +383,8 @@ Unlock:
     owned_free(owned);
 }
 
-// A refused request is put back where it was, with its sequence number and
-// its place on its file, so nothing is reordered. Zero is returned when a
-// newer open of the same file index has taken that entry over.
+// A refused request is put back where it was, so nothing is reordered. Zero
+// is returned when a newer open has taken its file entry over.
 static int
 requeue_job(struct io_queue* q, uint64_t seq, int64_t now)
 {

--- a/src/zarr/io_queue.c
+++ b/src/zarr/io_queue.c
@@ -9,6 +9,9 @@
 
 #define DEFAULT_MAX_REQUESTS 1024u
 #define NO_SEQ 0u
+// A busy backend with nothing in flight has no finish coming to wake a
+// wait, so the request is offered again on a timer instead.
+#define BUSY_RETRY_NS 100000LL
 
 enum io_job_state
 {
@@ -380,14 +383,51 @@ Unlock:
     owned_free(owned);
 }
 
+// A backend with no room for a request answers IO_BUSY and the request is
+// handed over again. It keeps its sequence number and its place on the file,
+// so nothing is reordered.
+static void
+requeue_job(struct io_queue* q, uint64_t seq)
+{
+  int wait_for_a_retirement = 0;
+
+  platform_mutex_lock(q->mutex);
+
+  struct io_job* slot = job_at(q, seq);
+  CHECK(Unlock, slot->seq == seq && slot->state == IO_JOB_RUNNING);
+
+  slot->state = IO_JOB_WAITING;
+  slot->started_ns = 0;
+  q->jobs_waiting++;
+  q->in_flight--;
+  io_queue_counters_in_flight(
+    &q->counters, q->in_flight, platform_monotonic_ns());
+
+  struct file_pending* f = file_find(q, slot->req.file);
+  if (f) {
+    f->in_flight--;
+    if (is_barrier(&slot->req))
+      f->barrier_running = 0;
+  }
+
+  // Whatever the backend has no room for is work it already holds, so the
+  // next request to finish is what frees it.
+  wait_for_a_retirement = q->in_flight > 0;
+  if (wait_for_a_retirement)
+    platform_cond_wait(q->cond_not_empty, q->mutex);
+
+Unlock:
+  platform_mutex_unlock(q->mutex);
+  if (!wait_for_a_retirement)
+    platform_sleep_ns(BUSY_RETRY_NS);
+}
+
 static void
 worker_thread(void* arg)
 {
   struct io_queue* q = (struct io_queue*)arg;
 
   for (;;) {
-    struct io_job job;
-
     platform_mutex_lock(q->mutex);
     uint64_t seq;
     // A submitted request is still running, so only an empty window means
@@ -417,19 +457,22 @@ worker_thread(void* arg)
       if (is_barrier(&slot->req))
         f->barrier_running = 1;
     }
-    job = *slot;
-    platform_mutex_unlock(q->mutex);
-
+    // The slot outlives the call, so a backend that finishes later can keep
+    // reading the request until it reports the outcome.
+    const struct io_request* req = &slot->req;
     struct io_completion done = {
-      .seq = job.seq,
-      .nbytes = job.req.nbytes,
+      .seq = seq,
+      .nbytes = slot->req.nbytes,
       .status = IO_OK,
     };
-    const int dispatch =
-      q->backend.execute(q->backend.ctx, &job.req, job.seq, &done);
+    platform_mutex_unlock(q->mutex);
+
+    const int dispatch = q->backend.execute(q->backend.ctx, req, seq, &done);
 
     if (dispatch == IO_DONE)
       retire_job(q, done, platform_monotonic_ns());
+    else if (dispatch == IO_BUSY)
+      requeue_job(q, seq);
   }
 }
 
@@ -523,6 +566,9 @@ io_queue_destroy(struct io_queue* q)
 
   for (uint64_t i = 0; i < q->nthreads; ++i)
     platform_thread_join(q->threads[i]);
+
+  if (q->backend.stop)
+    q->backend.stop(q->backend.ctx);
 
   // Shutdown is set, so nothing parks from here on.
   platform_mutex_lock(q->mutex);

--- a/src/zarr/io_queue.h
+++ b/src/zarr/io_queue.h
@@ -29,8 +29,7 @@ io_queue_create(struct io_backend backend, struct io_queue_limits limits);
 
 // Every other call must have returned, or be parked inside the queue already,
 // before this runs. A thread still on its way in cannot be counted, and the
-// lock it is about to take is one of the things freed here. The backend is
-// stopped after the last worker finishes.
+// lock it is about to take is one of the things freed here.
 void
 io_queue_destroy(struct io_queue* q);
 

--- a/src/zarr/io_queue.h
+++ b/src/zarr/io_queue.h
@@ -29,7 +29,8 @@ io_queue_create(struct io_backend backend, struct io_queue_limits limits);
 
 // Every other call must have returned, or be parked inside the queue already,
 // before this runs. A thread still on its way in cannot be counted, and the
-// lock it is about to take is one of the things freed here.
+// lock it is about to take is one of the things freed here. The backend is
+// stopped after the last worker finishes.
 void
 io_queue_destroy(struct io_queue* q);
 

--- a/src/zarr/io_request.h
+++ b/src/zarr/io_request.h
@@ -2,6 +2,7 @@
 // so it can be reordered and gated.
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 enum io_op
@@ -42,6 +43,24 @@ struct io_request
   void* owned;
   void (*owned_free)(void*);
 };
+
+// The part of a write still to be done. A short write is finished by the
+// backend that reported it, retrying this until nothing is left. The queue's
+// own copy is left alone, so the room it gives back still matches what was
+// asked for, and this copy owns nothing.
+static inline struct io_request
+io_write_remaining(const struct io_request* req, uint64_t written)
+{
+  const uint64_t done = written < req->nbytes ? written : req->nbytes;
+  struct io_request rest = *req;
+  rest.borrowed = 1;
+  rest.payload = (const char*)req->payload + done;
+  rest.nbytes = req->nbytes - done;
+  rest.offset = req->offset + done;
+  rest.owned = NULL;
+  rest.owned_free = NULL;
+  return rest;
+}
 
 enum io_status
 {

--- a/src/zarr/io_request.h
+++ b/src/zarr/io_request.h
@@ -44,10 +44,10 @@ struct io_request
   void (*owned_free)(void*);
 };
 
-// The part of a write still to be done. A short write is finished by the
-// backend that reported it, retrying this until nothing is left. The queue's
-// own copy is left alone, so the room it gives back still matches what was
-// asked for, and this copy owns nothing.
+// The part of a write still to be done is returned here. A short write is
+// finished by the backend that saw it, which retries this until nothing is
+// left. The queue's own copy is untouched, so the room it gives back still
+// matches what was asked for, and this copy owns nothing.
 static inline struct io_request
 io_write_remaining(const struct io_request* req, uint64_t written)
 {

--- a/src/zarr/io_request.h
+++ b/src/zarr/io_request.h
@@ -44,8 +44,9 @@ struct io_request
   void (*owned_free)(void*);
 };
 
-// The part of a write still to be done is returned here. Nothing is owned by
-// the copy, so a retry cannot free a payload twice.
+// The part of a write still to be done is returned here, for the backend to
+// finish rather than the queue. Nothing is owned by the copy, so a retry
+// cannot free a payload twice.
 static inline struct io_request
 io_write_remaining(const struct io_request* req, uint64_t written)
 {
@@ -71,6 +72,6 @@ enum io_status
 struct io_completion
 {
   uint64_t seq;
-  uint64_t nbytes; // written; never more than the request asked for
-  int status;
+  uint64_t nbytes; // written; never more than asked for, and not read here
+  int status;      // not read here, so a backend raises the error flag itself
 };

--- a/src/zarr/io_request.h
+++ b/src/zarr/io_request.h
@@ -44,11 +44,8 @@ struct io_request
   void (*owned_free)(void*);
 };
 
-// The part of a write still to be done is returned here. A short write is
-// finished by the backend that saw it, which retries this until nothing is
-// left. The queue's own copy is untouched, so the room it gives back still
-// matches what was asked for, and nothing is owned by this copy, so retrying
-// it cannot free a payload twice.
+// The part of a write still to be done is returned here. Nothing is owned by
+// the copy, so a retry cannot free a payload twice.
 static inline struct io_request
 io_write_remaining(const struct io_request* req, uint64_t written)
 {

--- a/src/zarr/io_request.h
+++ b/src/zarr/io_request.h
@@ -47,14 +47,15 @@ struct io_request
 // The part of a write still to be done is returned here. A short write is
 // finished by the backend that saw it, which retries this until nothing is
 // left. The queue's own copy is untouched, so the room it gives back still
-// matches what was asked for, and this copy owns nothing.
+// matches what was asked for, and nothing is owned by this copy, so retrying
+// it cannot free a payload twice.
 static inline struct io_request
 io_write_remaining(const struct io_request* req, uint64_t written)
 {
   const uint64_t done = written < req->nbytes ? written : req->nbytes;
   struct io_request rest = *req;
   rest.borrowed = 1;
-  rest.payload = (const char*)req->payload + done;
+  rest.payload = req->payload ? (const char*)req->payload + done : NULL;
   rest.nbytes = req->nbytes - done;
   rest.offset = req->offset + done;
   rest.owned = NULL;

--- a/tests/test_io_backend_fake.c
+++ b/tests/test_io_backend_fake.c
@@ -3,8 +3,6 @@
 
 #include <string.h>
 
-// A refusal is taken only while one is left, so several workers cannot take
-// the same one.
 static int
 take_a_refusal(struct io_backend_fake* f)
 {
@@ -18,7 +16,6 @@ take_a_refusal(struct io_backend_fake* f)
   return 1;
 }
 
-// A short write is the backend's to finish, so what is left is retried here.
 static void
 copy_the_write(struct io_backend_fake* f, const struct io_request* req)
 {
@@ -56,7 +53,7 @@ fake_execute(void* ctx,
     };
   atomic_fetch_add(&f->nrecords, 1);
 
-  // Held ahead of the refusal, so a request can be both held and refused.
+  // The hold is first, so a request can be both held and refused.
   while (f->gate && atomic_load(f->gate) == 0)
     platform_sleep_ns(1000000LL);
 
@@ -161,8 +158,6 @@ io_backend_fake_short_write(struct io_backend_fake* f, uint64_t nbytes)
 const struct io_request*
 io_backend_fake_deferred_request(const struct io_backend_fake* f, uint64_t i)
 {
-  // The published count says how many places are taken, not which, so the
-  // place itself is what says whether a call has filled it in.
   if (i >= IO_BACKEND_FAKE_CAPACITY)
     return NULL;
   return atomic_load(&f->deferred_requests[i]);

--- a/tests/test_io_backend_fake.c
+++ b/tests/test_io_backend_fake.c
@@ -3,6 +3,37 @@
 
 #include <string.h>
 
+// A refusal is taken only while one is left, so several workers cannot take
+// the same one.
+static int
+take_a_refusal(struct io_backend_fake* f)
+{
+  uint64_t left = atomic_load(&f->refusals_left);
+  while (left > 0 &&
+         !atomic_compare_exchange_weak(&f->refusals_left, &left, left - 1)) {
+  }
+  if (left == 0)
+    return 0;
+  atomic_fetch_add(&f->nrefused, 1);
+  return 1;
+}
+
+// A short write is the backend's to finish, so what is left is retried here.
+static void
+copy_the_write(struct io_backend_fake* f, const struct io_request* req)
+{
+  struct io_request rest = io_write_remaining(req, 0);
+  while (rest.nbytes > 0) {
+    uint64_t taken = rest.nbytes;
+    if (f->bytes_per_attempt && taken > f->bytes_per_attempt)
+      taken = f->bytes_per_attempt;
+    if (rest.offset + taken <= f->dest_nbytes)
+      memcpy((char*)f->dest + rest.offset, rest.payload, (size_t)taken);
+    atomic_fetch_add(&f->write_attempts, 1);
+    rest = io_write_remaining(&rest, taken);
+  }
+}
+
 static int
 fake_execute(void* ctx,
              const struct io_request* req,
@@ -25,24 +56,40 @@ fake_execute(void* ctx,
     };
   atomic_fetch_add(&f->nrecords, 1);
 
-  while (f->gate && atomic_load(f->gate) == 0)
-    platform_sleep_ns(1000000LL);
+  int dispatch = IO_BUSY;
+  if (!take_a_refusal(f)) {
+    while (f->gate && atomic_load(f->gate) == 0)
+      platform_sleep_ns(1000000LL);
 
-  out->seq = seq;
-  out->nbytes = f->outcome_chosen ? f->outcome_nbytes : req->nbytes;
-  out->status = f->outcome_chosen ? f->outcome_status : IO_OK;
+    if (f->dest && req->op == IO_OP_WRITE)
+      copy_the_write(f, req);
 
-  int dispatch = IO_DONE;
-  if (atomic_load(&f->defer)) {
-    const uint64_t d = atomic_fetch_add(&f->nclaimed_deferred, 1);
-    if (d < IO_BACKEND_FAKE_CAPACITY)
-      f->deferred[d] = seq;
-    atomic_fetch_add(&f->ndeferred, 1);
-    dispatch = IO_SUBMITTED;
+    out->seq = seq;
+    out->nbytes = f->outcome_chosen ? f->outcome_nbytes : req->nbytes;
+    out->status = f->outcome_chosen ? f->outcome_status : IO_OK;
+
+    dispatch = IO_DONE;
+    if (atomic_load(&f->defer)) {
+      const uint64_t d = atomic_fetch_add(&f->nclaimed_deferred, 1);
+      if (d < IO_BACKEND_FAKE_CAPACITY) {
+        f->deferred[d] = seq;
+        f->deferred_requests[d] = req;
+      }
+      atomic_fetch_add(&f->ndeferred, 1);
+      dispatch = IO_SUBMITTED;
+    }
   }
 
   atomic_fetch_sub(&f->inside_execute, 1);
   return dispatch;
+}
+
+static void
+fake_stop(void* ctx)
+{
+  struct io_backend_fake* f = (struct io_backend_fake*)ctx;
+  f->stops++;
+  f->records_when_stopped = atomic_load(&f->nrecords);
 }
 
 void
@@ -54,12 +101,17 @@ io_backend_fake_init(struct io_backend_fake* f)
   atomic_init(&f->nclaimed_deferred, 0);
   atomic_init(&f->ndeferred, 0);
   atomic_init(&f->inside_execute, 0);
+  atomic_init(&f->refusals_left, 0);
+  atomic_init(&f->nrefused, 0);
+  atomic_init(&f->write_attempts, 0);
 }
 
 struct io_backend
 io_backend_fake_as_backend(struct io_backend_fake* f)
 {
-  return (struct io_backend){ .ctx = f, .execute = fake_execute };
+  return (struct io_backend){ .ctx = f,
+                              .execute = fake_execute,
+                              .stop = fake_stop };
 }
 
 void
@@ -84,10 +136,51 @@ io_backend_fake_set_outcome(struct io_backend_fake* f,
   f->outcome_nbytes = nbytes;
 }
 
+void
+io_backend_fake_refuse(struct io_backend_fake* f, uint64_t requests)
+{
+  atomic_store(&f->refusals_left, requests);
+}
+
+void
+io_backend_fake_write_into(struct io_backend_fake* f,
+                           void* dest,
+                           uint64_t nbytes)
+{
+  f->dest = dest;
+  f->dest_nbytes = nbytes;
+}
+
+void
+io_backend_fake_short_write(struct io_backend_fake* f, uint64_t nbytes)
+{
+  f->bytes_per_attempt = nbytes;
+}
+
+const struct io_request*
+io_backend_fake_deferred_request(const struct io_backend_fake* f, uint64_t i)
+{
+  if (i >= atomic_load(&f->ndeferred) || i >= IO_BACKEND_FAKE_CAPACITY)
+    return NULL;
+  return f->deferred_requests[i];
+}
+
 uint64_t
 io_backend_fake_record_count(const struct io_backend_fake* f)
 {
   return atomic_load(&f->nrecords);
+}
+
+uint64_t
+io_backend_fake_refused_count(const struct io_backend_fake* f)
+{
+  return atomic_load(&f->nrefused);
+}
+
+uint64_t
+io_backend_fake_write_attempts(const struct io_backend_fake* f)
+{
+  return atomic_load(&f->write_attempts);
 }
 
 uint64_t

--- a/tests/test_io_backend_fake.c
+++ b/tests/test_io_backend_fake.c
@@ -27,7 +27,7 @@ copy_the_write(struct io_backend_fake* f, const struct io_request* req)
     uint64_t taken = rest.nbytes;
     if (f->bytes_per_attempt && taken > f->bytes_per_attempt)
       taken = f->bytes_per_attempt;
-    if (rest.offset + taken <= f->dest_nbytes)
+    if (rest.offset <= f->dest_nbytes && taken <= f->dest_nbytes - rest.offset)
       memcpy((char*)f->dest + rest.offset, rest.payload, (size_t)taken);
     atomic_fetch_add(&f->write_attempts, 1);
     rest = io_write_remaining(&rest, taken);
@@ -56,12 +56,13 @@ fake_execute(void* ctx,
     };
   atomic_fetch_add(&f->nrecords, 1);
 
+  // Held ahead of the refusal, so a request can be both held and refused.
+  while (f->gate && atomic_load(f->gate) == 0)
+    platform_sleep_ns(1000000LL);
+
   int dispatch = IO_BUSY;
   if (!take_a_refusal(f)) {
-    while (f->gate && atomic_load(f->gate) == 0)
-      platform_sleep_ns(1000000LL);
-
-    if (f->dest && req->op == IO_OP_WRITE)
+    if (f->dest && req->payload && req->op == IO_OP_WRITE)
       copy_the_write(f, req);
 
     out->seq = seq;
@@ -73,7 +74,7 @@ fake_execute(void* ctx,
       const uint64_t d = atomic_fetch_add(&f->nclaimed_deferred, 1);
       if (d < IO_BACKEND_FAKE_CAPACITY) {
         f->deferred[d] = seq;
-        f->deferred_requests[d] = req;
+        atomic_store(&f->deferred_requests[d], req);
       }
       atomic_fetch_add(&f->ndeferred, 1);
       dispatch = IO_SUBMITTED;
@@ -160,9 +161,11 @@ io_backend_fake_short_write(struct io_backend_fake* f, uint64_t nbytes)
 const struct io_request*
 io_backend_fake_deferred_request(const struct io_backend_fake* f, uint64_t i)
 {
-  if (i >= atomic_load(&f->ndeferred) || i >= IO_BACKEND_FAKE_CAPACITY)
+  // The published count says how many places are taken, not which, so the
+  // place itself is what says whether a call has filled it in.
+  if (i >= IO_BACKEND_FAKE_CAPACITY)
     return NULL;
-  return f->deferred_requests[i];
+  return atomic_load(&f->deferred_requests[i]);
 }
 
 uint64_t

--- a/tests/test_io_backend_fake.h
+++ b/tests/test_io_backend_fake.h
@@ -1,5 +1,5 @@
 // This backend is for tests only: nothing is run, every request is recorded,
-// and a test can hold, defer, or fail each one.
+// and a test can hold, defer, refuse or fail each one.
 #pragma once
 
 #include "zarr/io_backend.h"
@@ -26,6 +26,8 @@ struct io_backend_fake
   _Atomic uint64_t nrecords;
 
   uint64_t deferred[IO_BACKEND_FAKE_CAPACITY];
+  // The request each deferred call was handed, at its place in that list.
+  const struct io_request* deferred_requests[IO_BACKEND_FAKE_CAPACITY];
   _Atomic uint64_t nclaimed_deferred;
   _Atomic uint64_t ndeferred;
 
@@ -36,6 +38,18 @@ struct io_backend_fake
   uint8_t outcome_chosen;
   int outcome_status;
   uint64_t outcome_nbytes;
+
+  _Atomic uint64_t refusals_left;
+  _Atomic uint64_t nrefused;
+
+  void* dest;
+  uint64_t dest_nbytes;
+  uint64_t bytes_per_attempt;
+  _Atomic uint64_t write_attempts;
+
+  // Only io_queue_destroy calls stop, once, so neither of these is shared.
+  uint64_t stops;
+  uint64_t records_when_stopped;
 };
 
 void
@@ -60,8 +74,37 @@ io_backend_fake_set_outcome(struct io_backend_fake* f,
                             int status,
                             uint64_t nbytes);
 
+// Answer IO_BUSY for the next n requests handed over, and take them after
+// that. A request handed over again is recorded again.
+void
+io_backend_fake_refuse(struct io_backend_fake* f, uint64_t requests);
+
+// Copy every write into dest at the request's offset, so what landed can be
+// checked. A write reaching past the end is dropped.
+void
+io_backend_fake_write_into(struct io_backend_fake* f,
+                           void* dest,
+                           uint64_t nbytes);
+
+// Take at most this many bytes per attempt and retry what is left, the way a
+// backend seeing a short write has to. Zero takes a write in one attempt.
+void
+io_backend_fake_short_write(struct io_backend_fake* f, uint64_t nbytes);
+
+// The request a deferred call was handed. It stays valid until the queue is
+// told that request finished. NULL past the end of the list.
+const struct io_request*
+io_backend_fake_deferred_request(const struct io_backend_fake* f, uint64_t i);
+
 uint64_t
 io_backend_fake_record_count(const struct io_backend_fake* f);
+
+uint64_t
+io_backend_fake_refused_count(const struct io_backend_fake* f);
+
+// Attempts at a write, counting the retries a short one needed.
+uint64_t
+io_backend_fake_write_attempts(const struct io_backend_fake* f);
 
 uint64_t
 io_backend_fake_deferred_count(const struct io_backend_fake* f);

--- a/tests/test_io_backend_fake.h
+++ b/tests/test_io_backend_fake.h
@@ -1,5 +1,5 @@
 // This backend is for tests only: nothing is run, every request is recorded,
-// and a test can hold, defer, refuse or fail each one.
+// and a test can hold, defer, refuse, or fail each one.
 #pragma once
 
 #include "zarr/io_backend.h"
@@ -26,8 +26,6 @@ struct io_backend_fake
   _Atomic uint64_t nrecords;
 
   uint64_t deferred[IO_BACKEND_FAKE_CAPACITY];
-  // The request each deferred call was handed is kept at its place in that
-  // list.
   _Atomic(const struct io_request*) deferred_requests[IO_BACKEND_FAKE_CAPACITY];
   _Atomic uint64_t nclaimed_deferred;
   _Atomic uint64_t ndeferred;
@@ -48,7 +46,7 @@ struct io_backend_fake
   uint64_t bytes_per_attempt;
   _Atomic uint64_t write_attempts;
 
-  // Only io_queue_destroy calls stop, once, so neither of these is shared.
+  // These are written only at teardown, so neither is shared.
   uint64_t stops;
   uint64_t records_when_stopped;
 };
@@ -75,26 +73,25 @@ io_backend_fake_set_outcome(struct io_backend_fake* f,
                             int status,
                             uint64_t nbytes);
 
-// Answer IO_BUSY for the next n requests handed over, and take them after
-// that. A request handed over again is recorded again.
+// The next n requests handed over are refused, and every one after that is
+// taken. Each refusal is recorded.
 void
 io_backend_fake_refuse(struct io_backend_fake* f, uint64_t requests);
 
-// Copy every write carrying a payload into dest at the request's offset, so
-// what landed can be checked. A write reaching past the end is dropped.
+// Every write carrying a payload is copied into the buffer at its own offset.
+// A write reaching past the end is dropped.
 void
 io_backend_fake_write_into(struct io_backend_fake* f,
                            void* dest,
                            uint64_t nbytes);
 
-// Take at most this many bytes per attempt and retry what is left, the way a
-// backend seeing a short write has to. Zero takes a write in one attempt.
+// At most this many bytes are written per attempt, and the rest is retried.
+// Zero means a write is done in one attempt.
 void
 io_backend_fake_short_write(struct io_backend_fake* f, uint64_t nbytes);
 
-// The request a deferred call was handed is returned here, and it stays good
-// until the queue is told that request finished. A null result means no call
-// has filled that place in yet.
+// The request a deferred call was handed is returned here, good until that
+// request is reported finished. Null means that place is not filled in yet.
 const struct io_request*
 io_backend_fake_deferred_request(const struct io_backend_fake* f, uint64_t i);
 
@@ -104,7 +101,6 @@ io_backend_fake_record_count(const struct io_backend_fake* f);
 uint64_t
 io_backend_fake_refused_count(const struct io_backend_fake* f);
 
-// Attempts at a write, counting the retries a short one needed.
 uint64_t
 io_backend_fake_write_attempts(const struct io_backend_fake* f);
 

--- a/tests/test_io_backend_fake.h
+++ b/tests/test_io_backend_fake.h
@@ -1,5 +1,5 @@
 // This backend is for tests only: nothing is run, every request is recorded,
-// and a test can hold, defer, refuse, or fail each one.
+// and each one can be held, deferred, refused or failed on request.
 #pragma once
 
 #include "zarr/io_backend.h"

--- a/tests/test_io_backend_fake.h
+++ b/tests/test_io_backend_fake.h
@@ -26,8 +26,9 @@ struct io_backend_fake
   _Atomic uint64_t nrecords;
 
   uint64_t deferred[IO_BACKEND_FAKE_CAPACITY];
-  // The request each deferred call was handed, at its place in that list.
-  const struct io_request* deferred_requests[IO_BACKEND_FAKE_CAPACITY];
+  // The request each deferred call was handed is kept at its place in that
+  // list.
+  _Atomic(const struct io_request*) deferred_requests[IO_BACKEND_FAKE_CAPACITY];
   _Atomic uint64_t nclaimed_deferred;
   _Atomic uint64_t ndeferred;
 
@@ -79,8 +80,8 @@ io_backend_fake_set_outcome(struct io_backend_fake* f,
 void
 io_backend_fake_refuse(struct io_backend_fake* f, uint64_t requests);
 
-// Copy every write into dest at the request's offset, so what landed can be
-// checked. A write reaching past the end is dropped.
+// Copy every write carrying a payload into dest at the request's offset, so
+// what landed can be checked. A write reaching past the end is dropped.
 void
 io_backend_fake_write_into(struct io_backend_fake* f,
                            void* dest,
@@ -91,8 +92,9 @@ io_backend_fake_write_into(struct io_backend_fake* f,
 void
 io_backend_fake_short_write(struct io_backend_fake* f, uint64_t nbytes);
 
-// The request a deferred call was handed. It stays valid until the queue is
-// told that request finished. NULL past the end of the list.
+// The request a deferred call was handed is returned here, and it stays good
+// until the queue is told that request finished. A null result means no call
+// has filled that place in yet.
 const struct io_request*
 io_backend_fake_deferred_request(const struct io_backend_fake* f, uint64_t i);
 

--- a/tests/test_io_faults.c
+++ b/tests/test_io_faults.c
@@ -45,12 +45,22 @@ faults_execute(void* ctx,
   return IO_DONE;
 }
 
+static void
+faults_stop(void* ctx)
+{
+  struct io_faults* f = (struct io_faults*)ctx;
+  if (f->inner.stop)
+    f->inner.stop(f->inner.ctx);
+}
+
 static struct io_backend
 faults_wrap(void* ctx, struct io_backend inner)
 {
   struct io_faults* f = (struct io_faults*)ctx;
   f->inner = inner;
-  return (struct io_backend){ .ctx = f, .execute = faults_execute };
+  return (struct io_backend){ .ctx = f,
+                              .execute = faults_execute,
+                              .stop = faults_stop };
 }
 
 static struct shard_pool*

--- a/tests/test_io_queue.c
+++ b/tests/test_io_queue.c
@@ -1408,8 +1408,8 @@ test_backend_is_stopped_at_teardown(void)
 
   io_queue_destroy(q);
 
-  // Stopped once, and with every request already handed over, so a backend
-  // running a thread of its own has nothing left to do when it is stopped.
+  // The backend is stopped once, with every request already handed over, so
+  // one running a thread of its own has nothing left to do by then.
   CHECK(Fail, fake.stops == 1);
   CHECK(Fail, fake.records_when_stopped == STOP_REQUESTS);
   return 0;
@@ -1424,8 +1424,8 @@ Fail:
 
 // A backend that finishes later reads the request after execute has returned,
 // so what it was handed has to still be there and still say the same thing.
-// The second request goes to the same worker, and a request that lived only
-// as long as the call would leave both pointing at the same worn-out place.
+// Both requests go to the same worker, so a request living only as long as the
+// call would leave the two pointers aimed at the same spot on its stack.
 static int
 test_request_outlives_execute(void)
 {
@@ -1453,7 +1453,7 @@ test_request_outlives_execute(void)
                                            .offset = 7 * WRITE_BYTES }) == 0);
   CHECK(Cleanup, wait_for_deferred(&fake, 1, HANDOVER_TIMEOUT_MS) == 0);
 
-  // Another file, so this one is not held behind the first.
+  // This names another file, so it is not held behind the first.
   CHECK(Cleanup,
         io_queue_post(q,
                       (struct io_request){ .op = IO_OP_WRITE,
@@ -1509,11 +1509,10 @@ static int
 test_short_write_is_finished_by_the_backend(void)
 {
   char payload[WRITE_BYTES];
-  char landed[2 * WRITE_BYTES];
+  char landed[2 * WRITE_BYTES] = { 0 };
 
   for (uint64_t i = 0; i < WRITE_BYTES; ++i)
     payload[i] = (char)(i * 7 + 1);
-  memset(landed, 0, sizeof(landed));
 
   struct io_backend_fake fake;
   io_backend_fake_init(&fake);

--- a/tests/test_io_queue.c
+++ b/tests/test_io_queue.c
@@ -1556,6 +1556,64 @@ Fail:
   return 1;
 }
 
+// --- test: a refused request whose file index was reused ---
+
+// A close hands its file index back when it runs, so a new open can hold that
+// index while the close has not retired. A close refused in that window is on
+// no list any more, and putting it back would strand it with the queue unable
+// to drain.
+static int
+test_refused_request_after_the_index_is_reused(void)
+{
+  struct io_backend_fake fake;
+  io_backend_fake_init(&fake);
+
+  _Atomic int gate;
+  atomic_store(&gate, 0);
+  io_backend_fake_hold(&fake, &gate);
+  io_backend_fake_refuse(&fake, 1);
+
+  struct io_queue* q = io_queue_create(io_backend_fake_as_backend(&fake),
+                                       (struct io_queue_limits){ 0 });
+  CHECK(Fail, q);
+
+  int rc = 1;
+  test_thread* thr = NULL;
+  struct fence_wait w;
+  const struct io_file_token first = { .generation = 1, .index = 0 };
+  const struct io_file_token second = { .generation = 2, .index = 0 };
+
+  CHECK(Cleanup,
+        io_queue_post(
+          q, (struct io_request){ .op = IO_OP_CLOSE, .file = first }) == 0);
+  CHECK(Cleanup, wait_for_records(&fake, 1, HANDOVER_TIMEOUT_MS) == 0);
+
+  // The close is held in the backend, which is the window a new open claiming
+  // the same index takes the file entry over in.
+  CHECK(Cleanup,
+        io_queue_post(q,
+                      (struct io_request){ .op = IO_OP_WRITE,
+                                           .file = second,
+                                           .nbytes = WRITE_BYTES }) == 0);
+
+  // One worker, so the close is refused first and the write is taken after.
+  atomic_store(&gate, 1);
+  CHECK(Cleanup, fence_wait_start(&w, &thr, q, io_queue_record(q)) == 0);
+  CHECK(Cleanup, test_wait_flag(&w.done, HANDOVER_TIMEOUT_MS) == 0);
+  CHECK(Cleanup, io_backend_fake_refused_count(&fake) == 1);
+  CHECK(Cleanup, io_queue_pending_bytes(q) == 0);
+  rc = 0;
+
+Cleanup:
+  atomic_store(&gate, 1);
+  test_thread_join(thr);
+  io_queue_destroy(q);
+  return rc;
+
+Fail:
+  return 1;
+}
+
 // --- main ---
 
 int
@@ -1601,6 +1659,8 @@ main(void)
     { "request_outlives_execute", test_request_outlives_execute },
     { "short_write_is_finished_by_the_backend",
       test_short_write_is_finished_by_the_backend },
+    { "refused_request_after_the_index_is_reused",
+      test_refused_request_after_the_index_is_reused },
   };
   for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
     int r = tests[i].fn();

--- a/tests/test_io_queue.c
+++ b/tests/test_io_queue.c
@@ -420,8 +420,8 @@ wait_for_deferred(const struct io_backend_fake* f, uint64_t n, int timeout_ms)
   return 0;
 }
 
-// Poll until nothing is inside execute. Zero is returned once nothing is,
-// -1 if the wait ran out.
+// Poll until nothing is inside execute. Zero is returned once the wait is
+// over, -1 if it ran out.
 static int
 wait_out_of_execute(const struct io_backend_fake* f, int timeout_ms)
 {
@@ -455,8 +455,7 @@ answer_the_rest(struct io_queue* q,
   // A request already inside execute when defer was cleared is still added to
   // the list, and leaving it unanswered hangs destroy. Once nothing is inside
   // execute the list is final, because the cleared flag is read on the way in.
-  // Reading the list any sooner races the backend, and with a missed entry a
-  // running job is left behind to hang destroy.
+  // Reading it any sooner races the backend.
   if (wait_out_of_execute(f, HANDOVER_TIMEOUT_MS))
     log_error("io_queue test: the backend never came out of execute");
 
@@ -1284,12 +1283,12 @@ Fail:
   return 1;
 }
 
-// --- test: a backend that says "not now" ---
+// --- test: a refused request ---
 
 #define REFUSALS 3
 
-// A refused request keeps its place and is handed over again, so both writes
-// run in the order they were posted and neither is dropped.
+// A refused request is offered again in the same place, so both writes run in
+// the order they were posted.
 static int
 test_refused_request_is_handed_over_again(void)
 {
@@ -1324,7 +1323,7 @@ test_refused_request_is_handed_over_again(void)
   CHECK(Cleanup, io_queue_pending_bytes(q) == 0);
 
   // One worker, so a refusal that left the request counted as running would
-  // show up here as a second one running.
+  // show up as a peak of two.
   io_queue_get_stats(q, &stats);
   CHECK(Cleanup, stats.writes_in_flight_peak == 1);
   rc = 0;
@@ -1337,10 +1336,10 @@ Fail:
   return 1;
 }
 
-// --- test: a refused barrier does not stall its file ---
+// --- test: a refused barrier ---
 
-// A refused barrier is offered again, and the write posted behind it is not
-// left waiting once the barrier has run.
+// A refused barrier is offered again, and the write behind it is not left
+// waiting.
 static int
 test_refused_barrier_keeps_the_file_moving(void)
 {
@@ -1382,7 +1381,7 @@ Fail:
   return 1;
 }
 
-// --- test: the backend is stopped at teardown ---
+// --- test: backend stop at teardown ---
 
 #define STOP_REQUESTS 3
 
@@ -1408,8 +1407,6 @@ test_backend_is_stopped_at_teardown(void)
 
   io_queue_destroy(q);
 
-  // The backend is stopped once, with every request already handed over, so
-  // one running a thread of its own has nothing left to do by then.
   CHECK(Fail, fake.stops == 1);
   CHECK(Fail, fake.records_when_stopped == STOP_REQUESTS);
   return 0;
@@ -1420,12 +1417,11 @@ Fail:
   return 1;
 }
 
-// --- test: the request outlives the call ---
+// --- test: request lifetime ---
 
-// A backend that finishes later reads the request after execute has returned,
-// so what it was handed has to still be there and still say the same thing.
-// Both requests go to the same worker, so a request living only as long as the
-// call would leave the two pointers aimed at the same spot on its stack.
+// Both requests go to the same worker, so a request living only as long as
+// the call would leave both pointers aimed at one spot on that worker's
+// stack.
 static int
 test_request_outlives_execute(void)
 {
@@ -1453,7 +1449,7 @@ test_request_outlives_execute(void)
                                            .offset = 7 * WRITE_BYTES }) == 0);
   CHECK(Cleanup, wait_for_deferred(&fake, 1, HANDOVER_TIMEOUT_MS) == 0);
 
-  // This names another file, so it is not held behind the first.
+  // The file is a different one, so this write is not held behind the first.
   CHECK(Cleanup,
         io_queue_post(q,
                       (struct io_request){ .op = IO_OP_WRITE,
@@ -1499,12 +1495,12 @@ Fail:
   return 1;
 }
 
-// --- test: a short write is finished by the backend ---
+// --- test: a short write ---
 
 #define SHORT_WRITE_BYTES 1000
 
-// The backend's write takes only part of what it was given, and the rest is
-// retried behind the interface. The queue is handed the request once.
+// Only part of the payload is written per attempt, and the rest is retried
+// inside the backend, so the queue is handed the request once.
 static int
 test_short_write_is_finished_by_the_backend(void)
 {
@@ -1556,12 +1552,11 @@ Fail:
   return 1;
 }
 
-// --- test: a refused request whose file index was reused ---
+// --- test: a refusal after the file index is reused ---
 
-// A close hands its file index back when it runs, so a new open can hold that
-// index while the close has not retired. A close refused in that window is on
-// no list any more, and putting it back would strand it with the queue unable
-// to drain.
+// A file index is handed back when the close naming it runs, before that
+// close retires, so a new open can hold the index already. A close refused in
+// that window is on no list, and putting it back would strand it.
 static int
 test_refused_request_after_the_index_is_reused(void)
 {
@@ -1588,8 +1583,7 @@ test_refused_request_after_the_index_is_reused(void)
           q, (struct io_request){ .op = IO_OP_CLOSE, .file = first }) == 0);
   CHECK(Cleanup, wait_for_records(&fake, 1, HANDOVER_TIMEOUT_MS) == 0);
 
-  // The close is held in the backend, which is the window a new open claiming
-  // the same index takes the file entry over in.
+  // The close is waiting in the backend, the window a new open needs.
   CHECK(Cleanup,
         io_queue_post(q,
                       (struct io_request){ .op = IO_OP_WRITE,

--- a/tests/test_io_queue.c
+++ b/tests/test_io_queue.c
@@ -455,7 +455,7 @@ answer_the_rest(struct io_queue* q,
   // A request already inside execute when defer was cleared is still added to
   // the list, and leaving it unanswered hangs destroy. Once nothing is inside
   // execute the list is final, because the cleared flag is read on the way in.
-  // Reading it any sooner races the backend.
+  // Anything sooner is a race with the backend.
   if (wait_out_of_execute(f, HANDOVER_TIMEOUT_MS))
     log_error("io_queue test: the backend never came out of execute");
 
@@ -1419,9 +1419,8 @@ Fail:
 
 // --- test: request lifetime ---
 
-// Both requests go to the same worker, so a request living only as long as
-// the call would leave both pointers aimed at one spot on that worker's
-// stack.
+// One worker takes both requests, so a request kept only for the length of
+// the call would leave both pointers aimed at one spot on its stack.
 static int
 test_request_outlives_execute(void)
 {
@@ -1556,7 +1555,8 @@ Fail:
 
 // A file index is handed back when the close naming it runs, before that
 // close retires, so a new open can hold the index already. A close refused in
-// that window is on no list, and putting it back would strand it.
+// that window is on no list, and putting it back would strand it, leaving the
+// queue unable to drain.
 static int
 test_refused_request_after_the_index_is_reused(void)
 {

--- a/tests/test_io_queue.c
+++ b/tests/test_io_queue.c
@@ -7,6 +7,7 @@
 #include <stdatomic.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 // A backend hands out a fresh generation with the index of the slot it took,
 // and the queue finds a file by that index. The two only have to agree.
@@ -419,6 +420,21 @@ wait_for_deferred(const struct io_backend_fake* f, uint64_t n, int timeout_ms)
   return 0;
 }
 
+// Poll until nothing is inside execute. Zero is returned once nothing is,
+// -1 if the wait ran out.
+static int
+wait_out_of_execute(const struct io_backend_fake* f, int timeout_ms)
+{
+  int waited_ms = 0;
+  while (io_backend_fake_inside_execute(f) > 0) {
+    if (waited_ms >= timeout_ms)
+      return -1;
+    platform_sleep_ns(1000000LL);
+    waited_ms += 1;
+  }
+  return 0;
+}
+
 static void
 answer(struct io_queue* q, uint64_t* answered, struct io_completion c)
 {
@@ -439,15 +455,10 @@ answer_the_rest(struct io_queue* q,
   // A request already inside execute when defer was cleared is still added to
   // the list, and leaving it unanswered hangs destroy. Once nothing is inside
   // execute the list is final, because the cleared flag is read on the way in.
-  for (int waited_ms = 0; io_backend_fake_inside_execute(f) > 0; ++waited_ms) {
-    if (waited_ms >= HANDOVER_TIMEOUT_MS) {
-      // Reading the list now races the backend, and with a missed entry a
-      // running job is left behind to hang destroy.
-      log_error("io_queue test: the backend never came out of execute");
-      break;
-    }
-    platform_sleep_ns(1000000LL);
-  }
+  // Reading the list any sooner races the backend, and with a missed entry a
+  // running job is left behind to hang destroy.
+  if (wait_out_of_execute(f, HANDOVER_TIMEOUT_MS))
+    log_error("io_queue test: the backend never came out of execute");
 
   uint64_t n = io_backend_fake_deferred_count(f);
   if (n > IO_BACKEND_FAKE_CAPACITY)
@@ -1273,6 +1284,279 @@ Fail:
   return 1;
 }
 
+// --- test: a backend that says "not now" ---
+
+#define REFUSALS 3
+
+// A refused request keeps its place and is handed over again, so both writes
+// run in the order they were posted and neither is dropped.
+static int
+test_refused_request_is_handed_over_again(void)
+{
+  struct io_backend_fake fake;
+  io_backend_fake_init(&fake);
+  io_backend_fake_refuse(&fake, REFUSALS);
+
+  struct io_queue* q = io_queue_create(io_backend_fake_as_backend(&fake),
+                                       (struct io_queue_limits){ 0 });
+  CHECK(Fail, q);
+
+  int rc = 1;
+  struct io_queue_stats stats;
+
+  for (uint64_t i = 0; i < 2; ++i)
+    CHECK(Cleanup,
+          io_queue_post(q,
+                        (struct io_request){ .op = IO_OP_WRITE,
+                                             .file = file_token(1),
+                                             .nbytes = WRITE_BYTES,
+                                             .offset = i * WRITE_BYTES }) == 0);
+
+  CHECK(Cleanup,
+        wait_for_records(&fake, REFUSALS + 2, HANDOVER_TIMEOUT_MS) == 0);
+  io_event_wait(q, io_queue_record(q));
+
+  CHECK(Cleanup, io_backend_fake_refused_count(&fake) == REFUSALS);
+  CHECK(Cleanup, io_backend_fake_record_count(&fake) == REFUSALS + 2);
+  for (uint64_t i = 0; i <= REFUSALS; ++i)
+    CHECK(Cleanup, fake.records[i].seq == 1);
+  CHECK(Cleanup, fake.records[REFUSALS + 1].seq == 2);
+  CHECK(Cleanup, io_queue_pending_bytes(q) == 0);
+
+  // One worker, so a refusal that left the request counted as running would
+  // show up here as a second one running.
+  io_queue_get_stats(q, &stats);
+  CHECK(Cleanup, stats.writes_in_flight_peak == 1);
+  rc = 0;
+
+Cleanup:
+  io_queue_destroy(q);
+  return rc;
+
+Fail:
+  return 1;
+}
+
+// --- test: a refused barrier does not stall its file ---
+
+// A refused barrier is offered again, and the write posted behind it is not
+// left waiting once the barrier has run.
+static int
+test_refused_barrier_keeps_the_file_moving(void)
+{
+  struct io_backend_fake fake;
+  io_backend_fake_init(&fake);
+  io_backend_fake_refuse(&fake, 1);
+
+  struct io_queue* q = io_queue_create(io_backend_fake_as_backend(&fake),
+                                       (struct io_queue_limits){ 0 });
+  CHECK(Fail, q);
+
+  int rc = 1;
+
+  CHECK(Cleanup,
+        io_queue_post(q,
+                      (struct io_request){ .op = IO_OP_TRUNCATE,
+                                           .file = file_token(1),
+                                           .logical_size = WRITE_BYTES }) == 0);
+  CHECK(Cleanup,
+        io_queue_post(q,
+                      (struct io_request){ .op = IO_OP_WRITE,
+                                           .file = file_token(1),
+                                           .nbytes = WRITE_BYTES }) == 0);
+
+  CHECK(Cleanup, wait_for_records(&fake, 3, HANDOVER_TIMEOUT_MS) == 0);
+  io_event_wait(q, io_queue_record(q));
+
+  CHECK(Cleanup, fake.records[0].op == IO_OP_TRUNCATE);
+  CHECK(Cleanup, fake.records[1].op == IO_OP_TRUNCATE);
+  CHECK(Cleanup, fake.records[2].op == IO_OP_WRITE);
+  CHECK(Cleanup, io_queue_pending_bytes(q) == 0);
+  rc = 0;
+
+Cleanup:
+  io_queue_destroy(q);
+  return rc;
+
+Fail:
+  return 1;
+}
+
+// --- test: the backend is stopped at teardown ---
+
+#define STOP_REQUESTS 3
+
+static int
+test_backend_is_stopped_at_teardown(void)
+{
+  struct io_backend_fake fake;
+  io_backend_fake_init(&fake);
+
+  struct io_queue* q = io_queue_create(io_backend_fake_as_backend(&fake),
+                                       (struct io_queue_limits){ 0 });
+  CHECK(Fail, q);
+
+  for (uint64_t i = 0; i < STOP_REQUESTS; ++i)
+    CHECK(Fail2,
+          io_queue_post(q,
+                        (struct io_request){ .op = IO_OP_WRITE,
+                                             .file = file_token(1),
+                                             .nbytes = WRITE_BYTES,
+                                             .offset = i * WRITE_BYTES }) == 0);
+  io_event_wait(q, io_queue_record(q));
+  CHECK(Fail2, fake.stops == 0);
+
+  io_queue_destroy(q);
+
+  // Stopped once, and with every request already handed over, so a backend
+  // running a thread of its own has nothing left to do when it is stopped.
+  CHECK(Fail, fake.stops == 1);
+  CHECK(Fail, fake.records_when_stopped == STOP_REQUESTS);
+  return 0;
+
+Fail2:
+  io_queue_destroy(q);
+Fail:
+  return 1;
+}
+
+// --- test: the request outlives the call ---
+
+// A backend that finishes later reads the request after execute has returned,
+// so what it was handed has to still be there and still say the same thing.
+// The second request goes to the same worker, and a request that lived only
+// as long as the call would leave both pointing at the same worn-out place.
+static int
+test_request_outlives_execute(void)
+{
+  char first_payload[WRITE_BYTES];
+  char second_payload[WRITE_BYTES];
+
+  struct io_backend_fake fake;
+  io_backend_fake_init(&fake);
+  io_backend_fake_defer(&fake, 1);
+
+  struct io_queue* q = io_queue_create(io_backend_fake_as_backend(&fake),
+                                       (struct io_queue_limits){ 0 });
+  CHECK(Fail, q);
+
+  int rc = 1;
+  uint64_t answered = 0;
+
+  CHECK(Cleanup,
+        io_queue_post(q,
+                      (struct io_request){ .op = IO_OP_WRITE,
+                                           .borrowed = 1,
+                                           .file = file_token(5),
+                                           .payload = first_payload,
+                                           .nbytes = WRITE_BYTES,
+                                           .offset = 7 * WRITE_BYTES }) == 0);
+  CHECK(Cleanup, wait_for_deferred(&fake, 1, HANDOVER_TIMEOUT_MS) == 0);
+
+  // Another file, so this one is not held behind the first.
+  CHECK(Cleanup,
+        io_queue_post(q,
+                      (struct io_request){ .op = IO_OP_WRITE,
+                                           .borrowed = 1,
+                                           .file = file_token(6),
+                                           .payload = second_payload,
+                                           .nbytes = WRITE_BYTES / 2,
+                                           .offset = 0 }) == 0);
+  CHECK(Cleanup, wait_for_deferred(&fake, 2, HANDOVER_TIMEOUT_MS) == 0);
+  CHECK(Cleanup, wait_out_of_execute(&fake, HANDOVER_TIMEOUT_MS) == 0);
+
+  const struct io_request* first = io_backend_fake_deferred_request(&fake, 0);
+  const struct io_request* second = io_backend_fake_deferred_request(&fake, 1);
+  CHECK(Cleanup, first);
+  CHECK(Cleanup, second);
+  CHECK(Cleanup, first != second);
+  CHECK(Cleanup, first->op == IO_OP_WRITE);
+  CHECK(Cleanup, first->payload == first_payload);
+  CHECK(Cleanup, first->nbytes == WRITE_BYTES);
+  CHECK(Cleanup, first->offset == 7 * WRITE_BYTES);
+  CHECK(Cleanup, first->file.generation == 5);
+  CHECK(Cleanup, second->payload == second_payload);
+  CHECK(Cleanup, second->nbytes == WRITE_BYTES / 2);
+
+  answer(
+    q,
+    &answered,
+    (struct io_completion){ .seq = fake.deferred[0], .nbytes = first->nbytes });
+  answer(q,
+         &answered,
+         (struct io_completion){ .seq = fake.deferred[1],
+                                 .nbytes = second->nbytes });
+  io_event_wait(q, io_queue_record(q));
+  CHECK(Cleanup, io_queue_pending_bytes(q) == 0);
+  rc = 0;
+
+Cleanup:
+  answer_the_rest(q, &fake, &answered);
+  io_queue_destroy(q);
+  return rc;
+
+Fail:
+  return 1;
+}
+
+// --- test: a short write is finished by the backend ---
+
+#define SHORT_WRITE_BYTES 1000
+
+// The backend's write takes only part of what it was given, and the rest is
+// retried behind the interface. The queue is handed the request once.
+static int
+test_short_write_is_finished_by_the_backend(void)
+{
+  char payload[WRITE_BYTES];
+  char landed[2 * WRITE_BYTES];
+
+  for (uint64_t i = 0; i < WRITE_BYTES; ++i)
+    payload[i] = (char)(i * 7 + 1);
+  memset(landed, 0, sizeof(landed));
+
+  struct io_backend_fake fake;
+  io_backend_fake_init(&fake);
+  io_backend_fake_write_into(&fake, landed, sizeof(landed));
+  io_backend_fake_short_write(&fake, SHORT_WRITE_BYTES);
+
+  struct io_queue* q = io_queue_create(io_backend_fake_as_backend(&fake),
+                                       (struct io_queue_limits){ 0 });
+  CHECK(Fail, q);
+
+  int rc = 1;
+
+  CHECK(Cleanup,
+        io_queue_post(q,
+                      (struct io_request){ .op = IO_OP_WRITE,
+                                           .borrowed = 1,
+                                           .file = file_token(1),
+                                           .payload = payload,
+                                           .nbytes = WRITE_BYTES,
+                                           .offset = WRITE_BYTES }) == 0);
+  io_event_wait(q, io_queue_record(q));
+
+  CHECK(Cleanup, io_backend_fake_record_count(&fake) == 1);
+  CHECK(Cleanup,
+        io_backend_fake_write_attempts(&fake) ==
+          ceildiv(WRITE_BYTES, SHORT_WRITE_BYTES));
+  CHECK(Cleanup, memcmp(landed + WRITE_BYTES, payload, WRITE_BYTES) == 0);
+
+  uint64_t landed_before_the_offset = 0;
+  for (uint64_t i = 0; i < WRITE_BYTES; ++i)
+    landed_before_the_offset += (uint64_t)(landed[i] != 0);
+  CHECK(Cleanup, landed_before_the_offset == 0);
+  CHECK(Cleanup, io_queue_pending_bytes(q) == 0);
+  rc = 0;
+
+Cleanup:
+  io_queue_destroy(q);
+  return rc;
+
+Fail:
+  return 1;
+}
+
 // --- main ---
 
 int
@@ -1310,6 +1594,14 @@ main(void)
       test_barrier_waits_with_many_workers },
     { "index_reused_before_close_retires",
       test_index_reused_before_close_retires },
+    { "refused_request_is_handed_over_again",
+      test_refused_request_is_handed_over_again },
+    { "refused_barrier_keeps_the_file_moving",
+      test_refused_barrier_keeps_the_file_moving },
+    { "backend_is_stopped_at_teardown", test_backend_is_stopped_at_teardown },
+    { "request_outlives_execute", test_request_outlives_execute },
+    { "short_write_is_finished_by_the_backend",
+      test_short_write_is_finished_by_the_backend },
   };
   for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
     int r = tests[i].fn();


### PR DESCRIPTION
The backend interface is general enough to hold an io_uring backend, but
four things were missing from it. Settling them here keeps the ring
itself to one change.

A backend with no room for a request answers IO_BUSY instead of blocking
a worker or failing the request. The queue puts the request back where
it was, keeping its sequence number and its place on its file, and the
worker moves on to whatever else is ready. One case cannot go back: a
close hands its file index over when it runs, so a new open may already
hold that index, and the refused close is on no list to go back to. That
one is finished as cancelled rather than left waiting to be picked up by
nobody.

A backend can carry a stop, which io_queue_destroy calls once, after the
last request has finished and every worker has stopped, so a backend
running a thread of its own has somewhere to stop it. A backend wrapping
another passes it along, which the test backend that can make io fail now
does.

The request handed to execute is the queue's own copy rather than the
worker's, so it stays put until the outcome is reported and a backend
that finishes later can keep reading it instead of copying what it
needs.

Finishing a short write belongs to the backend that saw one, and
io_write_remaining hands back the part still to be done. platform_pwrite
loops internally so the filesystem backend never sees a short write, but
a ring will.

The filesystem backend is untouched. The fake backend in the tests can
now refuse a request, be stopped, keep the request it was handed and
take a write a few bytes at a time, with a case for each.

Closes #229
