### PR TITLE
Improve GPU CSR diagnostics and development setup

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,7 +6,8 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CHUCKY_ENABLE_GPU": "ON"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ The default build targets SM 100 (Blackwell). For other GPUs, set
 
 ### Build
 
-The build auto-detects CUDA. If a CUDA compiler is found, GPU backends are
-enabled automatically. To force a CPU-only build, use the `cpu-only` preset or
-pass `-DCHUCKY_ENABLE_GPU=OFF`.
+The default preset enables the GPU backend. To force a CPU-only build, use the
+`cpu-only` preset or pass `-DCHUCKY_ENABLE_GPU=OFF`. When
+`CHUCKY_ENABLE_GPU` is not set explicitly, the CMake option still auto-detects
+CUDA.
 
 ```
-# Full build (auto-detects CUDA)
+# Full build (GPU + CPU)
 cmake --preset default
 cmake --build build
 

--- a/bench/machines.toml
+++ b/bench/machines.toml
@@ -67,6 +67,8 @@ storage = "shared /mnt/main0"
 [[machine]]
 name = "auk"
 names = ["auk"]
+[machine.specs]
+storage = "2 TB Lexar NM790 NVMe SSD; measured 4.3 GB/s sequential direct write (64 GiB)"
 
 [[machine]]
 name = "oreb"

--- a/dev/devlog.md
+++ b/dev/devlog.md
@@ -45,9 +45,19 @@ Cleanup
 - [x] medfmt and smallepoch scenarios need some analysis/optimization
 - [ ] move bench sweep data to it's own repo
 
+## 2026-08-30
+
+Hello again devlog, it's been some time.
+
+The past few months have seen me making performance worse :/ Trying to take
+notes here to organize my thoughts around what's going wrong.
+
+- With compression, there's a problem transmitting bytes back to the host.
+- When IO has latency spikes, write performance degrades.
+
 ## 2026-04-01
 
-Noticed ls4 isn't supported by the zarr v3 spec! So so silly. Will warn here
+Noticed lz4 isn't supported by the zarr v3 spec! So so silly. Will warn here
 and rip out the thing I just did for acquire-zarr.
 
 ## 2026-03-31

--- a/flake.lock
+++ b/flake.lock
@@ -23,6 +23,29 @@
         "type": "github"
       }
     },
+    "codex-cli": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787798436,
+        "narHash": "sha256-sgQx7yUo2I1c4McylOW1vRklIxDL3Kwzq35ilr7firc=",
+        "owner": "sadjow",
+        "repo": "codex-cli-nix",
+        "rev": "18eb1cac4e17c8cbc40f3a2a83940d8f38ddace5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sadjow",
+        "repo": "codex-cli-nix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -119,6 +142,7 @@
     "root": {
       "inputs": {
         "claude-code": "claude-code",
+        "codex-cli": "codex-cli",
         "flake-utils": "flake-utils",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,9 @@
     claude-code.url = "github:sadjow/claude-code-nix";
     claude-code.inputs.nixpkgs.follows = "nixpkgs";
     claude-code.inputs.flake-utils.follows = "flake-utils";
+    codex-cli.url = "github:sadjow/codex-cli-nix";
+    codex-cli.inputs.nixpkgs.follows = "nixpkgs";
+    codex-cli.inputs.flake-utils.follows = "flake-utils";
     git-hooks.url = "github:cachix/git-hooks.nix";
     git-hooks.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -17,6 +20,7 @@
       nixpkgs,
       flake-utils,
       claude-code,
+      codex-cli,
       git-hooks,
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -57,6 +61,8 @@
           c-blosc
           lz4Static
           zstdStatic
+          zlib
+          snappy
           # s3 writer
           aws-c-common
           aws-c-cal
@@ -161,6 +167,7 @@
             commonNativeBuildInputs
             ++ (with pkgs; [
               claude-code.packages.${system}.default
+              codex-cli.packages.${system}.default
               docker
               gdb
               gh

--- a/src/gpu/lod.cu
+++ b/src/gpu/lod.cu
@@ -975,22 +975,12 @@ lod_build_csr_gpu_launch(CUdeviceptr d_starts,
   CUdeviceptr d_cub_temp = 0, d_params = 0;
   int ret = 1;
 
-  CUresult r;
-  r = cuMemAlloc(&d_params, sizeof(csr_level_params));
-  if (r != CUDA_SUCCESS)
-    goto cleanup;
-  r = cuMemcpyHtoD(d_params, p, sizeof(csr_level_params));
-  if (r != CUDA_SUCCESS)
-    goto cleanup;
-  r = cuMemAlloc(&d_map, 2 * src_total * sizeof(uint64_t));
-  if (r != CUDA_SUCCESS)
-    goto cleanup;
-  r = cuMemAlloc(&d_counts, dst_total * sizeof(uint64_t));
-  if (r != CUDA_SUCCESS)
-    goto cleanup;
-  r = cuMemsetD8Async(d_counts, 0, dst_total * sizeof(uint64_t), stream);
-  if (r != CUDA_SUCCESS)
-    goto cleanup;
+  CU(cleanup, cuMemAlloc(&d_params, sizeof(csr_level_params)));
+  CU(cleanup, cuMemcpyHtoD(d_params, p, sizeof(csr_level_params)));
+  CU(cleanup, cuMemAlloc(&d_map, 2 * src_total * sizeof(uint64_t)));
+  CU(cleanup, cuMemAlloc(&d_counts, dst_total * sizeof(uint64_t)));
+  CU(cleanup,
+     cuMemsetD8Async(d_counts, 0, dst_total * sizeof(uint64_t), stream));
 
   // Step 1+2: Map + histogram.
   CUDA_LAUNCH_OR(cleanup,
@@ -1011,9 +1001,7 @@ lod_build_csr_gpu_launch(CUdeviceptr d_starts,
                                                (int)dst_total,
                                                stream));
     if (cub_temp_bytes > 0) {
-      r = cuMemAlloc(&d_cub_temp, cub_temp_bytes);
-      if (r != CUDA_SUCCESS)
-        goto cleanup;
+      CU(cleanup, cuMemAlloc(&d_cub_temp, cub_temp_bytes));
     }
     CUDA_CALL_OR(cleanup,
                  cub::DeviceScan::ExclusiveSum((void*)d_cub_temp,
@@ -1027,19 +1015,15 @@ lod_build_csr_gpu_launch(CUdeviceptr d_starts,
   // Sentinel: starts[dst_total] = src_total.  Writes a non-overlapping
   // element past the prefix-sum output, so no sync needed before this.
   // Synchronous copy — 8 bytes, safe from stack, negligible at init time.
-  r = cuMemcpyHtoD(
-    d_starts + dst_total * sizeof(uint64_t), &src_total, sizeof(uint64_t));
-  if (r != CUDA_SUCCESS)
-    goto cleanup;
+  CU(cleanup,
+     cuMemcpyHtoD(
+       d_starts + dst_total * sizeof(uint64_t), &src_total, sizeof(uint64_t)));
 
   // Step 4: Scatter into indices.
-  r = cuMemAlloc(&d_write_pos, dst_total * sizeof(uint64_t));
-  if (r != CUDA_SUCCESS)
-    goto cleanup;
-  r = cuMemcpyDtoDAsync(
-    d_write_pos, d_starts, dst_total * sizeof(uint64_t), stream);
-  if (r != CUDA_SUCCESS)
-    goto cleanup;
+  CU(cleanup, cuMemAlloc(&d_write_pos, dst_total * sizeof(uint64_t)));
+  CU(cleanup,
+     cuMemcpyDtoDAsync(
+       d_write_pos, d_starts, dst_total * sizeof(uint64_t), stream));
 
   CUDA_LAUNCH_OR(
     cleanup,

--- a/src/gpu/reduce_csr_gpu.c
+++ b/src/gpu/reduce_csr_gpu.c
@@ -2,6 +2,8 @@
 
 #include "gpu/lod.h"
 #include "gpu/prelude.cuda.h"
+#include "lod/lod_plan.h"
+#include "util/prelude.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -11,13 +13,14 @@ reduce_csr_gpu_alloc(struct reduce_csr_gpu* csr,
                      uint64_t src_total,
                      uint64_t dst_total)
 {
+  CHECK(Fail, csr);
   memset(csr, 0, sizeof(*csr));
   csr->batch_count = 1;
   csr->dst_segment_size = dst_total;
   csr->src_lod_count = src_total;
 
-  if (src_total == 0 || dst_total == 0)
-    return 0;
+  CHECK(Fail, src_total > 0);
+  CHECK(Fail, dst_total > 0);
 
   CU(Fail, cuMemAlloc(&csr->starts, (dst_total + 1) * sizeof(uint64_t)));
   CU(Fail, cuMemAlloc(&csr->indices, src_total * sizeof(uint64_t)));
@@ -34,9 +37,30 @@ reduce_csr_gpu_build(struct reduce_csr_gpu* csr,
                      const struct level_dims* dst,
                      CUstream stream)
 {
-  if (csr->src_lod_count == 0 || csr->dst_segment_size == 0)
-    return 0;
-  return lod_build_csr_gpu(csr->starts, csr->indices, src, dst, stream);
+  CHECK(Fail, csr);
+  CHECK(Fail, src);
+  CHECK(Fail, dst);
+
+  CHECK_MUL_OVERFLOW(Fail, src->fixed_dims_count, src->lod_nelem, UINT64_MAX);
+  const uint64_t src_total = src->fixed_dims_count * src->lod_nelem;
+  CHECK(Fail, src_total > 0);
+
+  CHECK_MUL_OVERFLOW(Fail, dst->fixed_dims_count, dst->lod_nelem, UINT64_MAX);
+  const uint64_t dst_total = dst->fixed_dims_count * dst->lod_nelem;
+  CHECK(Fail, dst_total > 0);
+
+  CHECK(Fail, csr->src_lod_count == src_total);
+  CHECK(Fail, csr->dst_segment_size == dst_total);
+  CHECK(Fail, csr->src_lod_count > 0);
+  CHECK(Fail, csr->dst_segment_size > 0);
+  CHECK(Fail, csr->starts);
+  CHECK(Fail, csr->indices);
+  CHECK(Fail,
+        lod_build_csr_gpu(csr->starts, csr->indices, src, dst, stream) == 0);
+  return 0;
+
+Fail:
+  return 1;
 }
 
 void

--- a/src/gpu/reduce_csr_gpu.h
+++ b/src/gpu/reduce_csr_gpu.h
@@ -23,7 +23,7 @@ extern "C"
   };
 
   // Allocate device memory for starts/indices sized by src_total/dst_total.
-  // If either is zero, allocates nothing and returns success; build is a no-op.
+  // Both totals must be non-zero.
   // On failure leaves *csr in a state safe to pass to reduce_csr_gpu_free.
   // Returns 0 on success, non-zero on failure.
   int reduce_csr_gpu_alloc(struct reduce_csr_gpu* csr,

--- a/src/gpu/stream.lod.c
+++ b/src/gpu/stream.lod.c
@@ -40,7 +40,6 @@ Fail:
 }
 
 // Compute LOD strides, upload to GPU, and build gather LUT.
-// Owns d_lod_strides — freed in both success and failure paths.
 static int
 build_gather_lut_with_strides(struct lod_state* lod,
                               const struct lod_plan* p,
@@ -170,8 +169,15 @@ init_csr_reduce_luts(struct lod_state* lod)
     const struct level_dims* src_ld = &lod->plan.levels.level[l];
     const struct level_dims* dst_ld = &lod->plan.levels.level[l + 1];
 
-    uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+    CHECK_MUL_OVERFLOW(
+      Fail, src_ld->fixed_dims_count, src_ld->lod_nelem, UINT64_MAX);
     uint64_t src_total = src_ld->fixed_dims_count * src_ld->lod_nelem;
+    CHECK(Fail, src_total > 0);
+
+    CHECK_MUL_OVERFLOW(
+      Fail, dst_ld->fixed_dims_count, dst_ld->lod_nelem, UINT64_MAX);
+    uint64_t dst_total = dst_ld->fixed_dims_count * dst_ld->lod_nelem;
+    CHECK(Fail, dst_total > 0);
 
     CHECK(Fail, reduce_csr_gpu_alloc(&lod->csrs[l], src_total, dst_total) == 0);
     CHECK(Fail, reduce_csr_gpu_build(&lod->csrs[l], src_ld, dst_ld, 0) == 0);


### PR DESCRIPTION
## Summary

- validate GPU CSR totals immediately after computation and recheck the CSR geometry and allocation preconditions at the build boundary
- report CUDA driver failures from CSR workspace allocation and copy operations instead of returning an unexplained generic failure
- make the default CMake preset explicitly enable the GPU backend and update the corresponding build documentation
- add Codex, zlib, and Snappy to the Nix development environment
- include the Auk benchmark metadata and current devlog updates

## Validation

- `cmake --list-presets`
- `nix fmt -- --ci`
- `nix flake check --no-build`
- `cmake --build build --target bench_stream_orca2_multiscale test_lod -j2`
- focused GPU LOD test passed
- full test run passed 57 of 59 tests; `test-test_zarr_s3_sink` and `test-test_store_s3` require a running MinIO service and failed because it was unavailable
- reproduced the original multiscale benchmark failure and confirmed it now reports `CUDA_ERROR_OUT_OF_MEMORY` at the `d_map` allocation before the propagated checks
