### PR TITLE
Remove compress-aggregate LUT debug logging

### DIFF
--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -169,14 +169,6 @@ compress_agg_destroy_shared(struct compress_agg_stage* stage)
     stage->t_compress_end[fc] = NULL;
     stage->t_aggregate_start[fc] = NULL;
   }
-  if (stage->lut_steady_count + stage->lut_recompute_count > 0) {
-    const uint64_t tot = stage->lut_steady_count + stage->lut_recompute_count;
-    log_debug("compress_agg unified lut_steady=%llu lut_recompute=%llu "
-              "(steady=%.1f%%)",
-              (unsigned long long)stage->lut_steady_count,
-              (unsigned long long)stage->lut_recompute_count,
-              100.0 * (double)stage->lut_steady_count / (double)tot);
-  }
   for (int fc = 0; fc < 2; ++fc)
     aggregate_slot_destroy(&stage->agg[fc]);
   cu_mem_free(stage->d_batch_gather);
@@ -516,12 +508,9 @@ build_and_upload_luts(struct compress_agg_stage* stage,
                (size_t)n_lv * sizeof(uint32_t)) != 0)
       lut_steady = 0;
   }
-  if (lut_steady) {
-    stage->lut_steady_count++;
+  if (lut_steady)
     return 0;
-  }
 
-  stage->lut_recompute_count++;
   if (layout->total_batch_chunks > 0) {
     aggregate_batch_luts_unified(layout,
                                  stage->ar.per_lod_agg_layouts,

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -238,8 +238,6 @@ struct compress_agg_stage
   uint32_t* cached_pool_epochs; // [LOD_MAX_LEVELS * pool_epochs_stride]
   uint32_t pool_epochs_stride;  // max K used by scratch + cache
   int lut_cache_valid;
-  uint64_t lut_steady_count;
-  uint64_t lut_recompute_count;
 
   // Per-shard tables shared across arrays (sized to maxima).
   struct shard_tables shards;

--- a/tests/test_compress_agg.c
+++ b/tests/test_compress_agg.c
@@ -771,7 +771,6 @@ test_compress_agg_lut_cache_position_shift(void)
   // Kick 2: only epoch 1 active (mask [0, 1]).
   // Same n_active=1 as kick 1, but pool_epochs=[1] — a steady-state cache
   // keyed on counts alone would mis-hit and gather from epoch 0 instead.
-  uint64_t lut_recompute_before = c.stage.lut_recompute_count;
   c.batch_active_masks[0] = 0x0;
   c.batch_active_masks[1] = 0x1;
   struct flush_handoff handoff2;
@@ -790,10 +789,6 @@ test_compress_agg_lut_cache_position_shift(void)
             0);
     CU(Fail, cuStreamSynchronize(c.compute));
   }
-
-  // The cache must have missed (recompute count incremented) because the
-  // pool_epoch values changed even though n_active didn't.
-  CHECK(Fail, c.stage.lut_recompute_count > lut_recompute_before);
 
   // The aggregated data must reflect epoch 1, not epoch 0.
   uint64_t C = handoff2.per_lod_agg_layouts[0].covering_count;


### PR DESCRIPTION
Summary:
- Remove the compress-aggregate LUT cache debug summary and its diagnostic counters.
- Keep the cache-position regression focused on byte-exact output behavior.
- Confirm no test or benchmark report parser consumes the removed log line; logs use stderr while sweep results parse stdout JSON.

Validation:
- clang-format --dry-run --Werror on changed C sources
- cmake --preset default -DCMAKE_BUILD_TYPE=Debug
- cmake --build build
- ctest --test-dir build --output-on-failure excluding S3: 57/57 passed