### PR TITLE
Take fault scheduling at create time

### DIFF
--- a/tests/test_destroy_drain.c
+++ b/tests/test_destroy_drain.c
@@ -70,7 +70,7 @@ test_destroy_waits_for_sink_io(const char* tmpdir)
   CHECK(Cleanup,
         test_zarr_sink_open_with_pool(
           &z,
-          io_faults_store_create(&faults, tmpdir, 1),
+          io_faults_store_create(&faults, tmpdir, 1, NULL),
           "0",
           dims,
           3,

--- a/tests/test_destroy_midstream.c
+++ b/tests/test_destroy_midstream.c
@@ -254,7 +254,7 @@ test_destroy_blocks_on_gated_sink(const char* tmpdir)
   CHECK(Cleanup,
         test_zarr_sink_open_with_pool(
           &z,
-          io_faults_store_create(&faults, tmpdir, 0),
+          io_faults_store_create(&faults, tmpdir, 0, NULL),
           "0",
           dims,
           3,

--- a/tests/test_flush_drain_cpu.c
+++ b/tests/test_flush_drain_cpu.c
@@ -76,7 +76,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
   CHECK(Cleanup,
         test_zarr_sink_open_with_pool(
           &z,
-          io_faults_store_create(&faults, tmpdir, /*unbuffered=*/1),
+          io_faults_store_create(&faults, tmpdir, /*unbuffered=*/1, NULL),
           "0",
           dims,
           3,

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -74,7 +74,7 @@ test_flush_waits_for_sink_io(const char* tmpdir)
   CHECK(Cleanup,
         test_zarr_sink_open_with_pool(
           &z,
-          io_faults_store_create(&faults, tmpdir, 1),
+          io_faults_store_create(&faults, tmpdir, 1, NULL),
           "0",
           dims,
           3,
@@ -184,7 +184,7 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
   CHECK(Cleanup,
         test_zarr_sink_open_with_pool(
           &z,
-          io_faults_store_create(&faults, tmpdir, 1),
+          io_faults_store_create(&faults, tmpdir, 1, NULL),
           "0",
           dims,
           3,

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -136,7 +136,7 @@ test_sink_flush_reports_io_failure(const char* tmpdir)
   CHECK(Cleanup,
         test_zarr_sink_open_with_pool(
           &z,
-          io_faults_store_create(&faults, tmpdir, /*unbuffered=*/0),
+          io_faults_store_create(&faults, tmpdir, /*unbuffered=*/0, NULL),
           "0",
           dims,
           3,

--- a/tests/test_flush_error_drain_cpu.c
+++ b/tests/test_flush_error_drain_cpu.c
@@ -51,7 +51,7 @@ test_flush_reports_queued_truncate_failure(const char* tmpdir)
   CHECK(Cleanup,
         test_zarr_sink_open_with_pool(
           &z,
-          io_faults_store_create(&faults, tmpdir, /*unbuffered=*/1),
+          io_faults_store_create(&faults, tmpdir, /*unbuffered=*/1, NULL),
           "0",
           dims,
           3,

--- a/tests/test_io_faults.c
+++ b/tests/test_io_faults.c
@@ -63,12 +63,13 @@ static struct shard_pool*
 pool_create(struct io_faults* f,
             const char* root,
             uint64_t nslots,
-            int unbuffered)
+            int unbuffered,
+            const struct io_scheduling* io)
 {
   f->pool = shard_pool_fs_create_wrapped(root,
                                          nslots,
                                          unbuffered,
-                                         &f->io,
+                                         io,
                                          (struct shard_pool_fs_wrapper){
                                            .ctx = f,
                                            .wrap = faults_wrap,
@@ -85,15 +86,7 @@ io_faults_pool_create(struct io_faults* f,
                       const struct io_scheduling* io)
 {
   memset(f, 0, sizeof(*f));
-  if (io)
-    f->io = *io;
-  return pool_create(f, root, nslots, unbuffered);
-}
-
-void
-io_faults_set_io_scheduling(struct io_faults* f, struct io_scheduling io)
-{
-  f->io = io;
+  return pool_create(f, root, nslots, unbuffered, io);
 }
 
 // --- Store ---
@@ -105,6 +98,7 @@ struct faults_store
   struct io_faults* faults;
   struct strbuf root; // owned
   int unbuffered;
+  struct io_scheduling io; // held until the pool is built
 };
 
 static int
@@ -138,7 +132,8 @@ faults_store_create_pool(struct store* self, uint64_t nslots)
   // A second pool would leave the first pool's queue calling the wrong
   // backend.
   CHECK(Fail, !s->faults->pool);
-  return pool_create(s->faults, strbuf_cstr(&s->root), nslots, s->unbuffered);
+  return pool_create(
+    s->faults, strbuf_cstr(&s->root), nslots, s->unbuffered, &s->io);
 Fail:
   return NULL;
 }
@@ -153,7 +148,10 @@ faults_store_destroy(struct store* self)
 }
 
 struct store*
-io_faults_store_create(struct io_faults* f, const char* root, int unbuffered)
+io_faults_store_create(struct io_faults* f,
+                       const char* root,
+                       int unbuffered,
+                       const struct io_scheduling* io)
 {
   memset(f, 0, sizeof(*f));
 
@@ -167,6 +165,8 @@ io_faults_store_create(struct io_faults* f, const char* root, int unbuffered)
   s->base.destroy = faults_store_destroy;
   s->faults = f;
   s->unbuffered = unbuffered;
+  if (io)
+    s->io = *io;
   CHECK(Fail_alloc, strbuf_set(&s->root, root) == 0);
 
   s->inner = store_fs_create(root, unbuffered);

--- a/tests/test_io_faults.h
+++ b/tests/test_io_faults.h
@@ -29,8 +29,6 @@ struct io_faults
   // the low, so that a request reads both as one value.
   _Atomic uint16_t armed;
   _Atomic int* block_gate;
-
-  struct io_scheduling io; // zero fields take the pool's own defaults
 };
 
 // Create a filesystem shard pool whose io can be made to fail or block.
@@ -42,15 +40,14 @@ io_faults_pool_create(struct io_faults* f,
                       int unbuffered,
                       const struct io_scheduling* io);
 
-// Set the write scheduling a later pool is built with. A store builds its pool
-// after it is created, so this is how that pool's scheduling is chosen.
-void
-io_faults_set_io_scheduling(struct io_faults* f, struct io_scheduling io);
-
 // Create a filesystem store whose pool can be made to fail or block. Only one
 // pool can be built from it, even after that pool is destroyed.
+// io: how much of the write backlog runs at once; NULL takes the defaults.
 struct store*
-io_faults_store_create(struct io_faults* f, const char* root, int unbuffered);
+io_faults_store_create(struct io_faults* f,
+                       const char* root,
+                       int unbuffered,
+                       const struct io_scheduling* io);
 
 // Queue a job that marks the pool errored when it runs. Returns 0 on a
 // successful enqueue.

--- a/tests/test_io_faults.h
+++ b/tests/test_io_faults.h
@@ -32,7 +32,7 @@ struct io_faults
 };
 
 // Create a filesystem shard pool whose io can be made to fail or block.
-// io: the limits on writes run at once; NULL for the defaults.
+// io: the limit on the write backlog run at once; NULL for the defaults.
 struct shard_pool*
 io_faults_pool_create(struct io_faults* f,
                       const char* root,
@@ -42,7 +42,7 @@ io_faults_pool_create(struct io_faults* f,
 
 // Create a filesystem store whose pool can be made to fail or block. Only one
 // pool can be built from it, even after that pool is destroyed.
-// io: the limits on writes run at once; NULL for the defaults.
+// io: the limit on the write backlog run at once; NULL for the defaults.
 struct store*
 io_faults_store_create(struct io_faults* f,
                        const char* root,

--- a/tests/test_io_faults.h
+++ b/tests/test_io_faults.h
@@ -32,7 +32,7 @@ struct io_faults
 };
 
 // Create a filesystem shard pool whose io can be made to fail or block.
-// io: how much of the write backlog runs at once; NULL takes the defaults.
+// io: the limits on writes run at once; NULL for the defaults.
 struct shard_pool*
 io_faults_pool_create(struct io_faults* f,
                       const char* root,
@@ -42,7 +42,7 @@ io_faults_pool_create(struct io_faults* f,
 
 // Create a filesystem store whose pool can be made to fail or block. Only one
 // pool can be built from it, even after that pool is destroyed.
-// io: how much of the write backlog runs at once; NULL takes the defaults.
+// io: the limits on writes run at once; NULL for the defaults.
 struct store*
 io_faults_store_create(struct io_faults* f,
                        const char* root,

--- a/tests/test_store_fs.c
+++ b/tests/test_store_fs.c
@@ -354,8 +354,8 @@ Fail:
 #define HELD_WRITE_BYTES 4096
 #define HELD_WRITES 8
 
-// The pool is built after the store, so the scheduling has to survive until
-// then. At one request in flight nothing behind the gated job can run.
+// The pool is built after the store, so the scheduling must be kept until
+// then. With one request in flight, nothing behind the gated job is started.
 static int
 test_store_scheduling_reaches_pool(void)
 {
@@ -393,7 +393,7 @@ test_store_scheduling_reaches_pool(void)
   CHECK(Fail3, shard_pool_pending_bytes(pool) == 0);
 
   // On the defaults the gated job would be overlapped with the writes behind
-  // it, so a depth of one means the scheduling arrived.
+  // it. A depth of one is proof that the scheduling was applied.
   struct shard_pool_io_stats io;
   shard_pool_io_stats(pool, &io);
   CHECK(Fail3, io.queue.writes_in_flight_peak == 1);

--- a/tests/test_store_fs.c
+++ b/tests/test_store_fs.c
@@ -286,25 +286,23 @@ static int
 test_shard_pool_io_stats(void)
 {
   log_info("=== test_shard_pool_io_stats ===");
-  struct io_faults faults;
-  struct store* s = io_faults_store_create(&faults, tmpdir, 0);
-  CHECK(Fail, s);
-  CHECK(Fail2, s->mkdirs(s, "stats") == 0);
 
   // One worker running one write at a time, so the injected blocking job
   // holds up everything behind it. A queued close keeps its handle, so all
   // six files stay open.
-  io_faults_set_io_scheduling(&faults,
-                              (struct io_scheduling){
-                                .workers = 1,
-                                .writes_in_flight = 1,
-                                .writes_in_flight_per_file = 1,
-                              });
+  const struct io_scheduling scheduling = { .workers = 1,
+                                            .writes_in_flight = 1,
+                                            .writes_in_flight_per_file = 1 };
+  struct io_faults faults;
+  struct store* s = io_faults_store_create(&faults, tmpdir, 0, &scheduling);
+  CHECK(Fail, s);
+  CHECK(Fail2, s->mkdirs(s, "stats") == 0);
+
   struct shard_pool* pool = s->create_pool(s, 2);
   CHECK(Fail2, pool);
 
   atomic_int gate = 0;
-  CHECK(Fail3, io_faults_inject_blocking_job(&faults, &gate) == 0);
+  CHECK(Fail4, io_faults_inject_blocking_job(&faults, &gate) == 0);
 
   for (int i = 0; i < 6; ++i) {
     char key[256];
@@ -347,6 +345,72 @@ Fail3:
 Fail2:
   s->destroy(s);
 Fail:
+  log_error("  FAIL");
+  return 1;
+}
+
+// --- store scheduling ---
+
+#define HELD_WRITE_BYTES 4096
+#define HELD_WRITES 8
+
+// The pool is built after the store, so the scheduling has to survive until
+// then. At one request in flight nothing behind the gated job can run.
+static int
+test_store_scheduling_reaches_pool(void)
+{
+  log_info("=== test_store_scheduling_reaches_pool ===");
+
+  const struct io_scheduling scheduling = { .workers = 1,
+                                            .writes_in_flight = 1,
+                                            .writes_in_flight_per_file = 1 };
+  struct io_faults faults;
+  struct store* s = io_faults_store_create(&faults, tmpdir, 0, &scheduling);
+  CHECK(Fail, s);
+  CHECK(Fail2, s->mkdirs(s, "scheduling") == 0);
+
+  struct shard_pool* pool = s->create_pool(s, 1);
+  CHECK(Fail2, pool);
+
+  struct shard_writer* w = pool->open(pool, 0, "scheduling/held.bin");
+  CHECK(Fail3, w);
+
+  atomic_int gate = 0;
+  CHECK(Fail4, io_faults_inject_blocking_job(&faults, &gate) == 0);
+
+  static const char payload[HELD_WRITE_BYTES] = { 0 };
+  for (uint64_t i = 0; i < HELD_WRITES; ++i)
+    CHECK(Fail4,
+          w->write(
+            w, i * HELD_WRITE_BYTES, payload, payload + HELD_WRITE_BYTES) == 0);
+
+  CHECK(Fail4,
+        shard_pool_pending_bytes(pool) ==
+          (uint64_t)HELD_WRITES * HELD_WRITE_BYTES);
+
+  atomic_store(&gate, 1);
+  CHECK(Fail3, pool->flush(pool) == 0);
+  CHECK(Fail3, shard_pool_pending_bytes(pool) == 0);
+
+  // On the defaults the gated job would be overlapped with the writes behind
+  // it, so a depth of one means the scheduling arrived.
+  struct shard_pool_io_stats io;
+  shard_pool_io_stats(pool, &io);
+  CHECK(Fail3, io.queue.writes_in_flight_peak == 1);
+
+  shard_pool_destroy(pool);
+  s->destroy(s);
+  log_info("  PASS");
+  return 0;
+
+Fail4:
+  atomic_store(&gate, 1);
+Fail3:
+  shard_pool_destroy(pool);
+Fail2:
+  s->destroy(s);
+Fail:
+  log_error("  FAIL");
   return 1;
 }
 
@@ -813,6 +877,7 @@ main(void)
   err |= test_shard_pool_on_demand_mkdir();
   err |= test_shard_pool_unbuffered();
   err |= test_shard_pool_io_stats();
+  err |= test_store_scheduling_reaches_pool();
   err |= test_shard_pool_error_propagation();
   err |= test_shard_pool_presize();
   err |= test_stale_file_token_refused();

--- a/tests/test_store_fs.c
+++ b/tests/test_store_fs.c
@@ -354,8 +354,8 @@ Fail:
 #define HELD_WRITE_BYTES 4096
 #define HELD_WRITES 8
 
-// The pool is built after the store, so the scheduling must be kept until
-// then. With one request in flight, nothing behind the gated job is started.
+// The pool is built after the store, so the scheduling must be kept until then.
+// With one request in flight, nothing behind the gated job can be started.
 static int
 test_store_scheduling_reaches_pool(void)
 {
@@ -393,7 +393,7 @@ test_store_scheduling_reaches_pool(void)
   CHECK(Fail3, shard_pool_pending_bytes(pool) == 0);
 
   // On the defaults the gated job would be overlapped with the writes behind
-  // it. A depth of one is proof that the scheduling was applied.
+  // it. A depth of one means the pool was given the scheduling.
   struct shard_pool_io_stats io;
   shard_pool_io_stats(pool, &io);
   CHECK(Fail3, io.queue.writes_in_flight_peak == 1);


### PR DESCRIPTION
The field written by io_faults_set_io_scheduling was cleared by
io_faults_store_create and io_faults_pool_create. A scheduling asked for
before the create was silently dropped and the pool left on its defaults. A
zero field is a request for the default, so the loss was indistinguishable
from a choice.

The scheduling is now an argument to both creates, and the setter is gone.
It is held in the store beside the root and the buffering flag until the
pool is built, so no order is left to get wrong. NULL is passed everywhere
the defaults are fine.

A new test is added in tests/test_store_fs.c. A store is created with one
worker and one request in flight, a job is held at a gate, and the eight
writes behind it must still be pending, with the pool's greatest depth at
one. On the defaults neither is true. The FAIL line missing from
test_shard_pool_io_stats is added, and in both tests the gate is now opened
on every teardown path.

Closes #239
