### PR TITLE
gpu: add C-Blosc LZ4 and Zstd support

### DIFF
--- a/src/gpu/CMakeLists.txt
+++ b/src/gpu/CMakeLists.txt
@@ -1,5 +1,11 @@
 add_src_lib(transpose SOURCES transpose.cu transpose.h LINKS CUDA::cuda_driver)
-add_src_lib(compress  SOURCES compress.cu compress.h   LINKS nvcomp::nvcomp CUDA::cudart_static chucky_log)
+add_src_lib(compress
+    SOURCES
+        compress.cu compress.h
+        blosc.frame.cu blosc.frame.h
+        blosc.shuffle.cu blosc.shuffle.h
+    LINKS nvcomp::nvcomp CUDA::cudart_static chucky_log
+)
 add_src_lib(aggregate SOURCES aggregate.cu aggregate.h LINKS CUDA::cudart_static CUDA::cuda_driver stream_config chucky_log)
 add_src_lib(lod       SOURCES lod.cu lod.h
                               reduce_csr_gpu.c reduce_csr_gpu.h

--- a/src/gpu/blosc.frame.cu
+++ b/src/gpu/blosc.frame.cu
@@ -1,0 +1,94 @@
+#include "gpu/blosc.frame.h"
+#include "gpu/prelude.cuda.h"
+
+__device__ static void
+put_u32le(unsigned char* dst, unsigned int value)
+{
+  dst[0] = (unsigned char)value;
+  dst[1] = (unsigned char)(value >> 8);
+  dst[2] = (unsigned char)(value >> 16);
+  dst[3] = (unsigned char)(value >> 24);
+}
+
+__global__ static void
+finalize_kernel(const unsigned char* original,
+                size_t original_stride,
+                unsigned char* encoded,
+                size_t encoded_stride,
+                size_t* sizes,
+                size_t chunk_bytes,
+                size_t typesize,
+                int codec_format,
+                int shuffle,
+                int force_copy,
+                size_t batch_size)
+{
+  const size_t chunk = blockIdx.x;
+  if (chunk >= batch_size)
+    return;
+
+  unsigned char* dst = encoded + chunk * encoded_stride;
+  const size_t payload_bytes = force_copy ? 0 : sizes[chunk];
+  const int compressed =
+    !force_copy && chunk_bytes > 8 && payload_bytes < chunk_bytes - 8;
+  unsigned char flags = (unsigned char)(0x10 | (codec_format << 5));
+  if (shuffle == CODEC_SHUFFLE_BYTE)
+    flags |= 0x01;
+  if (!compressed)
+    flags |= 0x02;
+
+  if (threadIdx.x == 0) {
+    dst[0] = 2; // BLOSC_VERSION_FORMAT
+    dst[1] = 1; // LZ4/Zstd payload format version
+    dst[2] = flags;
+    dst[3] = (unsigned char)typesize;
+    put_u32le(dst + 4, (unsigned int)chunk_bytes);
+    put_u32le(dst + 8, (unsigned int)chunk_bytes);
+    if (compressed) {
+      put_u32le(dst + 12,
+                (unsigned int)(GPU_BLOSC_PAYLOAD_OFFSET + payload_bytes));
+      put_u32le(dst + 16, 20); // absolute bstart
+      put_u32le(dst + 20, (unsigned int)payload_bytes);
+      sizes[chunk] = GPU_BLOSC_PAYLOAD_OFFSET + payload_bytes;
+    } else {
+      put_u32le(dst + 12, (unsigned int)(GPU_BLOSC_HEADER_BYTES + chunk_bytes));
+      sizes[chunk] = GPU_BLOSC_HEADER_BYTES + chunk_bytes;
+    }
+  }
+
+  if (!compressed) {
+    const unsigned char* src = original + chunk * original_stride;
+    for (size_t i = threadIdx.x; i < chunk_bytes; i += blockDim.x)
+      dst[GPU_BLOSC_HEADER_BYTES + i] = src[i];
+  }
+}
+
+extern "C" int
+gpu_blosc_finalize_async(enum compression_codec codec,
+                         enum codec_shuffle shuffle,
+                         size_t typesize,
+                         size_t chunk_bytes,
+                         const void* original,
+                         size_t original_stride,
+                         void* encoded,
+                         size_t encoded_stride,
+                         size_t* encoded_sizes,
+                         size_t batch_size,
+                         int force_copy,
+                         CUstream stream)
+{
+  const int format = codec == CODEC_BLOSC_LZ4 ? 1 : 4;
+  cudaStream_t cuda_stream = (cudaStream_t)stream;
+  return CUDA_LAUNCH(finalize_kernel<<<batch_size, 256, 0, cuda_stream>>>(
+    (const unsigned char*)original,
+    original_stride,
+    (unsigned char*)encoded,
+    encoded_stride,
+    encoded_sizes,
+    chunk_bytes,
+    typesize,
+    format,
+    shuffle,
+    force_copy,
+    batch_size));
+}

--- a/src/gpu/blosc.frame.h
+++ b/src/gpu/blosc.frame.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "types.codec.h"
+#include <cuda.h>
+#include <stddef.h>
+
+enum
+{
+  GPU_BLOSC_HEADER_BYTES = 16,
+  GPU_BLOSC_BLOCK_PREFIX_BYTES = 8,
+  GPU_BLOSC_PAYLOAD_OFFSET =
+    GPU_BLOSC_HEADER_BYTES + GPU_BLOSC_BLOCK_PREFIX_BYTES,
+  GPU_BLOSC_MIN_COMPRESS_BYTES = 128,
+};
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  // Turn raw nvCOMP payloads at encoded + GPU_BLOSC_PAYLOAD_OFFSET into
+  // complete one-block Blosc chunks. Incompressible inputs become whole-chunk
+  // MEMCPYED buffers copied from original without a host synchronization.
+  int gpu_blosc_finalize_async(enum compression_codec codec,
+                               enum codec_shuffle shuffle,
+                               size_t typesize,
+                               size_t chunk_bytes,
+                               const void* original,
+                               size_t original_stride,
+                               void* encoded,
+                               size_t encoded_stride,
+                               size_t* encoded_sizes,
+                               size_t batch_size,
+                               int force_copy,
+                               CUstream stream);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/gpu/blosc.shuffle.cu
+++ b/src/gpu/blosc.shuffle.cu
@@ -1,0 +1,52 @@
+#include "gpu/blosc.shuffle.h"
+#include "gpu/prelude.cuda.h"
+
+__global__ static void
+shuffle_kernel(const unsigned char* src,
+               size_t src_stride,
+               unsigned char* dst,
+               size_t dst_stride,
+               size_t chunk_bytes,
+               size_t typesize,
+               size_t batch_size)
+{
+  size_t p = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t total = batch_size * chunk_bytes;
+  if (p >= total)
+    return;
+
+  const size_t chunk = p / chunk_bytes;
+  const size_t out = p - chunk * chunk_bytes;
+  const size_t nelem = chunk_bytes / typesize;
+  const size_t complete = nelem * typesize;
+  size_t in = out;
+  if (out < complete) {
+    const size_t byte = out / nelem;
+    const size_t elem = out - byte * nelem;
+    in = elem * typesize + byte;
+  }
+  dst[chunk * dst_stride + out] = src[chunk * src_stride + in];
+}
+
+extern "C" int
+gpu_blosc_shuffle_async(const void* src,
+                        size_t src_stride,
+                        void* dst,
+                        size_t dst_stride,
+                        size_t chunk_bytes,
+                        size_t typesize,
+                        size_t batch_size,
+                        CUstream stream)
+{
+  const size_t total = batch_size * chunk_bytes;
+  const unsigned blocks = (unsigned)((total + 255) / 256);
+  cudaStream_t cuda_stream = (cudaStream_t)stream;
+  return CUDA_LAUNCH(
+    shuffle_kernel<<<blocks, 256, 0, cuda_stream>>>((const unsigned char*)src,
+                                                    src_stride,
+                                                    (unsigned char*)dst,
+                                                    dst_stride,
+                                                    chunk_bytes,
+                                                    typesize,
+                                                    batch_size));
+}

--- a/src/gpu/blosc.shuffle.h
+++ b/src/gpu/blosc.shuffle.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cuda.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  // Exact C-Blosc byte-plane mapping. Complete elements are transposed and any
+  // incomplete final element remains byte-for-byte at the end of the block.
+  int gpu_blosc_shuffle_async(const void* src,
+                              size_t src_stride,
+                              void* dst,
+                              size_t dst_stride,
+                              size_t chunk_bytes,
+                              size_t typesize,
+                              size_t batch_size,
+                              CUstream stream);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/gpu/compress.cu
+++ b/src/gpu/compress.cu
@@ -1,11 +1,27 @@
+#include "gpu/blosc.frame.h"
+#include "gpu/blosc.shuffle.h"
 #include "gpu/compress.h"
 #include "gpu/prelude.cuda.h"
 #include "log/log.h"
 #include "util/prelude.h"
+#include <limits.h>
 #include <nvcomp/lz4.h>
 #include <nvcomp/shared_types.h>
 #include <nvcomp/zstd.h>
 #include <string.h>
+
+static enum compression_codec
+nvcomp_codec(enum compression_codec type)
+{
+  switch (type) {
+    case CODEC_BLOSC_LZ4:
+      return CODEC_LZ4_NON_STANDARD;
+    case CODEC_BLOSC_ZSTD:
+      return CODEC_ZSTD;
+    default:
+      return type;
+  }
+}
 
 static const char*
 nvcomp_status_name(nvcompStatus_t st)
@@ -89,6 +105,7 @@ fill_sizes_kernel(size_t* d_sizes, size_t value, size_t count)
 extern "C" size_t
 codec_alignment(enum compression_codec type)
 {
+  type = nvcomp_codec(type);
   switch (type) {
     case CODEC_LZ4_NON_STANDARD:
       return nvcompLZ4RequiredCompressionAlignment;
@@ -107,6 +124,7 @@ codec_alignment(enum compression_codec type)
 extern "C" size_t
 codec_output_alignment(enum compression_codec type)
 {
+  type = nvcomp_codec(type);
   nvcompAlignmentRequirements_t written = {}, read = {};
   switch (type) {
     case CODEC_LZ4_NON_STANDARD:
@@ -138,6 +156,15 @@ Fail:
 extern "C" size_t
 codec_max_output_size(enum compression_codec type, size_t chunk_bytes)
 {
+  if (codec_is_blosc(type)) {
+    // C-Blosc stores these fields as signed 32-bit values and limits the
+    // source to INT_MAX - its 16-byte maximum overhead.
+    if (chunk_bytes == 0 ||
+        chunk_bytes > (size_t)INT_MAX - GPU_BLOSC_HEADER_BYTES)
+      return 0;
+    return chunk_bytes + GPU_BLOSC_HEADER_BYTES;
+  }
+
   size_t max_comp = 0;
   const size_t alignment = codec_output_alignment(type);
   CHECK(Fail, alignment > 0);
@@ -165,6 +192,46 @@ Fail:
   return 0;
 }
 
+static size_t
+nvcomp_max_output_size(enum compression_codec type, size_t chunk_bytes)
+{
+  size_t max_comp = 0;
+  switch (nvcomp_codec(type)) {
+    case CODEC_LZ4_NON_STANDARD:
+      NVCOMP(Fail,
+             nvcompBatchedLZ4CompressGetMaxOutputChunkSize(
+               chunk_bytes, nvcompBatchedLZ4CompressDefaultOpts, &max_comp));
+      return max_comp;
+    case CODEC_ZSTD:
+      NVCOMP(Fail,
+             nvcompBatchedZstdCompressGetMaxOutputChunkSize(
+               chunk_bytes, nvcompBatchedZstdCompressDefaultOpts, &max_comp));
+      return max_comp;
+    default:
+      return chunk_bytes;
+  }
+Fail:
+  return 0;
+}
+
+extern "C" size_t
+codec_output_stride(enum compression_codec type, size_t chunk_bytes)
+{
+  if (!codec_is_blosc(type))
+    return codec_max_output_size(type, chunk_bytes);
+
+  const size_t alignment = codec_output_alignment(type);
+  const size_t payload_bound = nvcomp_max_output_size(type, chunk_bytes);
+  if (alignment == 0 || payload_bound == 0 ||
+      GPU_BLOSC_PAYLOAD_OFFSET % alignment != 0 ||
+      payload_bound > SIZE_MAX - GPU_BLOSC_PAYLOAD_OFFSET)
+    return 0;
+  const size_t framed = GPU_BLOSC_PAYLOAD_OFFSET + payload_bound;
+  if (framed > SIZE_MAX - (alignment - 1))
+    return 0;
+  return align_up(framed, alignment);
+}
+
 // --- codec_temp_bytes ---
 
 extern "C" size_t
@@ -172,6 +239,7 @@ codec_temp_bytes(enum compression_codec type,
                  size_t chunk_bytes,
                  size_t batch_size)
 {
+  type = nvcomp_codec(type);
   size_t temp = 0;
   switch (type) {
     case CODEC_NONE:
@@ -208,13 +276,35 @@ Fail:
 extern "C" size_t
 codec_device_bytes(enum compression_codec type,
                    size_t chunk_bytes,
-                   size_t batch_size)
+                   size_t batch_size,
+                   int reserve_byte_shuffle)
 {
+  if (batch_size == 0 || batch_size > SIZE_MAX / sizeof(size_t))
+    return 0;
   size_t bytes = batch_size * sizeof(size_t); // d_comp_sizes
-  bytes += batch_size * sizeof(size_t);       // d_uncomp_sizes
-  if (type != CODEC_NONE)
-    bytes += 2 * batch_size * sizeof(void*);                // d_ptrs
-  bytes += codec_temp_bytes(type, chunk_bytes, batch_size); // d_temp
+  if (bytes > SIZE_MAX - batch_size * sizeof(size_t))
+    return 0;
+  bytes += batch_size * sizeof(size_t); // d_uncomp_sizes
+  if (type != CODEC_NONE) {
+    if (batch_size > SIZE_MAX / (2 * sizeof(void*)) ||
+        2 * batch_size * sizeof(void*) > SIZE_MAX - bytes)
+      return 0;
+    bytes += 2 * batch_size * sizeof(void*); // d_ptrs
+  }
+  const size_t temp = codec_temp_bytes(type, chunk_bytes, batch_size);
+  if (temp > SIZE_MAX - bytes)
+    return 0;
+  bytes += temp; // d_temp
+  if (codec_is_blosc(type) && reserve_byte_shuffle) {
+    const size_t alignment = codec_alignment(type);
+    if (alignment == 0 || chunk_bytes > SIZE_MAX - (alignment - 1))
+      return 0;
+    const size_t shuffle_stride = align_up(chunk_bytes, alignment);
+    if (shuffle_stride > SIZE_MAX / batch_size ||
+        shuffle_stride * batch_size > SIZE_MAX - bytes)
+      return 0;
+    bytes += shuffle_stride * batch_size; // d_shuffle
+  }
   return bytes;
 }
 
@@ -226,21 +316,83 @@ codec_init(struct codec* c,
            size_t chunk_bytes,
            size_t batch_size)
 {
+  struct codec_config config = {
+    .id = type,
+    .level = (uint8_t)(type == CODEC_LZ4_NON_STANDARD ? 1 : 0),
+    .shuffle = CODEC_SHUFFLE_NONE
+  };
+  return codec_init_config(c, config, 1, chunk_bytes, batch_size, 0);
+}
+
+extern "C" int
+codec_validate_gpu(struct codec_config config,
+                   size_t typesize,
+                   size_t chunk_bytes)
+{
+  if (!codec_is_gpu_supported(config.id)) {
+    log_error("codec %d is not supported on GPU", (int)config.id);
+    return 1;
+  }
+  if (!codec_is_blosc(config.id))
+    return 0;
+  if (config.level > 9) {
+    log_error("blosc level must be 0..9 (got %u)", config.level);
+    return 1;
+  }
+  if (config.shuffle == CODEC_SHUFFLE_BIT) {
+    log_error("GPU blosc bitshuffle is not supported");
+    return 1;
+  }
+  if (config.shuffle != CODEC_SHUFFLE_NONE &&
+      config.shuffle != CODEC_SHUFFLE_BYTE) {
+    log_error("invalid GPU blosc shuffle mode %d", (int)config.shuffle);
+    return 1;
+  }
+  if (typesize == 0 || typesize > 255) {
+    log_error("GPU blosc typesize must be 1..255 (got %zu)", typesize);
+    return 1;
+  }
+  // A single block must fit C-Blosc's decompressor scratch-size contract.
+  const size_t max_block = ((size_t)INT_MAX - 255 * 4) / 3;
+  if (chunk_bytes == 0 || chunk_bytes > max_block) {
+    log_error("GPU blosc single-block input %zu exceeds limit %zu",
+              chunk_bytes,
+              max_block);
+    return 1;
+  }
+  if (codec_max_output_size(config.id, chunk_bytes) == 0 ||
+      codec_output_stride(config.id, chunk_bytes) == 0) {
+    log_error("GPU blosc does not support %zu-byte chunks", chunk_bytes);
+    return 1;
+  }
+  return 0;
+}
+
+extern "C" int
+codec_init_config(struct codec* c,
+                  struct codec_config config,
+                  size_t typesize,
+                  size_t chunk_bytes,
+                  size_t batch_size,
+                  int reserve_byte_shuffle)
+{
   memset(c, 0, sizeof(*c));
-  c->type = type;
+  c->type = config.id;
+  c->config = config;
+  c->typesize = typesize;
   c->chunk_bytes = chunk_bytes;
   c->chunk_capacity = chunk_bytes;
   c->batch_size = batch_size;
 
-  if (!codec_is_gpu_supported(type)) {
-    log_error("codec %d is not supported on GPU", (int)type);
+  if (batch_size == 0 || codec_validate_gpu(config, typesize, chunk_bytes))
     goto Fail;
-  }
 
-  c->max_output_size = codec_max_output_size(type, chunk_bytes);
+  c->max_output_size = codec_max_output_size(config.id, chunk_bytes);
   CHECK(Fail, c->max_output_size > 0);
+  c->output_stride = codec_output_stride(config.id, chunk_bytes);
+  CHECK(Fail, c->output_stride > 0);
 
-  c->temp_bytes = codec_temp_bytes(type, chunk_bytes, batch_size);
+  c->temp_bytes = codec_temp_bytes(config.id, chunk_bytes, batch_size);
 
   // Allocate device arrays
   CU(Fail,
@@ -262,7 +414,7 @@ codec_init(struct codec* c,
   }
 
   // For CODEC_NONE, pre-fill d_comp_sizes with chunk_bytes
-  if (type == CODEC_NONE) {
+  if (config.id == CODEC_NONE) {
     size_t* h = (size_t*)malloc(batch_size * sizeof(size_t));
     if (!h)
       goto Fail;
@@ -275,7 +427,7 @@ codec_init(struct codec* c,
   }
 
   // Pointer arrays for nvcomp (not needed for CODEC_NONE)
-  if (type != CODEC_NONE) {
+  if (config.id != CODEC_NONE) {
     CU(Fail,
        cuMemAlloc((CUdeviceptr*)&c->d_ptrs, 2 * batch_size * sizeof(void*)));
   }
@@ -283,6 +435,14 @@ codec_init(struct codec* c,
   // Temp workspace
   if (c->temp_bytes > 0) {
     CU(Fail, cuMemAlloc((CUdeviceptr*)&c->d_temp, c->temp_bytes));
+  }
+
+  if (codec_is_blosc(config.id) && reserve_byte_shuffle) {
+    c->shuffle_stride = align_up(chunk_bytes, codec_alignment(config.id));
+    CHECK_MUL_OVERFLOW(Fail, batch_size, c->shuffle_stride, SIZE_MAX);
+    CU(Fail,
+       cuMemAlloc((CUdeviceptr*)&c->d_shuffle, batch_size * c->shuffle_stride));
+    c->has_shuffle_scratch = 1;
   }
 
   return 0;
@@ -295,21 +455,44 @@ Fail:
 extern "C" int
 codec_set_chunk_bytes(struct codec* c, size_t chunk_bytes, CUstream stream)
 {
+  return codec_bind(c, c->config, c->typesize, chunk_bytes, stream);
+}
+
+extern "C" int
+codec_bind(struct codec* c,
+           struct codec_config config,
+           size_t typesize,
+           size_t chunk_bytes,
+           CUstream stream)
+{
   const unsigned block = 256;
   unsigned grid = 0;
   cudaStream_t cuda_stream = (cudaStream_t)stream;
-  CHECK(Fail, c && chunk_bytes > 0 && chunk_bytes <= c->chunk_capacity);
-  if (chunk_bytes == c->chunk_bytes)
+  CHECK(Fail,
+        c && config.id == c->type && chunk_bytes > 0 &&
+          chunk_bytes <= c->chunk_capacity);
+  CHECK(Fail, codec_validate_gpu(config, typesize, chunk_bytes) == 0);
+  if (config.shuffle == CODEC_SHUFFLE_BYTE && !c->has_shuffle_scratch) {
+    log_error("GPU blosc byte shuffle scratch was not reserved");
+    goto Fail;
+  }
+  if (chunk_bytes == c->chunk_bytes && typesize == c->typesize &&
+      config.id == c->config.id && config.level == c->config.level &&
+      config.shuffle == c->config.shuffle)
     return 0;
 
-  grid = (unsigned)((c->batch_size + block - 1) / block);
-  CUDA_LAUNCH_OR(Fail,
-                 fill_sizes_kernel<<<grid, block, 0, cuda_stream>>>(
-                   c->d_uncomp_sizes, chunk_bytes, c->batch_size));
-  if (c->type == CODEC_NONE)
+  if (chunk_bytes != c->chunk_bytes) {
+    grid = (unsigned)((c->batch_size + block - 1) / block);
     CUDA_LAUNCH_OR(Fail,
                    fill_sizes_kernel<<<grid, block, 0, cuda_stream>>>(
-                     c->d_comp_sizes, chunk_bytes, c->batch_size));
+                     c->d_uncomp_sizes, chunk_bytes, c->batch_size));
+    if (c->type == CODEC_NONE)
+      CUDA_LAUNCH_OR(Fail,
+                     fill_sizes_kernel<<<grid, block, 0, cuda_stream>>>(
+                       c->d_comp_sizes, chunk_bytes, c->batch_size));
+  }
+  c->config = config;
+  c->typesize = typesize;
   c->chunk_bytes = chunk_bytes;
   return 0;
 
@@ -326,10 +509,12 @@ codec_free(struct codec* c)
   cu_mem_free((CUdeviceptr)c->d_uncomp_sizes);
   cu_mem_free((CUdeviceptr)c->d_ptrs);
   cu_mem_free((CUdeviceptr)c->d_temp);
+  cu_mem_free((CUdeviceptr)c->d_shuffle);
   c->d_comp_sizes = NULL;
   c->d_uncomp_sizes = NULL;
   c->d_ptrs = NULL;
   c->d_temp = NULL;
+  c->d_shuffle = NULL;
 }
 
 // --- codec_compress ---
@@ -346,6 +531,14 @@ codec_compress(struct codec* c,
   const void* const* uncomp_ptrs = (const void* const*)c->d_ptrs;
   void* const* comp_ptrs = (void* const*)(c->d_ptrs + n);
   cudaStream_t cuda_stream = (cudaStream_t)stream;
+  const int is_blosc = codec_is_blosc(c->type);
+  const int force_copy =
+    is_blosc &&
+    (c->config.level == 0 || c->chunk_bytes < GPU_BLOSC_MIN_COMPRESS_BYTES);
+  const void* nvcomp_input = d_input;
+  size_t nvcomp_input_stride = input_stride;
+
+  CHECK(Fail, n > 0 && n <= c->batch_size);
 
   if (c->type == CODEC_NONE) {
     // All callers pass input_stride == chunk_bytes.
@@ -369,20 +562,53 @@ codec_compress(struct codec* c,
     return 0;
   }
 
+  if (force_copy) {
+    CHECK(Fail,
+          gpu_blosc_finalize_async(c->type,
+                                   c->config.shuffle,
+                                   c->typesize,
+                                   c->chunk_bytes,
+                                   d_input,
+                                   input_stride,
+                                   d_output,
+                                   c->output_stride,
+                                   c->d_comp_sizes,
+                                   n,
+                                   1,
+                                   stream) == 0);
+    return 0;
+  }
+
+  if (is_blosc && c->config.shuffle == CODEC_SHUFFLE_BYTE && c->typesize > 1) {
+    CHECK_MUL_OVERFLOW(Fail, n, c->chunk_bytes, SIZE_MAX);
+    CHECK(Fail,
+          gpu_blosc_shuffle_async(d_input,
+                                  input_stride,
+                                  c->d_shuffle,
+                                  c->shuffle_stride,
+                                  c->chunk_bytes,
+                                  c->typesize,
+                                  n,
+                                  stream) == 0);
+    nvcomp_input = c->d_shuffle;
+    nvcomp_input_stride = c->shuffle_stride;
+  }
+
   // Fill pointer arrays
   {
     unsigned blocks = (unsigned)((n + 255) / 256);
     CUDA_LAUNCH_OR(
       Fail,
-      fill_ptrs_kernel<<<blocks, 256, 0, cuda_stream>>>(c->d_ptrs,
-                                                        (const char*)d_input,
-                                                        input_stride,
-                                                        (char*)d_output,
-                                                        c->max_output_size,
-                                                        n));
+      fill_ptrs_kernel<<<blocks, 256, 0, cuda_stream>>>(
+        c->d_ptrs,
+        (const char*)nvcomp_input,
+        nvcomp_input_stride,
+        (char*)d_output + (is_blosc ? GPU_BLOSC_PAYLOAD_OFFSET : 0),
+        c->output_stride,
+        n));
   }
 
-  switch (c->type) {
+  switch (nvcomp_codec(c->type)) {
     case CODEC_LZ4_NON_STANDARD:
       NVCOMP(Fail,
              nvcompBatchedLZ4CompressAsync(uncomp_ptrs,
@@ -416,6 +642,22 @@ codec_compress(struct codec* c,
 
     default:
       goto Fail;
+  }
+
+  if (is_blosc) {
+    CHECK(Fail,
+          gpu_blosc_finalize_async(c->type,
+                                   c->config.shuffle,
+                                   c->typesize,
+                                   c->chunk_bytes,
+                                   d_input,
+                                   input_stride,
+                                   d_output,
+                                   c->output_stride,
+                                   c->d_comp_sizes,
+                                   n,
+                                   0,
+                                   stream) == 0);
   }
 
   return 0;

--- a/src/gpu/compress.h
+++ b/src/gpu/compress.h
@@ -12,10 +12,15 @@ extern "C"
   struct codec
   {
     enum compression_codec type;
-    size_t max_output_size; // max compressed bytes per chunk
+    struct codec_config config;
+    size_t max_output_size; // max valid encoded bytes per chunk
+    size_t output_stride;   // fixed device slot stride (may be larger)
     size_t chunk_bytes;     // active uncompressed bytes per chunk
     size_t chunk_capacity;  // largest input size accepted by this instance
-    size_t batch_size;      // number of chunks
+    size_t typesize;        // active Blosc element size
+    size_t shuffle_stride;  // aligned per-chunk scratch stride
+    int has_shuffle_scratch;
+    size_t batch_size; // number of chunks
 
     // Device state (owned, allocated by codec_init)
     size_t* d_comp_sizes;   // [batch_size] filled by codec_compress
@@ -23,6 +28,7 @@ extern "C"
     void** d_ptrs;          // [2 * batch_size] scratch for nvcomp ptr arrays
     void* d_temp;           // workspace
     size_t temp_bytes;      // workspace size
+    void* d_shuffle;        // Blosc byte-shuffle batch scratch
   };
 
   // Alignment required of every uncompressed chunk handed to the codec.
@@ -31,15 +37,22 @@ extern "C"
   // Alignment required of every compressed chunk in the output pool.
   size_t codec_output_alignment(enum compression_codec type);
 
-  // Query max compressed output size per chunk, rounded up so chunks spaced by
-  // this value stay aligned (no GPU allocation).
+  // Query the maximum valid encoded size per chunk (no GPU allocation). Raw
+  // nvCOMP codecs return an aligned slot bound; Blosc returns nbytes + 16.
   size_t codec_max_output_size(enum compression_codec type, size_t chunk_bytes);
 
-  // Total device bytes codec_init allocates (size arrays, ptr table, nvcomp
-  // temp) — sizing mirror for the memory estimate (no GPU allocation).
+  // Fixed device slot stride. For Blosc this includes the 24-byte frame
+  // prefix plus nvCOMP's payload bound; it is intentionally distinct from
+  // codec_max_output_size(), the nbytes + 16 wire-format bound.
+  size_t codec_output_stride(enum compression_codec type, size_t chunk_bytes);
+
+  // Total device bytes codec_init_config allocates (size arrays, ptr table,
+  // nvCOMP temp, and optional byte-shuffle scratch) — sizing mirror for the
+  // memory estimate (no GPU allocation).
   size_t codec_device_bytes(enum compression_codec type,
                             size_t chunk_bytes,
-                            size_t batch_size);
+                            size_t batch_size,
+                            int reserve_byte_shuffle);
 
   size_t codec_temp_bytes(enum compression_codec type,
                           size_t chunk_bytes,
@@ -51,19 +64,38 @@ extern "C"
                  size_t chunk_bytes,
                  size_t batch_size);
 
+  int codec_init_config(struct codec* c,
+                        struct codec_config config,
+                        size_t typesize,
+                        size_t chunk_bytes,
+                        size_t batch_size,
+                        int reserve_byte_shuffle);
+
   // Select the active input geometry for a shared codec instance. The codec
-  // allocations remain sized to chunk_capacity/max_output_size; the per-chunk
+  // allocations remain sized to chunk_capacity/output_stride; the per-chunk
   // size arrays are refreshed on stream before the next compression/aggregate.
   int codec_set_chunk_bytes(struct codec* c,
                             size_t chunk_bytes,
                             CUstream stream);
+
+  // Bind all active per-array Blosc state as well as chunk geometry.
+  int codec_bind(struct codec* c,
+                 struct codec_config config,
+                 size_t typesize,
+                 size_t chunk_bytes,
+                 CUstream stream);
+
+  // Validate the GPU-specific Blosc contract without allocating device state.
+  int codec_validate_gpu(struct codec_config config,
+                         size_t typesize,
+                         size_t chunk_bytes);
 
   // Free device resources.
   void codec_free(struct codec* c);
 
   // Compress batch_size chunks.
   //   Input:  d_input  + i * input_stride  (each chunk_bytes bytes)
-  //   Output: d_output + i * max_output_size
+  //   Output: d_output + i * output_stride
   //   c->d_comp_sizes[i] filled with actual compressed size.
   // CODEC_NONE: single cuMemcpyDtoDAsync of batch_size * chunk_bytes bytes.
   // actual_batch_size: number of chunks to compress (0 = use c->batch_size).

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -43,7 +43,8 @@ Error:
 int
 compress_agg_init_shared(struct compress_agg_stage* stage,
                          const struct engine_limits* lim,
-                         enum compression_codec codec_id,
+                         struct codec_config codec,
+                         size_t typesize,
                          struct gpu_ordering* ord,
                          CUstream compute)
 {
@@ -63,7 +64,13 @@ compress_agg_init_shared(struct compress_agg_stage* stage,
   const uint64_t M = lim->codec_batch;
 
   // Codec
-  CHECK(Fail, codec_init(&stage->codec, codec_id, lim->chunk_bytes, M) == 0);
+  CHECK(Fail,
+        codec_init_config(&stage->codec,
+                          codec,
+                          typesize,
+                          lim->chunk_bytes,
+                          M,
+                          lim->any_byte_shuffle) == 0);
 
   stage->pool_epochs_stride = K;
   stage->pool_epochs_scratch =
@@ -72,16 +79,15 @@ compress_agg_init_shared(struct compress_agg_stage* stage,
     (uint32_t*)malloc((size_t)LOD_MAX_LEVELS * K * sizeof(uint32_t));
   CHECK(Fail, stage->pool_epochs_scratch && stage->cached_pool_epochs);
 
-  CHECK_MUL_OVERFLOW(Fail, M, stage->codec.max_output_size, SIZE_MAX);
+  CHECK_MUL_OVERFLOW(Fail, M, stage->codec.output_stride, SIZE_MAX);
   // Compressed buffers + events. CODEC_NONE aggregates directly from pool_buf
   // (see compress_agg_aggregate), so the d_compressed buffer is unused — skip
   // its M * chunk_bytes allocation per fc. Destroy is NULL-safe.
   const int need_compressed = (stage->codec.type != CODEC_NONE);
   for (int fc = 0; fc < 2; ++fc) {
     if (need_compressed)
-      CU(
-        Fail,
-        cuMemAlloc(&stage->d_compressed[fc], M * stage->codec.max_output_size));
+      CU(Fail,
+         cuMemAlloc(&stage->d_compressed[fc], M * stage->codec.output_stride));
     CU(Fail, cuEventCreate(&stage->t_compress_start[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->t_compress_end[fc], CU_EVENT_DEFAULT));
     CU(Fail, cuEventCreate(&stage->t_aggregate_start[fc], CU_EVENT_DEFAULT));
@@ -300,7 +306,8 @@ compress_agg_init(struct compress_agg_stage* stage,
   memset(&lim, 0, sizeof(lim));
   CHECK(Fail, engine_limits_accumulate(&lim, cl, config) == 0);
   CHECK(Fail,
-        compress_agg_init_shared(stage, &lim, config->codec.id, ord, compute) ==
+        compress_agg_init_shared(
+          stage, &lim, config->codec, dtype_bpe(config->dtype), ord, compute) ==
           0);
   CHECK(Fail, compress_agg_array_init(&stage->ar, cl) == 0);
   size_t output_bytes = 0;
@@ -336,14 +343,21 @@ compress_agg_memory_estimate(const struct engine_limits* lim,
                              size_t* aggregate_device_bytes,
                              size_t* aggregate_host_bytes)
 {
+  (void)cl;
   // d_compressed[2]; skipped for CODEC_NONE (kick aggregates from the pool).
-  *compressed_pool_bytes =
-    (codec_id == CODEC_NONE)
-      ? 0
-      : 2 * (size_t)lim->codec_batch * cl->max_output_size;
+  *compressed_pool_bytes = 0;
+  if (codec_id != CODEC_NONE) {
+    const size_t stride = codec_output_stride(codec_id, lim->chunk_bytes);
+    CHECK(Error, stride > 0);
+    CHECK_MUL_OVERFLOW(Error, lim->codec_batch, stride, SIZE_MAX);
+    const size_t one_pool = (size_t)lim->codec_batch * stride;
+    CHECK_MUL_OVERFLOW(Error, 2, one_pool, SIZE_MAX);
+    *compressed_pool_bytes = 2 * one_pool;
+  }
 
-  *codec_bytes =
-    codec_device_bytes(codec_id, lim->chunk_bytes, lim->codec_batch);
+  *codec_bytes = codec_device_bytes(
+    codec_id, lim->chunk_bytes, lim->codec_batch, lim->any_byte_shuffle);
+  CHECK(Error, *codec_bytes > 0);
 
   size_t dev = 0;
   size_t host = 0;
@@ -544,7 +558,7 @@ compress_agg_aggregate(struct compress_agg_stage* stage,
   if (plan->layout.total_batch_chunks > 0) {
     const size_t aggregate_source_stride = stage->codec.type == CODEC_NONE
                                              ? stage->codec.chunk_bytes
-                                             : stage->codec.max_output_size;
+                                             : stage->codec.output_stride;
     CHECK(Error,
           aggregate_batch_unified_async(
             (const void*)d_aggregate_src,

--- a/src/gpu/flush.compress_agg.h
+++ b/src/gpu/flush.compress_agg.h
@@ -10,7 +10,8 @@ struct engine_limits;
 int
 compress_agg_init_shared(struct compress_agg_stage* stage,
                          const struct engine_limits* lim,
-                         enum compression_codec codec_id,
+                         struct codec_config codec,
+                         size_t typesize,
                          struct gpu_ordering* ord,
                          CUstream compute);
 

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -297,6 +297,7 @@ struct engine_limits
   size_t lod_morton_bytes;
   size_t host_output_bytes;
   int any_multiscale;
+  int any_byte_shuffle;
   int max_threads; // max over arrays; 0 = platform default
 };
 
@@ -312,7 +313,8 @@ engine_limits_accumulate(struct engine_limits* lim,
 int
 stream_engine_init(struct stream_engine* e,
                    const struct engine_limits* lim,
-                   enum compression_codec codec_id,
+                   struct codec_config codec,
+                   size_t typesize,
                    int scatter_is_copy);
 
 // Free shared engine resources. Per-array state (engine_array_state) is

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -53,6 +53,8 @@ engine_limits_accumulate(struct engine_limits* lim,
     max_sz(lim->pool_bytes, (size_t)K * total_chunks * chunk_stride * bpe);
   lim->chunk_bytes = max_sz(lim->chunk_bytes, chunk_stride * bpe);
   lim->codec_batch = max_u64(lim->codec_batch, (uint64_t)K * total_chunks);
+  if (config->codec.shuffle == CODEC_SHUFFLE_BYTE)
+    lim->any_byte_shuffle = 1;
   if (K > lim->epochs_per_batch)
     lim->epochs_per_batch = K;
   if (cl->levels.nlod > lim->max_nlod)
@@ -110,7 +112,8 @@ destroy_chunk_pools(struct pool_state* pools)
 int
 stream_engine_init(struct stream_engine* e,
                    const struct engine_limits* lim,
-                   enum compression_codec codec_id,
+                   struct codec_config codec,
+                   size_t typesize,
                    int scatter_is_copy)
 {
   if (cuCtxGetCurrent(&e->cuda) != CUDA_SUCCESS)
@@ -153,15 +156,17 @@ stream_engine_init(struct stream_engine* e,
 
   e->sched.epochs_per_batch = lim->epochs_per_batch;
 
-  CHECK(Fail,
-        compress_agg_init_shared(
-          &e->compress_agg, lim, codec_id, &e->ord, e->streams.compute) == 0);
+  CHECK(
+    Fail,
+    compress_agg_init_shared(
+      &e->compress_agg, lim, codec, typesize, &e->ord, e->streams.compute) ==
+      0);
 
   // shard_alignment is per-array; set by stream_engine_bind_array.
   CHECK(Fail,
         d2h_deliver_init(&e->d2h_deliver,
                          0,
-                         codec_id == CODEC_NONE ? AGGREGATE_FIXED_SIZE
+                         codec.id == CODEC_NONE ? AGGREGATE_FIXED_SIZE
                                                 : AGGREGATE_VARIABLE_SIZE,
                          &e->ord,
                          e->streams.payload_copy,
@@ -303,10 +308,11 @@ stream_engine_bind_array(struct stream_engine* e,
   // Select fallible shared geometry before replacing the engine's per-array
   // views, so a failed bind leaves the prior binding intact.
   CHECK(Error,
-        codec_set_chunk_bytes(&e->compress_agg.codec,
-                              ctx->layout.chunk_stride *
-                                dtype_bpe(ctx->config.dtype),
-                              e->streams.compress) == 0);
+        codec_bind(&e->compress_agg.codec,
+                   ctx->config.codec,
+                   dtype_bpe(ctx->config.dtype),
+                   ctx->layout.chunk_stride * dtype_bpe(ctx->config.dtype),
+                   e->streams.compress) == 0);
 
   e->sched = st->sched;
   e->sched.lod_active =
@@ -386,6 +392,11 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
                                codec_max_output_size,
                                shard_sink_required_shard_alignment(sink),
                                &cl) == 0);
+  CHECK(FailPhase1,
+        codec_validate_gpu(config->codec,
+                           dtype_bpe(config->dtype),
+                           cl.layouts[0].chunk_stride *
+                             dtype_bpe(config->dtype)) == 0);
 
   struct tile_stream_gpu* out =
     (struct tile_stream_gpu*)calloc(1, sizeof(*out));
@@ -402,9 +413,11 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
   memset(&lim, 0, sizeof(lim));
   CHECK(FailPhase2, engine_limits_accumulate(&lim, &cl, config) == 0);
   CHECK(FailPhase2,
-        stream_engine_init(
-          &out->engine, &lim, config->codec.id, cl.levels.enable_multiscale) ==
-          0);
+        stream_engine_init(&out->engine,
+                           &lim,
+                           config->codec,
+                           dtype_bpe(config->dtype),
+                           cl.levels.enable_multiscale) == 0);
   CHECK(FailPhase2,
         engine_array_state_init(
           &out->ar, &out->ctx, &cl, &out->engine.delivery) == 0);
@@ -494,6 +507,10 @@ tile_stream_gpu_memory_estimate(const struct tile_stream_configuration* config,
                              shard_alignment,
                              &cl))
     return 1;
+  if (codec_validate_gpu(config->codec,
+                         dtype_bpe(config->dtype),
+                         cl.layouts[0].chunk_stride * dtype_bpe(config->dtype)))
+    goto Fail;
 
   struct engine_limits lim;
   memset(&lim, 0, sizeof(lim));

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -108,6 +108,11 @@ init_array_descriptor(struct array_descriptor_gpu* desc,
                              desc->ctx.shard_alignment,
                              &desc->cl))
     return 1;
+  if (codec_validate_gpu(config->codec,
+                         dtype_bpe(config->dtype),
+                         desc->cl.layouts[0].chunk_stride *
+                           dtype_bpe(config->dtype)))
+    return 1;
 
   // Fold this array into the shared-resource maxima before
   // engine_array_state_init moves cl->plan out.
@@ -433,7 +438,8 @@ multiarray_tile_stream_gpu_create(
   CHECK(Fail,
         stream_engine_init(&ms->engine,
                            &lim,
-                           ms->arrays[0].ctx.config.codec.id,
+                           ms->arrays[0].ctx.config.codec,
+                           dtype_bpe(ms->arrays[0].ctx.config.dtype),
                            all_multiscale) == 0);
 
   ms->output_pool = compress_agg_output_pool_create(lim.host_output_bytes);

--- a/src/stream.gpu.h
+++ b/src/stream.gpu.h
@@ -14,10 +14,10 @@ struct tile_stream_memory_info
   // Breakdown (device)
   size_t staging_bytes;         // 2 x buffer_capacity_bytes
   size_t chunk_pool_bytes;      // 2 x total_chunks x chunk_stride x bpe
-  size_t compressed_pool_bytes; // 2 x total_chunks x max_output_size
+  size_t compressed_pool_bytes; // 2 x codec_batch x device output stride
   size_t aggregate_bytes;       // sum over levels: device aggregate buffers
   size_t lod_bytes;             // d_linear + d_morton + shape arrays
-  size_t codec_bytes;           // nvcomp workspace + pointer arrays
+  size_t codec_bytes; // nvCOMP workspace + pointer/size arrays + filter scratch
 
   // Breakdown (host heap, not pinned)
   size_t shard_bytes; // active_shard arrays + index buffers

--- a/src/stream/config.c
+++ b/src/stream/config.c
@@ -176,6 +176,13 @@ validate_config(const struct tile_stream_configuration* config,
     goto Fail;
   }
 
+  if (codec_is_blosc(config->codec.id) &&
+      (config->codec.shuffle < CODEC_SHUFFLE_NONE ||
+       config->codec.shuffle > CODEC_SHUFFLE_BIT)) {
+    log_error("invalid blosc shuffle mode %d", (int)config->codec.shuffle);
+    goto Fail;
+  }
+
   if (config->max_nlod < 0) {
     log_error("max_nlod must be >= 0 (got %d)", config->max_nlod);
     goto Fail;

--- a/src/types.codec.c
+++ b/src/types.codec.c
@@ -9,5 +9,6 @@ codec_is_blosc(enum compression_codec c)
 int
 codec_is_gpu_supported(enum compression_codec c)
 {
-  return c == CODEC_NONE || c == CODEC_LZ4_NON_STANDARD || c == CODEC_ZSTD;
+  return c == CODEC_NONE || c == CODEC_LZ4_NON_STANDARD || c == CODEC_ZSTD ||
+         codec_is_blosc(c);
 }

--- a/src/types.codec.h
+++ b/src/types.codec.h
@@ -29,7 +29,8 @@ extern "C"
     enum compression_codec id;
     uint8_t level;              // LZ4: 1..12 (HC), 0 rejected.
                                 // ZSTD: 0 valid (ZSTD default).
-                                // Blosc: 0 = store only.
+                                // Blosc: 0 = store only; on GPU, 1..9 are
+                                // accepted hints for nvCOMP's single mode.
     enum codec_shuffle shuffle; // blosc only
   };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,10 @@ add_test_exe(test_multiarray_cpu test_multiarray_cpu.c multiarray_cpu stream_cpu
 
 # GPU multi-array stream test
 add_gpu_test_exe(test_multiarray_gpu test_multiarray_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static multiarray_gpu stream writer test_shard_sink)
+if(CHUCKY_ENABLE_GPU AND HAVE_BLOSC)
+    target_compile_definitions(test_multiarray_gpu PRIVATE HAVE_BLOSC)
+    target_link_libraries(test_multiarray_gpu PRIVATE Blosc::Blosc)
+endif()
 # A cross-array ordering cycle would otherwise strand the GPU test runner.
 if(CHUCKY_ENABLE_GPU)
     set_tests_properties(test-test_multiarray_gpu PROPERTIES TIMEOUT 60)
@@ -158,6 +162,23 @@ target_link_libraries(test_data PUBLIC stream_config writer chucky_log)
 # Tests with zstd
 add_gpu_test_exe(test_stream          test_stream.c          LINKS CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd index_ops_util test_shard_sink test_gpu_helpers test_shard_verify test_voxel_encode)
 add_gpu_test_exe(test_compress        test_compress.c        LINKS CUDA::cuda_driver CUDA::cudart_static stream Zstd::Zstd)
+if(CHUCKY_ENABLE_GPU AND HAVE_BLOSC)
+    add_gpu_test_exe(test_compress_blosc_gpu test_compress_blosc_gpu.c
+        LINKS CUDA::cuda_driver CUDA::cudart_static stream Blosc::Blosc
+    )
+    add_gpu_test_exe(test_zarr_readback_gpu test_zarr_readback_gpu.c
+        LINKS CUDA::cuda_driver CUDA::cudart_static stream test_zarr_helpers
+              writer test_platform chucky_log
+    )
+    target_compile_definitions(
+        test_zarr_readback_gpu
+        PRIVATE SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(
+        test-test_zarr_readback_gpu
+        PROPERTIES SKIP_RETURN_CODE 77 TIMEOUT 120
+    )
+endif()
 
 add_test_exe(test_json_writer test_json_writer.c zarr_metadata ngff_metadata strbuf chucky_log)
 add_test_exe(test_io_scheduler test_io_scheduler.c io_scheduler test_io_backend_fake test_platform chucky_log)

--- a/tests/test_compress_blosc_gpu.c
+++ b/tests/test_compress_blosc_gpu.c
@@ -153,6 +153,9 @@ run_case(struct codec_config config,
   CU(Fail, cuMemAlloc(&d_input, batch * input_stride));
   CU(Fail, cuMemAlloc(&d_encoded, batch * c.output_stride));
   CU(Fail, cuMemcpyHtoD(d_input, input, batch * input_stride));
+  // Pageable H2D copies can return before the default-stream DMA finishes.
+  // The nonblocking test stream does not inherit that dependency.
+  CU(Fail, cuStreamSynchronize(NULL));
   CHECK(Fail,
         codec_compress(&c,
                        (const void*)(uintptr_t)d_input,
@@ -333,6 +336,7 @@ test_frame_boundary(void)
   CU(Fail, cuMemAlloc(&d_sizes, sizeof(sizes)));
   CU(Fail, cuMemcpyHtoD(d_input, input, sizeof(input)));
   CU(Fail, cuMemcpyHtoD(d_sizes, sizes, sizeof(sizes)));
+  CU(Fail, cuStreamSynchronize(NULL));
   CHECK(Fail,
         gpu_blosc_finalize_async(CODEC_BLOSC_LZ4,
                                  CODEC_SHUFFLE_NONE,

--- a/tests/test_compress_blosc_gpu.c
+++ b/tests/test_compress_blosc_gpu.c
@@ -1,0 +1,380 @@
+#include "gpu/blosc.frame.h"
+#include "gpu/compress.h"
+#include "gpu/prelude.cuda.h"
+#include "stream.gpu.h"
+#include "util/prelude.h"
+
+#include <blosc.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "test_runner.h"
+
+enum pattern
+{
+  PATTERN_ZERO,
+  PATTERN_RAMP,
+  PATTERN_RANDOM,
+};
+
+static uint32_t
+get_u32le(const uint8_t* p)
+{
+  return (uint32_t)p[0] | (uint32_t)p[1] << 8 | (uint32_t)p[2] << 16 |
+         (uint32_t)p[3] << 24;
+}
+
+static void
+fill_input(uint8_t* p, size_t bytes, enum pattern pattern)
+{
+  if (pattern == PATTERN_ZERO) {
+    memset(p, 0, bytes);
+    return;
+  }
+  if (pattern == PATTERN_RAMP) {
+    for (size_t i = 0; i < bytes; ++i)
+      p[i] = (uint8_t)(i % 251);
+    return;
+  }
+
+  uint32_t state = 0x9e3779b9u;
+  for (size_t i = 0; i < bytes; ++i) {
+    state ^= state << 13;
+    state ^= state >> 17;
+    state ^= state << 5;
+    p[i] = (uint8_t)state;
+  }
+}
+
+static int
+verify_chunk(const struct codec* c,
+             const uint8_t* encoded,
+             size_t encoded_bytes,
+             const uint8_t* expected,
+             int expect_memcpy)
+{
+  uint8_t* recovered = NULL;
+  size_t validated_nbytes = 0;
+  size_t meta_typesize = 0;
+  int flags = 0;
+  int result = 1;
+
+  CHECK(Fail, encoded_bytes > 0 && encoded_bytes <= c->max_output_size);
+  CHECK(Fail, encoded[0] == 2 && encoded[1] == 1);
+  CHECK(Fail, encoded[3] == c->typesize);
+  CHECK(Fail, get_u32le(encoded + 4) == c->chunk_bytes);
+  CHECK(Fail, get_u32le(encoded + 8) == c->chunk_bytes);
+  CHECK(Fail, get_u32le(encoded + 12) == encoded_bytes);
+  CHECK(Fail, (encoded[2] & 0x10) != 0);
+  CHECK(Fail, ((encoded[2] >> 5) & 7) == (c->type == CODEC_BLOSC_LZ4 ? 1 : 4));
+  CHECK(Fail,
+        ((encoded[2] & BLOSC_DOSHUFFLE) != 0) ==
+          (c->config.shuffle == CODEC_SHUFFLE_BYTE));
+  CHECK(Fail, ((encoded[2] & BLOSC_MEMCPYED) != 0) == expect_memcpy);
+  if (expect_memcpy) {
+    CHECK(Fail, encoded_bytes == c->chunk_bytes + BLOSC_MAX_OVERHEAD);
+    CHECK(Fail,
+          memcmp(encoded + BLOSC_MAX_OVERHEAD, expected, c->chunk_bytes) == 0);
+  } else {
+    CHECK(Fail, get_u32le(encoded + 16) == 20);
+    CHECK(Fail, get_u32le(encoded + 20) + 24 == encoded_bytes);
+  }
+
+  CHECK(Fail,
+        blosc_cbuffer_validate(encoded, encoded_bytes, &validated_nbytes) == 0);
+  CHECK(Fail, validated_nbytes == c->chunk_bytes);
+  blosc_cbuffer_metainfo(encoded, &meta_typesize, &flags);
+  CHECK(Fail, meta_typesize == c->typesize);
+  CHECK(Fail, flags == (encoded[2] & 7));
+  CHECK(Fail,
+        strcmp(blosc_cbuffer_complib(encoded),
+               c->type == CODEC_BLOSC_LZ4 ? "LZ4" : "Zstd") == 0);
+
+  recovered = (uint8_t*)malloc(c->chunk_bytes);
+  CHECK(Fail, recovered);
+  CHECK(Fail,
+        blosc_decompress_ctx(encoded, recovered, c->chunk_bytes, 1) ==
+          (int)c->chunk_bytes);
+  CHECK(Fail, memcmp(recovered, expected, c->chunk_bytes) == 0);
+  result = 0;
+
+Fail:
+  free(recovered);
+  return result;
+}
+
+static int
+run_case(struct codec_config config,
+         size_t typesize,
+         size_t chunk_bytes,
+         enum pattern pattern,
+         int expect_memcpy,
+         size_t actual_batch)
+{
+  const size_t batch = 3;
+  const size_t input_stride = align_up(chunk_bytes, codec_alignment(config.id));
+  struct codec c = { 0 };
+  uint8_t* input = NULL;
+  uint8_t* encoded = NULL;
+  size_t* sizes = NULL;
+  CUdeviceptr d_input = 0;
+  CUdeviceptr d_encoded = 0;
+  CUstream stream = 0;
+  int result = 1;
+
+  CHECK(Fail,
+        codec_init_config(&c,
+                          config,
+                          typesize,
+                          chunk_bytes,
+                          batch,
+                          config.shuffle == CODEC_SHUFFLE_BYTE) == 0);
+  CHECK(Fail, c.max_output_size == chunk_bytes + BLOSC_MAX_OVERHEAD);
+  CHECK(Fail, c.output_stride >= c.max_output_size);
+  {
+    const int reserve = config.shuffle == CODEC_SHUFFLE_BYTE;
+    const size_t expected = 2 * batch * sizeof(size_t) +
+                            2 * batch * sizeof(void*) + c.temp_bytes +
+                            (reserve ? batch * c.shuffle_stride : 0);
+    CHECK(Fail,
+          codec_device_bytes(config.id, chunk_bytes, batch, reserve) ==
+            expected);
+  }
+
+  input = (uint8_t*)malloc(batch * input_stride);
+  encoded = (uint8_t*)malloc(batch * c.output_stride);
+  sizes = (size_t*)malloc(batch * sizeof(size_t));
+  CHECK(Fail, input && encoded && sizes);
+  for (size_t i = 0; i < batch; ++i)
+    fill_input(input + i * input_stride, chunk_bytes, pattern);
+
+  CU(Fail, cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+  CU(Fail, cuMemAlloc(&d_input, batch * input_stride));
+  CU(Fail, cuMemAlloc(&d_encoded, batch * c.output_stride));
+  CU(Fail, cuMemcpyHtoD(d_input, input, batch * input_stride));
+  CHECK(Fail,
+        codec_compress(&c,
+                       (const void*)(uintptr_t)d_input,
+                       input_stride,
+                       (void*)(uintptr_t)d_encoded,
+                       actual_batch,
+                       stream) == 0);
+  CU(Fail, cuStreamSynchronize(stream));
+  CU(Fail, cuMemcpyDtoH(encoded, d_encoded, actual_batch * c.output_stride));
+  CU(Fail,
+     cuMemcpyDtoH(
+       sizes, (CUdeviceptr)c.d_comp_sizes, actual_batch * sizeof(size_t)));
+
+  for (size_t i = 0; i < actual_batch; ++i)
+    CHECK(Fail,
+          verify_chunk(&c,
+                       encoded + i * c.output_stride,
+                       sizes[i],
+                       input + i * input_stride,
+                       expect_memcpy) == 0);
+  result = 0;
+
+Fail:
+  cu_mem_free(d_input);
+  cu_mem_free(d_encoded);
+  cu_stream_destroy(stream);
+  codec_free(&c);
+  free(input);
+  free(encoded);
+  free(sizes);
+  return result;
+}
+
+static int
+test_compressed_matrix(void)
+{
+  const enum compression_codec codecs[] = { CODEC_BLOSC_LZ4, CODEC_BLOSC_ZSTD };
+  const enum codec_shuffle shuffles[] = { CODEC_SHUFFLE_NONE,
+                                          CODEC_SHUFFLE_BYTE };
+  const size_t typesizes[] = { 1, 2, 4, 8 };
+  for (size_t c = 0; c < countof(codecs); ++c)
+    for (size_t s = 0; s < countof(shuffles); ++s)
+      for (size_t t = 0; t < countof(typesizes); ++t) {
+        struct codec_config config = { .id = codecs[c],
+                                       .level = 5,
+                                       .shuffle = shuffles[s] };
+        CHECK(Fail,
+              run_case(config, typesizes[t], 64 * 1024, PATTERN_ZERO, 0, 2) ==
+                0);
+      }
+  {
+    struct codec_config tail = { .id = CODEC_BLOSC_ZSTD,
+                                 .level = 5,
+                                 .shuffle = CODEC_SHUFFLE_BYTE };
+    CHECK(Fail, run_case(tail, 8, 65539, PATTERN_RAMP, 0, 2) == 0);
+  }
+  return 0;
+Fail:
+  return 1;
+}
+
+static int
+test_memcpy_fallbacks(void)
+{
+  const enum compression_codec codecs[] = { CODEC_BLOSC_LZ4, CODEC_BLOSC_ZSTD };
+  for (size_t i = 0; i < countof(codecs); ++i) {
+    struct codec_config level_zero = { .id = codecs[i],
+                                       .level = 0,
+                                       .shuffle = CODEC_SHUFFLE_BYTE };
+    struct codec_config enabled = { .id = codecs[i],
+                                    .level = 5,
+                                    .shuffle = CODEC_SHUFFLE_BYTE };
+    struct codec_config incompressible = enabled;
+    incompressible.shuffle = CODEC_SHUFFLE_NONE;
+    CHECK(Fail, run_case(level_zero, 8, 4096, PATTERN_ZERO, 1, 3) == 0);
+    CHECK(Fail, run_case(enabled, 4, 127, PATTERN_ZERO, 1, 3) == 0);
+    CHECK(Fail,
+          run_case(incompressible, 4, 64 * 1024, PATTERN_RANDOM, 1, 3) == 0);
+  }
+  return 0;
+Fail:
+  return 1;
+}
+
+static int
+test_rebind_and_rejection(void)
+{
+  struct codec c = { 0 };
+  CUstream stream = 0;
+  struct codec_config initial = { .id = CODEC_BLOSC_ZSTD,
+                                  .level = 2,
+                                  .shuffle = CODEC_SHUFFLE_NONE };
+  struct codec_config rebound = { .id = CODEC_BLOSC_ZSTD,
+                                  .level = 8,
+                                  .shuffle = CODEC_SHUFFLE_BYTE };
+  struct codec_config bitshuffle = { .id = CODEC_BLOSC_ZSTD,
+                                     .level = 5,
+                                     .shuffle = CODEC_SHUFFLE_BIT };
+  int result = 1;
+
+  CHECK(Fail, codec_validate_gpu(bitshuffle, 4, 4096) != 0);
+  CU(Fail, cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+  CHECK(Fail, codec_init_config(&c, initial, 2, 65536, 3, 1) == 0);
+  CHECK(Fail, codec_bind(&c, rebound, 8, 4096, stream) == 0);
+  CHECK(Fail, c.chunk_bytes == 4096 && c.typesize == 8);
+  CHECK(Fail, c.config.level == 8 && c.config.shuffle == CODEC_SHUFFLE_BYTE);
+  CHECK(Fail, codec_bind(&c, bitshuffle, 8, 4096, stream) != 0);
+  result = 0;
+
+Fail:
+  codec_free(&c);
+  cu_stream_destroy(stream);
+  return result;
+}
+
+static int
+test_memory_estimate(void)
+{
+  struct dimension dims[3];
+  dims_create(dims, "tyx", (uint64_t[]){ 0, 16, 16 });
+  dims_set_chunk_sizes(dims, 3, (uint64_t[]){ 1, 8, 8 });
+  dims[0].chunks_per_shard = 4;
+  dims_set_shard_counts(dims, 3, (uint64_t[]){ 0, 1, 1 });
+
+  struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_BLOSC_ZSTD,
+               .level = 5,
+               .shuffle = CODEC_SHUFFLE_NONE },
+    .epochs_per_batch = 2,
+  };
+
+  for (int shuffled = 0; shuffled < 2; ++shuffled) {
+    config.codec.shuffle = shuffled ? CODEC_SHUFFLE_BYTE : CODEC_SHUFFLE_NONE;
+    struct tile_stream_memory_info info = { 0 };
+    CHECK(Fail, tile_stream_gpu_memory_estimate(&config, 0, &info) == 0);
+    CHECK(Fail, info.max_output_size > 16);
+    const size_t chunk_bytes = info.max_output_size - 16;
+    const size_t batch = info.epochs_per_batch * info.total_chunks;
+    CHECK(Fail,
+          info.codec_bytes ==
+            codec_device_bytes(config.codec.id, chunk_bytes, batch, shuffled));
+    CHECK(Fail,
+          info.compressed_pool_bytes ==
+            2 * batch * codec_output_stride(config.codec.id, chunk_bytes));
+  }
+  return 0;
+
+Fail:
+  return 1;
+}
+
+static int
+test_frame_boundary(void)
+{
+  enum
+  {
+    CHUNK_BYTES = 256,
+    BATCH = 3,
+    STRIDE = 512,
+  };
+  uint8_t input[BATCH * CHUNK_BYTES];
+  uint8_t encoded[BATCH * STRIDE];
+  size_t sizes[BATCH] = { CHUNK_BYTES - 9, CHUNK_BYTES - 8, CHUNK_BYTES - 7 };
+  CUdeviceptr d_input = 0;
+  CUdeviceptr d_encoded = 0;
+  CUdeviceptr d_sizes = 0;
+  CUstream stream = 0;
+  int result = 1;
+
+  fill_input(input, sizeof(input), PATTERN_RAMP);
+  CU(Fail, cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+  CU(Fail, cuMemAlloc(&d_input, sizeof(input)));
+  CU(Fail, cuMemAlloc(&d_encoded, sizeof(encoded)));
+  CU(Fail, cuMemAlloc(&d_sizes, sizeof(sizes)));
+  CU(Fail, cuMemcpyHtoD(d_input, input, sizeof(input)));
+  CU(Fail, cuMemcpyHtoD(d_sizes, sizes, sizeof(sizes)));
+  CHECK(Fail,
+        gpu_blosc_finalize_async(CODEC_BLOSC_LZ4,
+                                 CODEC_SHUFFLE_NONE,
+                                 1,
+                                 CHUNK_BYTES,
+                                 (const void*)(uintptr_t)d_input,
+                                 CHUNK_BYTES,
+                                 (void*)(uintptr_t)d_encoded,
+                                 STRIDE,
+                                 (size_t*)(uintptr_t)d_sizes,
+                                 BATCH,
+                                 0,
+                                 stream) == 0);
+  CU(Fail, cuStreamSynchronize(stream));
+  CU(Fail, cuMemcpyDtoH(encoded, d_encoded, sizeof(encoded)));
+  CU(Fail, cuMemcpyDtoH(sizes, d_sizes, sizeof(sizes)));
+
+  CHECK(Fail, sizes[0] == CHUNK_BYTES + 15);
+  CHECK(Fail, (encoded[2] & BLOSC_MEMCPYED) == 0);
+  CHECK(Fail, get_u32le(encoded + 16) == 20);
+  CHECK(Fail, get_u32le(encoded + 20) == CHUNK_BYTES - 9);
+  for (size_t i = 1; i < BATCH; ++i) {
+    const uint8_t* chunk = encoded + i * STRIDE;
+    CHECK(Fail, sizes[i] == CHUNK_BYTES + BLOSC_MAX_OVERHEAD);
+    CHECK(Fail, (chunk[2] & BLOSC_MEMCPYED) != 0);
+    CHECK(Fail,
+          memcmp(chunk + BLOSC_MAX_OVERHEAD,
+                 input + i * CHUNK_BYTES,
+                 CHUNK_BYTES) == 0);
+  }
+  result = 0;
+
+Fail:
+  cu_mem_free(d_input);
+  cu_mem_free(d_encoded);
+  cu_mem_free(d_sizes);
+  cu_stream_destroy(stream);
+  return result;
+}
+
+RUN_GPU_TESTS({ "blosc_compressed_matrix", test_compressed_matrix },
+              { "blosc_memcpy_fallbacks", test_memcpy_fallbacks },
+              { "blosc_rebind_and_rejection", test_rebind_and_rejection },
+              { "blosc_memory_estimate", test_memory_estimate },
+              { "blosc_frame_boundary", test_frame_boundary }, )

--- a/tests/test_multiarray_gpu.c
+++ b/tests/test_multiarray_gpu.c
@@ -9,6 +9,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef HAVE_BLOSC
+#include <blosc.h>
+#endif
+
 #define SHARD_CAP (1 << 20)
 #define SINK_N_SHARDS 16
 #define test_sink_init_1(s) test_sink_init((s), SINK_N_SHARDS, SHARD_CAP)
@@ -22,6 +26,44 @@ test_sink_shard_count(const struct test_shard_sink* s)
       count++;
   return count;
 }
+
+#ifdef HAVE_BLOSC
+static int
+verify_one_blosc_chunk(const struct test_shard_sink* sink,
+                       size_t chunk_bytes,
+                       size_t typesize,
+                       int shuffled,
+                       uint8_t expected)
+{
+  uint8_t* recovered = NULL;
+  int result = 1;
+  for (int i = 0; i < TEST_SHARD_SINK_MAX_SHARDS; ++i) {
+    const struct test_shard_writer* sw = &sink->writers[0][i];
+    if (!sw->buf || sw->size == 0)
+      continue;
+    const size_t footer = 2 * sizeof(uint64_t) + 4;
+    CHECK(Fail, sw->size > footer);
+    const uint64_t* index = (const uint64_t*)(sw->buf + sw->size - footer);
+    CHECK(Fail, index[0] != UINT64_MAX && index[1] <= chunk_bytes + 16);
+    const uint8_t* encoded = sw->buf + index[0];
+    CHECK(Fail, encoded[3] == typesize);
+    CHECK(Fail, ((encoded[2] & BLOSC_DOSHUFFLE) != 0) == shuffled);
+    recovered = (uint8_t*)malloc(chunk_bytes);
+    CHECK(Fail, recovered);
+    CHECK(Fail,
+          blosc_decompress_ctx(encoded, recovered, chunk_bytes, 1) ==
+            (int)chunk_bytes);
+    for (size_t j = 0; j < chunk_bytes; ++j)
+      CHECK(Fail, recovered[j] == expected);
+    result = 0;
+    break;
+  }
+
+Fail:
+  free(recovered);
+  return result;
+}
+#endif
 
 // Helper: 2D config with given dtype. Shape 4x4, chunk 2x2, 2 shards along
 // dim0, 1 along dim1 (cps 1x2). epoch_elements = 8.
@@ -183,6 +225,73 @@ Fail:
   log_error("  FAIL");
   return 1;
 }
+
+#ifdef HAVE_BLOSC
+static int
+test_blosc_rebind(void)
+{
+  log_info("=== test_blosc_rebind ===");
+  struct test_shard_sink sink0, sink1;
+  struct multiarray_tile_stream_gpu* ms = NULL;
+  test_sink_init_1(&sink0);
+  test_sink_init_1(&sink1);
+
+  struct dimension dims0[2], dims1[2];
+  dims_create(dims0, "ty", (uint64_t[]){ 2, 256 });
+  dims_create(dims1, "ty", (uint64_t[]){ 2, 256 });
+  dims_set_chunk_sizes(dims0, 2, (uint64_t[]){ 1, 256 });
+  dims_set_chunk_sizes(dims1, 2, (uint64_t[]){ 1, 256 });
+  dims_set_shard_counts(dims0, 2, (uint64_t[]){ 2, 1 });
+  dims_set_shard_counts(dims1, 2, (uint64_t[]){ 2, 1 });
+  struct tile_stream_configuration configs[] = {
+    { .buffer_capacity_bytes = 4096,
+      .dtype = dtype_u16,
+      .rank = 2,
+      .dimensions = dims0,
+      .codec = { .id = CODEC_BLOSC_ZSTD,
+                 .level = 1,
+                 .shuffle = CODEC_SHUFFLE_NONE } },
+    { .buffer_capacity_bytes = 4096,
+      .dtype = dtype_u64,
+      .rank = 2,
+      .dimensions = dims1,
+      .codec = { .id = CODEC_BLOSC_ZSTD,
+                 .level = 8,
+                 .shuffle = CODEC_SHUFFLE_BYTE } },
+  };
+  struct shard_sink* sinks[] = { &sink0.base, &sink1.base };
+
+  ms = multiarray_tile_stream_gpu_create(2, configs, sinks, 0);
+  CHECK(Fail, ms);
+  struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(ms);
+  CHECK(Fail,
+        write_fill(w, 0, 256, sizeof(uint16_t), 0x11).error ==
+          multiarray_writer_ok);
+  CHECK(Fail,
+        write_fill(w, 1, 256, sizeof(uint64_t), 0x22).error ==
+          multiarray_writer_ok);
+  CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
+  CHECK(Fail,
+        verify_one_blosc_chunk(
+          &sink0, 256 * sizeof(uint16_t), sizeof(uint16_t), 0, 0x11) == 0);
+  CHECK(Fail,
+        verify_one_blosc_chunk(
+          &sink1, 256 * sizeof(uint64_t), sizeof(uint64_t), 1, 0x22) == 0);
+
+  multiarray_tile_stream_gpu_destroy(ms);
+  test_sink_free(&sink0);
+  test_sink_free(&sink1);
+  log_info("  PASS");
+  return 0;
+
+Fail:
+  multiarray_tile_stream_gpu_destroy(ms);
+  test_sink_free(&sink0);
+  test_sink_free(&sink1);
+  log_error("  FAIL");
+  return 1;
+}
+#endif
 
 // ---- Test: switch mid-epoch rejected ----
 
@@ -1479,6 +1588,9 @@ main(int ac, char* av[])
   int ret = 0;
   ret |= test_basic_two_array();
   ret |= test_switch_at_epoch_boundary();
+#ifdef HAVE_BLOSC
+  ret |= test_blosc_rebind();
+#endif
   ret |= test_switch_mid_epoch_rejected();
   ret |= test_flush_all();
   ret |= test_one_array_failure_spares_the_others();

--- a/tests/test_zarr_readback_gpu.c
+++ b/tests/test_zarr_readback_gpu.c
@@ -1,0 +1,138 @@
+// Write GPU Blosc stores and validate them through zarr-python/numcodecs.
+
+#include "gpu/prelude.cuda.h"
+#include "stream.gpu.h"
+#include "test_platform.h"
+#include "test_zarr_helpers.h"
+#include "util/prelude.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define NT 4
+#define NY 16
+#define NX 16
+
+static int
+write_zarr(const char* store_path, struct codec_config codec)
+{
+  const int total = NT * NY * NX;
+  uint16_t* src = (uint16_t*)malloc((size_t)total * sizeof(uint16_t));
+  CHECK(Fail, src);
+  for (int i = 0; i < total; ++i)
+    src[i] = (uint16_t)i;
+
+  struct dimension dims[3];
+  dims_create(dims, "tyx", (uint64_t[]){ 0, NY, NX });
+  dims_set_chunk_sizes(dims, 3, (uint64_t[]){ 1, 8, 8 });
+  dims[0].chunks_per_shard = NT;
+  dims_set_shard_counts(dims, 3, (uint64_t[]){ 0, 1, 1 });
+
+  struct test_zarr_sink zs = { 0 };
+  struct tile_stream_gpu* stream = NULL;
+  CHECK(FailSrc,
+        test_zarr_sink_open(
+          &zs, store_path, "0", dims, 3, dtype_u16, 0, codec, 0) == 0);
+
+  const struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = (size_t)total * sizeof(uint16_t),
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = codec,
+    .epochs_per_batch = 1,
+  };
+  stream = tile_stream_gpu_create(&config, test_zarr_sink_as_shard_sink(&zs));
+  CHECK(FailSink, stream);
+
+  struct slice input = { .beg = src, .end = src + total };
+  CHECK(FailStream,
+        writer_append(tile_stream_gpu_writer(stream), input).error == 0);
+  CHECK(FailStream, writer_flush(tile_stream_gpu_writer(stream)).error == 0);
+  CHECK(FailStream, test_zarr_sink_flush(&zs) == 0);
+
+  tile_stream_gpu_destroy(stream);
+  test_zarr_sink_close(&zs);
+  free(src);
+  return 0;
+
+FailStream:
+  tile_stream_gpu_destroy(stream);
+FailSink:
+  test_zarr_sink_close(&zs);
+FailSrc:
+  free(src);
+Fail:
+  return 1;
+}
+
+int
+main(void)
+{
+  if (system("uv --version > " NULL_DEV " 2>&1") != 0)
+    return 77;
+
+  CUcontext context = 0;
+  CUdevice device;
+  CU(RunFail, cuInit(0));
+  CU(RunFail, cuDeviceGet(&device, 0));
+  CU(RunFail, cu_ctx_create(&context, 0, device));
+
+  char tmpdir[256];
+  CHECK(RunFail, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+
+  const struct
+  {
+    const char* name;
+    struct codec_config codec;
+  } cases[] = {
+    { "blosc_lz4_noshuffle",
+      { .id = CODEC_BLOSC_LZ4, .level = 5, .shuffle = CODEC_SHUFFLE_NONE } },
+    { "blosc_lz4_shuffle",
+      { .id = CODEC_BLOSC_LZ4, .level = 5, .shuffle = CODEC_SHUFFLE_BYTE } },
+    { "blosc_zstd_noshuffle",
+      { .id = CODEC_BLOSC_ZSTD, .level = 5, .shuffle = CODEC_SHUFFLE_NONE } },
+    { "blosc_zstd_shuffle",
+      { .id = CODEC_BLOSC_ZSTD, .level = 5, .shuffle = CODEC_SHUFFLE_BYTE } },
+  };
+
+  int error = 0;
+  for (size_t i = 0; i < countof(cases); ++i) {
+    char store[512];
+    snprintf(store, sizeof(store), "%s/%s", tmpdir, cases[i].name);
+    if (test_mkdir(store) != 0) {
+      error = 1;
+      goto Cleanup;
+    }
+    log_info("Writing GPU %s ...", cases[i].name);
+    if (write_zarr(store, cases[i].codec) != 0) {
+      error = 1;
+      goto Cleanup;
+    }
+  }
+
+  {
+    char command[1024];
+    snprintf(command,
+             sizeof(command),
+             "uv run \"" SOURCE_DIR "/tests/validate_zarr.py\" \"%s\" %d %d %d",
+             tmpdir,
+             NT,
+             NY,
+             NX);
+    if (system(command) != 0) {
+      log_error("Python validation failed; output preserved at %s", tmpdir);
+      error = 1;
+    }
+  }
+
+Cleanup:
+  if (!error)
+    test_tmpdir_remove(tmpdir);
+  cuCtxDestroy(context);
+  return error;
+
+RunFail:
+  cuCtxDestroy(context);
+  return 1;
+}


### PR DESCRIPTION
## Summary

- add GPU C-Blosc-compatible framing around nvCOMP LZ4 and Zstd
- support no-shuffle and exact byte-shuffle modes with per-array codec rebinding
- preserve C-Blosc MEMCPYED behavior for level 0, small, and insufficiently-compressed inputs
- separate encoded wire bounds from aligned device output stride and account for shuffle scratch exactly
- reject unsupported bitshuffle and oversized single-block inputs
- add C-Blosc decompression, boundary, multiarray rebind, and Zarr/numcodecs readback coverage

This implements the first milestone described in #168. Bitshuffle and multi-block frames remain follow-on work.

## Validation

- full GPU-enabled build
- 59/59 non-S3 tests passed; MinIO-dependent S3 tests excluded
- GPU Zarr readback passed for LZ4 and Zstd, with and without byte shuffle
- compute-sanitizer memcheck passed with zero errors
- CPU-only build and focused readback tests passed
- git diff --check passed