### PR TITLE
Report the flush error in test helpers

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -207,12 +207,11 @@ if(CHUCKY_ENABLE_GPU)
     )
 endif()
 add_test_exe(test_flush_error_drain_cpu test_flush_error_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log test_io_faults test_zarr_helpers)
+# A fence that never retires would hang rather than fail; bound it.
+set_tests_properties(test-test_flush_error_drain_cpu PROPERTIES TIMEOUT 60)
 add_test_exe(test_pending_bytes_fs test_pending_bytes_fs.c shard_pool_fs platform writer test_platform chucky_log test_io_faults)
-# A worker left held would hang rather than fail; bound them.
-set_tests_properties(
-    test-test_flush_error_drain_cpu test-test_pending_bytes_fs
-    PROPERTIES TIMEOUT 60
-)
+# A worker left held would hang rather than fail; bound it.
+set_tests_properties(test-test_pending_bytes_fs PROPERTIES TIMEOUT 60)
 add_test_exe(test_shape_after_flush_cpu test_shape_after_flush_cpu.c stream_cpu test_shard_sink writer chucky_log)
 add_test_exe(test_stall_metrics_cpu test_stall_metrics_cpu.c stream_cpu test_shard_sink writer platform chucky_log)
 add_gpu_test_exe(test_shape_after_flush_gpu test_shape_after_flush_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink writer chucky_log)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -208,8 +208,11 @@ if(CHUCKY_ENABLE_GPU)
 endif()
 add_test_exe(test_flush_error_drain_cpu test_flush_error_drain_cpu.c stream_cpu zarr_array store_fs store_api shard_pool_fs platform writer test_platform chucky_log test_io_faults test_zarr_helpers)
 add_test_exe(test_pending_bytes_fs test_pending_bytes_fs.c shard_pool_fs platform writer test_platform chucky_log test_io_faults)
-# A worker left held would hang rather than fail; bound it.
-set_tests_properties(test-test_pending_bytes_fs PROPERTIES TIMEOUT 60)
+# A worker left held would hang rather than fail; bound them.
+set_tests_properties(
+    test-test_flush_error_drain_cpu test-test_pending_bytes_fs
+    PROPERTIES TIMEOUT 60
+)
 add_test_exe(test_shape_after_flush_cpu test_shape_after_flush_cpu.c stream_cpu test_shard_sink writer chucky_log)
 add_test_exe(test_stall_metrics_cpu test_stall_metrics_cpu.c stream_cpu test_shard_sink writer platform chucky_log)
 add_gpu_test_exe(test_shape_after_flush_gpu test_shape_after_flush_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink writer chucky_log)

--- a/tests/test_cpu_zarr_fs.c
+++ b/tests/test_cpu_zarr_fs.c
@@ -181,7 +181,7 @@ test_pipeline(const char* tmpdir)
     CHECK(Fail4, r.error == 0);
   }
 
-  test_zarr_sink_flush(&z);
+  CHECK(Fail4, test_zarr_sink_flush(&z) == 0);
 
   // Verify: correct number of shards, all chunks decompress.
   {
@@ -307,7 +307,7 @@ test_streaming_append(const char* tmpdir)
     CHECK(Fail4, r.error == 0);
   }
 
-  test_zarr_sink_flush(&z);
+  CHECK(Fail4, test_zarr_sink_flush(&z) == 0);
 
   // Verify all shards
   {
@@ -436,7 +436,7 @@ test_batch_readback_impl(const char* tmpdir, int epochs_per_batch)
     struct writer_result r = writer_flush(tile_stream_cpu_writer(s));
     CHECK(Fail4, r.error == 0);
   }
-  test_zarr_sink_flush(&z);
+  CHECK(Fail4, test_zarr_sink_flush(&z) == 0);
 
   // There should be exactly one shard (all epochs + all inner chunks).
   {

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -1,4 +1,5 @@
-// A flush is required to report the failures of the work it waited on.
+// A flush is required to wait for the work it queued and to report its
+// failures.
 
 #include "platform/platform.h"
 #include "stream.cpu.h"
@@ -42,7 +43,7 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
   };
   const size_t epoch_elements = 8 * 8;
 
-  struct io_faults faults;
+  struct io_faults faults = { 0 };
   struct test_zarr_sink z = { 0 };
   struct tile_stream_cpu* s = NULL;
   uint16_t* src = NULL;
@@ -124,20 +125,23 @@ test_sink_flush_reports_io_failure(const char* tmpdir)
       .storage_position = 2 },
   };
 
-  struct io_faults faults;
+  struct io_faults faults = { 0 };
   struct test_zarr_sink z = { 0 };
   int rc = 1;
 
   CHECK(Cleanup,
         test_zarr_sink_open_with_pool(
           &z,
-          io_faults_store_create(&faults, tmpdir, /*unbuffered=*/1),
+          io_faults_store_create(&faults, tmpdir, /*unbuffered=*/0),
           "0",
           dims,
           3,
           dtype_u16,
           (struct codec_config){ .id = CODEC_NONE }) == 0);
 
+  // The clean flush is checked first, so the failure below can only be the
+  // fault's.
+  CHECK(Cleanup, test_zarr_sink_flush(&z) == 0);
   CHECK(Cleanup, io_faults_inject_failing_job(&faults) == 0);
   CHECK(Cleanup, test_zarr_sink_flush(&z) != 0);
 

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -1,4 +1,4 @@
-// A flush is required to report the failures of the io it waited on.
+// A flush is required to report the failures of the work it waited on.
 
 #include "platform/platform.h"
 #include "stream.cpu.h"

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -1,7 +1,6 @@
 // A flush is required to wait for the work it queued and to report its
 // failures.
 
-#include "platform/platform.h"
 #include "stream.cpu.h"
 #include "test_io_faults.h"
 #include "test_platform.h"
@@ -9,7 +8,6 @@
 #include "util/prelude.h"
 #include "writer.h"
 
-#include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -1,7 +1,4 @@
-// Regression test (#218): a flush has to report the failures of the work it
-// queued. Finalizing a partial shard posts a truncate and a close, and a flush
-// that returned without waiting reported success for a shard whose size on disk
-// is wrong.
+// A flush is required to report the failures of the io it waited on.
 
 #include "platform/platform.h"
 #include "stream.cpu.h"
@@ -16,6 +13,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+// Regression (#218): finalizing a partial shard posts a truncate and a close,
+// and a flush that returned without waiting reported success for a shard whose
+// size on disk is wrong.
 static int
 test_flush_reports_queued_truncate_failure(const char* tmpdir)
 {
@@ -99,6 +99,56 @@ Cleanup:
   return rc;
 }
 
+// Regression (#240): the helper discarded what the array flush returned, so a
+// failed flush left the verdict to whatever had reached the store.
+static int
+test_sink_flush_reports_io_failure(const char* tmpdir)
+{
+  log_info("=== test_sink_flush_reports_io_failure (cpu) ===");
+
+  struct dimension dims[3] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 1,
+      .name = "t",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "x",
+      .storage_position = 2 },
+  };
+
+  struct io_faults faults;
+  struct test_zarr_sink z = { 0 };
+  int rc = 1;
+
+  CHECK(Cleanup,
+        test_zarr_sink_open_with_pool(
+          &z,
+          io_faults_store_create(&faults, tmpdir, /*unbuffered=*/1),
+          "0",
+          dims,
+          3,
+          dtype_u16,
+          (struct codec_config){ .id = CODEC_NONE }) == 0);
+
+  CHECK(Cleanup, io_faults_inject_failing_job(&faults) == 0);
+  CHECK(Cleanup, test_zarr_sink_flush(&z) != 0);
+
+  rc = 0;
+  log_info("  PASS");
+
+Cleanup:
+  test_zarr_sink_close(&z);
+  return rc;
+}
+
 int
 main(int ac, char* av[])
 {
@@ -116,6 +166,13 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/flush_error_drain_cpu", tmpdir);
     test_mkdir(sub);
     ecode |= test_flush_reports_queued_truncate_failure(sub);
+  }
+
+  {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/sink_flush_io_failure", tmpdir);
+    test_mkdir(sub);
+    ecode |= test_sink_flush_reports_io_failure(sub);
   }
 
   test_tmpdir_remove(tmpdir);

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -98,13 +98,16 @@ Cleanup:
   return rc;
 }
 
-// Regression (#240): the helper discarded what the array flush returned, so a
-// failed flush left the verdict to whatever had reached the store.
+// Regression (#240): at a call site that flushes and then reads the store
+// back, the reported error is the only signal, because the shard the site
+// checks is already whole on disk.
 static int
 test_sink_flush_reports_io_failure(const char* tmpdir)
 {
   log_info("=== test_sink_flush_reports_io_failure (cpu) ===");
 
+  // One epoch fills the whole shard, so the file a call site checks is
+  // complete before the fault is armed.
   struct dimension dims[3] = {
     { .size = 0,
       .chunk_size = 1,
@@ -122,9 +125,12 @@ test_sink_flush_reports_io_failure(const char* tmpdir)
       .name = "x",
       .storage_position = 2 },
   };
+  const size_t epoch_elements = 8 * 8;
 
   struct io_faults faults = { 0 };
   struct test_zarr_sink z = { 0 };
+  struct tile_stream_cpu* s = NULL;
+  uint16_t* src = NULL;
   int rc = 1;
 
   CHECK(Cleanup,
@@ -137,16 +143,48 @@ test_sink_flush_reports_io_failure(const char* tmpdir)
           dtype_u16,
           (struct codec_config){ .id = CODEC_NONE }) == 0);
 
-  // The clean flush is checked first, so the failure below can only be the
-  // fault's.
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = epoch_elements * sizeof(uint16_t),
+    .epochs_per_batch = 1,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+  };
+  s = tile_stream_cpu_create(&cfg, test_zarr_sink_as_shard_sink(&z));
+  CHECK(Cleanup, s);
+
+  src = (uint16_t*)calloc(epoch_elements, sizeof(uint16_t));
+  CHECK(Cleanup, src);
+
+  {
+    struct slice input = { .beg = src, .end = src + epoch_elements };
+    struct writer_result r = writer_append(tile_stream_cpu_writer(s), input);
+    CHECK(Cleanup, r.error == 0);
+  }
+  {
+    struct writer_result r = writer_flush(tile_stream_cpu_writer(s));
+    CHECK(Cleanup, r.error == 0);
+  }
+
+  // A clean flush is checked first, so the failure below can only come from
+  // the fault.
   CHECK(Cleanup, test_zarr_sink_flush(&z) == 0);
   CHECK(Cleanup, io_faults_inject_failing_job(&faults) == 0);
   CHECK(Cleanup, test_zarr_sink_flush(&z) != 0);
+
+  {
+    char path[4300];
+    snprintf(path, sizeof(path), "%s/0/c/0/0/0", tmpdir);
+    CHECK(Cleanup, test_file_exists(path));
+  }
 
   rc = 0;
   log_info("  PASS");
 
 Cleanup:
+  free(src);
+  tile_stream_cpu_destroy(s);
   test_zarr_sink_close(&z);
   return rc;
 }

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -222,7 +222,7 @@ test_pipeline(const char* tmpdir)
     CHECK(Fail4, r.error == 0);
   }
 
-  test_zarr_sink_flush(&z);
+  CHECK(Fail4, test_zarr_sink_flush(&z) == 0);
 
   // Verify shard files exist and contents are correct
   {
@@ -791,7 +791,7 @@ test_unbounded_metadata_update(const char* tmpdir)
   // The extent publishes in close, not flush.
   CHECK(Fail4, writer_close(tile_stream_gpu_writer(s)).error == 0);
 
-  test_zarr_sink_flush(&z);
+  CHECK(Fail4, test_zarr_sink_flush(&z) == 0);
 
   // After closing, zarr.json shape[0] should reflect data written.
   // 4 epochs of chunk_size=2 → shape[0] = 8.
@@ -1069,7 +1069,7 @@ test_midstream_metadata_update(const char* tmpdir)
     struct writer_result r = writer_flush(tile_stream_gpu_writer(s));
     CHECK(Fail4, r.error == 0);
   }
-  test_zarr_sink_flush(&z);
+  CHECK(Fail4, test_zarr_sink_flush(&z) == 0);
 
   // Verify final shape after flush: 6 epochs * chunk_size 2 = 12
   {
@@ -1169,7 +1169,7 @@ test_unbuffered_pipeline(const char* tmpdir)
     CHECK(Fail3, r.error == 0);
   }
 
-  test_zarr_sink_flush(&z);
+  CHECK(Fail3, test_zarr_sink_flush(&z) == 0);
 
   // Verify shard file exists
   char path[4096];
@@ -1378,7 +1378,7 @@ test_unbuffered_pipeline_multishard(const char* tmpdir)
     CHECK(Fail4, r.error == 0);
   }
 
-  test_zarr_sink_flush(&z);
+  CHECK(Fail4, test_zarr_sink_flush(&z) == 0);
 
   // Verify shard files: same loop as test_pipeline
   {
@@ -1833,7 +1833,7 @@ test_pipeline_storage_order(const char* tmpdir)
     CHECK(Fail4, r.error == 0);
   }
 
-  test_zarr_sink_flush(&z);
+  CHECK(Fail4, test_zarr_sink_flush(&z) == 0);
 
   // Verify shard files and chunk contents
   {

--- a/tests/test_zarr_helpers.c
+++ b/tests/test_zarr_helpers.c
@@ -158,10 +158,10 @@ test_zarr_sink_has_error(const struct test_zarr_sink* z)
   return zarr_array_has_error(z->array);
 }
 
-void
+int
 test_zarr_sink_flush(struct test_zarr_sink* z)
 {
-  zarr_array_flush(z->array);
+  return zarr_array_flush(z->array);
 }
 
 void
@@ -242,10 +242,10 @@ test_zarr_multiscale_as_shard_sink(struct test_zarr_multiscale* z)
   return ngff_multiscale_as_shard_sink(z->ms);
 }
 
-void
+int
 test_zarr_multiscale_flush(struct test_zarr_multiscale* z)
 {
-  ngff_multiscale_flush(z->ms);
+  return ngff_multiscale_flush(z->ms);
 }
 
 void

--- a/tests/test_zarr_helpers.c
+++ b/tests/test_zarr_helpers.c
@@ -242,12 +242,6 @@ test_zarr_multiscale_as_shard_sink(struct test_zarr_multiscale* z)
   return ngff_multiscale_as_shard_sink(z->ms);
 }
 
-int
-test_zarr_multiscale_flush(struct test_zarr_multiscale* z)
-{
-  return ngff_multiscale_flush(z->ms);
-}
-
 void
 test_zarr_multiscale_close(struct test_zarr_multiscale* z)
 {

--- a/tests/test_zarr_helpers.h
+++ b/tests/test_zarr_helpers.h
@@ -100,8 +100,5 @@ test_zarr_multiscale_open_in_store(struct test_zarr_multiscale* z,
 struct shard_sink*
 test_zarr_multiscale_as_shard_sink(struct test_zarr_multiscale* z);
 
-int
-test_zarr_multiscale_flush(struct test_zarr_multiscale* z);
-
 void
 test_zarr_multiscale_close(struct test_zarr_multiscale* z);

--- a/tests/test_zarr_helpers.h
+++ b/tests/test_zarr_helpers.h
@@ -59,7 +59,7 @@ test_zarr_sink_as_shard_sink(struct test_zarr_sink* z);
 int
 test_zarr_sink_has_error(const struct test_zarr_sink* z);
 
-void
+int
 test_zarr_sink_flush(struct test_zarr_sink* z);
 
 void
@@ -100,7 +100,7 @@ test_zarr_multiscale_open_in_store(struct test_zarr_multiscale* z,
 struct shard_sink*
 test_zarr_multiscale_as_shard_sink(struct test_zarr_multiscale* z);
 
-void
+int
 test_zarr_multiscale_flush(struct test_zarr_multiscale* z);
 
 void

--- a/tests/test_zarr_readback.c
+++ b/tests/test_zarr_readback.c
@@ -58,7 +58,7 @@ write_zarr(const char* store_path, struct codec_config codec)
   r = writer_flush(tile_stream_cpu_writer(s));
   CHECK(Fail_stream, r.error == 0);
 
-  test_zarr_sink_flush(&zs);
+  CHECK(Fail_stream, test_zarr_sink_flush(&zs) == 0);
   tile_stream_cpu_destroy(s);
   test_zarr_sink_close(&zs);
   free(src);

--- a/tests/test_zarr_s3_sink.c
+++ b/tests/test_zarr_s3_sink.c
@@ -384,7 +384,7 @@ test_concurrent_finalize(void)
   ss->wait_fence(ss, fence);
 
   // Flush to drain epoch 1's pending uploads
-  test_zarr_sink_flush(&sink);
+  CHECK(Fail_sink, test_zarr_sink_flush(&sink) == 0);
 
   // Verify epoch 0 shards arrived
   for (int i = 0; i < 4; ++i) {


### PR DESCRIPTION
The test helpers test_zarr_sink_flush and test_zarr_multiscale_flush returned
void, so the error their callees report never reached a test.
test_zarr_sink_flush now returns it, and all eleven call sites in
test_cpu_zarr_fs.c, test_zarr_fs_sink.c, test_zarr_readback.c and
test_zarr_s3_sink.c check it. Nine sit between a writer_flush that had to
succeed and a check of what reached the store, so none of them wanted the
error dropped. At the other two the flush return is the only signal:
test_zarr_readback flushed and then returned success with nothing checked in
between, and test_zarr_s3_sink drives the shard sink directly with no writer.
That S3 site also checks more than a drain, because pool_s3_flush finalizes an
upload left open and returns that error.

test_zarr_multiscale_flush is deleted rather than widened. It has had no caller
since it was added, so its return value could never be observed.

A new case in test_flush_error_drain_cpu.c has the shape of a real call site:
it writes an epoch, flushes the writer, makes one queued operation fail, and
requires the sink flush to report it while the shard file such a site would
check is whole on disk. Nothing else asserted that a zarr array flush surfaces
a pool error. It carries a 60 second bound, like the other tests that wait on
the io queue.

Closes #240
