### PR TITLE
Trace GPU delivery latency

### DIFF
--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -249,6 +249,54 @@ print_diagnostic_section(const struct diagnostic_entry entries[],
       print_diagnostic_row(&entries[i], wall_s);
 }
 
+static int
+delivery_timing_measured(const struct delivery_timing* timing)
+{
+  return timing->submitted_to_start.count > 0 ||
+         timing->start_to_payload_ready.count > 0 ||
+         timing->payload_ready_to_writes_posted.count > 0 ||
+         timing->writes_posted_to_completion.count > 0 ||
+         timing->submitted_to_slot_reuse.count > 0;
+}
+
+static void
+print_duration_row(const char* label, const struct duration_stats* stats)
+{
+  if (stats->count == 0)
+    return;
+  print_report("  %-34s %8llu %9.3f %9.3f %9.3f",
+               label,
+               (unsigned long long)stats->count,
+               (double)stats->total_ms / stats->count,
+               (double)stats->min_ms,
+               (double)stats->max_ms);
+}
+
+static void
+print_delivery_timing(const struct delivery_timing* timing)
+{
+  if (!delivery_timing_measured(timing))
+    return;
+
+  fputc('\n', stderr);
+  print_report("  --- Delivery latency ---");
+  print_report("  %-34s %8s %9s %9s %9s",
+               "Interval",
+               "samples",
+               "avg ms",
+               "min ms",
+               "max ms");
+  print_duration_row("Submitted to worker start", &timing->submitted_to_start);
+  print_duration_row("Delivery start to payload ready",
+                     &timing->start_to_payload_ready);
+  print_duration_row("Payload ready to writes posted",
+                     &timing->payload_ready_to_writes_posted);
+  print_duration_row("Writes posted to completion observed",
+                     &timing->writes_posted_to_completion);
+  print_duration_row("Submitted to slot reuse",
+                     &timing->submitted_to_slot_reuse);
+}
+
 void
 print_diagnostics_report(const struct stream_metrics* m, float wall_s)
 {
@@ -271,6 +319,8 @@ print_diagnostics_report(const struct stream_metrics* m, float wall_s)
                            wall_s);
   print_diagnostic_section(
     entries, DIAGNOSTIC_DEVICE_WORK, "Device work", "Measured work", wall_s);
+
+  print_delivery_timing(&m->delivery);
 
   if (m->scatter_samples_lost || m->lod_samples_lost) {
     fputc('\n', stderr);
@@ -591,6 +641,62 @@ json_diagnostics(struct json_writer* jw,
   jw_object_end(jw);
 }
 
+static void
+json_duration_stats(struct json_writer* jw,
+                    const char* id,
+                    const char* label,
+                    const struct duration_stats* stats)
+{
+  if (stats->count == 0)
+    return;
+  jw_key(jw, id);
+  jw_object_begin(jw);
+  jw_key(jw, "label");
+  jw_string(jw, label);
+  jw_key(jw, "total_ms");
+  jw_float(jw, (double)stats->total_ms);
+  jw_key(jw, "samples");
+  jw_uint(jw, stats->count);
+  jw_key(jw, "avg_ms");
+  jw_float(jw, (double)stats->total_ms / stats->count);
+  jw_key(jw, "min_ms");
+  jw_float(jw, (double)stats->min_ms);
+  jw_key(jw, "max_ms");
+  jw_float(jw, (double)stats->max_ms);
+  jw_object_end(jw);
+}
+
+static void
+json_delivery_timing(struct json_writer* jw,
+                     const struct delivery_timing* timing)
+{
+  if (!delivery_timing_measured(timing))
+    return;
+  jw_key(jw, "delivery_timing");
+  jw_object_begin(jw);
+  json_duration_stats(jw,
+                      "submitted_to_start",
+                      "Submitted to worker start",
+                      &timing->submitted_to_start);
+  json_duration_stats(jw,
+                      "start_to_payload_ready",
+                      "Delivery start to payload ready",
+                      &timing->start_to_payload_ready);
+  json_duration_stats(jw,
+                      "payload_ready_to_writes_posted",
+                      "Payload ready to writes posted",
+                      &timing->payload_ready_to_writes_posted);
+  json_duration_stats(jw,
+                      "writes_posted_to_completion",
+                      "Writes posted to completion observed",
+                      &timing->writes_posted_to_completion);
+  json_duration_stats(jw,
+                      "submitted_to_slot_reuse",
+                      "Submitted to slot reuse",
+                      &timing->submitted_to_slot_reuse);
+  jw_object_end(jw);
+}
+
 void
 print_bench_json_pass(const struct stream_metrics* m,
                       const struct stream_metric* sink_metric,
@@ -886,6 +992,7 @@ print_bench_json_pass(const struct stream_metrics* m,
   jw_object_end(&jw);
 
   json_diagnostics(&jw, m, wall_s);
+  json_delivery_timing(&jw, &m->delivery);
 
   jw_object_end(&jw);
   printf("%s\n", strbuf_cstr(&json_buf));

--- a/src/gpu/aggregate.h
+++ b/src/gpu/aggregate.h
@@ -30,6 +30,7 @@ extern "C"
     size_t device_capacity;
     size_t host_capacity;
     struct io_event io_done; // tracks IO completion from this slot's data
+    int64_t writes_posted_ns;
   };
 
   void aggregate_slot_destroy(struct aggregate_slot* slot);

--- a/src/gpu/flush.d2h_deliver.c
+++ b/src/gpu/flush.d2h_deliver.c
@@ -131,10 +131,14 @@ d2h_deliver_host_batch(struct d2h_deliver_stage* stage,
       struct aggregate_slot* slot =
         gpu_pool_at(handoff->batch.host_pool, fc, 0).p;
       slot->io_done = sink->record_fence(sink);
+      slot->writes_posted_ns =
+        slot->io_done.seq > 0 ? platform_monotonic_ns() : 0;
     }
 
     float sink_ms = platform_toc(&sink_clock) * 1000.0f;
     accumulate_metric_ms(&metrics->sink, sink_ms, sink_bytes, sink_bytes);
+    record_duration_ms(&metrics->delivery.payload_ready_to_writes_posted,
+                       sink_ms);
     if (sink_error)
       goto Error;
   }

--- a/src/gpu/schedule.c
+++ b/src/gpu/schedule.c
@@ -196,8 +196,16 @@ wait_io_fences(struct aggregate_slot* slot,
     return;
   struct platform_clock clk = { 0 };
   platform_toc(&clk);
-  if (slot->io_done.seq > 0)
+  if (slot->io_done.seq > 0) {
     sink->wait_fence(sink, slot->io_done);
+    if (metrics && slot->writes_posted_ns > 0) {
+      const float lifetime_ms =
+        (float)(platform_monotonic_ns() - slot->writes_posted_ns) / 1e6f;
+      record_duration_ms(&metrics->delivery.writes_posted_to_completion,
+                         lifetime_ms);
+    }
+    slot->writes_posted_ns = 0;
+  }
   if (metrics) {
     float ms = (float)(platform_toc(&clk) * 1000.0);
     accumulate_metric_ms(&metrics->io_fence_stall, ms, 0, 0);
@@ -223,6 +231,7 @@ schedule_deliver_batch(struct d2h_deliver_stage* stage,
                        struct stream_metrics* metrics,
                        struct platform_clock* metadata_update_clock)
 {
+  const int64_t delivery_start_ns = platform_monotonic_ns();
   const int fc = handoff->batch.slot_index;
   struct host_batch* host = NULL;
   int err = 1;
@@ -248,6 +257,12 @@ schedule_deliver_batch(struct d2h_deliver_stage* stage,
                                stage->shard_alignment,
                                &host))
       goto Done;
+
+    if (metrics) {
+      const float ready_ms =
+        (float)(platform_monotonic_ns() - delivery_start_ns) / 1e6f;
+      record_duration_ms(&metrics->delivery.start_to_payload_ready, ready_ms);
+    }
 
     float block_ms = platform_toc(&kick_clk) * 1000.0f;
     float own_ms = block_ms - (edge_stall_total_ms(metrics) - polls_before);
@@ -283,8 +298,8 @@ schedule_quiesce_output(struct stream_engine* e, struct shard_sink* sink)
   for (int fc = 0; fc < 2; ++fc) {
     struct aggregate_slot* slot =
       gpu_pool_at(&e->compress_agg.agg_host, fc, 0).p;
-    if (slot->io_done.seq > 0 && sink->wait_fence)
-      sink->wait_fence(sink, slot->io_done);
+    if (slot->io_done.seq > 0)
+      wait_io_fences(slot, sink, &e->metrics);
     slot->io_done.seq = 0;
   }
 }
@@ -365,6 +380,11 @@ delivery_main(void* arg)
     struct stream_engine* e = j->e;
     struct stream_context* ctx = j->ctx;
     const int cancel = d->sticky_error;
+    if (!cancel && j->submitted_ns > 0) {
+      const float queue_ms =
+        (float)(platform_monotonic_ns() - j->submitted_ns) / 1e6f;
+      record_duration_ms(&e->metrics.delivery.submitted_to_start, queue_ms);
+    }
     platform_mutex_unlock(d->mu);
 
     struct writer_result r;
@@ -417,7 +437,8 @@ gpu_delivery_enqueue(struct gpu_delivery* d,
                      struct stream_engine* e,
                      struct stream_context* ctx,
                      int fc,
-                     uint64_t generation)
+                     uint64_t generation,
+                     int64_t submitted_ns)
 {
   if (!d->thread)
     return 1;
@@ -427,6 +448,7 @@ gpu_delivery_enqueue(struct gpu_delivery* d,
   d->job[fc] = (struct delivery_job){
     .state = DELIVERY_JOB_SUBMITTED,
     .generation = generation,
+    .submitted_ns = submitted_ns,
     .e = e,
     .ctx = ctx,
   };
@@ -442,13 +464,14 @@ gpu_delivery_enqueue_submitted(struct gpu_delivery* d,
                                struct stream_engine* e,
                                struct stream_context* ctx,
                                int fc,
-                               uint64_t generation)
+                               uint64_t generation,
+                               int64_t submitted_ns)
 {
   // Aggregation is already queued, so without a worker the producer can deliver
   // this slot itself when it comes to refill it.
   if (!d->thread)
     return 0;
-  return gpu_delivery_enqueue(d, e, ctx, fc, generation);
+  return gpu_delivery_enqueue(d, e, ctx, fc, generation, submitted_ns);
 }
 
 int
@@ -622,6 +645,13 @@ deliver_slot(struct stream_engine* e, struct stream_context* ctx, int fc)
   float ms = (float)(platform_toc(&stall_clk) * 1000.0);
   accumulate_metric_ms(&e->metrics.flush_stall, ms, 0, 0);
 
+  if (s->delivery_submitted_ns > 0) {
+    const float reuse_ms =
+      (float)(platform_monotonic_ns() - s->delivery_submitted_ns) / 1e6f;
+    record_duration_ms(&e->metrics.delivery.submitted_to_slot_reuse, reuse_ms);
+    s->delivery_submitted_ns = 0;
+  }
+
   s->kicked = 0;
   return r;
 }
@@ -658,13 +688,15 @@ kick_batch(struct stream_engine* e,
         schedule_d2h_kick(&e->d2h_deliver, &s->handoff, e->streams.d2h) == 0);
 
   s->kicked = 1;
+  s->delivery_submitted_ns = platform_monotonic_ns();
 
   // Multiarray delivers inline. Single-array batches queue only their
   // oldest-first host copying and delivery.
   if (e->sched.mode == SCHEDULE_PIPELINED_DIRECT)
     CHECK(Error,
           gpu_delivery_enqueue_submitted(
-            &e->delivery, e, ctx, fc, generation) == 0);
+            &e->delivery, e, ctx, fc, generation, s->delivery_submitted_ns) ==
+            0);
 
   return 0;
 

--- a/src/gpu/schedule.h
+++ b/src/gpu/schedule.h
@@ -72,6 +72,7 @@ struct schedule_slot
   uint32_t* batch_active_masks; // [epochs_per_batch]; per-array allocation
   int kicked;
   uint64_t generation;
+  int64_t delivery_submitted_ns;
 
   // Retained through submission and oldest-first host copying. The views
   // remain owned by their pools; this slot carries their generation.
@@ -108,6 +109,7 @@ struct delivery_job
 {
   enum delivery_job_state state;
   uint64_t generation;
+  int64_t submitted_ns;
   struct stream_engine* e;
   struct stream_context* ctx;
   struct writer_result result;
@@ -145,7 +147,8 @@ gpu_delivery_enqueue_submitted(struct gpu_delivery* d,
                                struct stream_engine* e,
                                struct stream_context* ctx,
                                int fc,
-                               uint64_t generation);
+                               uint64_t generation,
+                               int64_t submitted_ns);
 
 int
 gpu_delivery_pending(struct gpu_delivery* d, int fc);

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -409,8 +409,10 @@ stream_flush_body(struct stream_engine* e, struct stream_context* ctx)
 
   // Writes queued anywhere above can still fail, and destroy frees the buffers
   // they read.
-  if (shard_sink_drain(ctx->sink))
+  if (shard_sink_drain(ctx->sink)) {
     r = writer_error();
+  }
+  schedule_quiesce_output(e, ctx->sink);
 
   collect_ingest_timing(e);
 

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -43,6 +43,23 @@ struct stream_metric
   uint64_t wait_calls;
 };
 
+struct duration_stats
+{
+  float total_ms;
+  float min_ms;
+  float max_ms;
+  uint64_t count;
+};
+
+struct delivery_timing
+{
+  struct duration_stats submitted_to_start;
+  struct duration_stats start_to_payload_ready;
+  struct duration_stats payload_ready_to_writes_posted;
+  struct duration_stats writes_posted_to_completion;
+  struct duration_stats submitted_to_slot_reuse;
+};
+
 struct stream_metrics
 {
   // Work done. Bytes may be summed across stages; times may not, since the
@@ -85,6 +102,8 @@ struct stream_metrics
   // Compatibility-only legacy field. GPU host copying leaves it at zero;
   // archived runs may still contain samples.
   struct stream_metric tail_gate;
+
+  struct delivery_timing delivery;
 
   // Optional GPU D2H copy totals. They remain zero for CPU runs.
   uint64_t d2h_payload_bytes_transferred;

--- a/src/util/metric.h
+++ b/src/util/metric.h
@@ -75,3 +75,14 @@ accumulate_metric_ms(struct stream_metric* m,
     m->best_output_bytes = (double)output_bytes;
   }
 }
+
+static inline void
+record_duration_ms(struct duration_stats* stats, float ms)
+{
+  stats->total_ms += ms;
+  if (stats->count == 0 || ms < stats->min_ms)
+    stats->min_ms = ms;
+  if (stats->count == 0 || ms > stats->max_ms)
+    stats->max_ms = ms;
+  stats->count++;
+}

--- a/tests/test_metric_check.h
+++ b/tests/test_metric_check.h
@@ -70,6 +70,30 @@ metric_any_arrived_timed(const struct stream_metric* m)
   return 1;
 }
 
+static inline int
+duration_any_arrived_timed(const char* name, const struct duration_stats* stats)
+{
+  if (stats->count == 0) {
+    log_error("  %s: no measurement arrived", name);
+    return 0;
+  }
+  if (!(stats->total_ms > 0.0f)) {
+    log_error("  %s: %llu measurements totalling %g ms",
+              name,
+              (unsigned long long)stats->count,
+              (double)stats->total_ms);
+    return 0;
+  }
+  if (stats->min_ms < 0.0f || stats->max_ms < stats->min_ms) {
+    log_error("  %s: invalid range %g to %g ms",
+              name,
+              (double)stats->min_ms,
+              (double)stats->max_ms);
+    return 0;
+  }
+  return 1;
+}
+
 // A ring that overwrote a measurement before anyone read it under-reports its
 // stage, and this counter is the only trace.
 static inline int

--- a/tests/test_metrics.c
+++ b/tests/test_metrics.c
@@ -92,6 +92,18 @@ check_shared_stages(const struct stream_metrics* m)
   ok &= metric_any_arrived_timed(&m->aggregate);
   ok &= metric_any_arrived_timed(&m->d2h);
   ok &= metric_any_arrived_timed(&m->sink);
+  ok &= duration_any_arrived_timed("delivery submitted to start",
+                                   &m->delivery.submitted_to_start);
+  ok &= duration_any_arrived_timed("delivery start to payload ready",
+                                   &m->delivery.start_to_payload_ready);
+  ok &= duration_any_arrived_timed("payload ready to writes posted",
+                                   &m->delivery.payload_ready_to_writes_posted);
+  ok &= duration_any_arrived_timed("delivery submitted to slot reuse",
+                                   &m->delivery.submitted_to_slot_reuse);
+  if (m->delivery.writes_posted_to_completion.count != 0) {
+    log_error("  test sink unexpectedly reported asynchronous writes");
+    ok = 0;
+  }
   if (m->tail_gate.count != 0 || m->tail_gate.ms != 0) {
     log_error("  %s: legacy metric is not zero", m->tail_gate.name);
     ok = 0;


### PR DESCRIPTION
## Summary

- record latency across submission, payload readiness, write posting, completion, and slot reuse
- report delivery timing in benchmark text and JSON output
- cover duration statistics and delivery timing metrics in tests

## Validation

- Release focused GPU tests: 4/4 passed
- Debug focused GPU tests: 4/4 passed
- Full Debug GPU suite: 58/58 passed
- L40 filesystem benchmark recorded completion timing for all 4 slots

## Stack

Based on #253 and intended to merge after it.