### PR TITLE
Clarify pipeline diagnostics in benchmark reports

### DIFF
--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -4,6 +4,85 @@
 #include "util/metric.h"
 #include "zarr/json_writer.h"
 
+enum diagnostic_section
+{
+  DIAGNOSTIC_HOST_BLOCK,
+  DIAGNOSTIC_PIPELINE_GAP,
+  DIAGNOSTIC_HOST_OVERHEAD,
+};
+
+struct diagnostic_entry
+{
+  const char* id;    // stable machine-readable identity
+  const char* label; // condition or work visible to a person
+  const char* kind;  // distinguishes waits from gaps and host work
+  enum diagnostic_section section;
+  const struct stream_metric* metric;
+};
+
+#define DIAGNOSTIC_COUNT 11
+
+static void
+diagnostic_entries(const struct stream_metrics* m,
+                   struct diagnostic_entry out[DIAGNOSTIC_COUNT])
+{
+  out[0] = (struct diagnostic_entry){ "batch_drain",
+                                      "Batch drain (wait/work)",
+                                      "host_block",
+                                      DIAGNOSTIC_HOST_BLOCK,
+                                      &m->flush_stall };
+  out[1] = (struct diagnostic_entry){ "d2h_dispatch",
+                                      "D2H dispatch work",
+                                      "host_overhead",
+                                      DIAGNOSTIC_HOST_OVERHEAD,
+                                      &m->drain_dispatch };
+  out[2] = (struct diagnostic_entry){ "output_slot_io",
+                                      "Output-slot writes",
+                                      "host_wait",
+                                      DIAGNOSTIC_HOST_BLOCK,
+                                      &m->io_fence_stall };
+  out[3] = (struct diagnostic_entry){ "footer_buffer_io",
+                                      "Footer-buffer write",
+                                      "host_wait",
+                                      DIAGNOSTIC_HOST_BLOCK,
+                                      &m->footer_buffer_stall };
+  out[4] = (struct diagnostic_entry){ "append_extent_io",
+                                      "Closed-shard writes",
+                                      "host_wait",
+                                      DIAGNOSTIC_HOST_BLOCK,
+                                      &m->append_extent_stall };
+  out[5] = (struct diagnostic_entry){ "final_io",
+                                      "Final queued writes",
+                                      "host_wait",
+                                      DIAGNOSTIC_HOST_BLOCK,
+                                      &m->flush_writes_stall };
+  out[6] = (struct diagnostic_entry){ "sink_backpressure",
+                                      "Sink queue below limit",
+                                      "host_wait",
+                                      DIAGNOSTIC_HOST_BLOCK,
+                                      &m->backpressure };
+  out[7] = (struct diagnostic_entry){ "prior_tail_state",
+                                      "Prior tail state",
+                                      "pipeline_gap",
+                                      DIAGNOSTIC_PIPELINE_GAP,
+                                      &m->tail_gate };
+  out[8] = (struct diagnostic_entry){ "staging_reuse",
+                                      "Staging-buffer reuse",
+                                      "host_wait",
+                                      DIAGNOSTIC_HOST_BLOCK,
+                                      &m->edge_stall[0] };
+  out[9] = (struct diagnostic_entry){ "chunk_metadata_d2h",
+                                      "Chunk offsets/sizes D2H",
+                                      "host_wait",
+                                      DIAGNOSTIC_HOST_BLOCK,
+                                      &m->edge_stall[1] };
+  out[10] = (struct diagnostic_entry){ "payload_d2h",
+                                       "Payload D2H",
+                                       "host_wait",
+                                       DIAGNOSTIC_HOST_BLOCK,
+                                       &m->edge_stall[2] };
+}
+
 // --- Throughput helpers ---
 
 double
@@ -81,6 +160,118 @@ print_metric_row(const struct stream_metric* m)
   } else {
     print_report(
       "  %-12s %8.2f %8s %10.2f %10s", m->name, avg_gbs, "-", avg_ms, "-");
+  }
+}
+
+static int
+diagnostic_measured(const struct stream_metric* m)
+{
+  return m->count > 0 || m->wait_calls > 0;
+}
+
+static void
+print_diagnostic_row(const struct diagnostic_entry* d, float wall_s)
+{
+  const struct stream_metric* m = d->metric;
+  const double wall_pct = wall_s > 0 ? (double)m->ms / (wall_s * 10.0) : 0.0;
+  char wait_calls[24];
+  if (m->wait_calls > 0)
+    snprintf(wait_calls,
+             sizeof(wait_calls),
+             "%llu",
+             (unsigned long long)m->wait_calls);
+  else
+    snprintf(wait_calls, sizeof(wait_calls), "-");
+
+  if (m->count > 0) {
+    print_report("  %-10s %-25s %8d %10s %9.3f %9.3f %7.2f",
+                 metric_owner_name(m->owner),
+                 d->label,
+                 m->count,
+                 wait_calls,
+                 (double)m->ms / m->count,
+                 (double)m->max_ms,
+                 wall_pct);
+  } else {
+    print_report("  %-10s %-25s %8d %10s %9s %9s %7.2f",
+                 metric_owner_name(m->owner),
+                 d->label,
+                 0,
+                 wait_calls,
+                 "-",
+                 "-",
+                 wall_pct);
+  }
+}
+
+static void
+print_diagnostic_section(const struct diagnostic_entry entries[],
+                         enum diagnostic_section section,
+                         const char* title,
+                         const char* interval_label,
+                         float wall_s)
+{
+  int have_section = 0;
+  for (size_t i = 0; i < DIAGNOSTIC_COUNT; ++i)
+    if (entries[i].section == section && diagnostic_measured(entries[i].metric))
+      have_section = 1;
+  if (!have_section)
+    return;
+
+  fputc('\n', stderr);
+  print_report("  --- %s ---", title);
+  print_report("  %-10s %-25s %8s %10s %9s %9s %7s",
+               "Timeline",
+               interval_label,
+               "samples",
+               "waits",
+               "avg ms",
+               "max ms",
+               "% wall");
+  for (size_t i = 0; i < DIAGNOSTIC_COUNT; ++i)
+    if (entries[i].section == section && diagnostic_measured(entries[i].metric))
+      print_diagnostic_row(&entries[i], wall_s);
+}
+
+void
+print_diagnostics_report(const struct stream_metrics* m, float wall_s)
+{
+  struct diagnostic_entry entries[DIAGNOSTIC_COUNT];
+  diagnostic_entries(m, entries);
+  print_diagnostic_section(entries,
+                           DIAGNOSTIC_HOST_BLOCK,
+                           "Host blocking",
+                           "Reason / awaited condition",
+                           wall_s);
+  print_diagnostic_section(entries,
+                           DIAGNOSTIC_PIPELINE_GAP,
+                           "Pipeline gaps",
+                           "Awaited condition",
+                           wall_s);
+  print_diagnostic_section(entries,
+                           DIAGNOSTIC_HOST_OVERHEAD,
+                           "Host overhead",
+                           "Measured work",
+                           wall_s);
+
+  if (m->scatter_samples_lost || m->lod_samples_lost) {
+    fputc('\n', stderr);
+    print_report("  TIMING SAMPLES LOST: scatter=%llu lod=%llu "
+                 "(stage totals under-report)",
+                 (unsigned long long)m->scatter_samples_lost,
+                 (unsigned long long)m->lod_samples_lost);
+  }
+  if (m->append_count > 0 || m->max_append_ms > 0) {
+    fputc('\n', stderr);
+    print_report("  --- Append latency ---");
+    print_append_latency(m);
+  }
+  if (m->peak_pending_bytes > 0) {
+    fputc('\n', stderr);
+    print_report("  --- Queue pressure ---");
+    char pbuf[32];
+    format_bytes(pbuf, sizeof(pbuf), m->peak_pending_bytes);
+    print_report("  peak pending:    %s", pbuf);
   }
 }
 
@@ -223,46 +414,7 @@ print_bench_report(const struct stream_metrics* metrics,
   print_metric_row(&metrics->d2h);
   print_metric_row(&metrics->sink);
 
-  // Stall stats — wall-clock time the host is blocked waiting. Emitted only
-  // if any stall was observed.
-  const size_t n_edge_stalls =
-    sizeof(metrics->edge_stall) / sizeof(metrics->edge_stall[0]);
-  int have_edge_stalls = 0;
-  for (size_t i = 0; i < n_edge_stalls; ++i)
-    if (metrics->edge_stall[i].count > 0)
-      have_edge_stalls = 1;
-  int have_stalls =
-    metrics->flush_stall.count > 0 || metrics->drain_dispatch.count > 0 ||
-    metrics->io_fence_stall.count > 0 ||
-    metrics->footer_buffer_stall.count > 0 ||
-    metrics->append_extent_stall.count > 0 ||
-    metrics->flush_writes_stall.count > 0 || metrics->backpressure.count > 0 ||
-    metrics->max_append_ms > 0 || metrics->peak_pending_bytes > 0 ||
-    metrics->tail_gate.count > 0 || metrics->scatter_samples_lost > 0 ||
-    metrics->lod_samples_lost > 0 || have_edge_stalls;
-  if (have_stalls) {
-    fputc('\n', stderr);
-    print_report("  --- Stall stats ---");
-    print_metric_row(&metrics->flush_stall);
-    print_metric_row(&metrics->drain_dispatch);
-    print_metric_row(&metrics->io_fence_stall);
-    print_metric_row(&metrics->footer_buffer_stall);
-    print_metric_row(&metrics->append_extent_stall);
-    print_metric_row(&metrics->flush_writes_stall);
-    print_metric_row(&metrics->backpressure);
-    print_metric_row(&metrics->tail_gate);
-    for (size_t i = 0; i < n_edge_stalls; ++i)
-      print_metric_row(&metrics->edge_stall[i]);
-    if (metrics->scatter_samples_lost || metrics->lod_samples_lost)
-      print_report("  TIMING SAMPLES LOST: scatter=%llu lod=%llu "
-                   "(stage totals under-report)",
-                   (unsigned long long)metrics->scatter_samples_lost,
-                   (unsigned long long)metrics->lod_samples_lost);
-    print_append_latency(metrics);
-    char pbuf[32];
-    format_bytes(pbuf, sizeof(pbuf), metrics->peak_pending_bytes);
-    print_report("  peak pending:    %s", pbuf);
-  }
+  print_diagnostics_report(metrics, wall_s);
 
   print_write_report(io);
 
@@ -322,6 +474,63 @@ json_stage_metric(struct json_writer* jw,
   jw_float(jw, in_gibs);
   jw_key(jw, "out_gibs");
   jw_float(jw, out_gibs);
+  jw_object_end(jw);
+}
+
+static void
+json_diagnostic_metric(struct json_writer* jw,
+                       const struct diagnostic_entry* d,
+                       float wall_s)
+{
+  const struct stream_metric* m = d->metric;
+  if (!diagnostic_measured(m))
+    return;
+
+  jw_key(jw, d->id);
+  jw_object_begin(jw);
+  jw_key(jw, "label");
+  jw_string(jw, d->label);
+  jw_key(jw, "kind");
+  jw_string(jw, d->kind);
+  jw_key(jw, "owner");
+  jw_string(jw, metric_owner_name(m->owner));
+  jw_key(jw, "total_ms");
+  jw_float(jw, (double)m->ms);
+  jw_key(jw, "samples");
+  jw_uint(jw, (uint64_t)m->count);
+  if (m->wait_calls > 0) {
+    jw_key(jw, "wait_calls");
+    jw_uint(jw, m->wait_calls);
+  }
+  if (m->count > 0) {
+    jw_key(jw, "avg_ms");
+    jw_float(jw, (double)m->ms / m->count);
+    if (m->best_ms < 1e29f) {
+      jw_key(jw, "min_ms");
+      jw_float(jw, (double)m->best_ms);
+    }
+    jw_key(jw, "max_ms");
+    jw_float(jw, (double)m->max_ms);
+  }
+  if (wall_s > 0) {
+    jw_key(jw, "wall_pct");
+    jw_float(jw, (double)m->ms / (wall_s * 10.0));
+  }
+  jw_object_end(jw);
+}
+
+static void
+json_diagnostics(struct json_writer* jw,
+                 const struct stream_metrics* m,
+                 float wall_s)
+{
+  struct diagnostic_entry entries[DIAGNOSTIC_COUNT];
+  diagnostic_entries(m, entries);
+
+  jw_key(jw, "diagnostics");
+  jw_object_begin(jw);
+  for (size_t i = 0; i < DIAGNOSTIC_COUNT; ++i)
+    json_diagnostic_metric(jw, &entries[i], wall_s);
   jw_object_end(jw);
 }
 
@@ -535,12 +744,17 @@ print_bench_json_pass(const struct stream_metrics* m,
   jw_object_end(&jw);
   jw_key(&jw, "edge_stalls");
   jw_object_begin(&jw);
+  // These keys shipped before display names and stable metric IDs were
+  // separated. Keep them frozen for existing JSON consumers.
+  static const char* legacy_edge_names[] = { "StagingFree",
+                                             "ChunkIndex",
+                                             "D2HDone" };
   for (size_t i = 0; i < sizeof(m->edge_stall) / sizeof(m->edge_stall[0]);
        ++i) {
     const struct stream_metric* es = &m->edge_stall[i];
     if (es->count <= 0 || !es->name)
       continue;
-    jw_key(&jw, es->name);
+    jw_key(&jw, legacy_edge_names[i]);
     jw_object_begin(&jw);
     jw_key(&jw, "owner");
     jw_string(&jw, metric_owner_name(es->owner));
@@ -584,6 +798,8 @@ print_bench_json_pass(const struct stream_metrics* m,
   jw_key(&jw, "peak_pending_mib");
   jw_float(&jw, (double)m->peak_pending_bytes / (1024.0 * 1024.0));
   jw_object_end(&jw);
+
+  json_diagnostics(&jw, m, wall_s);
 
   jw_object_end(&jw);
   printf("%s\n", strbuf_cstr(&json_buf));

--- a/bench/bench_report.h
+++ b/bench/bench_report.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "stream/layouts.h"
-#include "zarr/types.io.h"
 #include "types.stream.h"
+#include "zarr/types.io.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -47,6 +47,11 @@ print_memory_report(const struct bench_memory* mem);
 
 void
 print_metric_row(const struct stream_metric* m);
+
+// Print diagnostic intervals in separate wait, pipeline-gap, and host-work
+// sections. Unlike stage rows, these intervals do not claim a byte rate.
+void
+print_diagnostics_report(const struct stream_metrics* metrics, float wall_s);
 
 // The time taken per append is printed here.
 void

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -1140,22 +1140,7 @@ run_bench_two_streams(const struct bench_config* cfg)
     print_metric_row(&m[k].d2h);
     print_metric_row(&m[k].sink);
 
-    int have_stalls =
-      m[k].flush_stall.count > 0 || m[k].drain_dispatch.count > 0 ||
-      m[k].io_fence_stall.count > 0 || m[k].backpressure.count > 0 ||
-      m[k].max_append_ms > 0 || m[k].peak_pending_bytes > 0;
-    if (have_stalls) {
-      fputc('\n', stderr);
-      print_report("  --- Stall stats (stream-%d) ---", k);
-      print_metric_row(&m[k].flush_stall);
-      print_metric_row(&m[k].drain_dispatch);
-      print_metric_row(&m[k].io_fence_stall);
-      print_metric_row(&m[k].backpressure);
-      print_append_latency(&m[k]);
-      char pbuf[32];
-      format_bytes(pbuf, sizeof(pbuf), m[k].peak_pending_bytes);
-      print_report("  peak pending:    %s", pbuf);
-    }
+    print_diagnostics_report(&m[k], wall_s);
   }
 
   print_report("  PASS");

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -211,11 +211,12 @@ to work with. A configured ceiling is not evidence the run got near it:
 | `io_run_ms_mean` / `io_run_ms_max` | the time taken by a write once started |
 | `io_write_sizes` | request-size histogram, as `{at_least, n}` in powers of two |
 
-Under `stalls`, each of the producer's waits on io is reported on its own by
-the CPU path, as a total and a count. `footer_buffer` and `flush_writes` break
-down the `sink` stage total; `io_fence` and `append_extent` fall outside every
-stage. `io_fence` is measured by the GPU path too; the other three are left at
-count zero there, meaning not measured rather than no wait:
+The legacy `stalls` block is retained for existing consumers. Each of the
+producer's waits on io is reported there as a total and count. `footer_buffer`
+and `flush_writes` break down the `sink` stage total; `io_fence` and
+`append_extent` fall outside every stage. `io_fence` is measured by the GPU
+path too; the other three are left at count zero there, meaning not measured
+rather than no wait:
 
 | field | holds |
 |---|---|
@@ -224,9 +225,41 @@ count zero there, meaning not measured rather than no wait:
 | `append_extent_ms` / `append_extent_count` | the wait on shards closed since the append extent was last published |
 | `flush_writes_ms` / `flush_writes_count` | the wait on every queued write, at flush |
 
-The keys kept by the overview page are listed in `summary.py`, so a new counter
-is dropped from that page unless it is named there. Everything not explicitly
-dropped is taken by the explorer, so no change is needed there.
+New code should read `diagnostics`, whose keys are stable metric IDs rather than
+display labels. Each measured entry has `label`, `kind`, `owner`, `total_ms`,
+and `samples`; current binaries also report `avg_ms`, `min_ms`, `max_ms`, and
+`wall_pct` when available. `samples` counts recorded intervals. Host-poll
+entries add `wait_calls` and record a sample only when a call actually blocked;
+`wait_calls` counts every call, so zero samples with nonzero wait calls means
+the dependency was always ready. Missing means not measured. `owner` names the
+timeline; totals from different owners can overlap and must not be added
+together.
+
+The reports label `wait_calls` as **waits** and present cumulative diagnostics
+as `% wall`; `total_ms` remains in the full JSON as the lossless raw value.
+
+| diagnostic ID | interval |
+|---|---|
+| `batch_drain` | producer blocked inside batch drain; this can include inline drain work |
+| `d2h_dispatch` | drain-thread CPU work between its metadata and payload waits |
+| `output_slot_io` | host waiting for writes that still hold an output slot |
+| `footer_buffer_io` | host waiting for a shard's previous footer-buffer write |
+| `append_extent_io` | host waiting for writes to shards closed since the last published extent |
+| `final_io` | host waiting for all queued writes at flush |
+| `sink_backpressure` | producer waiting for the sink queue to fall below its limit |
+| `prior_tail_state` | compression-to-aggregation gap waiting for the preceding tail state |
+| `staging_reuse` | producer waiting to refill a staging buffer still used by H2D |
+| `chunk_metadata_d2h` | drain host waiting for chunk offsets and compressed sizes to arrive by D2H; not chunk-index kernel time |
+| `payload_d2h` | drain host waiting for the aggregated payload to arrive by D2H |
+
+`report.py` backfills this shape in memory from legacy `stalls`, so archived
+results remain usable without rewriting them. Historical files cannot recover
+`wait_calls`, `min_ms`, or `max_ms`, and the explorer shows those cells as
+unknown.
+Values retired because their meaning changed are not backfilled under a current
+diagnostic ID.
+The overview keys are listed in `summary.py`; the explorer receives all
+diagnostics and displays them below the selected run's stage chart.
 
 Measurement is from the first queued job of any kind until the run is flushed.
 Covered: streaming and every shard's closing footer, truncate and close, but
@@ -261,6 +294,9 @@ carry the block.
 the overview leaves those out of comparisons instead of converting them. Bump
 `CURRENT_VERSION` when a metric is renamed, removed, or changes meaning. Adding
 one does not need a bump.
+
+The canonical `diagnostics` block was added without changing an existing
+metric, so it is additive and did not bump the stored sweep version.
 
 A stored sweep records only its version number, so add a line here when you
 bump it.

--- a/scripts/sweep/models.py
+++ b/scripts/sweep/models.py
@@ -168,9 +168,122 @@ _MIGRATIONS = {
 }
 
 
-def migrate_run(run: dict) -> dict:
+# Canonical diagnostic IDs are deliberately independent of both terminal
+# labels and the legacy `stalls` keys. Keep this table in step with
+# bench/bench_report.c; it lets report.py give archived runs the same shape as
+# runs emitted by a current benchmark binary.
+_LEGACY_DIAGNOSTICS = {
+    "batch_drain": {
+        "label": "Batch drain (wait/work)", "kind": "host_block",
+        "ms": "flush_stall_ms", "count": "flush_stall_count",
+        "owner": "flush_stall",
+    },
+    "d2h_dispatch": {
+        "label": "D2H dispatch work", "kind": "host_overhead",
+        "ms": "drain_dispatch_ms", "count": "drain_dispatch_count",
+        "owner": "drain_dispatch",
+    },
+    "output_slot_io": {
+        "label": "Output-slot writes", "kind": "host_wait",
+        "ms": "io_fence_ms", "count": "io_fence_count", "owner": "io_fence",
+    },
+    "footer_buffer_io": {
+        "label": "Footer-buffer write", "kind": "host_wait",
+        "ms": "footer_buffer_ms", "count": "footer_buffer_count",
+        "owner": "footer_buffer",
+    },
+    "append_extent_io": {
+        "label": "Closed-shard writes", "kind": "host_wait",
+        "ms": "append_extent_ms", "count": "append_extent_count",
+        "owner": "append_extent",
+    },
+    "final_io": {
+        "label": "Final queued writes", "kind": "host_wait",
+        "ms": "flush_writes_ms", "count": "flush_writes_count",
+        "owner": "flush_writes",
+    },
+    "sink_backpressure": {
+        "label": "Sink queue below limit", "kind": "host_wait",
+        "ms": "backpressure_ms", "count": "backpressure_count",
+        "owner": "backpressure",
+    },
+    "prior_tail_state": {
+        "label": "Prior tail state", "kind": "pipeline_gap",
+        "ms": "tail_gate_ms", "count": "tail_gate_count", "owner": "tail_gate",
+    },
+}
+
+_LEGACY_EDGE_DIAGNOSTICS = {
+    "staging_reuse": ("StagingFree", "Staging-buffer reuse"),
+    "chunk_metadata_d2h": ("ChunkIndex", "Chunk offsets/sizes D2H"),
+    "payload_d2h": ("D2HDone", "Payload D2H"),
+}
+
+
+def _canonical_diagnostic(total_ms: object, samples: object, *, label: str,
+                          kind: str, owner: object, wall_s: object) -> dict | None:
+    if not isinstance(total_ms, (int, float)):
+        return None
+    n = samples if isinstance(samples, int) and samples >= 0 else 0
+    if total_ms <= 0 and n == 0:
+        return None
+    out = {
+        "label": label,
+        "kind": kind,
+        "owner": owner if isinstance(owner, str) else "unknown",
+        "total_ms": total_ms,
+        "samples": n,
+    }
+    if n > 0:
+        out["avg_ms"] = total_ms / n
+    if isinstance(wall_s, (int, float)) and wall_s > 0:
+        out["wall_pct"] = total_ms / (wall_s * 10.0)
+    return out
+
+
+def _backfill_diagnostics(run: dict, retired: tuple[str, ...]) -> None:
+    if isinstance(run.get("diagnostics"), dict):
+        return
+    stalls = run.get("stalls")
+    if not isinstance(stalls, dict):
+        return
+
+    owners = stalls.get("owners")
+    owners = owners if isinstance(owners, dict) else {}
+    wall_s = run.get("wall_s")
+    diagnostics = {}
+    for diagnostic_id, spec in _LEGACY_DIAGNOSTICS.items():
+        if spec["ms"] in retired:
+            continue
+        value = _canonical_diagnostic(
+            stalls.get(spec["ms"]), stalls.get(spec["count"]),
+            label=spec["label"], kind=spec["kind"],
+            owner=owners.get(spec["owner"]), wall_s=wall_s,
+        )
+        if value:
+            diagnostics[diagnostic_id] = value
+
+    edge_stalls = stalls.get("edge_stalls")
+    if isinstance(edge_stalls, dict):
+        for diagnostic_id, (legacy_name, label) in _LEGACY_EDGE_DIAGNOSTICS.items():
+            edge = edge_stalls.get(legacy_name)
+            if not isinstance(edge, dict):
+                continue
+            value = _canonical_diagnostic(
+                edge.get("total_ms"), edge.get("count"), label=label,
+                kind="host_wait", owner=edge.get("owner"), wall_s=wall_s,
+            )
+            if value:
+                diagnostics[diagnostic_id] = value
+
+    if diagnostics:
+        run["diagnostics"] = diagnostics
+
+
+def migrate_run(run: dict, retired: tuple[str, ...] = ()) -> dict:
     """Fill defaults for fields added after the initial schema."""
     run.setdefault("sink", "discard")
+    _backfill_diagnostics(run, retired)
     return run
 
 
@@ -198,6 +311,7 @@ def migrate_results(data: dict) -> dict:
             migrate(data)
         version += 1
         data["version"] = version
+    retired = retired_metrics(data)
     for run in data.get("runs", []):
-        migrate_run(run)
+        migrate_run(run, retired)
     return data

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -224,12 +224,20 @@ const METRICS = [
   {key: "stalls.max_append_ms", label: "Slowest append block", unit: "ms", better: "low",
    note: "one append is a multi-frame block push, not a single frame"},
   {key: "stalls.peak_pending_mib", label: "Peak pending bytes", unit: "MiB", better: "low"},
-  {key: "stalls.backpressure_ms", label: "Backpressure wait", unit: "ms", better: "low"},
-  {key: "stalls.flush_stall_ms", label: "Flush stall", unit: "ms", better: "low"},
-  {key: "stalls.io_fence_ms", label: "Wait to reuse an aggregate slot", unit: "ms", better: "low"},
-  {key: "stalls.footer_buffer_ms", label: "Wait to reuse a footer buffer", unit: "ms", better: "low"},
-  {key: "stalls.append_extent_ms", label: "Wait to publish the append extent", unit: "ms", better: "low"},
-  {key: "stalls.flush_writes_ms", label: "Wait for queued writes at flush", unit: "ms", better: "low"},
+  {key: "diagnostics.batch_drain.wall_pct", label: "Producer blocked in batch drain", unit: "% wall", better: "low",
+   note: "includes inline drain work when no delivery worker owns the drain"},
+  {key: "diagnostics.d2h_dispatch.wall_pct", label: "Drain CPU dispatch work", unit: "% wall", better: "low"},
+  {key: "diagnostics.output_slot_io.wall_pct", label: "Wait for output-slot writes", unit: "% wall", better: "low"},
+  {key: "diagnostics.footer_buffer_io.wall_pct", label: "Wait for footer-buffer write", unit: "% wall", better: "low"},
+  {key: "diagnostics.append_extent_io.wall_pct", label: "Wait for closed-shard writes", unit: "% wall", better: "low"},
+  {key: "diagnostics.final_io.wall_pct", label: "Wait for final queued writes", unit: "% wall", better: "low"},
+  {key: "diagnostics.sink_backpressure.wall_pct", label: "Wait for sink queue below limit", unit: "% wall", better: "low",
+   retired: "backpressure_ms"},
+  {key: "diagnostics.prior_tail_state.wall_pct", label: "Compress-to-aggregate gap: prior tail", unit: "% wall", better: "low",
+   retired: "tail_gate_ms"},
+  {key: "diagnostics.staging_reuse.wall_pct", label: "Wait for staging-buffer reuse", unit: "% wall", better: "low"},
+  {key: "diagnostics.chunk_metadata_d2h.wall_pct", label: "Wait for chunk offsets/sizes D2H", unit: "% wall", better: "low"},
+  {key: "diagnostics.payload_d2h.wall_pct", label: "Wait for payload D2H", unit: "% wall", better: "low"},
   {key: "io_files_waiting_mean", label: "Files with writes waiting", unit: "", better: "high",
    note: "how many writes could run at once; the sink runs one at a time, so this is room available, not room used"},
   {key: "io_files_waiting_peak", label: "Files with writes waiting, peak", unit: "", better: "high"},
@@ -387,8 +395,9 @@ function matchesSetup(run) {
 }
 
 function comparable(sweep) {
-  const leaf = state.metric.split(".").pop();
-  return !(sweep.retired || []).includes(leaf);
+  const meta = metricMeta(state.metric);
+  const retiredKey = meta.retired || state.metric.split(".").pop();
+  return !(sweep.retired || []).includes(retiredKey);
 }
 
 /** Best run of a sweep for one scenario and input, under the other filters. */

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -63,7 +63,7 @@ SITE_FILES = {
 # io_write_sizes is a list of objects, so it defeats the columnar packing and
 # no page reads it.
 EXPLORER_OMITS = ("id", "io_write_sizes")
-EXPLORER_VERSION = 5
+EXPLORER_VERSION = 6
 
 # These are the fields kept in the explorer's sweep list for each summarized sweep.
 EXPLORER_INDEX_KEYS = ("filename", "machine", "member", "commit", "day", "date", "host", "gpu",

--- a/scripts/sweep/summary.py
+++ b/scripts/sweep/summary.py
@@ -20,8 +20,10 @@ from models import retired_metrics
 # for every allocation.
 FILENAME_RE = re.compile(r"^(?P<machine>.+)-(?P<commit>[0-9a-f]{7,40})-(?P<date>\d{8})$")
 
-# Bumped to 2 when report.py started packing the runs into columns.
-OVERVIEW_VERSION = 2
+# Bumped to 2 when report.py started packing the runs into columns, to 3 when
+# canonical diagnostics were added, and to 4 when they changed from raw time
+# to percent of wall time in the trimmed overview payload.
+OVERVIEW_VERSION = 4
 
 CONFIG_KEYS = (
     "scenario", "codec", "fill", "backend", "dtype",
@@ -36,9 +38,13 @@ RUN_METRICS = (
 )
 
 STALL_METRICS = (
-    "max_append_ms", "peak_pending_mib", "backpressure_ms",
-    "flush_stall_ms", "io_fence_ms",
-    "footer_buffer_ms", "append_extent_ms", "flush_writes_ms",
+    "max_append_ms", "peak_pending_mib",
+)
+
+DIAGNOSTIC_METRICS = (
+    "batch_drain", "d2h_dispatch", "output_slot_io", "footer_buffer_io",
+    "append_extent_io", "final_io", "sink_backpressure", "prior_tail_state",
+    "staging_reuse", "chunk_metadata_d2h", "payload_d2h",
 )
 
 # The build keys a page shows. Both files this module feeds are fetched on
@@ -157,6 +163,18 @@ def trim_run(run: dict) -> dict:
                 if isinstance(stalls.get(k), (int, float))}
         if kept:
             out["stalls"] = kept
+    diagnostics = run.get("diagnostics")
+    if isinstance(diagnostics, dict):
+        kept = {}
+        for key in DIAGNOSTIC_METRICS:
+            item = diagnostics.get(key)
+            if (
+                isinstance(item, dict)
+                and isinstance(item.get("wall_pct"), (int, float))
+            ):
+                kept[key] = {"wall_pct": item["wall_pct"]}
+        if kept:
+            out["diagnostics"] = kept
     return out
 
 

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -50,14 +50,29 @@ input { accent-color: var(--series-1); }
 /* Charts. A chart wider than the panel scrolls inside it — letting the panel
    grow instead would drag the header and the controls off the side of a narrow
    window. */
-#chart, #stage-chart {
+#chart, #stage-chart, #diagnostic-table {
   background: var(--surface-1); border: 1px solid var(--border);
   border-radius: var(--radius-sm); padding: var(--gap-md);
-  display: flex; flex-direction: column; align-items: safe center;
   overflow-x: auto;
 }
+#chart, #stage-chart {
+  display: flex; flex-direction: column; align-items: safe center;
+}
 #stage-chart { margin-top: var(--gap-md); }
-#chart:empty, #stage-chart:empty { display: none; }
+#diagnostic-table { margin-top: var(--gap-md); }
+#chart:empty, #stage-chart:empty, #diagnostic-table:empty { display: none; }
+#diagnostic-table h2 { font-size: 0.9em; margin: 0 0 8px; }
+#diagnostic-table table { border-collapse: collapse; font-size: 0.75em; width: 100%; }
+#diagnostic-table th, #diagnostic-table td {
+  border-bottom: 1px solid var(--grid); padding: 5px 8px; text-align: right;
+  white-space: nowrap;
+}
+#diagnostic-table th { color: var(--text-secondary); font-weight: 600; }
+#diagnostic-table th:nth-child(-n+3), #diagnostic-table td:nth-child(-n+3) { text-align: left; }
+#diagnostic-table .diagnostic-note {
+  color: var(--text-secondary); font-size: 0.72em; line-height: 1.45;
+  margin: 8px 0 0;
+}
 
 /* SVG axes */
 .axis text { font-size: 12px; fill: var(--text-secondary); }
@@ -210,6 +225,7 @@ input { accent-color: var(--series-1); }
 
 <div id="chart"></div>
 <div id="stage-chart"></div>
+<div id="diagnostic-table"></div>
 <div id="failures"></div>
 
 </main>
@@ -760,6 +776,7 @@ function render() {
 
   d3.select("#chart").selectAll("*").remove();
   d3.select("#stage-chart").selectAll("*").remove();
+  d3.select("#diagnostic-table").selectAll("*").remove();
 
   if (filtered.length === 0) {
     d3.select("#chart").append("p").text("No matching runs.");
@@ -1087,6 +1104,8 @@ function renderStageLines(filtered, presentChunks, presentScenarios, stageMetric
 
 function renderStages(run) {
   d3.select("#stage-chart").selectAll("*").remove();
+  d3.select("#diagnostic-table").selectAll("*").remove();
+  renderDiagnostics(run);
   if (!run.stages) {
     d3.select("#stage-chart").append("p").text("No stage data for this run.");
     return;
@@ -1100,6 +1119,69 @@ function renderStages(run) {
   } else {
     renderStagesTiming(run, stages);
   }
+}
+
+const DIAGNOSTIC_ORDER = [
+  "batch_drain", "output_slot_io", "footer_buffer_io", "append_extent_io",
+  "final_io", "sink_backpressure", "staging_reuse", "chunk_metadata_d2h",
+  "payload_d2h", "prior_tail_state", "d2h_dispatch",
+];
+
+const DIAGNOSTIC_KIND_LABELS = {
+  host_wait: "Host wait",
+  host_block: "Host block/work",
+  pipeline_gap: "Pipeline gap",
+  host_overhead: "Host overhead",
+};
+
+function diagnosticNumber(value, suffix = "") {
+  if (typeof value !== "number" || !isFinite(value)) return "—";
+  return `${d3.format(value >= 100 ? ",.1f" : ",.3f")(value)}${suffix}`;
+}
+
+function renderDiagnostics(run) {
+  if (!run.diagnostics || typeof run.diagnostics !== "object") return;
+  const present = Object.keys(run.diagnostics);
+  const ordered = DIAGNOSTIC_ORDER.filter(id => present.includes(id))
+    .concat(present.filter(id => !DIAGNOSTIC_ORDER.includes(id)).sort());
+  const entries = ordered
+    .map(id => [id, run.diagnostics[id]]);
+  if (!entries.length) return;
+
+  const root = d3.select("#diagnostic-table");
+  root.append("h2").text(
+    `Diagnostics: ${run.scenario} ${run.chunk_bytes_label} ${run.codec} (${run.backend})`);
+  const table = root.append("table");
+  const headers = ["Category", "Timeline", "Reason / interval", "Samples",
+                   "Waits", "Average ms", "Min ms", "Max ms", "% wall"];
+  const head = table.append("thead").append("tr");
+  headers.forEach(label => head.append("th").text(label));
+  const body = table.append("tbody");
+
+  for (const [id, diagnostic] of entries) {
+    const samples = Number.isInteger(diagnostic.samples) ? diagnostic.samples : 0;
+    const average = diagnostic.avg_ms ?? (samples > 0 ? diagnostic.total_ms / samples : null);
+    const wallPct = diagnostic.wall_pct ??
+      (run.wall_s > 0 ? diagnostic.total_ms / (run.wall_s * 10) : null);
+    const row = body.append("tr");
+    row.append("td").text(DIAGNOSTIC_KIND_LABELS[diagnostic.kind] || diagnostic.kind || "Diagnostic");
+    row.append("td").text(diagnostic.owner || "unknown");
+    row.append("td").text(diagnostic.label || id);
+    row.append("td").text(samples.toLocaleString());
+    row.append("td").text(Number.isInteger(diagnostic.wait_calls)
+      ? diagnostic.wait_calls.toLocaleString() : "—");
+    row.append("td").text(diagnosticNumber(average));
+    row.append("td").text(diagnosticNumber(diagnostic.min_ms));
+    row.append("td").text(diagnosticNumber(diagnostic.max_ms));
+    row.append("td").text(diagnosticNumber(wallPct, "%"));
+  }
+
+  root.append("p").attr("class", "diagnostic-note").text(
+    "Samples count recorded intervals. Host waits record a sample only when they actually block; " +
+    "the waits column counts all wait calls, including calls that were already ready. " +
+    "Batch drain may include inline drain work. " +
+    "Chunk offsets/sizes D2H is the drain host waiting for offsets and compressed sizes to arrive, " +
+    "not chunk-index kernel time.");
 }
 
 function renderStagesTiming(run, stages) {

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -249,21 +249,21 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
   s->metrics.aggregate = mk_stream_metric("aggregate", METRIC_OWNER_COMPRESS);
   s->metrics.sink = mk_stream_metric("sink", METRIC_OWNER_DRAIN);
   s->metrics.io_fence_stall =
-    mk_stream_metric("io_fence", METRIC_OWNER_PRODUCER);
+    mk_stream_metric("Output-slot writes", METRIC_OWNER_PRODUCER);
   s->metrics.footer_buffer_stall =
-    mk_stream_metric("footer_buffer", METRIC_OWNER_PRODUCER);
+    mk_stream_metric("Footer-buffer write", METRIC_OWNER_PRODUCER);
   s->metrics.append_extent_stall =
-    mk_stream_metric("append_extent", METRIC_OWNER_PRODUCER);
+    mk_stream_metric("Closed-shard writes", METRIC_OWNER_PRODUCER);
   s->metrics.flush_writes_stall =
-    mk_stream_metric("flush_writes", METRIC_OWNER_PRODUCER);
+    mk_stream_metric("Final queued writes", METRIC_OWNER_PRODUCER);
   // These three are named so the report can list them, and only the GPU path
   // ever populates them.
   s->metrics.flush_stall =
-    mk_stream_metric("flush_stall", METRIC_OWNER_PRODUCER);
+    mk_stream_metric("Batch drain", METRIC_OWNER_PRODUCER);
   s->metrics.drain_dispatch =
-    mk_stream_metric("drain_dispatch", METRIC_OWNER_DRAIN);
+    mk_stream_metric("D2H dispatch", METRIC_OWNER_DRAIN);
   s->metrics.backpressure =
-    mk_stream_metric("backpressure", METRIC_OWNER_PRODUCER);
+    mk_stream_metric("Sink queue below limit", METRIC_OWNER_PRODUCER);
   if (s->levels.enable_multiscale) {
     s->metrics.lod_gather =
       mk_stream_metric("lod_gather", METRIC_OWNER_COMPUTE);

--- a/src/gpu/ordering.c
+++ b/src/gpu/ordering.c
@@ -305,6 +305,8 @@ gpu_edge_host_wait(struct gpu_ordering* ord, enum gpu_edge e, int i)
   ord->edge[e].waits[i]++;
 #endif
   struct stream_metric* m = ord->edge[e].stall;
+  if (m)
+    m->wait_calls++;
   struct platform_clock clk = { 0 };
   int timed = 0;
   for (;;) {

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -38,17 +38,21 @@ stream_engine_init_metrics(int enable_multiscale)
     .aggregate = mk_stream_metric("Aggregate", METRIC_OWNER_COMPRESS),
     .d2h = mk_stream_metric("D2H", METRIC_OWNER_D2H),
     .sink = mk_stream_metric("Sink", METRIC_OWNER_DRAIN),
-    .flush_stall = mk_stream_metric("FlushStall", METRIC_OWNER_PRODUCER),
-    .drain_dispatch = mk_stream_metric("DrainDisp", METRIC_OWNER_DRAIN),
-    .io_fence_stall = mk_stream_metric("IOFence", METRIC_OWNER_PRODUCER),
+    .flush_stall = mk_stream_metric("Batch drain", METRIC_OWNER_PRODUCER),
+    .drain_dispatch = mk_stream_metric("D2H dispatch", METRIC_OWNER_DRAIN),
+    .io_fence_stall =
+      mk_stream_metric("Output-slot writes", METRIC_OWNER_PRODUCER),
     // These three are named so the report can list them, and only the CPU
     // path populates them.
-    .footer_buffer_stall = mk_stream_metric("FooterBuf", METRIC_OWNER_PRODUCER),
-    .append_extent_stall = mk_stream_metric("AppendExt", METRIC_OWNER_PRODUCER),
+    .footer_buffer_stall =
+      mk_stream_metric("Footer-buffer write", METRIC_OWNER_PRODUCER),
+    .append_extent_stall =
+      mk_stream_metric("Closed-shard writes", METRIC_OWNER_PRODUCER),
     .flush_writes_stall =
-      mk_stream_metric("FlushWrites", METRIC_OWNER_PRODUCER),
-    .backpressure = mk_stream_metric("Backpres", METRIC_OWNER_PRODUCER),
-    .tail_gate = mk_stream_metric("TailGate", METRIC_OWNER_COMPRESS),
+      mk_stream_metric("Final queued writes", METRIC_OWNER_PRODUCER),
+    .backpressure =
+      mk_stream_metric("Sink queue below limit", METRIC_OWNER_PRODUCER),
+    .tail_gate = mk_stream_metric("Prior tail state", METRIC_OWNER_COMPRESS),
   };
 }
 
@@ -56,9 +60,11 @@ void
 stream_engine_attach_edge_stalls(struct stream_engine* e)
 {
   e->metrics.edge_stall[0] =
-    mk_stream_metric("StagingFree", METRIC_OWNER_PRODUCER);
-  e->metrics.edge_stall[1] = mk_stream_metric("ChunkIndex", METRIC_OWNER_DRAIN);
-  e->metrics.edge_stall[2] = mk_stream_metric("D2HDone", METRIC_OWNER_DRAIN);
+    mk_stream_metric("Staging-buffer reuse", METRIC_OWNER_PRODUCER);
+  e->metrics.edge_stall[1] =
+    mk_stream_metric("Chunk offsets/sizes D2H", METRIC_OWNER_DRAIN);
+  e->metrics.edge_stall[2] =
+    mk_stream_metric("Payload D2H", METRIC_OWNER_DRAIN);
   gpu_ordering_attach_stall_metric(
     &e->ord, GPU_EDGE_STAGING_FREE, &e->metrics.edge_stall[0]);
   gpu_ordering_attach_stall_metric(

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -32,11 +32,15 @@ struct stream_metric
   enum metric_owner owner;
   float ms;                 // cumulative
   float best_ms;            // fastest measurement; 1e30f = none yet
+  float max_ms;             // slowest measurement
   double best_input_bytes;  // bytes at the fastest measurement, for its rate
   double best_output_bytes; // likewise
   double input_bytes;       // cumulative, read by the stage
   double output_bytes;      // cumulative, written by the stage
   int count;                // measurements taken, not work items
+  // Calls that could have blocked. Used by host-poll metrics so count 0 can be
+  // distinguished from a metric that was never checked.
+  uint64_t wait_calls;
 };
 
 struct stream_metrics

--- a/src/util/metric.h
+++ b/src/util/metric.h
@@ -67,6 +67,8 @@ accumulate_metric_ms(struct stream_metric* m,
   m->input_bytes += input_bytes;
   m->output_bytes += output_bytes;
   m->count++;
+  if (ms > m->max_ms)
+    m->max_ms = ms;
   if (ms < m->best_ms) {
     m->best_ms = ms;
     m->best_input_bytes = (double)input_bytes;

--- a/tests/test_metric_check.h
+++ b/tests/test_metric_check.h
@@ -28,6 +28,13 @@ metric_arrived(const struct stream_metric* m, int expected_count)
       "  %s: a measurement ran backwards, %g ms", m->name, (double)m->best_ms);
     return 0;
   }
+  if (m->count > 0 && m->max_ms < m->best_ms) {
+    log_error("  %s: slowest measurement %g ms is below fastest %g ms",
+              m->name,
+              (double)m->max_ms,
+              (double)m->best_ms);
+    return 0;
+  }
   return 1;
 }
 

--- a/tests/test_metrics.c
+++ b/tests/test_metrics.c
@@ -96,6 +96,14 @@ check_shared_stages(const struct stream_metrics* m)
     log_error("  %s: no measurement arrived", m->tail_gate.name);
     ok = 0;
   }
+  for (size_t i = 0; i < sizeof(m->edge_stall) / sizeof(m->edge_stall[0]);
+       ++i) {
+    if (m->edge_stall[i].wait_calls == 0) {
+      log_error("  %s: host dependency was never checked",
+                m->edge_stall[i].name);
+      ok = 0;
+    }
+  }
   ok &= no_samples_lost("scatter", m->scatter_samples_lost);
   // The LOD arm cannot fail while the schedule collects every epoch; it guards
   // a change in that cadence rather than proving the collector kept up.


### PR DESCRIPTION
## Summary

- replace opaque stall-table names with categorized host blocking, pipeline gap, and host overhead diagnostics
- add stable diagnostic IDs and richer JSON fields while preserving the legacy stalls schema
- show waits, samples, latency extrema, and percent of wall time in terminal and sweep reports
- backfill canonical diagnostics for archived sweep results without relabeling retired semantics

## Compatibility

- legacy stalls keys, including stalls.edge_stalls.ChunkIndex, remain unchanged
- new machine consumers can use the top-level diagnostics object
- the overview uses wall_pct; full JSON retains lossless total_ms

## Validation

- CPU and GPU builds
- 57 non-MinIO tests: 56 passed in parallel; test_multiscale passed serially after transient parallel GPU memory contention
- compressed GPU benchmark smoke test, including terminal and JSON diagnostics
- report generation from 31 result files and 6703 runs
- Python bytecode checks, clang-format dry run, and git diff --check

The two MinIO-dependent tests were excluded because that service is not running in this environment.