### PR TITLE
gpu: add C-Blosc bitshuffle support

### DIFF
--- a/src/gpu/blosc.frame.cu
+++ b/src/gpu/blosc.frame.cu
@@ -28,9 +28,17 @@ finalize_kernel(const unsigned char* original,
     return;
 
   unsigned char* dst = encoded + chunk * encoded_stride;
-  const size_t payload_bytes = force_copy ? 0 : sizes[chunk];
-  const int compressed =
-    !force_copy && chunk_bytes > 8 && payload_bytes < chunk_bytes - 8;
+  __shared__ size_t payload_bytes;
+  __shared__ int compressed;
+  if (threadIdx.x == 0) {
+    payload_bytes = force_copy ? 0 : sizes[chunk];
+    compressed =
+      !force_copy && chunk_bytes > 8 && payload_bytes < chunk_bytes - 8;
+  }
+  // All warps must use the payload size before thread 0 replaces sizes[chunk]
+  // with the complete frame size. A late read could otherwise select fallback
+  // and overwrite a compressed payload near the compression threshold.
+  __syncthreads();
   unsigned char flags = (unsigned char)(0x10 | (codec_format << 5));
   if (shuffle == CODEC_SHUFFLE_BYTE)
     flags |= 0x01;

--- a/src/gpu/blosc.frame.cu
+++ b/src/gpu/blosc.frame.cu
@@ -34,6 +34,8 @@ finalize_kernel(const unsigned char* original,
   unsigned char flags = (unsigned char)(0x10 | (codec_format << 5));
   if (shuffle == CODEC_SHUFFLE_BYTE)
     flags |= 0x01;
+  else if (shuffle == CODEC_SHUFFLE_BIT)
+    flags |= 0x04;
   if (!compressed)
     flags |= 0x02;
 

--- a/src/gpu/blosc.shuffle.cu
+++ b/src/gpu/blosc.shuffle.cu
@@ -28,6 +28,50 @@ shuffle_kernel(const unsigned char* src,
   dst[chunk * dst_stride + out] = src[chunk * src_stride + in];
 }
 
+__global__ static void
+bitshuffle_kernel(const unsigned char* src,
+                  size_t src_stride,
+                  unsigned char* dst,
+                  size_t dst_stride,
+                  size_t chunk_bytes,
+                  size_t typesize,
+                  size_t batch_size)
+{
+  const size_t chunk = blockIdx.x;
+  if (chunk >= batch_size)
+    return;
+
+  const size_t nelem = chunk_bytes / typesize;
+  const size_t complete = nelem * typesize;
+  const unsigned char* chunk_src = src + chunk * src_stride;
+  unsigned char* chunk_dst = dst + chunk * dst_stride;
+
+  // C-Blosc 1.x bitshuffle is all-or-nothing for complete elements: if their
+  // count is not divisible by eight it copies the whole block unchanged.
+  if ((nelem & 7) != 0) {
+    for (size_t out = threadIdx.x; out < chunk_bytes; out += blockDim.x)
+      chunk_dst[out] = chunk_src[out];
+  } else {
+    const size_t groups = nelem / 8;
+    for (size_t out = threadIdx.x; out < complete; out += blockDim.x) {
+      const size_t row = out / groups;
+      const size_t group = out - row * groups;
+      const size_t byte = row / 8;
+      const unsigned bit = (unsigned)(row & 7);
+      unsigned char packed = 0;
+      for (unsigned elem = 0; elem < 8; ++elem) {
+        const unsigned char value =
+          chunk_src[(group * 8 + elem) * typesize + byte];
+        packed |= (unsigned char)(((value >> bit) & 1u) << elem);
+      }
+      chunk_dst[out] = packed;
+    }
+    for (size_t out = complete + threadIdx.x; out < chunk_bytes;
+         out += blockDim.x)
+      chunk_dst[out] = chunk_src[out];
+  }
+}
+
 extern "C" int
 gpu_blosc_shuffle_async(const void* src,
                         size_t src_stride,
@@ -49,4 +93,25 @@ gpu_blosc_shuffle_async(const void* src,
                                                     chunk_bytes,
                                                     typesize,
                                                     batch_size));
+}
+
+extern "C" int
+gpu_blosc_bitshuffle_async(const void* src,
+                           size_t src_stride,
+                           void* dst,
+                           size_t dst_stride,
+                           size_t chunk_bytes,
+                           size_t typesize,
+                           size_t batch_size,
+                           CUstream stream)
+{
+  cudaStream_t cuda_stream = (cudaStream_t)stream;
+  return CUDA_LAUNCH(bitshuffle_kernel<<<batch_size, 256, 0, cuda_stream>>>(
+    (const unsigned char*)src,
+    src_stride,
+    (unsigned char*)dst,
+    dst_stride,
+    chunk_bytes,
+    typesize,
+    batch_size));
 }

--- a/src/gpu/blosc.shuffle.h
+++ b/src/gpu/blosc.shuffle.h
@@ -19,6 +19,19 @@ extern "C"
                               size_t batch_size,
                               CUstream stream);
 
+  // Exact C-Blosc 1.x bitshuffle mapping. When the number of complete
+  // elements is not divisible by eight C-Blosc leaves the entire block
+  // unchanged. Otherwise complete elements are bit-transposed and any
+  // incomplete final element remains byte-for-byte at the end.
+  int gpu_blosc_bitshuffle_async(const void* src,
+                                 size_t src_stride,
+                                 void* dst,
+                                 size_t dst_stride,
+                                 size_t chunk_bytes,
+                                 size_t typesize,
+                                 size_t batch_size,
+                                 CUstream stream);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gpu/compress.cu
+++ b/src/gpu/compress.cu
@@ -277,7 +277,7 @@ extern "C" size_t
 codec_device_bytes(enum compression_codec type,
                    size_t chunk_bytes,
                    size_t batch_size,
-                   int reserve_byte_shuffle)
+                   int reserve_shuffle)
 {
   if (batch_size == 0 || batch_size > SIZE_MAX / sizeof(size_t))
     return 0;
@@ -295,7 +295,7 @@ codec_device_bytes(enum compression_codec type,
   if (temp > SIZE_MAX - bytes)
     return 0;
   bytes += temp; // d_temp
-  if (codec_is_blosc(type) && reserve_byte_shuffle) {
+  if (codec_is_blosc(type) && reserve_shuffle) {
     const size_t alignment = codec_alignment(type);
     if (alignment == 0 || chunk_bytes > SIZE_MAX - (alignment - 1))
       return 0;
@@ -339,12 +339,9 @@ codec_validate_gpu(struct codec_config config,
     log_error("blosc level must be 0..9 (got %u)", config.level);
     return 1;
   }
-  if (config.shuffle == CODEC_SHUFFLE_BIT) {
-    log_error("GPU blosc bitshuffle is not supported");
-    return 1;
-  }
   if (config.shuffle != CODEC_SHUFFLE_NONE &&
-      config.shuffle != CODEC_SHUFFLE_BYTE) {
+      config.shuffle != CODEC_SHUFFLE_BYTE &&
+      config.shuffle != CODEC_SHUFFLE_BIT) {
     log_error("invalid GPU blosc shuffle mode %d", (int)config.shuffle);
     return 1;
   }
@@ -374,7 +371,7 @@ codec_init_config(struct codec* c,
                   size_t typesize,
                   size_t chunk_bytes,
                   size_t batch_size,
-                  int reserve_byte_shuffle)
+                  int reserve_shuffle)
 {
   memset(c, 0, sizeof(*c));
   c->type = config.id;
@@ -437,7 +434,7 @@ codec_init_config(struct codec* c,
     CU(Fail, cuMemAlloc((CUdeviceptr*)&c->d_temp, c->temp_bytes));
   }
 
-  if (codec_is_blosc(config.id) && reserve_byte_shuffle) {
+  if (codec_is_blosc(config.id) && reserve_shuffle) {
     c->shuffle_stride = align_up(chunk_bytes, codec_alignment(config.id));
     CHECK_MUL_OVERFLOW(Fail, batch_size, c->shuffle_stride, SIZE_MAX);
     CU(Fail,
@@ -472,8 +469,9 @@ codec_bind(struct codec* c,
         c && config.id == c->type && chunk_bytes > 0 &&
           chunk_bytes <= c->chunk_capacity);
   CHECK(Fail, codec_validate_gpu(config, typesize, chunk_bytes) == 0);
-  if (config.shuffle == CODEC_SHUFFLE_BYTE && !c->has_shuffle_scratch) {
-    log_error("GPU blosc byte shuffle scratch was not reserved");
+  if (codec_is_blosc(c->type) && config.shuffle != CODEC_SHUFFLE_NONE &&
+      !c->has_shuffle_scratch) {
+    log_error("GPU blosc shuffle scratch was not reserved");
     goto Fail;
   }
   if (chunk_bytes == c->chunk_bytes && typesize == c->typesize &&
@@ -579,17 +577,29 @@ codec_compress(struct codec* c,
     return 0;
   }
 
-  if (is_blosc && c->config.shuffle == CODEC_SHUFFLE_BYTE && c->typesize > 1) {
+  if (is_blosc && c->config.shuffle != CODEC_SHUFFLE_NONE &&
+      !(c->config.shuffle == CODEC_SHUFFLE_BYTE && c->typesize == 1)) {
     CHECK_MUL_OVERFLOW(Fail, n, c->chunk_bytes, SIZE_MAX);
-    CHECK(Fail,
-          gpu_blosc_shuffle_async(d_input,
-                                  input_stride,
-                                  c->d_shuffle,
-                                  c->shuffle_stride,
-                                  c->chunk_bytes,
-                                  c->typesize,
-                                  n,
-                                  stream) == 0);
+    if (c->config.shuffle == CODEC_SHUFFLE_BIT)
+      CHECK(Fail,
+            gpu_blosc_bitshuffle_async(d_input,
+                                       input_stride,
+                                       c->d_shuffle,
+                                       c->shuffle_stride,
+                                       c->chunk_bytes,
+                                       c->typesize,
+                                       n,
+                                       stream) == 0);
+    else
+      CHECK(Fail,
+            gpu_blosc_shuffle_async(d_input,
+                                    input_stride,
+                                    c->d_shuffle,
+                                    c->shuffle_stride,
+                                    c->chunk_bytes,
+                                    c->typesize,
+                                    n,
+                                    stream) == 0);
     nvcomp_input = c->d_shuffle;
     nvcomp_input_stride = c->shuffle_stride;
   }

--- a/src/gpu/compress.cu
+++ b/src/gpu/compress.cu
@@ -350,7 +350,12 @@ codec_validate_gpu(struct codec_config config,
     return 1;
   }
   // A single block must fit C-Blosc's decompressor scratch-size contract.
-  const size_t max_block = ((size_t)INT_MAX - 255 * 4) / 3;
+  size_t max_block = ((size_t)INT_MAX - 255 * 4) / 3;
+  const size_t nvcomp_limit = config.id == CODEC_BLOSC_LZ4
+                                ? nvcompLZ4CompressionMaxAllowedChunkSize
+                                : nvcompZstdCompressionMaxAllowedChunkSize;
+  if (max_block > nvcomp_limit)
+    max_block = nvcomp_limit;
   if (chunk_bytes == 0 || chunk_bytes > max_block) {
     log_error("GPU blosc single-block input %zu exceeds limit %zu",
               chunk_bytes,

--- a/src/gpu/compress.h
+++ b/src/gpu/compress.h
@@ -28,7 +28,7 @@ extern "C"
     void** d_ptrs;          // [2 * batch_size] scratch for nvcomp ptr arrays
     void* d_temp;           // workspace
     size_t temp_bytes;      // workspace size
-    void* d_shuffle;        // Blosc byte-shuffle batch scratch
+    void* d_shuffle;        // Blosc byte/bit-shuffle batch scratch
   };
 
   // Alignment required of every uncompressed chunk handed to the codec.
@@ -47,12 +47,12 @@ extern "C"
   size_t codec_output_stride(enum compression_codec type, size_t chunk_bytes);
 
   // Total device bytes codec_init_config allocates (size arrays, ptr table,
-  // nvCOMP temp, and optional byte-shuffle scratch) — sizing mirror for the
+  // nvCOMP temp, and optional shuffle scratch) — sizing mirror for the
   // memory estimate (no GPU allocation).
   size_t codec_device_bytes(enum compression_codec type,
                             size_t chunk_bytes,
                             size_t batch_size,
-                            int reserve_byte_shuffle);
+                            int reserve_shuffle);
 
   size_t codec_temp_bytes(enum compression_codec type,
                           size_t chunk_bytes,
@@ -69,7 +69,7 @@ extern "C"
                         size_t typesize,
                         size_t chunk_bytes,
                         size_t batch_size,
-                        int reserve_byte_shuffle);
+                        int reserve_shuffle);
 
   // Select the active input geometry for a shared codec instance. The codec
   // allocations remain sized to chunk_capacity/output_stride; the per-chunk

--- a/src/gpu/flush.compress_agg.c
+++ b/src/gpu/flush.compress_agg.c
@@ -70,7 +70,7 @@ compress_agg_init_shared(struct compress_agg_stage* stage,
                           typesize,
                           lim->chunk_bytes,
                           M,
-                          lim->any_byte_shuffle) == 0);
+                          lim->any_shuffle) == 0);
 
   stage->pool_epochs_stride = K;
   stage->pool_epochs_scratch =
@@ -356,7 +356,7 @@ compress_agg_memory_estimate(const struct engine_limits* lim,
   }
 
   *codec_bytes = codec_device_bytes(
-    codec_id, lim->chunk_bytes, lim->codec_batch, lim->any_byte_shuffle);
+    codec_id, lim->chunk_bytes, lim->codec_batch, lim->any_shuffle);
   CHECK(Error, *codec_bytes > 0);
 
   size_t dev = 0;

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -297,7 +297,7 @@ struct engine_limits
   size_t lod_morton_bytes;
   size_t host_output_bytes;
   int any_multiscale;
-  int any_byte_shuffle;
+  int any_shuffle;
   int max_threads; // max over arrays; 0 = platform default
 };
 

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -53,8 +53,9 @@ engine_limits_accumulate(struct engine_limits* lim,
     max_sz(lim->pool_bytes, (size_t)K * total_chunks * chunk_stride * bpe);
   lim->chunk_bytes = max_sz(lim->chunk_bytes, chunk_stride * bpe);
   lim->codec_batch = max_u64(lim->codec_batch, (uint64_t)K * total_chunks);
-  if (config->codec.shuffle == CODEC_SHUFFLE_BYTE)
-    lim->any_byte_shuffle = 1;
+  if (codec_is_blosc(config->codec.id) &&
+      config->codec.shuffle != CODEC_SHUFFLE_NONE)
+    lim->any_shuffle = 1;
   if (K > lim->epochs_per_batch)
     lim->epochs_per_batch = K;
   if (cl->levels.nlod > lim->max_nlod)

--- a/tests/test_compress_blosc_gpu.c
+++ b/tests/test_compress_blosc_gpu.c
@@ -6,6 +6,7 @@
 #include "util/prelude.h"
 
 #include <blosc.h>
+#include <nvcomp/lz4.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -273,6 +274,16 @@ test_rebind_and_rejection(void)
   int result = 1;
 
   CHECK(Fail, codec_validate_gpu(invalid, 4, 4096) != 0);
+  {
+    struct codec_config lz4 = initial;
+    lz4.id = CODEC_BLOSC_LZ4;
+    CHECK(Fail,
+          codec_validate_gpu(lz4, 4, nvcompLZ4CompressionMaxAllowedChunkSize) ==
+            0);
+    CHECK(Fail,
+          codec_validate_gpu(
+            lz4, 4, nvcompLZ4CompressionMaxAllowedChunkSize + 1) != 0);
+  }
   CU(Fail, cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
   CHECK(Fail, codec_init_config(&c, initial, 2, 65536, 3, 1) == 0);
   CHECK(Fail, codec_bind(&c, rebound, 8, 4096, stream) == 0);
@@ -501,11 +512,13 @@ test_frame_boundary(void)
   int result = 1;
 
   fill_input(input, sizeof(input), PATTERN_RAMP);
+  memset(encoded, 0xa5, sizeof(encoded));
   CU(Fail, cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
   CU(Fail, cuMemAlloc(&d_input, sizeof(input)));
   CU(Fail, cuMemAlloc(&d_encoded, sizeof(encoded)));
   CU(Fail, cuMemAlloc(&d_sizes, sizeof(sizes)));
   CU(Fail, cuMemcpyHtoD(d_input, input, sizeof(input)));
+  CU(Fail, cuMemcpyHtoD(d_encoded, encoded, sizeof(encoded)));
   CU(Fail, cuMemcpyHtoD(d_sizes, sizes, sizeof(sizes)));
   CHECK(Fail,
         gpu_blosc_finalize_async(CODEC_BLOSC_LZ4,
@@ -528,6 +541,11 @@ test_frame_boundary(void)
   CHECK(Fail, (encoded[2] & BLOSC_MEMCPYED) == 0);
   CHECK(Fail, get_u32le(encoded + 16) == 20);
   CHECK(Fail, get_u32le(encoded + 20) == CHUNK_BYTES - 9);
+  // The compressed payload must survive finalization even when its length is
+  // just below the fallback threshold. Header-only assertions miss overwrites
+  // by other warps that observed the newly published frame size.
+  for (size_t i = 24; i < CHUNK_BYTES + 15; ++i)
+    CHECK(Fail, encoded[i] == 0xa5);
   for (size_t i = 1; i < BATCH; ++i) {
     const uint8_t* chunk = encoded + i * STRIDE;
     CHECK(Fail, sizes[i] == CHUNK_BYTES + BLOSC_MAX_OVERHEAD);

--- a/tests/test_compress_blosc_gpu.c
+++ b/tests/test_compress_blosc_gpu.c
@@ -1,4 +1,5 @@
 #include "gpu/blosc.frame.h"
+#include "gpu/blosc.shuffle.h"
 #include "gpu/compress.h"
 #include "gpu/prelude.cuda.h"
 #include "stream.gpu.h"
@@ -71,6 +72,9 @@ verify_chunk(const struct codec* c,
   CHECK(Fail,
         ((encoded[2] & BLOSC_DOSHUFFLE) != 0) ==
           (c->config.shuffle == CODEC_SHUFFLE_BYTE));
+  CHECK(Fail,
+        ((encoded[2] & BLOSC_DOBITSHUFFLE) != 0) ==
+          (c->config.shuffle == CODEC_SHUFFLE_BIT));
   CHECK(Fail, ((encoded[2] & BLOSC_MEMCPYED) != 0) == expect_memcpy);
   if (expect_memcpy) {
     CHECK(Fail, encoded_bytes == c->chunk_bytes + BLOSC_MAX_OVERHEAD);
@@ -129,11 +133,11 @@ run_case(struct codec_config config,
                           typesize,
                           chunk_bytes,
                           batch,
-                          config.shuffle == CODEC_SHUFFLE_BYTE) == 0);
+                          config.shuffle != CODEC_SHUFFLE_NONE) == 0);
   CHECK(Fail, c.max_output_size == chunk_bytes + BLOSC_MAX_OVERHEAD);
   CHECK(Fail, c.output_stride >= c.max_output_size);
   {
-    const int reserve = config.shuffle == CODEC_SHUFFLE_BYTE;
+    const int reserve = config.shuffle != CODEC_SHUFFLE_NONE;
     const size_t expected = 2 * batch * sizeof(size_t) +
                             2 * batch * sizeof(void*) + c.temp_bytes +
                             (reserve ? batch * c.shuffle_stride : 0);
@@ -190,8 +194,11 @@ static int
 test_compressed_matrix(void)
 {
   const enum compression_codec codecs[] = { CODEC_BLOSC_LZ4, CODEC_BLOSC_ZSTD };
-  const enum codec_shuffle shuffles[] = { CODEC_SHUFFLE_NONE,
-                                          CODEC_SHUFFLE_BYTE };
+  const enum codec_shuffle shuffles[] = {
+    CODEC_SHUFFLE_NONE,
+    CODEC_SHUFFLE_BYTE,
+    CODEC_SHUFFLE_BIT,
+  };
   const size_t typesizes[] = { 1, 2, 4, 8 };
   for (size_t c = 0; c < countof(codecs); ++c)
     for (size_t s = 0; s < countof(shuffles); ++s)
@@ -204,10 +211,18 @@ test_compressed_matrix(void)
                 0);
       }
   {
-    struct codec_config tail = { .id = CODEC_BLOSC_ZSTD,
-                                 .level = 5,
-                                 .shuffle = CODEC_SHUFFLE_BYTE };
-    CHECK(Fail, run_case(tail, 8, 65539, PATTERN_RAMP, 0, 2) == 0);
+    // C-Blosc 1.x leaves the complete block unchanged when its element count
+    // is not divisible by eight, while retaining the bitshuffle frame flag.
+    struct codec_config nonmultiple = { .id = CODEC_BLOSC_LZ4,
+                                        .level = 5,
+                                        .shuffle = CODEC_SHUFFLE_BIT };
+    CHECK(Fail, run_case(nonmultiple, 4, 65540, PATTERN_RAMP, 0, 1) == 0);
+  }
+  {
+    struct codec_config transformed = { .id = CODEC_BLOSC_ZSTD,
+                                        .level = 5,
+                                        .shuffle = CODEC_SHUFFLE_BIT };
+    CHECK(Fail, run_case(transformed, 8, 4096, PATTERN_RAMP, 0, 2) == 0);
   }
   return 0;
 Fail:
@@ -219,16 +234,20 @@ test_memcpy_fallbacks(void)
 {
   const enum compression_codec codecs[] = { CODEC_BLOSC_LZ4, CODEC_BLOSC_ZSTD };
   for (size_t i = 0; i < countof(codecs); ++i) {
-    struct codec_config level_zero = { .id = codecs[i],
-                                       .level = 0,
-                                       .shuffle = CODEC_SHUFFLE_BYTE };
-    struct codec_config enabled = { .id = codecs[i],
-                                    .level = 5,
-                                    .shuffle = CODEC_SHUFFLE_BYTE };
-    struct codec_config incompressible = enabled;
+    struct codec_config level_zero_byte = { .id = codecs[i],
+                                            .level = 0,
+                                            .shuffle = CODEC_SHUFFLE_BYTE };
+    struct codec_config level_zero_bit = { .id = codecs[i],
+                                           .level = 0,
+                                           .shuffle = CODEC_SHUFFLE_BIT };
+    struct codec_config enabled_bit = { .id = codecs[i],
+                                        .level = 5,
+                                        .shuffle = CODEC_SHUFFLE_BIT };
+    struct codec_config incompressible = enabled_bit;
     incompressible.shuffle = CODEC_SHUFFLE_NONE;
-    CHECK(Fail, run_case(level_zero, 8, 4096, PATTERN_ZERO, 1, 3) == 0);
-    CHECK(Fail, run_case(enabled, 4, 127, PATTERN_ZERO, 1, 3) == 0);
+    CHECK(Fail, run_case(level_zero_byte, 8, 4096, PATTERN_ZERO, 1, 3) == 0);
+    CHECK(Fail, run_case(level_zero_bit, 8, 4096, PATTERN_ZERO, 1, 3) == 0);
+    CHECK(Fail, run_case(enabled_bit, 4, 127, PATTERN_ZERO, 1, 3) == 0);
     CHECK(Fail,
           run_case(incompressible, 4, 64 * 1024, PATTERN_RANDOM, 1, 3) == 0);
   }
@@ -247,19 +266,19 @@ test_rebind_and_rejection(void)
                                   .shuffle = CODEC_SHUFFLE_NONE };
   struct codec_config rebound = { .id = CODEC_BLOSC_ZSTD,
                                   .level = 8,
-                                  .shuffle = CODEC_SHUFFLE_BYTE };
-  struct codec_config bitshuffle = { .id = CODEC_BLOSC_ZSTD,
-                                     .level = 5,
-                                     .shuffle = CODEC_SHUFFLE_BIT };
+                                  .shuffle = CODEC_SHUFFLE_BIT };
+  struct codec_config invalid = { .id = CODEC_BLOSC_ZSTD,
+                                  .level = 5,
+                                  .shuffle = (enum codec_shuffle)99 };
   int result = 1;
 
-  CHECK(Fail, codec_validate_gpu(bitshuffle, 4, 4096) != 0);
+  CHECK(Fail, codec_validate_gpu(invalid, 4, 4096) != 0);
   CU(Fail, cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
   CHECK(Fail, codec_init_config(&c, initial, 2, 65536, 3, 1) == 0);
   CHECK(Fail, codec_bind(&c, rebound, 8, 4096, stream) == 0);
   CHECK(Fail, c.chunk_bytes == 4096 && c.typesize == 8);
-  CHECK(Fail, c.config.level == 8 && c.config.shuffle == CODEC_SHUFFLE_BYTE);
-  CHECK(Fail, codec_bind(&c, bitshuffle, 8, 4096, stream) != 0);
+  CHECK(Fail, c.config.level == 8 && c.config.shuffle == CODEC_SHUFFLE_BIT);
+  CHECK(Fail, codec_bind(&c, invalid, 8, 4096, stream) != 0);
   result = 0;
 
 Fail:
@@ -288,8 +307,14 @@ test_memory_estimate(void)
     .epochs_per_batch = 2,
   };
 
-  for (int shuffled = 0; shuffled < 2; ++shuffled) {
-    config.codec.shuffle = shuffled ? CODEC_SHUFFLE_BYTE : CODEC_SHUFFLE_NONE;
+  const enum codec_shuffle shuffles[] = {
+    CODEC_SHUFFLE_NONE,
+    CODEC_SHUFFLE_BYTE,
+    CODEC_SHUFFLE_BIT,
+  };
+  for (size_t s = 0; s < countof(shuffles); ++s) {
+    config.codec.shuffle = shuffles[s];
+    const int reserve = shuffles[s] != CODEC_SHUFFLE_NONE;
     struct tile_stream_memory_info info = { 0 };
     CHECK(Fail, tile_stream_gpu_memory_estimate(&config, 0, &info) == 0);
     CHECK(Fail, info.max_output_size > 16);
@@ -297,11 +322,160 @@ test_memory_estimate(void)
     const size_t batch = info.epochs_per_batch * info.total_chunks;
     CHECK(Fail,
           info.codec_bytes ==
-            codec_device_bytes(config.codec.id, chunk_bytes, batch, shuffled));
+            codec_device_bytes(config.codec.id, chunk_bytes, batch, reserve));
     CHECK(Fail,
           info.compressed_pool_bytes ==
             2 * batch * codec_output_stride(config.codec.id, chunk_bytes));
   }
+  return 0;
+
+Fail:
+  return 1;
+}
+
+static void
+byte_shuffle_reference(const uint8_t* src,
+                       uint8_t* dst,
+                       size_t chunk_bytes,
+                       size_t typesize)
+{
+  const size_t nelem = chunk_bytes / typesize;
+  const size_t complete = nelem * typesize;
+  for (size_t byte = 0; byte < typesize; ++byte)
+    for (size_t elem = 0; elem < nelem; ++elem)
+      dst[byte * nelem + elem] = src[elem * typesize + byte];
+  memcpy(dst + complete, src + complete, chunk_bytes - complete);
+}
+
+static void
+bitshuffle_reference(const uint8_t* src,
+                     uint8_t* dst,
+                     size_t chunk_bytes,
+                     size_t typesize)
+{
+  const size_t nelem = chunk_bytes / typesize;
+  const size_t complete = nelem * typesize;
+  if ((nelem & 7) != 0) {
+    memcpy(dst, src, chunk_bytes);
+    return;
+  }
+
+  const size_t groups = nelem / 8;
+  for (size_t byte = 0; byte < typesize; ++byte)
+    for (unsigned bit = 0; bit < 8; ++bit)
+      for (size_t group = 0; group < groups; ++group) {
+        uint8_t packed = 0;
+        for (unsigned elem = 0; elem < 8; ++elem) {
+          const uint8_t value = src[(group * 8 + elem) * typesize + byte];
+          packed |= (uint8_t)(((value >> bit) & 1u) << elem);
+        }
+        dst[(byte * 8 + bit) * groups + group] = packed;
+      }
+  memcpy(dst + complete, src + complete, chunk_bytes - complete);
+}
+
+static int
+run_shuffle_filter_case(enum codec_shuffle shuffle,
+                        size_t typesize,
+                        size_t chunk_bytes)
+{
+  const size_t batch = 1;
+  const size_t stride = align_up(chunk_bytes, 64);
+  uint8_t* input = NULL;
+  uint8_t* expected = NULL;
+  uint8_t* actual = NULL;
+  CUdeviceptr d_input = 0;
+  CUdeviceptr d_output = 0;
+  CUstream stream = 0;
+  int result = 1;
+
+  input = (uint8_t*)calloc(batch, stride);
+  expected = (uint8_t*)calloc(batch, stride);
+  actual = (uint8_t*)calloc(batch, stride);
+  CHECK(Fail, input && expected && actual);
+  for (size_t chunk = 0; chunk < batch; ++chunk) {
+    for (size_t i = 0; i < chunk_bytes; ++i)
+      input[chunk * stride + i] = (uint8_t)(i + 17 * chunk);
+    if (shuffle == CODEC_SHUFFLE_BIT)
+      bitshuffle_reference(input + chunk * stride,
+                           expected + chunk * stride,
+                           chunk_bytes,
+                           typesize);
+    else
+      byte_shuffle_reference(input + chunk * stride,
+                             expected + chunk * stride,
+                             chunk_bytes,
+                             typesize);
+  }
+
+  CU(Fail, cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+  CU(Fail, cuMemAlloc(&d_input, batch * stride));
+  CU(Fail, cuMemAlloc(&d_output, batch * stride));
+  CU(Fail, cuMemcpyHtoD(d_input, input, batch * stride));
+  if (shuffle == CODEC_SHUFFLE_BIT)
+    CHECK(Fail,
+          gpu_blosc_bitshuffle_async((const void*)(uintptr_t)d_input,
+                                     stride,
+                                     (void*)(uintptr_t)d_output,
+                                     stride,
+                                     chunk_bytes,
+                                     typesize,
+                                     batch,
+                                     stream) == 0);
+  else
+    CHECK(Fail,
+          gpu_blosc_shuffle_async((const void*)(uintptr_t)d_input,
+                                  stride,
+                                  (void*)(uintptr_t)d_output,
+                                  stride,
+                                  chunk_bytes,
+                                  typesize,
+                                  batch,
+                                  stream) == 0);
+  CU(Fail, cuStreamSynchronize(stream));
+  CU(Fail, cuMemcpyDtoH(actual, d_output, batch * stride));
+  for (size_t chunk = 0; chunk < batch; ++chunk)
+    CHECK(Fail,
+          memcmp(actual + chunk * stride,
+                 expected + chunk * stride,
+                 chunk_bytes) == 0);
+  result = 0;
+
+Fail:
+  cu_mem_free(d_input);
+  cu_mem_free(d_output);
+  cu_stream_destroy(stream);
+  free(input);
+  free(expected);
+  free(actual);
+  return result;
+}
+
+static int
+test_shuffle_filters(void)
+{
+  // Pinned C-Blosc 1.21.6 scalar-format vector: sixteen 2-byte elements whose
+  // input bytes are 0..31.
+  const uint8_t golden[] = { 0x00, 0x00, 0xaa, 0xaa, 0xcc, 0xcc, 0xf0, 0xf0,
+                             0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                             0xff, 0xff, 0xaa, 0xaa, 0xcc, 0xcc, 0xf0, 0xf0,
+                             0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+  uint8_t input[countof(golden)];
+  uint8_t actual[countof(golden)];
+  for (size_t i = 0; i < countof(input); ++i)
+    input[i] = (uint8_t)i;
+  bitshuffle_reference(input, actual, sizeof(input), 2);
+  CHECK(Fail, memcmp(actual, golden, sizeof(golden)) == 0);
+
+  const size_t typesizes[] = { 1, 2, 4, 8 };
+  for (size_t i = 0; i < countof(typesizes); ++i)
+    CHECK(Fail,
+          run_shuffle_filter_case(CODEC_SHUFFLE_BIT,
+                                  typesizes[i],
+                                  16 * typesizes[i] + typesizes[i] - 1) == 0);
+  CHECK(Fail, run_shuffle_filter_case(CODEC_SHUFFLE_BIT, 8, 65539) == 0);
+  CHECK(Fail, run_shuffle_filter_case(CODEC_SHUFFLE_BIT, 4, 17 * 4 + 3) == 0);
+  CHECK(Fail, run_shuffle_filter_case(CODEC_SHUFFLE_BYTE, 8, 65539) == 0);
   return 0;
 
 Fail:
@@ -377,4 +551,5 @@ RUN_GPU_TESTS({ "blosc_compressed_matrix", test_compressed_matrix },
               { "blosc_memcpy_fallbacks", test_memcpy_fallbacks },
               { "blosc_rebind_and_rejection", test_rebind_and_rejection },
               { "blosc_memory_estimate", test_memory_estimate },
+              { "blosc_shuffle_filters", test_shuffle_filters },
               { "blosc_frame_boundary", test_frame_boundary }, )

--- a/tests/test_multiarray_gpu.c
+++ b/tests/test_multiarray_gpu.c
@@ -32,7 +32,7 @@ static int
 verify_one_blosc_chunk(const struct test_shard_sink* sink,
                        size_t chunk_bytes,
                        size_t typesize,
-                       int shuffled,
+                       enum codec_shuffle shuffle,
                        uint8_t expected)
 {
   uint8_t* recovered = NULL;
@@ -47,7 +47,12 @@ verify_one_blosc_chunk(const struct test_shard_sink* sink,
     CHECK(Fail, index[0] != UINT64_MAX && index[1] <= chunk_bytes + 16);
     const uint8_t* encoded = sw->buf + index[0];
     CHECK(Fail, encoded[3] == typesize);
-    CHECK(Fail, ((encoded[2] & BLOSC_DOSHUFFLE) != 0) == shuffled);
+    CHECK(Fail,
+          ((encoded[2] & BLOSC_DOSHUFFLE) != 0) ==
+            (shuffle == CODEC_SHUFFLE_BYTE));
+    CHECK(Fail,
+          ((encoded[2] & BLOSC_DOBITSHUFFLE) != 0) ==
+            (shuffle == CODEC_SHUFFLE_BIT));
     recovered = (uint8_t*)malloc(chunk_bytes);
     CHECK(Fail, recovered);
     CHECK(Fail,
@@ -257,7 +262,7 @@ test_blosc_rebind(void)
       .dimensions = dims1,
       .codec = { .id = CODEC_BLOSC_ZSTD,
                  .level = 8,
-                 .shuffle = CODEC_SHUFFLE_BYTE } },
+                 .shuffle = CODEC_SHUFFLE_BIT } },
   };
   struct shard_sink* sinks[] = { &sink0.base, &sink1.base };
 
@@ -272,11 +277,17 @@ test_blosc_rebind(void)
           multiarray_writer_ok);
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
   CHECK(Fail,
-        verify_one_blosc_chunk(
-          &sink0, 256 * sizeof(uint16_t), sizeof(uint16_t), 0, 0x11) == 0);
+        verify_one_blosc_chunk(&sink0,
+                               256 * sizeof(uint16_t),
+                               sizeof(uint16_t),
+                               CODEC_SHUFFLE_NONE,
+                               0x11) == 0);
   CHECK(Fail,
-        verify_one_blosc_chunk(
-          &sink1, 256 * sizeof(uint64_t), sizeof(uint64_t), 1, 0x22) == 0);
+        verify_one_blosc_chunk(&sink1,
+                               256 * sizeof(uint64_t),
+                               sizeof(uint64_t),
+                               CODEC_SHUFFLE_BIT,
+                               0x22) == 0);
 
   multiarray_tile_stream_gpu_destroy(ms);
   test_sink_free(&sink0);

--- a/tests/test_zarr_readback_gpu.c
+++ b/tests/test_zarr_readback_gpu.c
@@ -90,10 +90,14 @@ main(void)
       { .id = CODEC_BLOSC_LZ4, .level = 5, .shuffle = CODEC_SHUFFLE_NONE } },
     { "blosc_lz4_shuffle",
       { .id = CODEC_BLOSC_LZ4, .level = 5, .shuffle = CODEC_SHUFFLE_BYTE } },
+    { "blosc_lz4_bitshuffle",
+      { .id = CODEC_BLOSC_LZ4, .level = 5, .shuffle = CODEC_SHUFFLE_BIT } },
     { "blosc_zstd_noshuffle",
       { .id = CODEC_BLOSC_ZSTD, .level = 5, .shuffle = CODEC_SHUFFLE_NONE } },
     { "blosc_zstd_shuffle",
       { .id = CODEC_BLOSC_ZSTD, .level = 5, .shuffle = CODEC_SHUFFLE_BYTE } },
+    { "blosc_zstd_bitshuffle",
+      { .id = CODEC_BLOSC_ZSTD, .level = 5, .shuffle = CODEC_SHUFFLE_BIT } },
   };
 
   int error = 0;


### PR DESCRIPTION
## Summary

Add the exact C-Blosc 1.x bitshuffle CUDA filter for GPU Blosc LZ4 and Zstd, including pass-through behavior when the element count is not divisible by eight and incomplete-element tails. Shared shuffle scratch supports byte and bit shuffle, with per-array rebinding and Zarr/numcodecs interoperability coverage.

Synchronize the frame-finalization decision before publishing the final chunk size, preventing later warps from treating that size as a payload length and overwriting compressed bytes. Enforce nvCOMP's codec-specific single-block input limits.

Stacked on #261. Multi-block packing remains separate follow-on work for #168.

## Validation

- Initial bitshuffle implementation: full GPU build; 59/59 non-S3 tests; CPU-only build; C-Blosc golden vectors and round trips across compressors, shuffle modes, and element widths; CUDA memcheck and racecheck.
- Finalizer/limit revision: rebuilt GPU Blosc, multiarray, and Zarr readback tests all passed on RTX 5070 Laptop.
- Boundary regression checks compressed payload preservation and LZ4's 16 MiB single-input limit.
- CUDA memcheck and synccheck: zero errors on the revised codec suite.
- Formatting and diff checks passed.
