### PR TITLE
bench: add GPU Blosc sweep coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ multiscale, and multiscale-with-dim0-downsampling modes.
 | `--codec` | `none`, `lz4`, `zstd`, `blosc-lz4`, `blosc-zstd` | `zstd` | Compression codec |
 | `--blosc-block-bytes` | e.g. `16K`, `64K`, `4097` | Required for Blosc | Internal Blosc block size in bytes |
 | `--blosc-shuffle` | `none`, `byte`, `bit` | `none` | Blosc filter; recorded with the level in benchmark JSON |
+| `--level` | Integer; 0–9 for Blosc | Blosc: 3; LZ4: 1; Zstd: 0 | Compression level; Blosc level 0 stores input without compression |
 | `--reduce` | `mean`, `min`, `max`, `median`, `max_sup`, `min_sup` | `mean` | LOD reduction method |
 | `-o path` | output directory | omit to discard | Write Zarr output to disk |
 
@@ -290,11 +291,13 @@ Benchmarks require `--blosc-block-bytes` when a Blosc codec is selected:
   --blosc-block-bytes 16K --blosc-shuffle bit
 ```
 
-The benchmark executable exposes `--blosc-shuffle none|byte|bit` and records
-the selected shuffle and level in JSON. Blosc level remains fixed at 3 because
-the CLI does not expose `--level`. The retained L40 tuning sweep used the older
-[`--shuffle`/`--level` controls][blosc-benchmark-controls] preserved with that
-archive. The command above matches the bitshuffle API example at level 3.
+The benchmark executable exposes `--blosc-shuffle none|byte|bit` and `--level`.
+Blosc JSON records `blosc_shuffle` and `blosc_level`; raw codecs record `level`.
+Blosc defaults to level 3, and `--level 0` selects store-only mode regardless
+of its position before or after `--codec`. The retained L40 tuning sweep used
+the older [`--shuffle`/`--level` controls][blosc-benchmark-controls] preserved
+with that archive. The command above matches the bitshuffle API example at
+level 3.
 
 The existing sweep suite explicitly selects 16 KiB for its Blosc cases; this is
 a benchmark choice, not a codec API default.

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -85,3 +85,13 @@ foreach(src IN LISTS BENCH_STREAM_SOURCES)
     string(REPLACE ".c" "" target ${src})
     add_bench(${target} ${src} bench_util Zstd::Zstd)
 endforeach()
+
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if(Python3_Interpreter_FOUND AND HAVE_BLOSC)
+    add_test(
+        NAME test-bench-cli
+        COMMAND
+            ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_cli.py
+            $<TARGET_FILE:bench_stream_smallepoch_single>
+    )
+endif()

--- a/bench/bench_parse.c
+++ b/bench/bench_parse.c
@@ -120,16 +120,57 @@ parse_codec(const char* s, struct codec_config* out)
   int i = match_option(s, names, 5);
   if (i < 5) {
     out->id = vals[i];
-    if (out->id == CODEC_LZ4_NON_STANDARD && out->level == 0)
-      out->level = 1;
-    if (codec_is_blosc(out->id) && out->level == 0)
-      out->level = 3;
     return 1;
   }
   fprintf(stderr,
           "Unknown codec: %s (expected none, lz4, zstd, blosc-lz4, "
           "blosc-zstd)\n",
           s);
+  return 0;
+}
+
+uint8_t
+bench_default_level(enum compression_codec codec)
+{
+  if (codec == CODEC_LZ4_NON_STANDARD)
+    return 1;
+  return codec_is_blosc(codec) ? 3 : 0;
+}
+
+static const char* const shuffle_names[] = { "none", "byte", "bit" };
+
+const char*
+bench_shuffle_name(enum codec_shuffle shuffle)
+{
+  return shuffle >= CODEC_SHUFFLE_NONE && shuffle <= CODEC_SHUFFLE_BIT
+           ? shuffle_names[shuffle]
+           : "unknown";
+}
+
+int
+parse_shuffle(const char* s, enum codec_shuffle* out)
+{
+  int i = match_option(s, shuffle_names, 3);
+  if (i < 3) {
+    *out = (enum codec_shuffle)i;
+    return 1;
+  }
+  fprintf(stderr, "Unknown shuffle: %s (expected none, byte, bit)\n", s);
+  return 0;
+}
+
+int
+parse_level(const char* s, uint8_t* out)
+{
+  char* end = NULL;
+  errno = 0;
+  long value = strtol(s, &end, 10);
+  if (end != s && *end == '\0' && errno != ERANGE && value >= 0 &&
+      value <= UINT8_MAX) {
+    *out = (uint8_t)value;
+    return 1;
+  }
+  fprintf(stderr, "Invalid level: %s (expected integer 0..255)\n", s);
   return 0;
 }
 

--- a/bench/bench_parse.h
+++ b/bench/bench_parse.h
@@ -28,6 +28,18 @@ int
 parse_codec(const char* s, struct codec_config* out);
 
 int
+parse_shuffle(const char* s, enum codec_shuffle* out);
+
+const char*
+bench_shuffle_name(enum codec_shuffle shuffle);
+
+int
+parse_level(const char* s, uint8_t* out);
+
+uint8_t
+bench_default_level(enum compression_codec codec);
+
+int
 parse_reduce(const char* s, enum lod_reduce_method* out);
 
 int

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -1,4 +1,5 @@
 #include "bench_report.h"
+#include "bench_parse.h"
 
 #include "util/format_bytes.h"
 #include "util/metric.h"
@@ -672,9 +673,11 @@ print_bench_json_pass(const struct stream_metrics* m,
     jw_key(&jw, "blosc_block_bytes");
     jw_uint(&jw, codec.blosc_block_bytes);
     jw_key(&jw, "blosc_shuffle");
-    jw_string(&jw, codec.shuffle == CODEC_SHUFFLE_BIT ? "bit" :
-                     codec.shuffle == CODEC_SHUFFLE_BYTE ? "byte" : "none");
+    jw_string(&jw, bench_shuffle_name(codec.shuffle));
     jw_key(&jw, "blosc_level");
+    jw_uint(&jw, codec.level);
+  } else {
+    jw_key(&jw, "level");
     jw_uint(&jw, codec.level);
   }
   jw_key(&jw, "throughput_in_gibs");

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -669,7 +669,7 @@ read_size(const char* flag, const char* text, uint64_t* out)
 //   --json --chunk-bytes
 //   --memory-budget -o --s3-bucket --s3-prefix --s3-region --s3-endpoint
 //   --s3-throughput-gbps --io-bw-mbps --io-latency-us --backpressure
-//   --max-threads.
+//   --max-threads --blosc-shuffle --level --blosc-block-bytes.
 // Drivers that don't honor a given flag (e.g. two-streams ignores --backend)
 // just don't read the corresponding field afterward.
 static int
@@ -695,6 +695,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
   out->io_latency_us = 0;
   out->backpressure_bytes = 0;
   out->max_threads = 0;
+  int level_set = 0;
 
   for (int i = 1; i < ac; ++i) {
     if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
@@ -714,18 +715,12 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
       out->codec.blosc_block_bytes = (uint32_t)block_bytes;
       ++i;
     } else if (strcmp(av[i], "--blosc-shuffle") == 0 && i + 1 < ac) {
-      const char* shuffle = av[++i];
-      if (strcmp(shuffle, "none") == 0)
-        out->codec.shuffle = CODEC_SHUFFLE_NONE;
-      else if (strcmp(shuffle, "byte") == 0)
-        out->codec.shuffle = CODEC_SHUFFLE_BYTE;
-      else if (strcmp(shuffle, "bit") == 0)
-        out->codec.shuffle = CODEC_SHUFFLE_BIT;
-      else {
-        fprintf(stderr, "Invalid --blosc-shuffle: %s (expected none|byte|bit)\n",
-                shuffle);
+      if (!parse_shuffle(av[++i], &out->codec.shuffle))
         return 1;
-      }
+    } else if (strcmp(av[i], "--level") == 0 && i + 1 < ac) {
+      if (!parse_level(av[++i], &out->codec.level))
+        return 1;
+      level_set = 1;
     } else if (strcmp(av[i], "--reduce") == 0 && i + 1 < ac) {
       if (!parse_reduce(av[++i], &out->reduce))
         return 1;
@@ -781,7 +776,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
               "Usage: %s [--fill xor|zeros|rand] [--codec "
               "none|lz4|zstd|blosc-lz4|blosc-zstd] "
               "[--blosc-block-bytes N (required for Blosc, e.g. 16K)] "
-              "[--blosc-shuffle none|byte|bit] "
+              "[--blosc-shuffle none|byte|bit (Blosc only)] [--level N] "
               "[--reduce mean|min|max|median|max_sup|min_sup] "
               "[--backend gpu|cpu] [--dtype u8|u16|...] [--frames N] "
               "[--json] [--chunk-bytes N] [--batch-bytes N] "
@@ -794,6 +789,21 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
               av[0]);
       return 1;
     }
+  }
+  if (!level_set)
+    out->codec.level = bench_default_level(out->codec.id);
+  if (!codec_is_blosc(out->codec.id) &&
+      out->codec.shuffle != CODEC_SHUFFLE_NONE) {
+    fprintf(stderr, "--blosc-shuffle byte/bit requires a Blosc codec\n");
+    return 1;
+  }
+  if (out->codec.id == CODEC_LZ4_NON_STANDARD && out->codec.level == 0) {
+    fprintf(stderr, "LZ4 --level must be at least 1\n");
+    return 1;
+  }
+  if (codec_is_blosc(out->codec.id) && out->codec.level > 9) {
+    fprintf(stderr, "Blosc --level must be 0..9\n");
+    return 1;
   }
   return codec_config_validate_blosc(out->codec);
 }

--- a/bench/test_cli.py
+++ b/bench/test_cli.py
@@ -1,0 +1,95 @@
+"""CPU smoke coverage for the shared benchmark CLI and its JSON settings."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+
+BENCH = Path(sys.argv.pop(1)).resolve()
+
+
+class CodecOptionsTest(unittest.TestCase):
+    def run_bench(self, *options):
+        return subprocess.run(
+            [str(BENCH), "--backend", "cpu", "--frames", "128",
+             "--chunk-bytes", "16K", "--batch-bytes", "1M",
+             "--memory-budget", "64M", "--max-threads", "2", "--json",
+             *options],
+            capture_output=True, text=True, timeout=30,
+        )
+
+    def passed(self, *options):
+        result = self.run_bench(*options)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["status"], "pass")
+        return data
+
+    def test_blosc_filters_and_defaults(self):
+        for codec in ("blosc-lz4", "blosc-zstd"):
+            for shuffle in ("none", "byte", "bit"):
+                with self.subTest(codec=codec, shuffle=shuffle):
+                    data = self.passed("--blosc-block-bytes", "4K",
+                                       "--blosc-shuffle", shuffle, "--codec", codec)
+                    self.assertEqual((data["blosc_shuffle"], data["blosc_level"]), (shuffle, 3))
+                    self.assertEqual(data["blosc_block_bytes"], 4096)
+                    self.assertNotIn("shuffle", data)
+                    self.assertNotIn("level", data)
+
+    def test_explicit_zero_is_order_independent(self):
+        for codec in ("blosc-lz4", "blosc-zstd"):
+            for options in (("--level", "0", "--codec", codec),
+                            ("--codec", codec, "--level", "0")):
+                with self.subTest(options=options):
+                    data = self.passed(*options, "--blosc-shuffle", "bit",
+                                       "--blosc-block-bytes", "16K")
+                    self.assertEqual(data["blosc_level"], 0)
+                    self.assertEqual(data["blosc_block_bytes"], 16384)
+                    self.assertLessEqual(data["compression_fold"], 1)
+
+    def test_final_codec_supplies_default(self):
+        for options, key, expected in (
+            (("--codec", "blosc-lz4", "--codec", "zstd"), "level", 0),
+            (("--codec", "lz4"), "level", 1),
+            (("--level", "1", "--codec", "blosc-zstd",
+              "--blosc-block-bytes", "16K"), "blosc_level", 1),
+        ):
+            with self.subTest(options=options):
+                data = self.passed(*options)
+                self.assertEqual(data[key], expected)
+                if key == "level":
+                    self.assertNotIn("blosc_shuffle", data)
+                    self.assertNotIn("blosc_level", data)
+
+    def test_invalid_options(self):
+        cases = [
+            ("--blosc-shuffle", "invalid"), ("--blosc-shuffle", "byte"),
+            ("--codec", "lz4", "--level", "0"),
+            ("--codec", "blosc-lz4", "--blosc-block-bytes", "16K", "--level", "10"),
+            ("--codec", "blosc-zstd", "--blosc-block-bytes", "16K", "--level", "-1"),
+            ("--level", "256"), ("--level", "1x"),
+            ("--level", "9999999999999999999999999"),
+            ("--level", ""), ("--level",), ("--blosc-shuffle",),
+        ]
+        for options in cases:
+            with self.subTest(options=options):
+                result = self.run_bench(*options)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertTrue(result.stderr)
+
+    def test_blosc_requires_explicit_valid_blocks_with_every_filter(self):
+        for codec in ("blosc-lz4", "blosc-zstd"):
+            for shuffle in ("none", "byte", "bit"):
+                for block in ((), ("--blosc-block-bytes", "0"),
+                              ("--blosc-block-bytes", "127")):
+                    with self.subTest(codec=codec, shuffle=shuffle, block=block):
+                        result = self.run_bench("--codec", codec, "--blosc-shuffle", shuffle,
+                                                "--level", "0", *block)
+                        self.assertNotEqual(result.returncode, 0)
+                        self.assertTrue(result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/blosc-performance.md
+++ b/docs/blosc-performance.md
@@ -383,14 +383,14 @@ record; it does not drive current site membership.
 
 ## Incorporating Blosc into the regular sweeps
 
-The recommended integration is a small regression matrix plus a separate
-tuning tier. This is a proposal, not a claim that the runner already implements
-the following tiers or repetition controls.
+The runner now includes GPU Blosc across the existing tiers and a focused
+`blosc` filter comparison. The following block-size tuning matrix and repetition
+controls remain a proposal; see the current runner status below.
 
 ### Routine regression coverage
 
-- Run GPU Blosc in the existing `compress`/`backend`, `fill`, and selected LOD
-  cases. Remove the obsolete CPU-only classification when implementing this.
+- Keep GPU Blosc in the existing `compress`/`backend`, `fill`, and selected LOD
+  cases.
 - Use a fixed, explicit 16 KiB block size, level 3, and bitshuffle for both
   Blosc codecs as a stable comparison configuration, not as a universal optimum.
   Keep raw LZ4/Zstd and no-compression controls.
@@ -423,34 +423,35 @@ the real filesystem or S3 sink.
 
 ### Runner and report status
 
-The current matrices still schedule Blosc only on CPU, with level 3, no shuffle,
-and an explicit 16 KiB block request. This is a scheduling limitation; the GPU
-backend supports both Blosc codecs. The following support is already available:
+The current matrices schedule Blosc on CPU and GPU with explicit 16 KiB
+blocks. Existing tiers use no shuffle and level 3; the focused `blosc` tier
+compares all three filters on 16 KiB, 256 KiB, and 1 MiB chunks, with raw
+LZ4/Zstd controls (48 cases). The following support is available:
 
 - `RunSpec` requires explicit `blosc_block_bytes` for Blosc runs; zero is
   invalid. The benchmark command and result metadata include the request,
   including error and timeout results.
-- Run identities and resume checks distinguish block sizes. Archived
-  unrecorded sizes remain unknown, and existing raw-codec identities and
-  archived results are preserved.
+- Run identities and resume checks distinguish block sizes, shuffle, and level.
+  Archived unrecorded sizes remain unknown, and existing raw-codec identities
+  and archived results are preserved.
+- The CLI exposes `--blosc-shuffle` and `--level`, including order-independent
+  store-only level 0. Blosc results retain the `blosc_shuffle` and `blosc_level`
+  fields; raw-codec results record `level`. The sweep's overrides apply to
+  Blosc cases and preserve raw controls.
 - The Over time and Benchmark explorer tabs offer block-request selectors and
-  distinguish unknown settings from explicit sizes in comparisons. The Blosc
-  Pareto analysis filters the explicit sizes in its retained tuning datasets.
+  codec labels that distinguish shuffle/level variants. Unrecorded block sizes
+  remain unknown. The Blosc Pareto analysis filters explicit sizes in its
+  retained tuning datasets.
 - GPU-independent regression tests cover block-size validation, run identities,
   deduplication, resume, CLI propagation, matrix counts, report serialization,
   and block-aware filtering.
 
 Remaining work for the expanded matrices:
 
-1. Add explicit shuffle and level fields to Blosc run specs, commands, and
-   results, including failures. Extend identities, resume checks, and comparison
-   labels to include them. The benchmark parser exposes `--blosc-shuffle` and
-   successful benchmark JSON records `blosc_shuffle` and `blosc_level`;
-   level CLI control and integration into the regular runner remain to be added.
-   Validate returned settings against requests.
-2. Add the routine GPU Blosc cases and opt-in tuning tier described above, with
-   warmups, seeded run order, and measured repetitions. Keep each repetition
-   distinct from its configuration identity.
+1. Validate returned settings against requests.
+2. Add the broader block-size comparisons and opt-in tuning tier described
+   above, with warmups, seeded run order, and measured repetitions. Keep each
+   repetition distinct from its configuration identity.
 3. Complete tuning metadata with actual chunk geometry, batch size, device
    budget, output bytes, driver/nvCOMP/build provenance, and capacity failures.
    Include codec workspace alongside the existing allocation estimates and
@@ -458,8 +459,7 @@ Remaining work for the expanded matrices:
 4. Extend the regression tests to cover the new settings, failure metadata,
    repetitions, and expanded matrix counts. Keep validation and dry-run tests
    runnable without a GPU.
-5. Add shuffle/level fields and filters to the regular sweep reports, with
-   summaries showing median plus spread.
+5. Add repetition summaries showing median plus spread.
    Compute frontiers only within matching input/geometry/backend/sink groups;
    never pool CPU/GPU, synthetic fills, or differently padded chunk layouts.
 

--- a/scripts/sweep/README.md
+++ b/scripts/sweep/README.md
@@ -3,16 +3,10 @@
 For Blosc measurements, memory accounting, and the proposed split between
 routine coverage and an opt-in block-size tuning matrix, see the
 [Blosc performance guide][blosc-performance-guide].
-The current runner has not yet adopted that matrix; its Blosc entries still
-use CPU, level 3, the default no-shuffle setting, and an explicit 16 KiB block
-request. The GPU backend supports both Blosc codecs; CPU-only scheduling is a
-limit of the current routine matrices. The benchmark executable exposes
-`--blosc-shuffle` and reports shuffle/level metadata, but `RunSpec` does not yet
-carry either setting and the executable has no level option. The
-[retained L40 tuning sweep][l40-measurements] used an older archived patch with
-`--shuffle` and `--level` controls.
-Blosc run identities include the requested block size. Resume checks and report
-comparisons distinguish each explicit size from historical runs with an
+The runner includes CPU and GPU Blosc with an explicit 16 KiB block request.
+The full block-size tuning matrix and repetition controls remain proposed.
+Blosc run identities include block size, shuffle, and level. Resume checks and
+report comparisons distinguish each explicit size from historical runs with an
 unrecorded size; those remain **unknown**, not an assumed default. Both sweep report
 pages offer a Blosc block-request selector.
 
@@ -32,14 +26,61 @@ The explorer picks a machine first and then one of its sweeps, newest at the
 top, so it opens on the most recent sweep run anywhere. A control disappears
 when the open sweep leaves it nothing to choose.
 
-## Tests
+## GPU Blosc comparisons
 
-The runner and report regression tests do not require a GPU or benchmark build:
+The focused `blosc` tier compares raw LZ4/Zstd with Blosc LZ4/Zstd on CPU and
+GPU, using `none`, `byte`, and `bit` shuffle on 16 KiB, 256 KiB, and 1 MiB
+chunks, with an explicit 16 KiB Blosc block request. It runs 48 cases on
+`orca2_single`, or 24 with a backend filter:
+
+```sh
+uv run scripts/sweep/sweep.py --tier blosc --dry-run
+uv run scripts/sweep/sweep.py --tier blosc --backend gpu
+```
+
+The other tiers also include GPU Blosc, using the historical defaults of no
+shuffle and level 3. Shuffle variants are confined to the focused tier to keep
+the I/O and LOD matrices manageable. `--blosc-shuffle byte` or `--level 0` overrides
+only the selected Blosc cases and deduplicates them; raw codec controls keep
+their defaults. All three shuffle modes can be selected this way in any tier.
+
+The benchmark executables accept the same settings directly:
+
+```sh
+./build/bench/bench_stream_orca2_single --codec blosc-lz4 --blosc-block-bytes 16K --blosc-shuffle bit --json
+```
+
+`--level 0` means store-only Blosc, regardless of its position before or after
+`--codec`. Blosc accepts levels 0 through 9. GPU levels 1 through 9 all use
+nvCOMP's single compression mode; CPU Blosc uses the level. The defaults
+remain level 3 for Blosc, 1 for raw LZ4, and 0 for Zstd. A nontrivial shuffle
+requires a Blosc codec.
+
+The block request is independent of the outer Zarr chunk size. With the current
+GPU backend, requesting a block at least as large as the chunk gives one block;
+smaller requests give multiple blocks. Use the executable's
+`--blosc-block-bytes` to compare those layouts at fixed chunk geometry. CPU
+Blosc may adjust the actual block size or split blocks.
+
+For comparisons across builds, use Release mode and the same explicit settings.
+Each result records the checkout's commit and build metadata. Use separate
+output files for two builds of the same commit; `--build-dir` selects the build
+to execute. Archived runs without recorded block sizes remain unknown and
+cannot establish parity of block settings. Compare compression ratio, input
+throughput, the compression stage (including filtering and framing), and
+device memory.
+
+Run the focused checks with:
 
 ```sh
 uv run scripts/sweep/test_sweep.py
 node --test scripts/sweep/test_reports.mjs
+ctest --test-dir build -R test-bench-cli --output-on-failure
 ```
+
+The runner and report checks require no GPU or benchmark build. The CLI check
+is registered when CMake finds Python and C-Blosc, and runs the
+`bench_stream_smallepoch_single` executable on CPU, including in GPU builds.
 
 ## Running S3 benchmarks
 
@@ -203,6 +244,16 @@ Each run records its `frames` and the `worker_threads` its pool ran on. The two
 backends count different pools. The GPU number is the staging-copy pool, which
 stops at three helpers. The CPU number is the pipeline pool, which takes one
 thread per allowed core, so it matches `cpu_count`.
+
+Blosc runs record `blosc_shuffle` and `blosc_level`, including failed and
+timed-out cases, using the benchmark executable's existing JSON fields.
+Raw-codec runs record `level`. The defaults preserve the block-aware run IDs;
+nondefault settings add
+`__shuffle-byte`/`__shuffle-bit` and/or `__level-N`. The report's codec selector
+shows each settings variant separately, so filter choices cannot overwrite one
+another in charts. Archived settings remain absent in the JSON schema; report
+labels use the historical CLI defaults when those fields were not recorded.
+These additive fields do not change the result schema version.
 
 GPU runs may also contain a `d2h_transfer` block.
 `payload_bytes_transferred` is the compact shard payload copied across PCIe.

--- a/scripts/sweep/blosc.js
+++ b/scripts/sweep/blosc.js
@@ -11,7 +11,7 @@ export function bloscBlockLabel(key) {
 
 export function bloscBlockChoices(runs, codec) {
   if (!codec?.startsWith("blosc-")) return [];
-  return [...new Set(runs.filter(r => r.codec === codec).map(bloscBlockKey))]
+  return [...new Set(runs.filter(r => (r.codec_label ?? r.codec) === codec).map(bloscBlockKey))]
     .sort((a, b) => a === b ? 0 : a === "unknown" ? 1 : b === "unknown" ? -1 : Number(a) - Number(b));
 }
 

--- a/scripts/sweep/models.py
+++ b/scripts/sweep/models.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import re
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 # ---------------------------------------------------------------------------
 # Schema enums (single source of truth)
 # ---------------------------------------------------------------------------
 
 VALID_CODECS = {"none", "lz4", "zstd", "blosc-lz4", "blosc-zstd"}
+VALID_SHUFFLES = {"none", "byte", "bit"}
 VALID_FILLS = {"xor", "zeros", "rand"}
 VALID_BACKENDS = {"gpu", "cpu"}
 VALID_SINKS = {"discard", "fs", "s3"}
@@ -31,11 +32,40 @@ def run_id(run: dict) -> str:
         if throughput > 0:
             parts.append(f"{int(throughput)}gbps")
         identity = "__".join(parts)
+    identity = re.sub(r"__blosc-block-(?:[0-9]+|unknown)(?=__|$)", "", identity)
+    shuffle = run.get("blosc_shuffle")
+    if shuffle is not None:
+        identity = re.sub(r"__shuffle-(?:none|byte|bit)(?=__|$)", "", identity)
+    level = run_level(run)
+    if level is not None:
+        identity = re.sub(r"__level-[0-9]+(?=__|$)", "", identity)
+    if shuffle is not None and shuffle != "none":
+        identity += f"__shuffle-{shuffle}"
+    if level is not None and level != default_level(run["codec"]):
+        identity += f"__level-{level}"
     if run["codec"].startswith("blosc-"):
-        identity = re.sub(r"__blosc-block-(?:[0-9]+|unknown)$", "", identity)
         block_bytes = run.get("blosc_block_bytes")
         identity += f"__blosc-block-{block_bytes if block_bytes is not None else 'unknown'}"
     return identity
+
+
+def default_level(codec: str) -> int:
+    return 3 if codec.startswith("blosc-") else 1 if codec == "lz4" else 0
+
+
+def run_level(run: dict) -> int | None:
+    return run.get("blosc_level" if run.get("codec", "").startswith("blosc-") else "level")
+
+
+def codec_label(run: dict) -> str:
+    codec = run.get("codec", "")
+    shuffle = run.get("blosc_shuffle") or "none"
+    level = run_level(run)
+    if level is None:
+        level = default_level(codec)
+    if shuffle == "none" and level == default_level(codec):
+        return codec
+    return f"{codec} ({shuffle}, level {level})"
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +96,9 @@ class RunResult(BaseModel, extra="allow"):
     chunk_bytes: int
     chunk_bytes_label: str
     sink: str = "discard"
+    blosc_shuffle: str | None = None
+    blosc_level: int | None = Field(default=None, ge=0, le=9)
+    level: int | None = Field(default=None, ge=0, le=255)
     # Absent in files written before the runner recorded them.
     frames: int | None = None
     worker_threads: int | None = None
@@ -91,6 +124,8 @@ class RunResult(BaseModel, extra="allow"):
     def _validate_enums(self) -> RunResult:
         if self.status not in VALID_STATUSES:
             raise ValueError(f"Unknown status: {self.status}")
+        if self.blosc_shuffle is not None and self.blosc_shuffle not in VALID_SHUFFLES:
+            raise ValueError(f"Unknown shuffle: {self.blosc_shuffle}")
         return self
 
 

--- a/scripts/sweep/overview.html
+++ b/scripts/sweep/overview.html
@@ -342,7 +342,7 @@ function distinct(key) {
 }
 
 const ALL_SCENARIOS = sortedScenarios(distinct("scenario"));
-const ALL_CODECS = distinct("codec").sort();
+const ALL_CODECS = distinct("codec_label").sort();
 const ALL_FILLS = sortedFills(distinct("fill"));
 const ALL_BACKENDS = distinct("backend").sort();
 const ALL_SINKS = distinct("sink").sort();
@@ -367,7 +367,7 @@ function pickDefaults() {
     const here = new Set();
     for (const r of s.runs) {
       if (r.status !== "pass" || metricValue(r, state.metric) == null) continue;
-      here.add([r.scenario, r.codec, r.backend, r.sink, r.fill, bloscBlockKey(r)].join("|"));
+      here.add([r.scenario, r.codec_label, r.backend, r.sink, r.fill, bloscBlockKey(r)].join("|"));
     }
     for (const combo of here) counts.set(combo, (counts.get(combo) || 0) + 1);
   }
@@ -391,7 +391,7 @@ function availableCombinations(scenario) {
     for (const run of sweep.runs) {
       if (run.status !== "pass" || metricValue(run, state.metric) == null) continue;
       if (scenario && run.scenario !== scenario) continue;
-      found.add([run.codec, run.backend, run.sink, run.fill, bloscBlockKey(run)].join("|"));
+      found.add([run.codec_label, run.backend, run.sink, run.fill, bloscBlockKey(run)].join("|"));
     }
   }
   return found;

--- a/scripts/sweep/report.py
+++ b/scripts/sweep/report.py
@@ -47,7 +47,7 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from columnar import pack
-from models import migrate_results, validate_results
+from models import codec_label, migrate_results, validate_results
 from summary import build_summary, find_registry, load_registry
 from pareto_data import DEFAULT_MANIFEST, write_datasets
 from site_server import ReportHandler
@@ -105,6 +105,8 @@ def load_files(paths: list[Path], *, warn: bool = True) -> list[tuple[Path, dict
                     loc = " -> ".join(str(x) for x in err["loc"])
                     print(f"Warning: {p.name}: {loc}: {err['msg']}", file=sys.stderr)
 
+        for run in data.get("runs", []):
+            run["codec_label"] = codec_label(run)
         loaded.append((p, data))
     return loaded
 

--- a/scripts/sweep/selection.mjs
+++ b/scripts/sweep/selection.mjs
@@ -11,7 +11,7 @@ export function metricValue(run, key) {
 }
 
 export function matchesSetup(run, state) {
-  return run.codec === state.codec && run.backend === state.backend && run.sink === state.sink
+  return (run.codec_label ?? run.codec) === state.codec && run.backend === state.backend && run.sink === state.sink
     && matchesBloscBlock(run, state.bloscBlock);
 }
 
@@ -79,7 +79,7 @@ export function moversFor(machine, state, meta) {
 export function filterRuns(runs, selection, {includeBackend = true} = {}) {
   const {codec, fill, backend, dtype, sink, bloscBlock, scenarios, s3Throughput} = selection;
   return runs.filter(run => {
-    if (run.codec !== codec || run.fill !== fill || run.dtype !== dtype || run.sink !== sink) return false;
+    if ((run.codec_label ?? run.codec) !== codec || run.fill !== fill || run.dtype !== dtype || run.sink !== sink) return false;
     if (!matchesBloscBlock(run, bloscBlock)) return false;
     if (includeBackend && run.backend !== backend) return false;
     if (!scenarios.has(run.scenario)) return false;

--- a/scripts/sweep/summary.py
+++ b/scripts/sweep/summary.py
@@ -13,7 +13,7 @@ import sys
 import tomllib
 from pathlib import Path
 
-from models import retired_metrics, run_id
+from models import codec_label, retired_metrics, run_id
 
 # <machine>-<commit>-<yyyymmdd>.json, the name sweep.py writes. The machine part
 # is the name a person chose, so it survives a cluster handing out a new hostname
@@ -28,6 +28,7 @@ OVERVIEW_VERSION = 4
 CONFIG_KEYS = (
     "scenario", "codec", "fill", "backend", "dtype",
     "chunk_bytes", "chunk_bytes_label", "blosc_block_bytes", "sink", "status",
+    "blosc_shuffle", "blosc_level", "level",
 )
 
 RUN_METRICS = (
@@ -148,7 +149,7 @@ def sweep_day(machine: dict, path: Path) -> str:
 
 
 def trim_run(run: dict) -> dict:
-    out = {"id": run_id(run)}
+    out = {"id": run_id(run), "codec_label": codec_label(run)}
     for key in CONFIG_KEYS:
         if key in run:
             out[key] = run[key]

--- a/scripts/sweep/sweep.py
+++ b/scripts/sweep/sweep.py
@@ -39,6 +39,8 @@ from models import (
     VALID_DTYPES,
     VALID_FILLS,
     VALID_SINKS,
+    VALID_SHUFFLES,
+    default_level,
     run_id,
     validate_results,
 )
@@ -102,6 +104,8 @@ class RunSpec(BaseModel):
     sink: str = "discard"
     s3_throughput_gbps: float = 0
     blosc_block_bytes: int | None = Field(default=None, ge=128, le=715827542, strict=True)
+    blosc_shuffle: str = "none"
+    level: int | None = Field(default=None, ge=0, le=255)
 
     @model_validator(mode="after")
     def _validate_enums(self) -> RunSpec:
@@ -124,6 +128,16 @@ class RunSpec(BaseModel):
                 raise ValueError("Blosc runs require explicit blosc_block_bytes")
         elif self.blosc_block_bytes is not None:
             raise ValueError("blosc_block_bytes is only valid for Blosc runs")
+        if self.blosc_shuffle not in VALID_SHUFFLES:
+            raise ValueError(f"Unknown shuffle: {self.blosc_shuffle}")
+        if self.blosc_shuffle != "none" and not self.codec.startswith("blosc-"):
+            raise ValueError("Byte/bit shuffle requires a Blosc codec")
+        if self.level is None:
+            self.level = default_level(self.codec)
+        if self.codec.startswith("blosc-") and self.level > 9:
+            raise ValueError("Blosc level must be 0..9")
+        if self.codec == "lz4" and self.level == 0:
+            raise ValueError("LZ4 level must be at least 1")
         return self
 
     @property
@@ -136,12 +150,11 @@ class RunSpec(BaseModel):
 
     @property
     def id(self) -> str:
-        return run_id({**self.model_dump(), "chunk_bytes_label": self.chunk_label})
+        return self.base_result()["id"]
 
     def base_result(self) -> dict:
         """Common fields shared by success, error, and timeout results."""
         d = {
-            "id": self.id,
             "scenario": self.scenario,
             "codec": self.codec,
             "fill": self.fill,
@@ -156,6 +169,11 @@ class RunSpec(BaseModel):
             d["s3_throughput_gbps"] = self.s3_throughput_gbps
         if self.codec.startswith("blosc-"):
             d["blosc_block_bytes"] = self.blosc_block_bytes
+            d["blosc_shuffle"] = self.blosc_shuffle
+            d["blosc_level"] = self.level
+        else:
+            d["level"] = self.level
+        d["id"] = run_id(d)
         return d
 
 
@@ -168,9 +186,13 @@ def compress_runs() -> list[RunSpec]:
     """Core sweep: chunk_size x scenario x codec (GPU-only)."""
     runs = []
     for sc in SINGLE_SCENARIOS:
-        for codec in ["none", "lz4", "zstd"]:
+        for codec in ["none", "lz4", "zstd", "blosc-lz4", "blosc-zstd"]:
             for cl in CHUNK_BYTES:
-                runs.append(RunSpec(scenario=sc, codec=codec, fill="xor", backend="gpu", dtype="u16", chunk_label=cl))
+                runs.append(RunSpec(
+                    scenario=sc, codec=codec, fill="xor",
+                    backend="gpu", dtype="u16", chunk_label=cl,
+                    blosc_block_bytes=16 * 1024 if codec.startswith("blosc-") else None,
+                ))
     return runs
 
 
@@ -178,14 +200,14 @@ def backend_runs() -> list[RunSpec]:
     """GPU vs CPU backend comparison (superset of compress tier)."""
     runs = []
     for sc in SINGLE_SCENARIOS:
-        for codec in ["none", "lz4", "zstd"]:
+        for codec in ["none", "lz4", "zstd", "blosc-lz4", "blosc-zstd"]:
             for cl in CHUNK_BYTES:
                 for backend in ["gpu", "cpu"]:
-                    runs.append(RunSpec(scenario=sc, codec=codec, fill="xor", backend=backend, dtype="u16", chunk_label=cl))
-        # Routine Blosc cases currently run on CPU; GPU codecs are supported.
-        for codec in ["blosc-lz4", "blosc-zstd"]:
-            for cl in CHUNK_BYTES:
-                runs.append(RunSpec(scenario=sc, codec=codec, fill="xor", backend="cpu", dtype="u16", chunk_label=cl, blosc_block_bytes=16 * 1024))
+                    runs.append(RunSpec(
+                        scenario=sc, codec=codec, fill="xor",
+                        backend=backend, dtype="u16", chunk_label=cl,
+                        blosc_block_bytes=16 * 1024 if codec.startswith("blosc-") else None,
+                    ))
     return runs
 
 
@@ -197,12 +219,13 @@ def lod_runs() -> list[RunSpec]:
                  "orca2_multiscale_dim0", "256cube_multiscale_dim0", "medfmt_multiscale_dim0"]
     for sc in scenarios:
         for cl in chunk_labels:
-            for codec in ["none", "zstd"]:
+            for codec in ["none", "zstd", "blosc-lz4", "blosc-zstd"]:
                 for backend in ["gpu", "cpu"]:
-                    runs.append(RunSpec(scenario=sc, codec=codec, fill="xor", backend=backend, dtype="u16", chunk_label=cl))
-            # Routine Blosc cases currently run on CPU; GPU codecs are supported.
-            for codec in ["blosc-lz4", "blosc-zstd"]:
-                runs.append(RunSpec(scenario=sc, codec=codec, fill="xor", backend="cpu", dtype="u16", chunk_label=cl, blosc_block_bytes=16 * 1024))
+                    runs.append(RunSpec(
+                        scenario=sc, codec=codec, fill="xor",
+                        backend=backend, dtype="u16", chunk_label=cl,
+                        blosc_block_bytes=16 * 1024 if codec.startswith("blosc-") else None,
+                    ))
     return runs
 
 
@@ -220,12 +243,13 @@ def io_runs() -> list[RunSpec]:
             else default_chunk_labels
         )
         for cl in chunk_labels:
-            for codec in ["none", "zstd"]:
+            for codec in ["none", "zstd", "blosc-lz4", "blosc-zstd"]:
                 for backend in ["gpu", "cpu"]:
-                    runs.append(RunSpec(scenario=sc, codec=codec, fill="xor", backend=backend, dtype="u16", chunk_label=cl, sink="fs"))
-            # Routine Blosc cases currently run on CPU; GPU codecs are supported.
-            for codec in ["blosc-lz4", "blosc-zstd"]:
-                runs.append(RunSpec(scenario=sc, codec=codec, fill="xor", backend="cpu", dtype="u16", chunk_label=cl, sink="fs", blosc_block_bytes=16 * 1024))
+                    runs.append(RunSpec(
+                        scenario=sc, codec=codec, fill="xor",
+                        backend=backend, dtype="u16", chunk_label=cl,
+                        sink="fs", blosc_block_bytes=16 * 1024 if codec.startswith("blosc-") else None,
+                    ))
     return runs
 
 
@@ -236,9 +260,13 @@ def fill_runs() -> list[RunSpec]:
     scenarios = ["orca2_single", "256cube_single"]
     for sc in scenarios:
         for fill in ["xor", "zeros", "rand"]:
-            for codec in ["none", "lz4", "zstd"]:
+            for codec in ["none", "lz4", "zstd", "blosc-lz4", "blosc-zstd"]:
                 for cl in chunk_labels:
-                    runs.append(RunSpec(scenario=sc, codec=codec, fill=fill, backend="gpu", dtype="u16", chunk_label=cl))
+                    runs.append(RunSpec(
+                        scenario=sc, codec=codec, fill=fill,
+                        backend="gpu", dtype="u16", chunk_label=cl,
+                        blosc_block_bytes=16 * 1024 if codec.startswith("blosc-") else None,
+                    ))
     return runs
 
 
@@ -249,27 +277,36 @@ def s3_runs() -> list[RunSpec]:
     scenarios = ["orca2_single", "256cube_single"]
     for sc in scenarios:
         for cl in chunk_labels:
-            for codec in ["none", "zstd"]:
+            for codec in ["none", "zstd", "blosc-lz4", "blosc-zstd"]:
                 for backend in ["gpu", "cpu"]:
                     for throughput in [10, 100]:
                         for sink in ["discard", "fs", "s3"]:
                             runs.append(RunSpec(
                                 scenario=sc, codec=codec, fill="xor",
                                 backend=backend, dtype="u16", chunk_label=cl,
+                                blosc_block_bytes=16 * 1024 if codec.startswith("blosc-") else None,
                                 sink=sink,
                                 s3_throughput_gbps=throughput if sink == "s3" else 0,
                             ))
-            # Routine Blosc cases currently run on CPU; GPU codecs are supported.
+    return runs
+
+
+def blosc_runs() -> list[RunSpec]:
+    runs = []
+    for cl in ["16K", "256K", "1M"]:
+        for backend in ["gpu", "cpu"]:
+            for codec in ["lz4", "zstd"]:
+                runs.append(RunSpec(
+                    scenario="orca2_single", codec=codec, fill="xor",
+                    backend=backend, dtype="u16", chunk_label=cl,
+                ))
             for codec in ["blosc-lz4", "blosc-zstd"]:
-                for throughput in [10, 100]:
-                    for sink in ["discard", "fs", "s3"]:
-                        runs.append(RunSpec(
-                            scenario=sc, codec=codec, fill="xor",
-                            backend="cpu", dtype="u16", chunk_label=cl,
-                            blosc_block_bytes=16 * 1024,
-                            sink=sink,
-                            s3_throughput_gbps=throughput if sink == "s3" else 0,
-                        ))
+                for shuffle in ["none", "byte", "bit"]:
+                    runs.append(RunSpec(
+                        scenario="orca2_single", codec=codec, fill="xor",
+                        backend=backend, dtype="u16", chunk_label=cl,
+                        blosc_shuffle=shuffle, blosc_block_bytes=16 * 1024,
+                    ))
     return runs
 
 
@@ -280,6 +317,7 @@ TIERS = {
     "fill": fill_runs,
     "io": io_runs,
     "s3": s3_runs,
+    "blosc": blosc_runs,
 }
 
 ALL_TIER_NAMES = list(TIERS.keys())
@@ -385,6 +423,7 @@ def run_one(spec: RunSpec, build_dir: Path, s3_bucket: str | None = None,
     cmd = [
         str(exe),
         "--codec", spec.codec,
+        "--level", str(spec.level),
         "--fill", spec.fill,
         "--backend", spec.backend,
         "--dtype", spec.dtype,
@@ -393,7 +432,8 @@ def run_one(spec: RunSpec, build_dir: Path, s3_bucket: str | None = None,
         "--json",
     ]
     if spec.codec.startswith("blosc-"):
-        cmd.extend(["--blosc-block-bytes", str(spec.blosc_block_bytes)])
+        cmd.extend(["--blosc-block-bytes", str(spec.blosc_block_bytes),
+                    "--blosc-shuffle", spec.blosc_shuffle])
 
     tmpdir = None
     if spec.sink == "fs":
@@ -474,6 +514,10 @@ def status_style(status: str) -> str:
 @click.option("--all", "run_all", is_flag=True, help="Run all tiers.")
 @click.option("--backend", "backend_filter", type=click.Choice(sorted(VALID_BACKENDS)),
               help="Only run benchmarks for this backend.")
+@click.option("--blosc-shuffle", type=click.Choice(sorted(VALID_SHUFFLES)), default=None,
+              help="Use this shuffle for all selected Blosc runs (deduplicated).")
+@click.option("--level", type=click.IntRange(0, 9), default=None,
+              help="Use this level for all selected Blosc runs (0 = store only).")
 @click.option("--build-dir", type=click.Path(exists=False, path_type=Path),
               default=Path("build"),
               show_default=True, help="CMake build directory.")
@@ -493,7 +537,7 @@ def status_style(status: str) -> str:
               help="Name this machine goes by in the report (default: hostname). "
                    "Give a stable name where the hostname changes between runs, as "
                    "it does on a cluster; group names live in bench/machines.toml.")
-def main(tier, run_all, backend_filter, build_dir, output, skip, retry, rerun, dry_run,
+def main(tier, run_all, backend_filter, blosc_shuffle, level, build_dir, output, skip, retry, rerun, dry_run,
          s3_bucket, s3_region, s3_endpoint, tmpdir_root, machine_name):
     """Benchmark sweep runner for chucky."""
     commit = git_commit()
@@ -529,6 +573,14 @@ def main(tier, run_all, backend_filter, build_dir, output, skip, retry, rerun, d
     runs: list[RunSpec] = []
     for t in selected_tiers:
         runs.extend(TIERS[t]())
+    if blosc_shuffle is not None or level is not None:
+        overrides = {}
+        if blosc_shuffle is not None:
+            overrides["blosc_shuffle"] = blosc_shuffle
+        if level is not None:
+            overrides["level"] = level
+        runs = [RunSpec(**{**r.model_dump(), **overrides})
+                if r.codec.startswith("blosc-") else r for r in runs]
     runs = deduplicate(runs)
     if backend_filter:
         runs = [r for r in runs if r.backend == backend_filter]
@@ -548,6 +600,8 @@ def main(tier, run_all, backend_filter, build_dir, output, skip, retry, rerun, d
         table.add_column("#", justify="right", style="dim")
         table.add_column("Scenario")
         table.add_column("Codec")
+        table.add_column("Shuffle")
+        table.add_column("Level", justify="right")
         table.add_column("Fill")
         table.add_column("Backend")
         table.add_column("Dtype")
@@ -556,7 +610,7 @@ def main(tier, run_all, backend_filter, build_dir, output, skip, retry, rerun, d
         table.add_column("Sink", justify="center")
         for i, r in enumerate(runs, 1):
             table.add_row(
-                str(i), r.scenario, r.codec, r.fill,
+                str(i), r.scenario, r.codec, r.blosc_shuffle, str(r.level), r.fill,
                 r.backend, r.dtype, r.chunk_label,
                 str(r.blosc_block_bytes) if r.blosc_block_bytes is not None else "",
                 r.sink if r.sink != "discard" else "",
@@ -626,6 +680,8 @@ def main(tier, run_all, backend_filter, build_dir, output, skip, retry, rerun, d
 
         for spec in to_run:
             tag = f"{spec.scenario} {spec.codec} {spec.backend} {spec.chunk_label}"
+            if spec.codec.startswith("blosc-"):
+                tag += f" {spec.blosc_shuffle} level={spec.level}"
             if spec.sink != "discard":
                 tag += f" {spec.sink}"
             progress.update(task, description=f"[bold]{tag}")

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -350,7 +350,7 @@ function rebuildData() {
   failedRuns = file.runs.filter(r => r.status && r.status !== "pass");
 
   function uniq(key) { return [...new Set(runs.map(r => r[key]))].sort(); }
-  allCodecs = uniq("codec");
+  allCodecs = uniq("codec_label");
   allFills = uniq("fill");
   allBackends = uniq("backend");
   allDtypes = uniq("dtype");
@@ -390,7 +390,7 @@ function metricLabel(key) {
 
 function tooltipText(r) {
   let t = `${r.scenario} | ${r.chunk_bytes_label}\n`;
-  t += `codec: ${r.codec}  fill: ${r.fill}  backend: ${r.backend}  data type: ${r.dtype}\n`;
+  t += `codec: ${r.codec_label}  fill: ${r.fill}  backend: ${r.backend}  data type: ${r.dtype}\n`;
   if (bloscBlockKey(r)) t += `Blosc block request: ${bloscBlockLabel(bloscBlockKey(r))}\n`;
   if (r.sink && r.sink !== "discard") {
     t += `sink: ${r.sink}`;
@@ -716,7 +716,7 @@ function rebuildFailures() {
     const cells = [
       r.status || "?",
       r.scenario || "?",
-      r.codec || "",
+      r.codec_label || "",
       r.backend || "",
       r.dtype || "",
       r.chunk_bytes_label || "",
@@ -1165,7 +1165,7 @@ function renderDiagnostics(run) {
   if (run.d2h_transfer && typeof run.d2h_transfer === "object") {
     const d = run.d2h_transfer;
     root.append("h2").text(
-      `D2H transfer: ${run.scenario} ${run.chunk_bytes_label} ${run.codec} (${run.backend})`);
+      `D2H transfer: ${run.scenario} ${run.chunk_bytes_label} ${run.codec_label} (${run.backend})`);
     const table = root.append("table");
     const head = table.append("thead").append("tr");
     ["Payload bytes transferred", "Metadata bytes", "Payload copies"]
@@ -1179,7 +1179,7 @@ function renderDiagnostics(run) {
   if (run.shard_padding && typeof run.shard_padding === "object") {
     const p = run.shard_padding;
     root.append("h2").text(
-      `Shard write layout: ${run.scenario} ${run.chunk_bytes_label} ${run.codec} (${run.backend})`);
+      `Shard write layout: ${run.scenario} ${run.chunk_bytes_label} ${run.codec_label} (${run.backend})`);
     const table = root.append("table");
     const head = table.append("thead").append("tr");
     ["Logical payload bytes", "Internal padding bytes", "Physical data-region bytes",
@@ -1205,7 +1205,7 @@ function renderDiagnostics(run) {
   if (!entries.length) return;
 
   root.append("h2").text(
-    `Diagnostics: ${run.scenario} ${run.chunk_bytes_label} ${run.codec} (${run.backend})`);
+    `Diagnostics: ${run.scenario} ${run.chunk_bytes_label} ${run.codec_label} (${run.backend})`);
   const table = root.append("table");
   const headers = ["Category", "Timeline", "Reason / interval", "Samples",
                    "Waits", "Average ms", "Min ms", "Max ms", "% wall"];
@@ -1266,7 +1266,7 @@ function renderStagesTiming(run, stages) {
     .call(d3.axisBottom(x).ticks(5).tickFormat(d => d + " ms"));
 
   svg.append("text").attr("x", mL).attr("y", 18).attr("font-size","13px").attr("font-weight",700)
-    .text(`Stage breakdown: ${run.scenario} ${run.chunk_bytes_label} ${run.codec} (${run.backend})`);
+    .text(`Stage breakdown: ${run.scenario} ${run.chunk_bytes_label} ${run.codec_label} (${run.backend})`);
 }
 
 function renderStagesThroughput(run, stages) {
@@ -1337,7 +1337,7 @@ function renderStagesThroughput(run, stages) {
     .call(d3.axisBottom(xGibs).ticks(4).tickFormat(d3.format(".1f")));
 
   svg.append("text").attr("x", mL).attr("y", 18).attr("font-size","13px").attr("font-weight",700)
-    .text(`Stage breakdown: ${run.scenario} ${run.chunk_bytes_label} ${run.codec} (${run.backend})`);
+    .text(`Stage breakdown: ${run.scenario} ${run.chunk_bytes_label} ${run.codec_label} (${run.backend})`);
 
   const leg = svg.append("g").attr("transform", `translate(${mL},${legY})`);
   leg.append("rect").attr("width",12).attr("height",12).attr("fill",colorIn).attr("rx",2);

--- a/scripts/sweep/test_reports.mjs
+++ b/scripts/sweep/test_reports.mjs
@@ -66,3 +66,29 @@ test("selection respects metric direction, retirement, and missing values", () =
   assert.equal(comparable(sweep, meta), false);
   assert.deepEqual(moversFor({sweeps: [sweep]}, state, meta), {rows: [], newest: null});
 });
+
+test("codec variants and block requests stay distinct throughout report selection", () => {
+  const variant = (block, shuffle, level, throughput = 1) => run(block, {
+    blosc_shuffle: shuffle, blosc_level: level, codec_label: `blosc-zstd (${shuffle}, level ${level})`,
+    id: `${block}-${shuffle}-${level}`, throughput_in_gibs: throughput,
+  });
+  const selected = variant(16384, "bit", 0);
+  const runs = [selected, variant(32768, "bit", 0, 100),
+    variant(16384, "byte", 0, 200), variant(16384, "bit", 3, 300),
+    variant(4096, "byte", 0, 400), run(undefined, {codec_label: "blosc-zstd"})];
+  const state = {codec: selected.codec_label, backend: "cpu", sink: "discard",
+    bloscBlock: "16384", metric: "throughput_in_gibs"};
+  const meta = {key: state.metric, better: "high"};
+  assert.deepEqual(blosc.bloscBlockChoices(runs, state.codec), ["16384", "32768"]);
+  assert.deepEqual(filterRuns(runs, {...state, fill: "xor", dtype: "u16",
+    scenarios: new Set(["orca2_single"])}), [selected]);
+  assert.equal(bestRun({runs}, "orca2_single", "xor", state, meta).run, selected);
+  const before = {runs: runs.slice(1)};
+  const after = {runs};
+  assert.deepEqual(moversFor({sweeps: [before, after]}, state, meta).rows, []);
+  before.runs.push({...selected, throughput_in_gibs: 2});
+  const rows = moversFor({sweeps: [before, after]}, state, meta).rows;
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].pct, -50);
+  assert.equal(rows[0].run, selected);
+});

--- a/scripts/sweep/test_sweep.py
+++ b/scripts/sweep/test_sweep.py
@@ -13,9 +13,13 @@ from click.testing import CliRunner
 from pydantic import ValidationError
 
 from columnar import decode_runs, pack
-from models import CURRENT_VERSION, run_id
+from models import CURRENT_VERSION, codec_label, run_id, validate_results
+from report import load_files
 from summary import trim_run
-from sweep import RunSpec, TIERS, deduplicate, main, run_one
+from sweep import (
+    RunSpec, TIERS, backend_runs, blosc_runs, compress_runs, deduplicate,
+    main, run_one,
+)
 
 
 def spec(**overrides):
@@ -73,7 +77,7 @@ class BloscSweepTests(unittest.TestCase):
 
     def test_all_tiers_specify_blosc_blocks(self):
         runs = deduplicate([run for matrix in TIERS.values() for run in matrix()])
-        self.assertEqual(len(runs), 598)
+        self.assertEqual(len(runs), 816)
         for run in runs:
             with self.subTest(id=run.id):
                 if run.codec.startswith("blosc-"):
@@ -91,6 +95,7 @@ class BloscSweepTests(unittest.TestCase):
                 cmd = execute.call_args.args[0]
                 if run.blosc_block_bytes is None:
                     self.assertNotIn("--blosc-block-bytes", cmd)
+                    self.assertNotIn("--blosc-shuffle", cmd)
                 else:
                     self.assertEqual(cmd[cmd.index("--blosc-block-bytes") + 1], "4097")
                     self.assertEqual(result["blosc_block_bytes"], 4097)
@@ -135,6 +140,164 @@ class BloscSweepTests(unittest.TestCase):
                 saved = json.loads(output.read_text())["runs"]
                 self.assertEqual(saved[0], previous)
                 self.assertEqual(len(saved), 1 + calls)
+
+
+def filter_spec(**overrides):
+    return RunSpec(**{
+        "scenario": "orca2_single", "codec": "blosc-lz4", "fill": "xor",
+        "backend": "gpu", "dtype": "u16", "chunk_label": "16K",
+        "blosc_block_bytes": 16384 if overrides.get("codec", "blosc-lz4").startswith("blosc-") else None,
+        **overrides,
+    })
+
+
+class RunSpecTest(unittest.TestCase):
+    def test_defaults_keep_archived_identity(self):
+        run = filter_spec()
+        self.assertEqual(run.id, "orca2_single__blosc-lz4__xor__gpu__u16__16K__blosc-block-16384")
+        self.assertEqual((run.blosc_shuffle, run.level), ("none", 3))
+        self.assertEqual(filter_spec(codec="lz4").level, 1)
+        self.assertEqual(filter_spec(codec="zstd").level, 0)
+
+    def test_filter_and_store_only_identities_do_not_collide(self):
+        runs = [filter_spec(blosc_shuffle=s, level=level, blosc_block_bytes=block)
+                for s in ("none", "byte", "bit") for level in (0, 3)
+                for block in (4096, 16384)]
+        self.assertEqual(len(deduplicate(runs * 2)), 12)
+        self.assertIn("__shuffle-bit__level-0", filter_spec(blosc_shuffle="bit", level=0).id)
+        self.assertIn("__fs__shuffle-byte", filter_spec(sink="fs", blosc_shuffle="byte").id)
+        for run in runs:
+            base = run.base_result()
+            self.assertEqual((base["blosc_shuffle"], base["blosc_level"]), (run.blosc_shuffle, run.level))
+            self.assertNotIn("shuffle", base)
+            self.assertNotIn("level", base)
+            self.assertEqual(run_id(base), run.id)
+            self.assertEqual(trim_run(base)["id"], run.id)
+
+    def test_recorded_settings_normalize_old_or_stale_identity_suffixes(self):
+        run = filter_spec(blosc_shuffle="bit", level=0, blosc_block_bytes=4096)
+        root = "orca2_single__blosc-lz4__xor__gpu__u16__16K"
+        for suffix in ("", "__blosc-block-16384__shuffle-byte__level-3",
+                       "__level-0__blosc-block-4096__shuffle-bit"):
+            with self.subTest(suffix=suffix):
+                archived = {**run.base_result(), "id": root + suffix}
+                self.assertEqual(run_id(archived), run.id)
+                self.assertEqual(run_id({**archived, "id": run.id}), run.id)
+
+    def test_invalid_settings(self):
+        for options in ({"blosc_shuffle": "bad"}, {"level": -1}, {"level": 256},
+                        {"level": 10}, {"codec": "zstd", "blosc_shuffle": "byte"},
+                        {"codec": "lz4", "level": 0}):
+            with self.subTest(options=options), self.assertRaises(ValidationError):
+                filter_spec(**options)
+
+
+class MatrixTest(unittest.TestCase):
+    def test_compress_is_subset_of_backend(self):
+        self.assertLessEqual({r.id for r in compress_runs()}, {r.id for r in backend_runs()})
+
+    def test_every_tier_can_measure_gpu_blosc(self):
+        for name, generate in TIERS.items():
+            runs = generate()
+            with self.subTest(tier=name):
+                self.assertEqual({r.codec for r in runs
+                                  if r.backend == "gpu" and r.codec.startswith("blosc-")},
+                                 {"blosc-lz4", "blosc-zstd"})
+                if name != "blosc":
+                    self.assertTrue(all(r.blosc_shuffle == "none" for r in runs))
+
+    def test_focused_blosc_comparison(self):
+        runs = blosc_runs()
+        self.assertEqual(len(runs), 48)
+        self.assertEqual(len(deduplicate(runs)), len(runs))
+        self.assertEqual({r.chunk_label for r in runs}, {"16K", "256K", "1M"})
+        for backend in ("cpu", "gpu"):
+            for codec in ("blosc-lz4", "blosc-zstd"):
+                self.assertEqual({r.blosc_shuffle for r in runs
+                                  if r.codec == codec and r.backend == backend},
+                                 {"none", "byte", "bit"})
+            self.assertEqual({r.codec for r in runs if r.backend == backend},
+                             {"lz4", "zstd", "blosc-lz4", "blosc-zstd"})
+
+    @patch("sweep.git_commit", return_value="abcdef0")
+    def test_cli_overrides_are_blosc_only_and_deduplicated(self, _commit):
+        captured = []
+        with tempfile.TemporaryDirectory() as directory:
+            result_file = Path(directory) / "results.json"
+            with patch("sweep.gpu_and_driver", return_value=("test", "test")), \
+                 patch("sweep.run_one", side_effect=lambda run, *args, **kwargs:
+                       captured.append(run) or {**run.base_result(), "status": "pass"}):
+                result = CliRunner().invoke(main, [
+                    "--tier", "blosc", "--backend", "gpu", "--blosc-shuffle", "bit",
+                    "--level", "0", "--output", str(result_file),
+                ])
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(len(captured), 12)
+            for run in captured:
+                if run.codec.startswith("blosc-"):
+                    self.assertEqual((run.blosc_shuffle, run.level), ("bit", 0))
+                else:
+                    self.assertEqual(run.blosc_shuffle, "none")
+                    self.assertEqual(run.level, 1 if run.codec == "lz4" else 0)
+
+
+class RunnerAndReportTest(unittest.TestCase):
+    @patch("sweep.Path.exists", return_value=True)
+    @patch("sweep.subprocess.run", return_value=subprocess.CompletedProcess(
+        [], 0, '{"status":"pass","blosc_shuffle":"bit","blosc_level":0}', ""))
+    def test_runner_forwards_flags_and_records_settings(self, execute, _exists):
+        result = run_one(filter_spec(blosc_shuffle="bit", level=0), Path("build"))
+        command = execute.call_args.args[0]
+        self.assertEqual(command[command.index("--blosc-shuffle") + 1], "bit")
+        self.assertEqual(command[command.index("--level") + 1], "0")
+        self.assertEqual(command[command.index("--blosc-block-bytes") + 1], "16384")
+        self.assertEqual((result["blosc_shuffle"], result["blosc_level"]), ("bit", 0))
+        self.assertEqual(result["blosc_block_bytes"], 16384)
+
+    def test_resume_matches_all_three_settings(self):
+        current = filter_spec(blosc_shuffle="bit", level=0, blosc_block_bytes=4096)
+        for block, shuffle, level, calls in ((4096, "bit", 0, 0),
+                                           (16384, "bit", 0, 1),
+                                           (4096, "byte", 0, 1),
+                                           (4096, "bit", 3, 1)):
+            with self.subTest(block=block, blosc_shuffle=shuffle, level=level), \
+                 tempfile.TemporaryDirectory() as directory:
+                previous = {**filter_spec(blosc_block_bytes=block, blosc_shuffle=shuffle,
+                                          level=level).base_result(), "status": "pass"}
+                output = Path(directory) / "results.json"
+                output.write_text(json.dumps({"version": CURRENT_VERSION, "machine": {},
+                                             "runs": [previous]}))
+                with patch.dict(TIERS, {"blosc": lambda: [current]}), \
+                     patch("sweep.git_commit", return_value="abcdef0"), \
+                     patch("sweep.run_one", return_value={**current.base_result(),
+                                                         "status": "pass"}) as execute:
+                    result = CliRunner().invoke(main, ["--tier", "blosc", "-o", str(output)])
+                self.assertEqual(result.exit_code, 0, result.output)
+                self.assertEqual(execute.call_count, calls)
+                saved = json.loads(output.read_text())["runs"]
+                self.assertEqual(saved[0], previous)
+                self.assertEqual(len(saved), 1 + calls)
+
+    def test_archives_and_variants_remain_distinct_in_reports(self):
+        archived = {**filter_spec().base_result(), "status": "pass"}
+        del archived["blosc_shuffle"], archived["blosc_level"]
+        variant = {**filter_spec(blosc_shuffle="bit", level=0).base_result(), "status": "pass"}
+        data = {"version": CURRENT_VERSION, "machine": {}, "runs": [archived, variant]}
+        validated = validate_results(data)
+        self.assertIsNone(validated.runs[0].blosc_shuffle)
+        self.assertIsNone(validated.runs[0].blosc_level)
+        self.assertEqual(codec_label(archived), "blosc-lz4")
+        self.assertEqual(codec_label(filter_spec().base_result()), "blosc-lz4")
+        self.assertEqual(codec_label(variant), "blosc-lz4 (bit, level 0)")
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "test-abcdef0-20260904.json"
+            path.write_text(json.dumps(data))
+            loaded = load_files([path])[0][1]["runs"]
+        self.assertEqual({r["codec_label"] for r in loaded},
+                         {"blosc-lz4", "blosc-lz4 (bit, level 0)"})
+        trimmed = trim_run(variant)
+        self.assertEqual((trimmed["blosc_shuffle"], trimmed["blosc_level"]), ("bit", 0))
+        self.assertEqual(trimmed["codec_label"], codec_label(variant))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
GPU Blosc was missing from the regular benchmark sweeps. Add both codecs across the existing tiers and a focused 48-case CPU/GPU comparison covering all shuffle modes and raw LZ4/Zstd controls. The full deduplicated matrix has 816 cases, with explicit 16 KiB block requests for Blosc.

Keep `--blosc-shuffle` and the existing `blosc_shuffle`/`blosc_level` JSON fields. Add `--level`, including order-independent store-only level 0, and distinguish block size, shuffle, and level in run identities, resume checks, and report selection. Preserve default raw-codec identities, historical `__io` suffixes, and unrecorded settings.

Validation:

- Release CPU-only and GPU builds; eight focused CPU-only checks and six GPU-enabled checks pass, including the benchmark CLI and Zarr readback.
- All 26 GPU benchmark smoke cases pass on an L40 with nvCOMP 5.3.0.16, covering both Blosc codecs, every shuffle mode, store-only/compressed modes, 4/16 KiB blocks, and raw controls.
- All 29 Python and 15 JavaScript tests pass; the dry-run matrix contains 816 cases.
- Rebuilt the complete report from 34 archives (8,371 runs) and three retained Blosc datasets. All archived run identities match main. Browser comparisons preserve the existing page text and SVG output, exercise the new settings and block selectors, and pass the Pareto desktop/mobile, theme, navigation, and download checks.

Full performance and S3 execution sweeps were not rerun.
