### PR TITLE
Raise default S3 throughput target to 100 Gb/s

### DIFF
--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -28,7 +28,7 @@ struct bench_config
   const char* s3_prefix;     // key prefix (no leading/trailing /)
   const char* s3_region;     // e.g. "us-east-1"
   const char* s3_endpoint;   // e.g. "https://s3.us-east-1.amazonaws.com"
-  double s3_throughput_gbps; // gigabits/s, 0 = CRT default (10.0)
+  double s3_throughput_gbps; // gigabits/s, 0 = CRT default (100.0)
   struct codec_config codec;
   enum lod_reduce_method reduce_method;
   enum lod_reduce_method append_reduce_method;
@@ -43,20 +43,20 @@ struct bench_config
   size_t memory_budget;        // 0 = auto-detect
   size_t min_shard_bytes;      // minimum uncompressed bytes per shard
   uint32_t
-    target_concurrent_shards; // cap on inner shard product (active files)
-  uint32_t min_append_shards; // require at least N shards along the outer
-                              // append dim (0 = no minimum). Forces
-                              // shard-switching in benchmarks that would
-                              // otherwise collapse to a single shard.
-  size_t append_elements;     // elements per append; 0 = default block. Set to
-                              // one frame to measure per-frame latency.
-  int json_output;            // print JSON to stdout after run
-  uint64_t io_bw_mbps;        // 0 = no bandwidth cap (MiB/s)
-  uint64_t io_latency_us;     // 0 = no fixed per-job latency
+    target_concurrent_shards;  // cap on inner shard product (active files)
+  uint32_t min_append_shards;  // require at least N shards along the outer
+                               // append dim (0 = no minimum). Forces
+                               // shard-switching in benchmarks that would
+                               // otherwise collapse to a single shard.
+  size_t append_elements;      // elements per append; 0 = default block. Set to
+                               // one frame to measure per-frame latency.
+  int json_output;             // print JSON to stdout after run
+  uint64_t io_bw_mbps;         // 0 = no bandwidth cap (MiB/s)
+  uint64_t io_latency_us;      // 0 = no fixed per-job latency
   uint64_t backpressure_bytes; // 0 = disabled; >0 = stall when pending > N
-  int max_threads;            // 0 = OpenMP default (omp_get_max_threads)
-  struct io_scheduling io;    // filesystem sink write scheduling
-  const char* io_backend;     // which write backend; NULL = the default
+  int max_threads;             // 0 = OpenMP default (omp_get_max_threads)
+  struct io_scheduling io;     // filesystem sink write scheduling
+  const char* io_backend;      // which write backend; NULL = the default
 };
 
 int

--- a/docs/s3-guide.md
+++ b/docs/s3-guide.md
@@ -28,7 +28,7 @@ The S3 transport is configured via `store_s3_config`, defined in
 | `region` | *required* | AWS region (e.g. `"us-east-1"`) |
 | `endpoint` | *required* | S3-compatible endpoint URL (e.g. `"https://s3.us-east-1.amazonaws.com"` or `"http://localhost:9000"`) |
 | `part_size` | 8 MiB | [Multipart upload][mpu] part size (see [Limitations](#limitations)) |
-| `throughput_gbps` | 10.0 | Target throughput in gigabits/s for the CRT |
+| `throughput_gbps` | 100.0 | Target throughput in gigabits/s for the CRT |
 | `max_retries` | 10 | Retry count per part |
 | `backoff_scale_ms` | 500 | Exponential backoff scale in ms |
 | `max_backoff_secs` | 20 | Maximum backoff delay in seconds |

--- a/src/defs.limits.h
+++ b/src/defs.limits.h
@@ -28,7 +28,7 @@
 // S3
 #define S3_MAX_PARTS 10000
 #define S3_DEFAULT_PART_SIZE (8 * 1024 * 1024)
-#define S3_DEFAULT_THROUGHPUT_GBPS 10.0
+#define S3_DEFAULT_THROUGHPUT_GBPS 100.0
 
 // Shard backend limits — applied uniformly across sinks (conservative).
 // One chunk per upload part, so parts-count = chunks per shard.

--- a/src/store.h
+++ b/src/store.h
@@ -46,7 +46,7 @@ struct store*
 store_s3_create(const struct store_s3_config* cfg);
 
 // Fill zero fields with S3 transport defaults (part_size=8MiB,
-// throughput=10Gbps).
+// throughput=100Gbps).
 void
 store_s3_config_set_defaults(struct store_s3_config* cfg);
 

--- a/src/zarr/s3_client.h
+++ b/src/zarr/s3_client.h
@@ -13,7 +13,7 @@ struct s3_client_config
   const char* region;   // required (e.g. "us-east-1")
   const char* endpoint; // required (e.g. "https://s3.us-east-1.amazonaws.com")
   size_t part_size;     // 0 = default (8 MiB)
-  double throughput_gbps;    // gigabits/s, 0 = default (10.0)
+  double throughput_gbps;    // gigabits/s, 0 = default (100.0)
   size_t max_retries;        // 0 = CRT default (10)
   uint32_t backoff_scale_ms; // 0 = CRT default (500)
   uint32_t max_backoff_secs; // 0 = CRT default (20)

--- a/src/zarr/store_s3.h
+++ b/src/zarr/store_s3.h
@@ -28,7 +28,7 @@ struct store*
 store_s3_create(const struct store_s3_config* cfg);
 
 // Fill zero fields with S3 transport defaults (part_size=8MiB,
-// throughput=10Gbps).
+// throughput=100Gbps).
 void
 store_s3_config_set_defaults(struct store_s3_config* cfg);
 

--- a/tests/test_zarr_s3_sink.c
+++ b/tests/test_zarr_s3_sink.c
@@ -604,7 +604,7 @@ test_s3_config_defaults(void)
   struct store_s3_config cfg = { 0 };
   store_s3_config_set_defaults(&cfg);
   CHECK(Fail, cfg.part_size == 8 * 1024 * 1024);
-  CHECK(Fail, cfg.throughput_gbps == 10.0);
+  CHECK(Fail, cfg.throughput_gbps == 100.0);
 
   // Already-set values should not be overwritten
   struct store_s3_config cfg2 = { .part_size = 42, .throughput_gbps = 1.0 };


### PR DESCRIPTION
## Summary

- raise the zero-value S3 CRT throughput target from 10 to 100 Gb/s
- update public comments and S3 documentation to match
- update the S3 configuration-default test expectation

## Validation

- cmake --build build --target test_zarr_s3_sink bench_stream_orca2_single -j 4
- repository pre-commit hooks
- git diff --check
- test_s3_config_defaults passes; the remaining integration test requires a running MinIO instance, which was unavailable locally