### PR TITLE
Fail fs sink test on CUDA setup error

### DIFF
--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -2283,6 +2283,10 @@ main(int ac, char* av[])
 
   int ecode = 0;
 
+  // The cases before the CUDA setup are already folded into ecode, so a failed
+  // setup is tracked apart from them.
+  int cuda_ready = 0;
+
   // Create temp directory
   char tmpdir[512];
   CHECK(Fail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
@@ -2387,6 +2391,7 @@ main(int ac, char* av[])
     CU(Cleanup, cuInit(0));
     CU(Cleanup, cuDeviceGet(&dev, 0));
     CU(Cleanup, cu_ctx_create(&ctx, 0, dev));
+    cuda_ready = 1;
 
     {
       char sub[576];
@@ -2435,7 +2440,8 @@ main(int ac, char* av[])
 
 Cleanup:
   test_tmpdir_remove(tmpdir);
+  return ecode | !cuda_ready;
 
 Fail:
-  return ecode;
+  return 1;
 }

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -2282,9 +2282,6 @@ main(int ac, char* av[])
   (void)av;
 
   int ecode = 0;
-
-  // The cases before the CUDA setup are already folded into ecode, so a failed
-  // setup is tracked apart from them.
   int cuda_ready = 0;
 
   // Create temp directory


### PR DESCRIPTION
In `tests/test_zarr_fs_sink.c`, `ecode` was declared at 0 and `Cleanup` fell
through into `Fail: return ecode`, so a jump out of the CUDA setup returned
whatever the cases before it had recorded. On a machine with no visible device
that is 0, and the six pipeline cases behind the setup were skipped silently.

The twelve CPU-only cases that run first are counted in `ecode`. Were it
started at 1 and cleared after the setup, as in #237, a clean run would be
reported as a failure or those results discarded. Instead a `cuda_ready` flag
is set once the three setup calls pass, and `Cleanup` returns
`ecode | !cuda_ready`. `Fail`, reached only when the temporary directory cannot
be created, returns 1.

Closes #241
