### PR TITLE
fs: queue metadata publication behind shard writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,11 @@ multiscale, and multiscale-with-dim0-downsampling modes.
 | `--blosc-block-bytes` | e.g. `16K`, `64K`, `4097` | Required for Blosc | Internal Blosc block size in bytes |
 | `--blosc-shuffle` | `none`, `byte`, `bit` | `none` | Blosc filter; recorded with the level in benchmark JSON |
 | `--reduce` | `mean`, `min`, `max`, `median`, `max_sup`, `min_sup` | `mean` | LOD reduction method |
+| `--full-memcpy-timing` | flag | off | GPU profiling: time every host copy instead of sampling small copies |
 | `-o path` | output directory | omit to discard | Write Zarr output to disk |
 
 Benchmarks report per-stage throughput and latency, compression ratio, memory
-breakdown, and overall pipeline GB/s.
+breakdown, and overall pipeline GiB/s.
 
 ## Architecture
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -85,3 +85,15 @@ foreach(src IN LISTS BENCH_STREAM_SOURCES)
     string(REPLACE ".c" "" target ${src})
     add_bench(${target} ${src} bench_util Zstd::Zstd)
 endforeach()
+
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if(Python3_Interpreter_FOUND)
+    add_bench(test_bench_report test_bench_report.c bench_util Zstd::Zstd)
+    add_test(
+        NAME test-bench_report
+        COMMAND
+            ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test_bench_report.py
+            $<TARGET_FILE:test_bench_report>
+    )
+endif()

--- a/bench/bench_gpu.cuda.c
+++ b/bench/bench_gpu.cuda.c
@@ -83,18 +83,19 @@ bench_gpu_report_memory(const struct tile_stream_configuration* config,
   char a[32], b[32];
   format_bytes(a, sizeof(a), mem.device_bytes);
   format_bytes(b, sizeof(b), mem.host_pinned_bytes);
-  print_report("  GPU memory:  %s device, %s pinned", a, b);
+  print_report("  %-17s %s device, %s pinned", "GPU memory:", a, b);
   format_bytes(a, sizeof(a), mem.staging_bytes);
   format_bytes(b, sizeof(b), mem.chunk_pool_bytes);
-  print_report("    staging:   %s   chunk_pool: %s", a, b);
+  print_report("    %-12s %12s   %-12s %12s", "Staging:", a, "Chunk pool:", b);
   format_bytes(a, sizeof(a), mem.compressed_pool_bytes);
   format_bytes(b, sizeof(b), mem.aggregate_bytes);
-  print_report("    comp_pool: %s   aggregate: %s", a, b);
+  print_report(
+    "    %-12s %12s   %-12s %12s", "Compressed:", a, "Aggregate:", b);
   format_bytes(a, sizeof(a), mem.lod_bytes);
   format_bytes(b, sizeof(b), mem.codec_bytes);
-  print_report("    lod:       %s   codec:     %s", a, b);
+  print_report("    %-12s %12s   %-12s %12s", "LOD:", a, "Codec:", b);
   print_report(
-    "    chunks:    %llu/epoch, %llu total (%d LOD levels, batch=%u)",
+    "    Chunks:      %llu/epoch, %llu total (%d LOD levels, batch=%u)",
     (unsigned long long)mem.chunks_per_epoch,
     (unsigned long long)mem.total_chunks,
     mem.nlod,

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -4,6 +4,9 @@
 #include "util/metric.h"
 #include "zarr/json_writer.h"
 
+#include <math.h>
+#include <string.h>
+
 enum diagnostic_section
 {
   DIAGNOSTIC_HOST_BLOCK,
@@ -100,21 +103,46 @@ gb_per_s(double bytes, double ms)
 
 // --- Report + pipeline helpers ---
 
+// Tiny timings must remain distinguishable from zero.
+static void
+format_measurement(char buf[32], double value, int decimals)
+{
+  int n = snprintf(buf, 32, "%.*f", decimals, value);
+  if (n > 8 || (value != 0 && fabs(value) < (decimals == 3 ? 0.001 : 0.01)))
+    snprintf(buf, 32, "%.2e", value);
+}
+
+static void
+format_count(char buf[32], uint64_t count)
+{
+  int n = snprintf(buf, 32, "%llu", (unsigned long long)count);
+  if (n > 10)
+    snprintf(buf, 32, "%.3e", (double)count);
+}
+
 void
 print_append_latency(const struct stream_metrics* m)
 {
   if (m->append_count == 0) {
-    print_report("  max append ms:   %.2f", (double)m->max_append_ms);
+    char max_ms[32];
+    format_measurement(max_ms, m->max_append_ms, 3);
+    print_report("  %-17s %s ms", "Max append:", max_ms);
     return;
   }
-  print_report("  append ms:       p50 %.3f  p90 %.3f  p99 %.3f  p99.9 %.3f"
-               "  max %.3f  (%llu appends)",
-               (double)append_ms_at(m, 0.50),
-               (double)append_ms_at(m, 0.90),
-               (double)append_ms_at(m, 0.99),
-               (double)append_ms_at(m, 0.999),
-               (double)m->max_append_ms,
-               (unsigned long long)m->append_count);
+  char p50[32], p90[32], p99[32], p999[32], max_ms[32];
+  format_measurement(p50, append_ms_at(m, 0.50), 3);
+  format_measurement(p90, append_ms_at(m, 0.90), 3);
+  format_measurement(p99, append_ms_at(m, 0.99), 3);
+  format_measurement(p999, append_ms_at(m, 0.999), 3);
+  format_measurement(max_ms, m->max_append_ms, 3);
+  print_report("  %-17s %llu", "Appends:", (unsigned long long)m->append_count);
+  print_report("  %9s %9s %9s %9s %9s",
+               "p50 ms",
+               "p90 ms",
+               "p99 ms",
+               "p99.9 ms",
+               "max ms");
+  print_report("  %9s %9s %9s %9s %9s", p50, p90, p99, p999, max_ms);
 }
 
 void
@@ -125,28 +153,37 @@ print_memory_report(const struct bench_memory* mem)
   if (!mem->host_reading_failed) {
     format_bytes(a, sizeof(a), mem->host_baseline_bytes);
     format_bytes(b, sizeof(b), mem->host_peak_bytes);
-    print_report("  Host memory:   %s at rest, %s peak", a, b);
+    print_report("  %-17s %s at rest, %s peak", "Host memory:", a, b);
   } else {
-    print_report("  Host memory:   unavailable");
+    print_report("  %-17s unavailable", "Host memory:");
   }
   if (mem->device_used_bytes) {
     format_bytes(a, sizeof(a), mem->device_used_bytes);
-    print_report("  Device memory: %s", a);
+    print_report("  %-17s %s", "Device memory:", a);
   }
-  if (mem->device_overhead_valid)
-    print_report("  Device overhead: %+.2f MiB (observed minus estimated)",
-                 (double)mem->device_overhead_bytes / (1024 * 1024));
+  if (mem->device_overhead_valid) {
+    const int negative = mem->device_overhead_bytes < 0;
+    const uint64_t magnitude = negative
+                                 ? 0 - (uint64_t)mem->device_overhead_bytes
+                                 : (uint64_t)mem->device_overhead_bytes;
+    format_bytes(a, sizeof(a), magnitude);
+    print_report("  %-17s %c%s (observed minus estimated)",
+                 "Device overhead:",
+                 negative ? '-' : '+',
+                 a);
+  }
   if (mem->measured_bytes && mem->estimate_total_bytes) {
     format_bytes(a, sizeof(a), mem->estimate_total_bytes);
-    print_report("  Estimate:      %s (%.2fx measured)",
+    print_report("  %-17s %s (%.2fx measured)",
+                 "Estimate:",
                  a,
                  (double)mem->estimate_total_bytes /
                    (double)mem->measured_bytes);
   }
 }
 
-void
-print_metric_row(const struct stream_metric* m)
+static void
+print_metric_row(const char* name, const struct stream_metric* m)
 {
   if (m->count <= 0)
     return;
@@ -154,20 +191,62 @@ print_metric_row(const struct stream_metric* m)
   double avg_ms = (double)m->ms / N;
   double avg_gbs = gb_per_s(m->input_bytes, (double)m->ms);
   int has_best = m->best_ms < 1e29f;
+  char avg_rate[32], best_rate[32] = "-", avg_time[32], best_time[32] = "-";
+  format_measurement(avg_rate, avg_gbs, 2);
+  format_measurement(avg_time, avg_ms, 3);
 
   if (has_best) {
-    // Use the bytes recorded for that exact call so partial-batch tails
-    // don't inflate "best" via an average-bytes / min-time fudge.
+    // Average bytes would inflate the best rate for partial batches.
     double best_gbs = gb_per_s(m->best_input_bytes, (double)m->best_ms);
-    print_report("  %-12s %8.2f %8.2f %10.2f %10.2f",
-                 m->name,
-                 avg_gbs,
-                 best_gbs,
-                 avg_ms,
-                 (double)m->best_ms);
-  } else {
+    format_measurement(best_rate, best_gbs, 2);
+    format_measurement(best_time, m->best_ms, 3);
+  }
+  print_report("  %-14s %10s %10s %9s %9s",
+               name,
+               avg_rate,
+               best_rate,
+               avg_time,
+               best_time);
+}
+
+void
+print_stage_report(const struct stream_metrics* m)
+{
+  const int sampled = m->memcpy_calls > (uint64_t)m->memcpy.count;
+  print_report("  %-14s %10s %10s %9s %9s",
+               "Stage",
+               "avg GiB/s",
+               "best GiB/s",
+               "avg ms",
+               "best ms");
+  print_metric_row(sampled ? "Memcpy[smp]" : "Memcpy", &m->memcpy);
+  print_metric_row("H2D", &m->h2d);
+  print_metric_row(m->scatter.name && strcmp(m->scatter.name, "Copy") == 0
+                     ? "Copy"
+                     : "Scatter",
+                   &m->scatter);
+  print_metric_row("LOD gather", &m->lod_gather);
+  print_metric_row("LOD reduce", &m->lod_reduce);
+  print_metric_row("Append fold", &m->lod_append_fold);
+  print_metric_row("LOD to chunks", &m->lod_morton_chunk);
+  print_metric_row("Compress", &m->compress);
+  print_metric_row("Aggregate", &m->aggregate);
+  print_metric_row("D2H", &m->d2h);
+  print_metric_row("Sink", &m->sink);
+
+  if (m->memcpy_calls) {
+    fputc('\n', stderr);
+    print_report("  Memcpy work:");
+    print_report("  %-14s %20s %20s", "Coverage", "copies", "bytes");
+    print_report("  %-14s %20llu %20llu",
+                 "Total",
+                 (unsigned long long)m->memcpy_calls,
+                 (unsigned long long)m->memcpy_bytes);
     print_report(
-      "  %-12s %8.2f %8s %10.2f %10s", m->name, avg_gbs, "-", avg_ms, "-");
+      "  %-14s %20d %20.0f", "Timed", m->memcpy.count, m->memcpy.input_bytes);
+    print_report("  %s",
+                 sampled ? "Sample times/rates/extrema only; not extrapolated."
+                         : "All copies timed.");
   }
 }
 
@@ -182,34 +261,26 @@ print_diagnostic_row(const struct diagnostic_entry* d, float wall_s)
 {
   const struct stream_metric* m = d->metric;
   const double wall_pct = wall_s > 0 ? (double)m->ms / (wall_s * 10.0) : 0.0;
-  char wait_calls[24];
+  char wait_calls[32] = "-", avg_ms[32] = "-", max_ms[32] = "-", pct[32];
   if (m->wait_calls > 0)
-    snprintf(wait_calls,
-             sizeof(wait_calls),
-             "%llu",
-             (unsigned long long)m->wait_calls);
-  else
-    snprintf(wait_calls, sizeof(wait_calls), "-");
-
+    format_count(wait_calls, m->wait_calls);
+  format_measurement(pct, wall_pct, 2);
   if (m->count > 0) {
-    print_report("  %-10s %-25s %8d %10s %9.3f %9.3f %7.2f",
-                 metric_owner_name(m->owner),
-                 d->label,
-                 m->count,
-                 wait_calls,
-                 (double)m->ms / m->count,
-                 (double)m->max_ms,
-                 wall_pct);
-  } else {
-    print_report("  %-10s %-25s %8d %10s %9s %9s %7.2f",
-                 metric_owner_name(m->owner),
-                 d->label,
-                 0,
-                 wait_calls,
-                 "-",
-                 "-",
-                 wall_pct);
+    format_measurement(avg_ms, (double)m->ms / m->count, 3);
+    format_measurement(max_ms, m->max_ms, 3);
   }
+  const char* label = d->label;
+  if (strlen(label) > 26) {
+    print_report("  %s", label);
+    label = "";
+  }
+  print_report("  %-26s %10d %10s %9s %9s %8s",
+               label,
+               m->count,
+               wait_calls,
+               avg_ms,
+               max_ms,
+               pct);
 }
 
 static void
@@ -228,17 +299,27 @@ print_diagnostic_section(const struct diagnostic_entry entries[],
 
   fputc('\n', stderr);
   print_report("  --- %s ---", title);
-  print_report("  %-10s %-25s %8s %10s %9s %9s %7s",
-               "Timeline",
+  print_report("  %-26s %10s %10s %9s %9s %8s",
                interval_label,
                "samples",
                "waits",
                "avg ms",
                "max ms",
                "% wall");
-  for (size_t i = 0; i < DIAGNOSTIC_COUNT; ++i)
-    if (entries[i].section == section && diagnostic_measured(entries[i].metric))
+  for (enum metric_owner owner = METRIC_OWNER_NONE; owner <= METRIC_OWNER_D2H;
+       ++owner) {
+    int have_owner = 0;
+    for (size_t i = 0; i < DIAGNOSTIC_COUNT; ++i) {
+      if (entries[i].section != section || entries[i].metric->owner != owner ||
+          !diagnostic_measured(entries[i].metric))
+        continue;
+      if (!have_owner) {
+        print_report("  [%s timeline]", metric_owner_name(owner));
+        have_owner = 1;
+      }
       print_diagnostic_row(&entries[i], wall_s);
+    }
+  }
 }
 
 static int
@@ -255,12 +336,13 @@ print_duration_row(const char* label, const struct duration_stats* stats)
 {
   if (stats->count == 0)
     return;
-  print_report("  %-34s %8llu %9.3f %9.3f %9.3f",
-               label,
-               (unsigned long long)stats->count,
-               (double)stats->total_ms / stats->count,
-               (double)stats->min_ms,
-               (double)stats->max_ms);
+  char count[32], avg_ms[32], min_ms[32], max_ms[32];
+  format_count(count, stats->count);
+  format_measurement(avg_ms, (double)stats->total_ms / stats->count, 3);
+  format_measurement(min_ms, stats->min_ms, 3);
+  format_measurement(max_ms, stats->max_ms, 3);
+  print_report(
+    "  %-34s %10s %9s %9s %9s", label, count, avg_ms, min_ms, max_ms);
 }
 
 static void
@@ -271,7 +353,7 @@ print_delivery_timing(const struct delivery_timing* timing)
 
   fputc('\n', stderr);
   print_report("  --- Delivery latency ---");
-  print_report("  %-34s %8s %9s %9s %9s",
+  print_report("  %-34s %10s %9s %9s %9s",
                "Interval",
                "samples",
                "avg ms",
@@ -294,7 +376,7 @@ print_diagnostics_report(const struct stream_metrics* m, float wall_s)
   print_diagnostic_section(entries,
                            DIAGNOSTIC_HOST_BLOCK,
                            "Host blocking",
-                           "Reason / awaited condition",
+                           "Awaited condition",
                            wall_s);
   print_diagnostic_section(entries,
                            DIAGNOSTIC_HOST_OVERHEAD,
@@ -307,10 +389,11 @@ print_diagnostics_report(const struct stream_metrics* m, float wall_s)
 
   if (m->scatter_samples_lost || m->lod_samples_lost) {
     fputc('\n', stderr);
-    print_report("  TIMING SAMPLES LOST: scatter=%llu lod=%llu "
-                 "(stage totals under-report)",
-                 (unsigned long long)m->scatter_samples_lost,
-                 (unsigned long long)m->lod_samples_lost);
+    print_report("  TIMING SAMPLES LOST (stage totals under-report)");
+    print_report(
+      "  %-17s %llu", "Scatter:", (unsigned long long)m->scatter_samples_lost);
+    print_report(
+      "  %-17s %llu", "LOD:", (unsigned long long)m->lod_samples_lost);
   }
   if (m->append_count > 0 || m->max_append_ms > 0) {
     fputc('\n', stderr);
@@ -322,7 +405,7 @@ print_diagnostics_report(const struct stream_metrics* m, float wall_s)
     print_report("  --- Queue pressure ---");
     char pbuf[32];
     format_bytes(pbuf, sizeof(pbuf), m->peak_pending_bytes);
-    print_report("  peak pending:    %s", pbuf);
+    print_report("  %-17s %s", "Peak pending:", pbuf);
   }
 }
 
@@ -340,29 +423,34 @@ log_bench_header(const struct tile_stream_layout* layout,
 
   char buf[32];
   format_bytes(buf, sizeof(buf), (uint64_t)total_bytes);
-  print_report("  total:       %s (%zu elements, %zu epochs)",
+  print_report("  %-17s %s (%zu elements, %zu epochs)",
+               "Total:",
                buf,
                total_elements,
                num_epochs);
   format_bytes(
     buf, sizeof(buf), (uint64_t)(layout->chunk_stride * dtype_bpe(dtype)));
-  print_report("  chunk:       %lu elements = %s  (stride=%lu)",
+  print_report("  %-17s %lu elements = %s (stride=%lu)",
+               "Chunk:",
                (unsigned long)layout->chunk_elements,
                buf,
                (unsigned long)layout->chunk_stride);
   format_bytes(buf, sizeof(buf), (uint64_t)layout->chunk_pool_bytes);
-  print_report("  epoch:       %lu slots, %s pool",
+  print_report("  %-17s %lu slots, %s pool",
+               "Epoch:",
                (unsigned long)layout->chunks_per_epoch,
                buf);
   if (codec.id != CODEC_NONE && max_compressed_size > 0) {
     format_bytes(
       buf, sizeof(buf), (uint64_t)(codec_batch_size * max_compressed_size));
-    print_report(
-      "  compress:    max_output=%zu comp_pool=%s", max_compressed_size, buf);
+    print_report("  %-17s %zu bytes/chunk max, %s pool",
+                 "Compression:",
+                 max_compressed_size,
+                 buf);
   }
   if (codec_is_blosc(codec.id))
-    print_report("  Blosc block: %u bytes (requested)",
-                 codec.blosc_block_bytes);
+    print_report(
+      "  %-17s %u bytes (requested)", "Blosc block:", codec.blosc_block_bytes);
 }
 
 void
@@ -390,36 +478,20 @@ print_bench_report(const struct stream_metrics* metrics,
       : 0.0;
 
   fputc('\n', stderr);
-  print_report("  --- Benchmark Results ---");
+  print_report("  --- Benchmark results ---");
   char fbuf[32];
   format_bytes(fbuf, sizeof(fbuf), (uint64_t)total_bytes);
-  print_report("  Input:        %s (%zu elements)", fbuf, total_elements);
+  print_report("  %-17s %s (%zu elements)", "Input:", fbuf, total_elements);
   format_bytes(fbuf, sizeof(fbuf), (uint64_t)ss->total_bytes);
-  print_report("  Compressed:   %s (ratio: %.3f)", fbuf, comp_ratio);
-  print_report("  Chunks:       %zu (%llu/epoch x %zu epochs)",
+  print_report("  %-17s %s (ratio: %.3f)", "Output:", fbuf, comp_ratio);
+  print_report("  %-17s %zu (%llu/epoch x %zu epochs)",
+               "Chunks:",
                total_chunks,
                (unsigned long long)chunks_per_epoch,
                num_epochs);
 
   fputc('\n', stderr);
-  print_report("  %-12s %8s %8s %10s %10s",
-               "Stage",
-               "avg GB/s",
-               "best GB/s",
-               "avg ms",
-               "best ms");
-
-  print_metric_row(&metrics->memcpy);
-  print_metric_row(&metrics->h2d);
-  print_metric_row(&metrics->scatter);
-  print_metric_row(&metrics->lod_gather);
-  print_metric_row(&metrics->lod_reduce);
-  print_metric_row(&metrics->lod_append_fold);
-  print_metric_row(&metrics->lod_morton_chunk);
-  print_metric_row(&metrics->compress);
-  print_metric_row(&metrics->aggregate);
-  print_metric_row(&metrics->d2h);
-  print_metric_row(&metrics->sink);
+  print_stage_report(metrics);
 
   if (metrics->d2h_payload_bytes_transferred ||
       metrics->d2h_metadata_bytes_transferred ||
@@ -429,9 +501,12 @@ print_bench_report(const struct stream_metrics* metrics,
       payload, sizeof(payload), metrics->d2h_payload_bytes_transferred);
     format_bytes(
       metadata, sizeof(metadata), metrics->d2h_metadata_bytes_transferred);
-    print_report("  D2H transfer: payload %s, metadata %s, %llu copies",
-                 payload,
-                 metadata,
+    fputc('\n', stderr);
+    print_report("  --- D2H transfer ---");
+    print_report("  %-17s %s", "Payload:", payload);
+    print_report("  %-17s %s", "Metadata:", metadata);
+    print_report("  %-17s %llu",
+                 "Payload copies:",
                  (unsigned long long)metrics->d2h_payload_copy_count);
   }
   if (metrics->shard_padding_logical_payload_bytes ||
@@ -449,13 +524,15 @@ print_bench_report(const struct stream_metrics* metrics,
     format_bytes(
       padding, sizeof(padding), metrics->shard_padding_internal_bytes);
     format_bytes(physical_buf, sizeof(physical_buf), physical);
+    fputc('\n', stderr);
+    print_report("  --- Shard layout ---");
+    print_report("  %-17s %s", "Logical payload:", logical);
     print_report(
-      "  Shard layout: logical %s, padding %s, physical %s "
-      "(%.2f%%), %llu/%llu padded updates",
-      logical,
-      padding,
-      physical_buf,
-      ratio * 100.0,
+      "  %-17s %s (%.2f%% of physical)", "Padding:", padding, ratio * 100.0);
+    print_report("  %-17s %s", "Physical payload:", physical_buf);
+    print_report(
+      "  %-17s %llu / %llu",
+      "Padded updates:",
       (unsigned long long)metrics->shard_padding_padded_update_count,
       (unsigned long long)metrics->shard_padding_physical_update_count);
   }
@@ -466,18 +543,18 @@ print_bench_report(const struct stream_metrics* metrics,
     wall_s > 0 ? ((double)total_bytes / (1024.0 * 1024.0 * 1024.0)) / wall_s
                : 0.0;
   fputc('\n', stderr);
-  print_report("  Init time:     %.3f s", (double)init_s);
+  print_report("  %-17s %.3f s", "Init time:", (double)init_s);
   if (flush_pending_bytes > 0 && flush_s > 0) {
     double flush_gib =
       ((double)flush_pending_bytes / (1024.0 * 1024.0 * 1024.0)) /
       (double)flush_s;
     print_report(
-      "  Flush time:    %.3f s (%.2f GiB/s)", (double)flush_s, flush_gib);
+      "  %-17s %.3f s (%.2f GiB/s)", "Flush time:", (double)flush_s, flush_gib);
   } else {
-    print_report("  Flush time:    %.3f s", (double)flush_s);
+    print_report("  %-17s %.3f s", "Flush time:", (double)flush_s);
   }
-  print_report("  Wall time:     %.3f s", wall_s);
-  print_report("  Throughput:    %.2f GiB/s", throughput_gib);
+  print_report("  %-17s %.3f s", "Wall time:", wall_s);
+  print_report("  %-17s %.2f GiB/s", "Throughput:", throughput_gib);
 }
 
 static void
@@ -672,8 +749,10 @@ print_bench_json_pass(const struct stream_metrics* m,
     jw_key(&jw, "blosc_block_bytes");
     jw_uint(&jw, codec.blosc_block_bytes);
     jw_key(&jw, "blosc_shuffle");
-    jw_string(&jw, codec.shuffle == CODEC_SHUFFLE_BIT ? "bit" :
-                     codec.shuffle == CODEC_SHUFFLE_BYTE ? "byte" : "none");
+    jw_string(&jw,
+              codec.shuffle == CODEC_SHUFFLE_BIT    ? "bit"
+              : codec.shuffle == CODEC_SHUFFLE_BYTE ? "byte"
+                                                    : "none");
     jw_key(&jw, "blosc_level");
     jw_uint(&jw, codec.level);
   }
@@ -748,9 +827,26 @@ print_bench_json_pass(const struct stream_metrics* m,
     jw_object_end(&jw);
   }
 
+  if (m->memcpy_calls) {
+    jw_key(&jw, "memcpy_work");
+    jw_object_begin(&jw);
+    jw_key(&jw, "calls");
+    jw_uint(&jw, m->memcpy_calls);
+    jw_key(&jw, "bytes");
+    jw_uint(&jw, m->memcpy_bytes);
+    jw_key(&jw, "timing_scope");
+    jw_string(&jw,
+              m->memcpy_calls > (uint64_t)m->memcpy.count ? "sampled" : "full");
+    jw_object_end(&jw);
+  }
+
   jw_key(&jw, "stages");
   jw_object_begin(&jw);
-  json_stage_metric(&jw, "memcpy", &m->memcpy);
+  // Existing consumers must not mistake sampled time for a full-stage total.
+  json_stage_metric(
+    &jw,
+    m->memcpy_calls > (uint64_t)m->memcpy.count ? "memcpy_sample" : "memcpy",
+    &m->memcpy);
   json_stage_metric(&jw, "h2d", &m->h2d);
   json_stage_metric(&jw, "scatter", &m->scatter);
   json_stage_metric(&jw, "lod_gather", &m->lod_gather);

--- a/bench/bench_report.h
+++ b/bench/bench_report.h
@@ -23,7 +23,7 @@ void
 print_memory_report(const struct bench_memory* mem);
 
 void
-print_metric_row(const struct stream_metric* m);
+print_stage_report(const struct stream_metrics* m);
 
 // Print diagnostic intervals grouped by where the work or wait happened.
 // Unlike stage rows, these intervals do not claim a byte rate.

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -304,7 +304,8 @@ print_shard_summary(const struct dimension* dims,
   const uint64_t shard_bytes = chunk_bytes * cps_total;
   char buf[32];
   format_bytes(buf, sizeof(buf), shard_bytes);
-  print_report("  shard:       %s uncompressed (%llu chunks), %llu total",
+  print_report("  %-17s %s uncompressed (%llu chunks), %llu total",
+               "Shard:",
                buf,
                (unsigned long long)cps_total,
                (unsigned long long)total_shards);
@@ -434,6 +435,7 @@ run_bench(const struct bench_config* cfg)
     .target_batch_bytes = resolved_batch_bytes(cfg),
     .backpressure_bytes = cfg->backpressure_bytes,
     .max_threads = cfg->max_threads,
+    .full_memcpy_timing = cfg->full_memcpy_timing,
   };
 
   uint64_t est_total_chunks = 0;
@@ -451,20 +453,22 @@ run_bench(const struct bench_config* cfg)
       est_total_bytes = mem.heap_bytes;
       char a[32], b[32];
       format_bytes(a, sizeof(a), mem.heap_bytes);
-      print_report("  CPU memory:  %s heap", a);
+      print_report("  %-17s %s heap", "CPU memory:", a);
       format_bytes(a, sizeof(a), mem.chunk_pool_bytes);
       format_bytes(b, sizeof(b), mem.compressed_pool_bytes);
-      print_report("    chunk_pool: %s   comp_pool: %s", a, b);
+      print_report(
+        "    %-12s %12s   %-12s %12s", "Chunk pool:", a, "Compressed:", b);
       format_bytes(a, sizeof(a), mem.comp_sizes_bytes);
       format_bytes(b, sizeof(b), mem.aggregate_bytes);
-      print_report("    comp_sizes: %s   aggregate: %s", a, b);
+      print_report(
+        "    %-12s %12s   %-12s %12s", "Comp. sizes:", a, "Aggregate:", b);
       format_bytes(a, sizeof(a), mem.host_output_pool_bytes);
-      print_report("    host output: %s", a);
+      print_report("    %-12s %12s", "Host output:", a);
       format_bytes(a, sizeof(a), mem.lod_bytes);
       format_bytes(b, sizeof(b), mem.shard_bytes);
-      print_report("    lod:       %s   shards:    %s", a, b);
+      print_report("    %-12s %12s   %-12s %12s", "LOD:", a, "Shards:", b);
       print_report(
-        "    chunks:    %llu/epoch, %llu total (%d LOD levels, batch=%u)",
+        "    Chunks:      %llu/epoch, %llu total (%d LOD levels, batch=%u)",
         (unsigned long long)mem.chunks_per_epoch,
         (unsigned long long)mem.total_chunks,
         mem.nlod,
@@ -512,14 +516,14 @@ run_bench(const struct bench_config* cfg)
                    total_bytes,
                    total_elements);
   if (is_multiscale && nlod > 0)
-    print_report("  LOD levels:  %d", nlod);
+    print_report("  %-17s %d", "LOD levels:", nlod);
 
   if (cfg->append_elements > 0) {
     char abuf[32];
     format_bytes(
       abuf, sizeof(abuf), (uint64_t)(cfg->append_elements * dtype_bpe(dtype)));
     print_report(
-      "  append size: %zu elements = %s", cfg->append_elements, abuf);
+      "  %-17s %zu elements = %s", "Append size:", cfg->append_elements, abuf);
   }
 
   struct platform_clock clock = { 0 };
@@ -655,6 +659,7 @@ struct bench_cli_args
   uint64_t io_latency_us;
   uint64_t backpressure_bytes;
   int max_threads;
+  int full_memcpy_timing;
 };
 
 static int
@@ -666,15 +671,6 @@ read_size(const char* flag, const char* text, uint64_t* out)
   return 0;
 }
 
-// Parse the shared bench CLI flags into out. Unknown options print a usage
-// string and return 1. Flags accepted:
-//   --fill --codec --blosc-block-bytes --reduce --backend --dtype --frames
-//   --json --chunk-bytes
-//   --memory-budget -o --s3-bucket --s3-prefix --s3-region --s3-endpoint
-//   --s3-throughput-gbps --io-bw-mbps --io-latency-us --backpressure
-//   --max-threads.
-// Drivers that don't honor a given flag (e.g. two-streams ignores --backend)
-// just don't read the corresponding field afterward.
 static int
 parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
 {
@@ -698,6 +694,7 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
   out->io_latency_us = 0;
   out->backpressure_bytes = 0;
   out->max_threads = 0;
+  out->full_memcpy_timing = 0;
 
   for (int i = 1; i < ac; ++i) {
     if (strcmp(av[i], "--fill") == 0 && i + 1 < ac) {
@@ -725,7 +722,8 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
       else if (strcmp(shuffle, "bit") == 0)
         out->codec.shuffle = CODEC_SHUFFLE_BIT;
       else {
-        fprintf(stderr, "Invalid --blosc-shuffle: %s (expected none|byte|bit)\n",
+        fprintf(stderr,
+                "Invalid --blosc-shuffle: %s (expected none|byte|bit)\n",
                 shuffle);
         return 1;
       }
@@ -778,6 +776,8 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
       ++i;
     } else if (strcmp(av[i], "--max-threads") == 0 && i + 1 < ac) {
       out->max_threads = (int)strtol(av[++i], NULL, 10);
+    } else if (strcmp(av[i], "--full-memcpy-timing") == 0) {
+      out->full_memcpy_timing = 1;
     } else {
       fprintf(stderr, "Unknown option: %s\n", av[i]);
       fprintf(stderr,
@@ -793,7 +793,8 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
               "[--s3-throughput-gbps N]] "
               "[--io-bw-mbps N (MiB/s)] [--io-latency-us N] "
               "[--backpressure N (bytes, e.g. 256M)] "
-              "[--max-threads N (0 = OpenMP default)]\n",
+              "[--max-threads N (0 = OpenMP default)] "
+              "[--full-memcpy-timing (GPU profiling)]\n",
               av[0]);
       return 1;
     }
@@ -848,6 +849,7 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
     .io_latency_us = a.io_latency_us,
     .backpressure_bytes = a.backpressure_bytes,
     .max_threads = a.max_threads,
+    .full_memcpy_timing = a.full_memcpy_timing,
   };
   int ecode = run_bench(&cfg);
 
@@ -1015,6 +1017,7 @@ run_bench_two_streams(const struct bench_config* cfg)
     .target_batch_bytes = resolved_batch_bytes(cfg),
     .backpressure_bytes = cfg->backpressure_bytes,
     .max_threads = cfg->max_threads,
+    .full_memcpy_timing = cfg->full_memcpy_timing,
   };
 
   bench_gpu_report_memory_pair(&config);
@@ -1081,44 +1084,30 @@ run_bench_two_streams(const struct bench_config* cfg)
     char buf[32];
     format_bytes(buf, sizeof(buf), 2 * (uint64_t)total_bytes);
     print_report(
-      "  Input:        %s (%zu elements x 2 streams)", buf, total_elements);
+      "  %-17s %s (%zu elements x 2 streams)", "Input:", buf, total_elements);
     format_bytes(buf, sizeof(buf), (uint64_t)(sink_bytes[0] + sink_bytes[1]));
-    print_report("  Compressed:   %s", buf);
+    print_report("  %-17s %s", "Output:", buf);
   }
-  print_report("  Init time:     %.3f s", (double)init_s);
+  print_report("  %-17s %.3f s", "Init time:", (double)init_s);
   if (flush_s > 0)
-    print_report("  Flush time:    %.3f s", (double)flush_s);
-  print_report("  Wall time:     %.3f s", (double)wall_s);
-  print_report("  Throughput:    %.2f GiB/s (combined)",
+    print_report("  %-17s %.3f s", "Flush time:", (double)flush_s);
+  print_report("  %-17s %.3f s", "Wall time:", (double)wall_s);
+  print_report("  %-17s %.2f GiB/s (combined)",
+               "Throughput:",
                wall_s > 0 ? combined_gib / wall_s : 0.0);
 
   // --- Per-stream reports ---
   for (int k = 0; k < 2; ++k) {
     fputc('\n', stderr);
-    print_report("  --- stream-%d ---", k);
-    print_report("  Throughput:    %.2f GiB/s",
+    print_report("  --- Stream %d ---", k);
+    print_report("  %-17s %.2f GiB/s",
+                 "Throughput:",
                  wall_s > 0 ? per_stream_gib / wall_s : 0.0);
     char cbuf[32];
     format_bytes(cbuf, sizeof(cbuf), (uint64_t)sink_bytes[k]);
-    print_report("  Compressed:    %s", cbuf);
+    print_report("  %-17s %s", "Output:", cbuf);
     fputc('\n', stderr);
-    print_report("  %-12s %8s %8s %10s %10s",
-                 "Stage",
-                 "avg GB/s",
-                 "best GB/s",
-                 "avg ms",
-                 "best ms");
-    print_metric_row(&m[k].memcpy);
-    print_metric_row(&m[k].h2d);
-    print_metric_row(&m[k].scatter);
-    print_metric_row(&m[k].lod_gather);
-    print_metric_row(&m[k].lod_reduce);
-    print_metric_row(&m[k].lod_append_fold);
-    print_metric_row(&m[k].lod_morton_chunk);
-    print_metric_row(&m[k].compress);
-    print_metric_row(&m[k].aggregate);
-    print_metric_row(&m[k].d2h);
-    print_metric_row(&m[k].sink);
+    print_stage_report(&m[k]);
 
     print_diagnostics_report(&m[k], wall_s);
   }
@@ -1201,6 +1190,7 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
     .io_latency_us = a.io_latency_us,
     .backpressure_bytes = a.backpressure_bytes,
     .max_threads = a.max_threads,
+    .full_memcpy_timing = a.full_memcpy_timing,
   };
   int ecode = run_bench_two_streams(&cfg);
 

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -531,6 +531,9 @@ run_bench(const struct bench_config* cfg)
                                   dtype_bpe(dtype),
                                   cfg->append_elements) == 0);
 
+  // Final metadata publication belongs to the measured operation too.
+  CHECK(Fail, writer_close(bench_writer(&h)).error == 0);
+
   uint64_t pending_bytes = bench_zarr_pending_bytes(&zarr);
 
   struct platform_clock flush_clock = { 0 };

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -55,6 +55,7 @@ struct bench_config
   uint64_t io_latency_us;      // 0 = no fixed per-job latency
   uint64_t backpressure_bytes; // 0 = disabled; >0 = stall when pending > N
   int max_threads;             // 0 = OpenMP default (omp_get_max_threads)
+  int full_memcpy_timing;
 };
 
 int

--- a/bench/sink_metering.c
+++ b/bench/sink_metering.c
@@ -153,15 +153,13 @@ metering_update_append(struct shard_sink* self,
 }
 
 static int
-metering_update_append_after(struct shard_sink* self,
-                             uint8_t level,
-                             uint8_t n_append,
-                             const uint64_t* append_sizes,
-                             struct io_event after)
+metering_queue_append(struct shard_sink* self,
+                      uint8_t level,
+                      uint8_t n_append,
+                      const uint64_t* append_sizes)
 {
   struct metering_sink* s = (struct metering_sink*)self;
-  return s->inner->update_append_after(
-    s->inner, level, n_append, append_sizes, after);
+  return s->inner->queue_append(s->inner, level, n_append, append_sizes);
 }
 
 static int
@@ -178,7 +176,7 @@ metering_sink_init(struct metering_sink* ms, struct shard_sink* inner)
     .base = {
       .open = metering_open,
       .update_append = inner->update_append ? metering_update_append : NULL,
-      .update_append_after = inner->update_append_after ? metering_update_append_after : NULL,
+      .queue_append = inner->queue_append ? metering_queue_append : NULL,
       .flush = inner->flush ? metering_flush : NULL,
       .record_fence = inner->record_fence ? metering_record_fence : NULL,
       .wait_fence = inner->wait_fence ? metering_wait_fence : NULL,

--- a/bench/sink_metering.c
+++ b/bench/sink_metering.c
@@ -152,6 +152,25 @@ metering_update_append(struct shard_sink* self,
   return ms->inner->update_append(ms->inner, level, n_append, append_sizes);
 }
 
+static int
+metering_update_append_after(struct shard_sink* self,
+                             uint8_t level,
+                             uint8_t n_append,
+                             const uint64_t* append_sizes,
+                             struct io_event after)
+{
+  struct metering_sink* s = (struct metering_sink*)self;
+  return s->inner->update_append_after(
+    s->inner, level, n_append, append_sizes, after);
+}
+
+static int
+metering_flush(struct shard_sink* self)
+{
+  struct metering_sink* s = (struct metering_sink*)self;
+  return s->inner->flush(s->inner);
+}
+
 void
 metering_sink_init(struct metering_sink* ms, struct shard_sink* inner)
 {
@@ -159,6 +178,8 @@ metering_sink_init(struct metering_sink* ms, struct shard_sink* inner)
     .base = {
       .open = metering_open,
       .update_append = inner->update_append ? metering_update_append : NULL,
+      .update_append_after = inner->update_append_after ? metering_update_append_after : NULL,
+      .flush = inner->flush ? metering_flush : NULL,
       .record_fence = inner->record_fence ? metering_record_fence : NULL,
       .wait_fence = inner->wait_fence ? metering_wait_fence : NULL,
       .has_error = inner->has_error ? metering_has_error : NULL,

--- a/bench/test_bench_report.c
+++ b/bench/test_bench_report.c
@@ -1,0 +1,135 @@
+#include "bench_report.h"
+
+#include <limits.h>
+#include <string.h>
+
+int
+main(int argc, char** argv)
+{
+  if (argc != 2)
+    return 1;
+  const int full = strcmp(argv[1], "full") == 0;
+  const int large = strcmp(argv[1], "large") == 0;
+  const int empty = strcmp(argv[1], "empty") == 0;
+  struct stream_metrics m = { 0 };
+  if (!empty) {
+    struct stream_metric stage = {
+      .name = "backend_internal_name",
+      .count = 2,
+      .ms = 0.00008f,
+      .best_ms = 0.00003f,
+      .max_ms = 0.00005f,
+      .best_input_bytes = 512,
+      .best_output_bytes = 512,
+      .input_bytes = 1024,
+      .output_bytes = 1024,
+    };
+    m.memcpy = m.h2d = m.scatter = m.lod_gather = m.lod_reduce =
+      m.lod_append_fold = m.lod_morton_chunk = m.compress = m.aggregate =
+        m.d2h = m.sink = stage;
+    m.scatter.name = strcmp(argv[1], "copy") == 0 ? "Copy" : "scatter";
+    m.memcpy_calls = large ? UINT64_MAX : 128;
+    m.memcpy_bytes = large ? UINT64_MAX : 65536;
+    if (full) {
+      m.memcpy.count = 128;
+      m.memcpy.ms *= 64;
+      m.memcpy.input_bytes = m.memcpy.output_bytes = 65536;
+    }
+    m.compress.best_ms = 1e30f;
+    m.sink.ms = 2000;
+    m.sink.best_ms = 1000;
+    m.sink.input_bytes = 2147483648.0;
+    m.sink.best_input_bytes = 1073741824.0;
+
+    struct stream_metric wait = {
+      .owner = METRIC_OWNER_PRODUCER,
+      .count = large ? INT_MAX : 2,
+      .wait_calls = large ? UINT64_MAX : 3,
+      .ms = large ? 1e20f : 0.00008f,
+      .max_ms = large ? 1e20f : 0.00005f,
+    };
+    m.flush_stall = m.footer_buffer_stall = m.append_extent_stall =
+      m.flush_writes_stall = m.backpressure = wait;
+    m.flush_stall.wait_calls = 0;
+    m.edge_stall[0].owner = METRIC_OWNER_PRODUCER;
+    m.edge_stall[0].wait_calls = 1;
+    wait.owner = METRIC_OWNER_DELIVERY;
+    m.edge_stall[1] = m.edge_stall[2] = m.indexed_aggregate_wait =
+      m.chunk_metadata_wait = m.delivery_dispatch = wait;
+    wait.owner = METRIC_OWNER_D2H;
+    m.chunk_metadata_copy = wait;
+
+    struct duration_stats duration = {
+      .count = large ? UINT64_MAX : 2,
+      .total_ms = large ? 1e20f : 0.00008f,
+      .min_ms = 0.00003f,
+      .max_ms = large ? 1e20f : 0.00005f,
+    };
+    m.delivery.submitted_to_start = m.delivery.start_to_payload_ready =
+      m.delivery.payload_ready_to_writes_posted =
+        m.delivery.submitted_to_slot_reuse = duration;
+    m.append_count = large ? UINT64_MAX : 128;
+    m.append_ms_buckets[0] = m.append_count;
+    m.max_append_ms = 0.00004f;
+    m.d2h_payload_bytes_transferred = 65536;
+    m.d2h_metadata_bytes_transferred = 1024;
+    m.d2h_payload_copy_count = large ? UINT64_MAX : 128;
+    m.shard_padding_logical_payload_bytes = 65536;
+    m.shard_padding_internal_bytes = 1024;
+    m.shard_padding_physical_update_count = large ? UINT64_MAX : 128;
+    m.shard_padding_padded_update_count = large ? UINT64_MAX : 8;
+    m.scatter_samples_lost = large ? UINT64_MAX : 1;
+    m.lod_samples_lost = large ? UINT64_MAX : 2;
+    m.peak_pending_bytes = 65536;
+  }
+  const struct tile_stream_layout layout = {
+    .epoch_elements = 4096,
+    .chunk_elements = 4096,
+    .chunk_stride = 4096,
+    .chunk_pool_bytes = 4096,
+    .chunks_per_epoch = 1,
+  };
+  const struct bench_memory mem = {
+    .host_reading_failed = empty,
+    .host_baseline_bytes = 1024,
+    .host_peak_bytes = 65536,
+    .device_used_bytes = empty ? 0 : 4096,
+    .device_overhead_valid = !empty,
+    .device_overhead_bytes = -1024,
+    .measured_bytes = empty ? 0 : 4096,
+    .estimate_total_bytes = empty ? 0 : 5120,
+  };
+  const struct sink_stats sink = { .total_bytes = 32768 };
+  log_bench_header(&layout,
+                   dtype_u8,
+                   (struct codec_config){ .id = CODEC_NONE },
+                   0,
+                   0,
+                   65536,
+                   65536);
+  print_bench_report(&m,
+                     &layout,
+                     dtype_u8,
+                     &sink,
+                     65536,
+                     65536,
+                     1,
+                     0.1f,
+                     empty ? 0 : 0.2f,
+                     empty ? 0 : 65536);
+  print_memory_report(&mem);
+  print_bench_json_pass(&m,
+                        &m.sink,
+                        &layout,
+                        dtype_u8,
+                        (struct codec_config){ .id = CODEC_NONE },
+                        &sink,
+                        65536,
+                        65536,
+                        1,
+                        0.1f,
+                        empty ? 0 : 0.2f,
+                        &mem,
+                        1);
+  return 0;
+}

--- a/bench/test_bench_report.py
+++ b/bench/test_bench_report.py
@@ -1,0 +1,110 @@
+import json
+import math
+import subprocess
+import sys
+
+
+def section(lines, title):
+    start = next(i for i, line in enumerate(lines) if line.strip() == title)
+    end = next((i for i in range(start + 1, len(lines)) if not lines[i]), len(lines))
+    return lines[start + 1:end]
+
+
+stage_names = [
+    "Memcpy", "H2D", "Scatter", "LOD gather", "LOD reduce", "Append fold",
+    "LOD to chunks", "Compress", "Aggregate", "D2H", "Sink",
+]
+stage_header = (
+    f"  {'Stage':<14} {'avg GiB/s':>10} {'best GiB/s':>10}"
+    f" {'avg ms':>9} {'best ms':>9}"
+)
+
+for mode in ("sampled", "full", "copy", "large", "empty"):
+    p = subprocess.run([sys.argv[1], mode], capture_output=True, text=True, check=True)
+    report = json.loads(p.stdout)
+    stages = report["stages"]
+    lines = p.stderr.splitlines()
+    for line in lines:
+        assert len(line) <= 80, (mode, len(line), line)
+        assert "\t" not in line and "\x1b" not in line, repr(line)
+    assert "GB/s" not in p.stderr
+    assert "backend_internal_name" not in p.stderr
+    assert stage_header in lines
+    if mode == "empty":
+        assert "Host memory:      unavailable" in p.stderr
+        assert "Append latency" not in p.stderr
+        assert "Host blocking" not in p.stderr
+        assert "Memcpy work" not in p.stderr
+        assert "memcpy_work" not in report
+        assert not {"memcpy", "memcpy_sample"} & stages.keys()
+        continue
+
+    sampled = mode != "full"
+    observations = 2 if sampled else 128
+    observed_bytes = observations * 512
+    total_copies = 2**64 - 1 if mode == "large" else 128
+    total_bytes = 2**64 - 1 if mode == "large" else 65536
+    assert report["memcpy_work"] == {
+        "calls": total_copies, "bytes": total_bytes,
+        "timing_scope": "sampled" if sampled else "full",
+    }
+    key = "memcpy_sample" if sampled else "memcpy"
+    assert ("memcpy" if sampled else "memcpy_sample") not in stages
+    row = stages[key]
+    assert row["count"] == observations
+    assert row["in_bytes"] == row["out_bytes"] == observed_bytes
+    assert math.isclose(row["total_ms"], observations * 0.00004, rel_tol=1e-6)
+    expected_rate = observed_bytes / 2**30 / (row["total_ms"] / 1000)
+    assert math.isclose(row["in_gibs"], expected_rate, rel_tol=1e-5)
+    assert ("Memcpy[smp]" in p.stderr) == sampled
+    assert ("not extrapolated" in p.stderr) == sampled
+
+    start = lines.index(stage_header) + 1
+    rows = lines[start:start + len(stage_names)]
+    for name, row in zip(stage_names, rows):
+        if name == "Memcpy" and sampled:
+            name = "Memcpy[smp]"
+        if name == "Scatter" and mode == "copy":
+            name = "Copy"
+        assert row[2:16].rstrip() == name, row
+        assert len(row) == len(stage_header), row
+        cells = [row[17:27], row[28:38], row[39:48], row[49:58]]
+        assert all(cell == cell.strip().rjust(len(cell)) for cell in cells), row
+    assert rows[0].split()[-2:] == ["4.00e-05", "3.00e-05"]
+    assert rows[7].split()[-3:] == ["-", "4.00e-05", "-"]
+    assert rows[-1].split()[1:3] == ["1.00", "1.00"]
+    assert lines[start + len(stage_names)] == "", "Coverage must not split stage rows"
+
+    coverage = section(lines, "Memcpy work:")
+    assert coverage[1].split() == ["Total", str(total_copies), str(total_bytes)]
+    assert coverage[2].split() == ["Timed", str(observations), str(observed_bytes)]
+
+    blocking = section(lines, "--- Host blocking ---")
+    assert len(blocking[0]) == 79
+    assert "  [producer timeline]" in blocking
+    assert "  [delivery timeline]" in blocking
+    assert "  Aggregate dependency before metadata" in blocking
+    assert "  Chunk metadata ready (inclusive)" in blocking
+    numeric = [line for line in blocking[1:] if len(line) == 79]
+    assert len(numeric) == 10, numeric
+    for row in numeric:
+        cells = [row[29:39], row[40:50], row[51:60], row[61:70], row[71:79]]
+        assert all(cell == cell.strip().rjust(len(cell)) for cell in cells), row
+    if mode == "large":
+        assert "1.845e+19" in p.stderr, "Large table counts must stay bounded"
+    staging = next(line for line in numeric if "Staging-buffer reuse" in line)
+    assert staging[29:].split() == ["0", "1", "-", "-", "0.00"]
+    for row in section(lines, "--- Delivery latency ---"):
+        assert len(row) == 77, row
+    latency = section(lines, "--- Append latency ---")
+    assert latency[0].split() == ["Appends:", str(2**64 - 1 if mode == "large" else 128)]
+    assert len(latency[1]) == len(latency[2]) == 51
+    assert all(float(cell) > 0 for cell in latency[2].split())
+    assert "-1.00 KiB (observed minus estimated)" in p.stderr
+
+    for label in ("Input:", "Output:", "Chunks:", "Host memory:", "Device memory:",
+                  "Device overhead:", "Estimate:", "Init time:", "Flush time:",
+                  "Wall time:", "Throughput:", "Payload:", "Metadata:",
+                  "Logical payload:", "Physical payload:", "Peak pending:"):
+        row = next(line for line in lines if line.startswith(f"  {label}"))
+        assert row[:20] == f"  {label:<17} ", row

--- a/docs/design.md
+++ b/docs/design.md
@@ -623,10 +623,10 @@ The caller interacts with the pipeline through a `struct writer` vtable:
   Returns once those writes have landed, so a write that failed is reported
   here.
 
-- **`close(self)`** — publishes the append extent and lets the sink write its
-  own metadata. This is where the array becomes readable. Idempotent, and
-  destroy runs it if the caller did not — so the sink has to outlive the
-  stream.
+- **`close(self)`** — publishes the final append extent and waits for metadata
+  completion. Closed shards can already be readable through periodic metadata
+  publication. Idempotent, and destroy runs it if the caller did not — so the
+  sink has to outlive the stream.
 
   Finalizing is what makes that last partial chunk readable — it is padded out
   and its shard is closed. Taking more input afterwards would have to start past
@@ -635,21 +635,31 @@ The caller interacts with the pipeline through a `struct writer` vtable:
 
 #### Shard sink interface
 
-`struct shard_sink` is the extension point for storage backends. Any
-implementation that provides these four operations can receive output:
+`struct shard_sink` is the extension point for storage backends. It provides
+`open` and optional metadata, fencing, and completion hooks:
 
 - **`open(self, level, shard_index) → shard_writer*`** — return a writer for
   the given shard. The library calls this once per shard per batch.
 
-- **`update_dim0(self, level, dim0_size)`** — called periodically as the
-  append dimension grows, allowing the backend to update metadata.
+- **`update_append(self, level, n_append, append_sizes)`** — synchronously
+  publish append extents, including the empty extent at stream creation.
 
-- **`record_fence(self, level) → io_event`** — snapshot the current I/O
+- **`queue_append(self, level, n_append, append_sizes)`** — snapshot append
+  metadata and publish it after earlier sink IO succeeds. The sink owns the
+  snapshot before returning. Writers use this hook only when `flush` is also
+  provided; otherwise they use synchronous publication.
+
+- **`record_fence(self) → io_event`** — snapshot the current I/O
   position for backpressure.
 
-- **`wait_fence(self, level, event)`** — block until the I/O subsystem has
+- **`wait_fence(self, event)`** — block until the I/O subsystem has
   retired past the given fence, preventing the pipeline from outrunning
   storage.
+
+- **`flush(self)`** — publish dirty sink metadata and wait for accepted
+  publication work. The writer calls it after publishing the final extent.
+
+- **`has_error(self)`** — report an asynchronous IO failure.
 
 Each `struct shard_writer` returned by `open` provides:
 
@@ -716,9 +726,9 @@ tile_stream_gpu_destroy(s);
 The library ships a concrete `shard_sink` targeting Zarr v3 stores with the
 sharding codec.
 
-**`zarr_sink`** implements `shard_sink` for a single zarr array.
-**`zarr_multiscale_sink`** wraps an array of `zarr_sink` instances — one per
-LOD level — and manages OME-NGFF group metadata.
+**`zarr_array`** implements `shard_sink` for a single Zarr array.
+**`ngff_multiscale`** wraps an array of `zarr_array` instances — one per
+LOD level — and manages OME-NGFF attributes and level relationships.
 
 **Writer pool.** Each sink maintains a pool of `shard_writer` objects (one per
 inner shard index), reused across epochs. This bounds open file
@@ -734,10 +744,19 @@ read-side data. The alignment requirement is queried from the sink via
 `required_shard_alignment`; sinks that don't need alignment (S3, in-memory)
 return 0 and skip all padding overhead.
 
-**Dynamic metadata.** `update_dim0` regenerates the zarr array metadata
-(`zarr.json`) as the append dimension grows, and for multiscale sinks also
-regenerates OME-NGFF group metadata. Metadata is written at a configurable
-interval rather than every epoch.
+**Dynamic metadata.** Periodic publication snapshots the append extent of
+closed shards. Zarr builds the array and group metadata envelopes; NGFF
+supplies OME attributes. A private Zarr API constructs each `zarr.json` key
+and submits the immutable bytes through the injected store and pool.
+
+Filesystem metadata uses one ordered submission path. `queue_append` returns
+after submission; `update_append` submits through the same path and then waits,
+even when an unchanged extent refers to a snapshot still in flight. A queued
+replacement becomes runnable after every earlier queue entry completes, while
+later independent file operations can continue. Failures suppress publication
+and become sticky pool errors. S3 metadata uses synchronous `put` without
+flushing active uploads. The publication interval is configurable through
+`metadata_update_interval_s`.
 
 For the zarr shard binary format, see [sharding.md][sharding-md] and the
 [zarr sharding codec specification][zarr-shard].

--- a/docs/design.md
+++ b/docs/design.md
@@ -749,14 +749,22 @@ closed shards. Zarr builds the array and group metadata envelopes; NGFF
 supplies OME attributes. A private Zarr API constructs each `zarr.json` key
 and submits the immutable bytes through the injected store and pool.
 
-Filesystem metadata uses one ordered submission path. `queue_append` returns
-after submission; `update_append` submits through the same path and then waits,
-even when an unchanged extent refers to a snapshot still in flight. A queued
-replacement becomes runnable after every earlier queue entry completes, while
-later independent file operations can continue. Failures suppress publication
-and become sticky pool errors. S3 metadata uses synchronous `put` without
-flushing active uploads. The publication interval is configurable through
-`metadata_update_interval_s`.
+Filesystem streaming metadata uses one ordered submission path. `queue_append`
+returns after submission; `update_append` submits through the same path and
+then waits, even when an unchanged extent refers to a snapshot still in flight.
+A queued replacement becomes runnable after every earlier queue entry
+completes, while later independent file operations can continue. Failures on
+this path suppress publication and become sticky pool errors. S3 metadata uses
+synchronous `put` without flushing active uploads. The publication interval is
+configurable through `metadata_update_interval_s`.
+
+**Atomic metadata replacement.** The filesystem backend owns the complete
+temporary-file write and rename operation. Direct store writes and queued
+replacements both call it; neither higher layer implements that protocol.
+It creates missing parent directories and uses buffered IO for metadata,
+even when shard writes are unbuffered. Readers see the old or new complete
+file. Replacement does not add an `fsync` durability guarantee, and callers
+must serialize replacements of the same path.
 
 For the zarr shard binary format, see [sharding.md][sharding-md] and the
 [zarr sharding codec specification][zarr-shard].

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -31,6 +31,10 @@ failures are sticky pool errors, including failures reported by synchronous
 calls. Stores without queued metadata support use synchronous `put`; metadata
 completion does not finalize active S3 uploads.
 
+Filesystem metadata writes create missing parent directories. They do not
+create Zarr group metadata for those directories; use the group API where
+the hierarchy requires groups.
+
 ## Quick start
 
 ### Single array on filesystem

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -19,6 +19,18 @@ Each layer uses the one below. `hcs_plate` creates `ngff_multiscale`
 instances, which create `zarr_array` instances. Pool and shard geometry
 are managed internally.
 
+The private Zarr metadata API owns `zarr.json` keys, the Zarr group envelope,
+and metadata submission and completion. NGFF and HCS supply their attributes
+and pass the existing store and pool down to Zarr. Zarr has no dependency on
+either higher-level format.
+
+With a filesystem streaming pool, metadata is submitted to the same ordered
+queue as shard data. Synchronous metadata calls submit and then wait;
+asynchronous calls return after the queue owns the snapshot. Metadata IO
+failures are sticky pool errors, including failures reported by synchronous
+calls. Stores without queued metadata support use synchronous `put`; metadata
+completion does not finalize active S3 uploads.
+
 ## Quick start
 
 ### Single array on filesystem

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -63,11 +63,18 @@ internal conventions, and key concepts.
 | Target | Source | Purpose |
 |--------|--------|---------|
 | `json_writer` | `src/zarr/json_writer.c` | JSON serialization for zarr metadata |
-| `zarr_metadata` | `src/zarr/zarr_metadata.c` | Write zarr.json / .zarray / OME-NGFF metadata |
+| `zarr_metadata` | `src/zarr/zarr_metadata.c` | Serialize Zarr v3 array and group metadata |
+| `zarr_metadata_io` | `src/zarr/metadata_io.c` | Construct metadata keys, submit snapshots, and wait for publication |
+| `zarr_array` | `src/zarr/zarr_array.c` | Zarr array geometry, metadata, and shard sink |
+| `zarr_group` | `src/zarr/zarr_group.c` | Zarr group envelopes and attributes |
+| `ngff_metadata` | `src/ngff/ngff_metadata.c` | Serialize OME-NGFF multiscale attributes |
+| `ngff_multiscale` | `src/ngff/ngff_multiscale.c` | Compose Zarr arrays and group metadata |
 | `shard_delivery` | `src/zarr/shard_delivery.c` | Write shard index + CRC, deliver to shard_writer |
-| `zarr_fs_sink` | `src/zarr/zarr_fs_sink.c` | `shard_sink` for local filesystem Zarr stores |
+| `shard_pool_fs` | `src/zarr/shard_pool_fs.c` | Queue filesystem shard writes and metadata publication |
+| `store_fs` | `src/zarr/store_fs.c` | Filesystem store keys and pool creation |
 | `s3_client` | `src/zarr/s3_client.c` | AWS S3 multipart upload client |
-| `zarr_s3_sink` | `src/zarr/zarr_s3_sink.c` | `shard_sink` for S3-backed Zarr stores |
+| `shard_pool_s3` | `src/zarr/shard_pool_s3.c` | S3 shard upload slots |
+| `store_s3` | `src/zarr/store_s3.c` | S3 metadata keys and pool creation |
 
 ## Public API headers
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -71,6 +71,7 @@ internal conventions, and key concepts.
 | `ngff_multiscale` | `src/ngff/ngff_multiscale.c` | Compose Zarr arrays and group metadata |
 | `shard_delivery` | `src/zarr/shard_delivery.c` | Write shard index + CRC, deliver to shard_writer |
 | `shard_pool_fs` | `src/zarr/shard_pool_fs.c` | Queue filesystem shard writes and metadata publication |
+| `io_backend_fs` | `src/zarr/io_backend.fs.c` | Execute filesystem IO and own atomic metadata replacement |
 | `store_fs` | `src/zarr/store_fs.c` | Filesystem store keys and pool creation |
 | `s3_client` | `src/zarr/s3_client.c` | AWS S3 multipart upload client |
 | `shard_pool_s3` | `src/zarr/shard_pool_s3.c` | S3 shard upload slots |

--- a/scripts/sweep/template.html
+++ b/scripts/sweep/template.html
@@ -265,7 +265,7 @@ const LAYOUT = {
 
 const LEGEND_FONT_PX = 12;
 
-const STAGE_ORDER = ["memcpy","h2d","scatter","lod_gather","lod_reduce","lod_append_fold","lod_morton_chunk","compress","aggregate","d2h","sink"];
+const STAGE_ORDER = ["memcpy","memcpy_sample","h2d","scatter","lod_gather","lod_reduce","lod_append_fold","lod_morton_chunk","compress","aggregate","d2h","sink"];
 
 const GROUP_LABELS = { single: "Single", multiscale: "Multiscale", dim0: "Dim0" };
 const GROUP_ORDER = ["single", "multiscale", "dim0"];

--- a/scripts/sweep/test_sweep.py
+++ b/scripts/sweep/test_sweep.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 from pydantic import ValidationError
 
 from columnar import decode_runs, pack
-from models import CURRENT_VERSION, run_id
+from models import CURRENT_VERSION, migrate_results, run_id
 from summary import trim_run
 from sweep import RunSpec, TIERS, deduplicate, main, run_one
 
@@ -24,6 +24,23 @@ def spec(**overrides):
         "backend": "cpu", "dtype": "u16", "chunk_label": "256K",
         "blosc_block_bytes": 16384, **overrides,
     })
+
+
+class MemcpyTimingTests(unittest.TestCase):
+    def test_old_full_timing_is_not_relabelled_as_a_sample(self):
+        row = {"count": 128, "in_bytes": 65536, "total_ms": 1}
+        data = {"version": 10, "runs": [{"stages": {"memcpy": row.copy()}}]}
+        migrate_results(data)
+        self.assertEqual(data["version"], CURRENT_VERSION)
+        self.assertEqual(data["runs"][0]["stages"], {"memcpy": row})
+        self.assertNotIn("memcpy_work", data["runs"][0])
+
+    def test_sample_and_exact_work_survive_columnar_round_trip(self):
+        runs = [{"stages": {"memcpy_sample": {"count": 2, "in_bytes": 1024}},
+                 "memcpy_work": {"calls": 128, "bytes": 65536,
+                                 "timing_scope": "sampled"}}]
+        strings, blocks = pack([runs])
+        self.assertEqual(decode_runs(blocks[0], strings), runs)
 
 
 class BloscSweepTests(unittest.TestCase):

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -24,6 +24,8 @@ static struct writer_result
 cpu_close_final(struct writer* self);
 static struct cpu_stream_view
 make_view(struct tile_stream_cpu* s);
+static void
+tile_stream_cpu_release_resources(struct tile_stream_cpu* s);
 
 // ---- Create / Destroy ----
 
@@ -43,8 +45,6 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
   if (!s)
     return NULL;
 
-  s->flushed = 1;
-  s->closed = 1;
   s->config = *config;
   {
     int nthreads = config->max_threads > 0 ? config->max_threads
@@ -303,31 +303,16 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
   return s;
 
 Fail:
-  tile_stream_cpu_destroy(s);
+  // Construction rollback releases resources without finalizing the sink.
+  tile_stream_cpu_release_resources(s);
   return NULL;
 }
 
-void
-tile_stream_cpu_destroy(struct tile_stream_cpu* s)
+static void
+tile_stream_cpu_release_resources(struct tile_stream_cpu* s)
 {
   if (!s)
     return;
-
-  // Auto-finalize any unwritten data so destroy is a safe commit point for
-  // callers that didn't explicitly flush. Errors are logged but not
-  // propagated — destroy returns void.
-  if (!s->flushed) {
-    struct cpu_stream_view v = make_view(s);
-    if (cpu_stream_flush_body(&v).error)
-      log_error("CPU stream auto-flush failed during destroy");
-    s->flushed = 1;
-    s->closed = 0;
-  }
-  // Whatever queued those writes, they point into buffers teardown frees, so
-  // they have to be waited out here. Skipped only when a close already did it,
-  // which is also the case where the caller may have released the sink.
-  if (cpu_close_final(&s->writer).error)
-    log_error("CPU stream close failed during destroy");
 
   for (int lv = 0; lv < s->levels.nlod; ++lv) {
     shard_state_destroy(&s->shard[lv]);
@@ -368,6 +353,31 @@ tile_stream_cpu_destroy(struct tile_stream_cpu* s)
   computed_stream_layouts_free(&s->cl);
   threadpool_free(s->pool);
   free(s);
+}
+
+void
+tile_stream_cpu_destroy(struct tile_stream_cpu* s)
+{
+  if (!s)
+    return;
+
+  // Auto-finalize any unwritten data so destroy is a safe commit point for
+  // callers that didn't explicitly flush. Errors are logged but not
+  // propagated — destroy returns void.
+  if (!s->flushed) {
+    struct cpu_stream_view v = make_view(s);
+    if (cpu_stream_flush_body(&v).error)
+      log_error("CPU stream auto-flush failed during destroy");
+    s->flushed = 1;
+    s->closed = 0;
+  }
+  // Whatever queued those writes, they point into buffers teardown frees, so
+  // they have to be waited out here. Skipped only when a close already did it,
+  // which is also the case where the caller may have released the sink.
+  if (cpu_close_final(&s->writer).error)
+    log_error("CPU stream close failed during destroy");
+
+  tile_stream_cpu_release_resources(s);
 }
 
 // ---- Accessors ----

--- a/src/cpu/stream.c
+++ b/src/cpu/stream.c
@@ -290,6 +290,8 @@ tile_stream_cpu_create(const struct tile_stream_configuration* config,
     }
   }
 
+  CHECK(Fail, shard_sink_init_append(sink, &s->cl.dims, s->levels.nlod) == 0);
+
   s->writer.append = cpu_append;
   s->writer.flush = cpu_flush_final;
   s->writer.close = cpu_close_final;

--- a/src/gpu/stream.c
+++ b/src/gpu/stream.c
@@ -273,18 +273,28 @@ stream_append_body(struct stream_engine* e,
     }
 
     {
+      int timed = ctx->config.full_memcpy_timing || payload >= (8u << 10);
+      if (!timed) {
+        // Avoid correlating samples with periodic buffer boundaries.
+        const uint64_t n = ctx->memcpy_small_copies++;
+        timed = ((n ^ (n >> 6)) & 63u) == 0;
+      }
       struct platform_clock mc = { 0 };
-      platform_toc(&mc);
+      if (timed)
+        platform_toc(&mc);
       ingest_copy(
         e->copy_pool,
         gpu_pool_at(&e->stage.h_pool, e->stage.current, e->stage.bytes_written)
           .p,
         src,
         payload);
-      accumulate_metric_ms(&e->metrics.memcpy,
-                           (float)(platform_toc(&mc) * 1000.0),
-                           payload,
-                           payload);
+      if (timed)
+        accumulate_metric_ms(&e->metrics.memcpy,
+                             (float)(platform_toc(&mc) * 1000.0),
+                             payload,
+                             payload);
+      e->metrics.memcpy_calls++;
+      e->metrics.memcpy_bytes += payload;
     }
     e->stage.bytes_written += payload;
     ctx->cursor_elements += elements;

--- a/src/gpu/stream.engine.h
+++ b/src/gpu/stream.engine.h
@@ -237,6 +237,8 @@ struct engine_array_state
 // swapped via bind/unbind when switching arrays (multiarray only).
 struct stream_context
 {
+  // Sharing a phase could leave some arrays entirely unmeasured.
+  uint64_t memcpy_small_copies;
   struct tile_stream_configuration config;
   struct shard_sink* sink;
   struct tile_stream_layout layout;

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -332,6 +332,25 @@ Error:
 
 // --- Create / Destroy ---
 
+static void
+tile_stream_gpu_release_resources(struct tile_stream_gpu* s, int pushed)
+{
+  stream_engine_destroy(&s->engine);
+  engine_array_state_destroy(&s->ar);
+  cu_ctx_pop(pushed);
+  free(s);
+}
+
+static void
+tile_stream_gpu_rollback(struct tile_stream_gpu* s)
+{
+  // Quiesce setup work, then release resources without finalizing the sink.
+  const int pushed = cu_ctx_push(s->engine.cuda);
+  gpu_delivery_stop_join(&s->engine.delivery);
+  gpu_streams_sync(&s->engine.streams);
+  tile_stream_gpu_release_resources(s, pushed);
+}
+
 void
 tile_stream_gpu_destroy(struct tile_stream_gpu* s)
 {
@@ -364,12 +383,9 @@ tile_stream_gpu_destroy(struct tile_stream_gpu* s)
   if (writer_close(&s->writer).error)
     log_error("GPU stream close failed during destroy");
 
-  // Copy state can still name the output pool after a failed
-  // cancellation, so tear down the shared stages before their array state.
-  stream_engine_destroy(&s->engine);
-  engine_array_state_destroy(&s->ar);
-  cu_ctx_pop(pushed);
-  free(s);
+  // Copy state can still name the output pool after a failed cancellation, so
+  // release the shared stages before their array state.
+  tile_stream_gpu_release_resources(s, pushed);
 }
 
 struct tile_stream_gpu*
@@ -403,8 +419,6 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
     (struct tile_stream_gpu*)calloc(1, sizeof(*out));
   CHECK(FailPhase1b, out);
 
-  out->flushed = 1;
-  out->closed = 1;
   out->ctx.config = *config;
   out->ctx.sink = sink;
   out->ctx.shard_alignment = shard_sink_required_shard_alignment(sink);
@@ -437,7 +451,7 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
   return out;
 
 FailPhase2:
-  tile_stream_gpu_destroy(out);
+  tile_stream_gpu_rollback(out);
 FailPhase1b:
   computed_stream_layouts_free(&cl);
 FailPhase1:

--- a/src/gpu/stream.init.c
+++ b/src/gpu/stream.init.c
@@ -427,6 +427,9 @@ tile_stream_gpu_create(const struct tile_stream_configuration* config,
           0);
   CHECK(FailPhase2,
         stream_engine_bind_array(&out->engine, &out->ar, &out->ctx) == 0);
+  CHECK(FailPhase2,
+        shard_sink_init_append(sink, &out->ctx.dims, out->ctx.levels.nlod) ==
+          0);
 
   out->flushed = 0;
   out->closed = 0;

--- a/src/hcs/hcs.c
+++ b/src/hcs/hcs.c
@@ -97,7 +97,6 @@ static int
 write_plate_group(struct hcs_plate* p)
 {
   struct strbuf attrs = { 0 };
-  struct strbuf key = { 0 };
   int rc = 1;
 
   if (hcs_plate_attributes_json(&attrs,
@@ -109,16 +108,13 @@ write_plate_group(struct hcs_plate* p)
                                 p->well_mask,
                                 &p->plate_attrs))
     goto done;
-  if (strbuf_appendf(&key, "%s/zarr.json", strbuf_cstr(&p->name)))
-    goto done;
-  rc = zarr_group_write_with_raw_attrs(
-    p->store, strbuf_cstr(&key), strbuf_cstr(&attrs));
+  rc = zarr_group_submit(
+    p->store, NULL, strbuf_cstr(&p->name), strbuf_cstr(&attrs));
   if (rc == 0)
     p->plate_attrs.dirty = 0;
 
 done:
   strbuf_free(&attrs);
-  strbuf_free(&key);
   return rc;
 }
 
@@ -127,23 +123,22 @@ write_well_group(struct hcs_plate* p, int r, int c)
 {
   struct attr_set* w = &p->well_attrs[well_idx(p, r, c)];
   struct strbuf attrs = { 0 };
-  struct strbuf key = { 0 };
+  struct strbuf prefix = { 0 };
   int rc = 1;
 
   if (hcs_well_attributes_json(&attrs, p->field_count, w))
     goto done;
   char rc_ch = plate_row_char(p, r);
-  if (strbuf_appendf(
-        &key, "%s/%c/%d/zarr.json", strbuf_cstr(&p->name), rc_ch, c + 1))
+  if (strbuf_appendf(&prefix, "%s/%c/%d", strbuf_cstr(&p->name), rc_ch, c + 1))
     goto done;
-  rc = zarr_group_write_with_raw_attrs(
-    p->store, strbuf_cstr(&key), strbuf_cstr(&attrs));
+  rc = zarr_group_submit(
+    p->store, NULL, strbuf_cstr(&prefix), strbuf_cstr(&attrs));
   if (rc == 0)
     w->dirty = 0;
 
 done:
   strbuf_free(&attrs);
-  strbuf_free(&key);
+  strbuf_free(&prefix);
   return rc;
 }
 

--- a/src/multiarray.cpu.h
+++ b/src/multiarray.cpu.h
@@ -7,6 +7,8 @@ struct multiarray_tile_stream_cpu;
 struct stream_metrics;
 
 // Create a multiarray stream.  Pass enable_metrics != 0 to collect timing.
+// Initializes every sink's supported append metadata to an empty extent;
+// configured dimension sizes still bound each array's input capacity.
 struct multiarray_tile_stream_cpu*
 multiarray_tile_stream_cpu_create(
   int n_arrays,

--- a/src/multiarray.gpu.h
+++ b/src/multiarray.gpu.h
@@ -12,6 +12,8 @@ struct stream_metrics;
 // at a time; switching requires an epoch boundary.
 // All arrays must use the same codec id and, for Blosc, blosc_block_bytes.
 // Dtype, compression level, shuffle, and chunk geometry may differ.
+// Initializes every sink's supported append metadata to an empty extent;
+// configured dimension sizes still bound each array's input capacity.
 //
 // enable_metrics is currently ignored on the GPU path: metrics are always
 // collected (CUDA events are required for stream synchronization regardless).

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -17,6 +17,21 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef CHUCKY_TEST_MULTIARRAY_DESCRIPTOR_ALLOC
+void*
+chucky_test_multiarray_descriptor_alloc(size_t count, size_t size);
+#endif
+
+static void*
+allocate_array_descriptors(size_t count, size_t size)
+{
+#ifdef CHUCKY_TEST_MULTIARRAY_DESCRIPTOR_ALLOC
+  return chucky_test_multiarray_descriptor_alloc(count, size);
+#else
+  return calloc(count, size);
+#endif
+}
+
 // ---- Per-array descriptor ----
 
 struct array_descriptor
@@ -93,6 +108,9 @@ close_impl(struct multiarray_writer* self);
 static struct cpu_stream_view
 make_multiarray_view(struct multiarray_tile_stream_cpu* ms,
                      struct array_descriptor* desc);
+static void
+multiarray_tile_stream_cpu_release_resources(
+  struct multiarray_tile_stream_cpu* ms);
 
 // ---- Helpers ----
 
@@ -416,15 +434,9 @@ multiarray_tile_stream_cpu_create(
     CHECK(Fail, ms->pool);
   }
 
-  ms->arrays = (struct array_descriptor*)calloc(
+  ms->arrays = (struct array_descriptor*)allocate_array_descriptors(
     (size_t)n_arrays, sizeof(struct array_descriptor));
   CHECK(Fail, ms->arrays);
-  // Failed construction must not flush or republish partially initialized
-  // arrays.
-  for (int i = 0; i < n_arrays; ++i) {
-    ms->arrays[i].flushed = 1;
-    ms->arrays[i].closed = 1;
-  }
 
   struct pool_maxima maxima = { 0 };
   for (int i = 0; i < n_arrays; ++i)
@@ -474,27 +486,17 @@ multiarray_tile_stream_cpu_create(
   return ms;
 
 Fail:
-  multiarray_tile_stream_cpu_destroy(ms);
+  // Construction rollback releases resources without finalizing any sink.
+  multiarray_tile_stream_cpu_release_resources(ms);
   return NULL;
 }
 
-void
-multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
+static void
+multiarray_tile_stream_cpu_release_resources(
+  struct multiarray_tile_stream_cpu* ms)
 {
   if (!ms)
     return;
-
-  // Auto-finalize any unflushed arrays so destroy is a safe commit point
-  // for callers that didn't explicitly flush. Errors are logged but not
-  // propagated — destroy returns void.
-  {
-    struct multiarray_writer_result r = flush_impl(&ms->writer);
-    if (r.error)
-      log_error("CPU multiarray auto-flush failed during destroy");
-  }
-
-  if (ms->arrays && close_impl(&ms->writer).error)
-    log_error("CPU multiarray close failed during destroy");
 
   if (ms->arrays) {
     for (int i = 0; i < ms->n_arrays; ++i) {
@@ -540,6 +542,27 @@ multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
   free(ms->lod_values);
   threadpool_free(ms->pool);
   free(ms);
+}
+
+void
+multiarray_tile_stream_cpu_destroy(struct multiarray_tile_stream_cpu* ms)
+{
+  if (!ms)
+    return;
+
+  // Auto-finalize any unflushed arrays so destroy is a safe commit point
+  // for callers that didn't explicitly flush. Errors are logged but not
+  // propagated — destroy returns void.
+  {
+    struct multiarray_writer_result r = flush_impl(&ms->writer);
+    if (r.error)
+      log_error("CPU multiarray auto-flush failed during destroy");
+  }
+
+  if (ms->arrays && close_impl(&ms->writer).error)
+    log_error("CPU multiarray close failed during destroy");
+
+  multiarray_tile_stream_cpu_release_resources(ms);
 }
 
 struct multiarray_writer*

--- a/src/multiarray/stream.c
+++ b/src/multiarray/stream.c
@@ -419,6 +419,12 @@ multiarray_tile_stream_cpu_create(
   ms->arrays = (struct array_descriptor*)calloc(
     (size_t)n_arrays, sizeof(struct array_descriptor));
   CHECK(Fail, ms->arrays);
+  // Failed construction must not flush or republish partially initialized
+  // arrays.
+  for (int i = 0; i < n_arrays; ++i) {
+    ms->arrays[i].flushed = 1;
+    ms->arrays[i].closed = 1;
+  }
 
   struct pool_maxima maxima = { 0 };
   for (int i = 0; i < n_arrays; ++i)
@@ -454,6 +460,17 @@ multiarray_tile_stream_cpu_create(
     }
   }
 
+  // Publish every empty extent before enabling input on any array.
+  for (int i = 0; i < n_arrays; ++i) {
+    const struct array_descriptor* desc = &ms->arrays[i];
+    CHECK(Fail,
+          shard_sink_init_append(
+            desc->sink, &desc->cl.dims, desc->levels.nlod) == 0);
+  }
+  for (int i = 0; i < n_arrays; ++i) {
+    ms->arrays[i].flushed = 0;
+    ms->arrays[i].closed = 0;
+  }
   return ms;
 
 Fail:

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -16,6 +16,21 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef CHUCKY_TEST_MULTIARRAY_DESCRIPTOR_ALLOC
+void*
+chucky_test_multiarray_descriptor_alloc(size_t count, size_t size);
+#endif
+
+static void*
+allocate_array_descriptors(size_t count, size_t size)
+{
+#ifdef CHUCKY_TEST_MULTIARRAY_DESCRIPTOR_ALLOC
+  return chucky_test_multiarray_descriptor_alloc(count, size);
+#else
+  return calloc(count, size);
+#endif
+}
+
 // ---- Per-array descriptor ----
 // Extends stream_context with the per-array engine state that is swapped
 // into/out of the engine on array switch.
@@ -337,6 +352,36 @@ close_impl(struct multiarray_writer* self)
 
 // ---- Create / Destroy ----
 
+static void
+multiarray_tile_stream_gpu_release_resources(
+  struct multiarray_tile_stream_gpu* ms,
+  int pushed)
+{
+  // Copy state can still name the shared output pool after a failed
+  // cancellation, so tear down the shared stages before the descriptors.
+  stream_engine_destroy(&ms->engine);
+
+  if (ms->arrays) {
+    for (int a = 0; a < ms->n_arrays; ++a)
+      destroy_array_descriptor(&ms->arrays[a]);
+    free(ms->arrays);
+  }
+  host_output_pool_destroy(ms->output_pool);
+
+  cu_ctx_pop(pushed);
+  free(ms);
+}
+
+static void
+multiarray_tile_stream_gpu_rollback(struct multiarray_tile_stream_gpu* ms)
+{
+  // Quiesce setup work, then release resources without finalizing any sink.
+  const int pushed = cu_ctx_push(ms->engine.cuda);
+  gpu_delivery_stop_join(&ms->engine.delivery);
+  gpu_streams_sync(&ms->engine.streams);
+  multiarray_tile_stream_gpu_release_resources(ms, pushed);
+}
+
 void
 multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
 {
@@ -362,19 +407,7 @@ multiarray_tile_stream_gpu_destroy(struct multiarray_tile_stream_gpu* ms)
   if (ms->arrays && close_impl(&ms->writer).error)
     log_error("GPU multiarray close failed during destroy");
 
-  // Copy state can still name the shared output pool after a failed
-  // cancellation, so tear down the shared stages before the descriptors.
-  stream_engine_destroy(&ms->engine);
-
-  if (ms->arrays) {
-    for (int a = 0; a < ms->n_arrays; ++a)
-      destroy_array_descriptor(&ms->arrays[a]);
-    free(ms->arrays);
-  }
-  host_output_pool_destroy(ms->output_pool);
-
-  cu_ctx_pop(pushed);
-  free(ms);
+  multiarray_tile_stream_gpu_release_resources(ms, pushed);
 }
 
 struct multiarray_tile_stream_gpu*
@@ -403,15 +436,9 @@ multiarray_tile_stream_gpu_create(
   ms->writer.flush = flush_impl;
   ms->writer.close = close_impl;
 
-  ms->arrays = (struct array_descriptor_gpu*)calloc(
+  ms->arrays = (struct array_descriptor_gpu*)allocate_array_descriptors(
     n_arrays, sizeof(struct array_descriptor_gpu));
   CHECK(Fail, ms->arrays);
-  // Failed construction must not flush or republish partially initialized
-  // arrays.
-  for (int a = 0; a < n_arrays; ++a) {
-    ms->arrays[a].flushed = 1;
-    ms->arrays[a].closed = 1;
-  }
 
   struct engine_limits lim;
   memset(&lim, 0, sizeof(lim));
@@ -473,7 +500,7 @@ multiarray_tile_stream_gpu_create(
   return ms;
 
 Fail:
-  multiarray_tile_stream_gpu_destroy(ms);
+  multiarray_tile_stream_gpu_rollback(ms);
   return NULL;
 }
 

--- a/src/multiarray/stream.gpu.c
+++ b/src/multiarray/stream.gpu.c
@@ -406,6 +406,12 @@ multiarray_tile_stream_gpu_create(
   ms->arrays = (struct array_descriptor_gpu*)calloc(
     n_arrays, sizeof(struct array_descriptor_gpu));
   CHECK(Fail, ms->arrays);
+  // Failed construction must not flush or republish partially initialized
+  // arrays.
+  for (int a = 0; a < n_arrays; ++a) {
+    ms->arrays[a].flushed = 1;
+    ms->arrays[a].closed = 1;
+  }
 
   struct engine_limits lim;
   memset(&lim, 0, sizeof(lim));
@@ -454,6 +460,16 @@ multiarray_tile_stream_gpu_create(
   for (int a = 0; a < n_arrays; ++a)
     ms->arrays[a].st.agg.output_pool = ms->output_pool;
 
+  // Publish every empty extent before enabling input on any array.
+  for (int a = 0; a < n_arrays; ++a) {
+    const struct stream_context* ctx = &ms->arrays[a].ctx;
+    CHECK(Fail,
+          shard_sink_init_append(ctx->sink, &ctx->dims, ctx->levels.nlod) == 0);
+  }
+  for (int a = 0; a < n_arrays; ++a) {
+    ms->arrays[a].flushed = 0;
+    ms->arrays[a].closed = 0;
+  }
   return ms;
 
 Fail:

--- a/src/ngff/CMakeLists.txt
+++ b/src/ngff/CMakeLists.txt
@@ -3,5 +3,5 @@ add_src_lib(ngff_metadata SOURCES ngff_metadata.c ngff_metadata.h
 )
 
 add_src_lib(ngff_multiscale SOURCES ngff_multiscale.c ngff_multiscale.h
-    LINKS ngff_metadata attr_set zarr_array zarr_group zarr_metadata lod_plan dimension strbuf chucky_log
+    LINKS ngff_metadata attr_set zarr_array zarr_group zarr_metadata_io lod_plan dimension strbuf chucky_log
 )

--- a/src/ngff/ngff_metadata.c
+++ b/src/ngff/ngff_metadata.c
@@ -8,30 +8,18 @@
 #include <stdio.h>
 
 int
-ngff_multiscale_group_json(struct strbuf* sb,
-                           uint8_t rank,
-                           int nlod,
-                           const struct dimension* const* level_dims,
-                           const struct ngff_axis* axes,
-                           const struct attr_set* extras)
+ngff_multiscale_attributes_json(struct strbuf* sb,
+                                uint8_t rank,
+                                int nlod,
+                                const struct dimension* const* level_dims,
+                                const struct ngff_axis* axes,
+                                const struct attr_set* extras)
 {
   struct json_writer jw;
   jw_init(&jw, sb);
 
   const struct dimension* l0 = level_dims[0];
 
-  jw_object_begin(&jw);
-
-  jw_key(&jw, "zarr_format");
-  jw_int(&jw, 3);
-
-  jw_key(&jw, "node_type");
-  jw_string(&jw, "group");
-
-  jw_key(&jw, "consolidated_metadata");
-  jw_null(&jw);
-
-  jw_key(&jw, "attributes");
   jw_object_begin(&jw);
 
   jw_key(&jw, "ome");
@@ -151,7 +139,6 @@ ngff_multiscale_group_json(struct strbuf* sb,
   jw_object_end(&jw); // ome
   attr_set_emit(extras, &jw);
   jw_object_end(&jw); // attributes
-  jw_object_end(&jw); // root
 
   return jw_error(&jw) ? 1 : 0;
 }

--- a/src/ngff/ngff_metadata.h
+++ b/src/ngff/ngff_metadata.h
@@ -10,15 +10,15 @@
 struct ngff_axis;
 struct attr_set;
 
-// Append OME-NGFF v0.5 multiscale group JSON to sb.
-// level_dims[lv] points to the rank-length dimension array for level lv.
-// axes may be NULL; if so, all axes default to space/no-unit/scale-1.0.
+// Append an attributes JSON object containing OME-NGFF v0.5 multiscale
+// metadata. level_dims[lv] points to the rank-length dimension array for level
+// lv. axes may be NULL; if so, all axes default to space/no-unit/scale-1.0.
 // extras: optional custom attrs written alongside the OME block. May be NULL.
 // Returns 0 on success.
 int
-ngff_multiscale_group_json(struct strbuf* sb,
-                           uint8_t rank,
-                           int nlod,
-                           const struct dimension* const* level_dims,
-                           const struct ngff_axis* axes,
-                           const struct attr_set* extras);
+ngff_multiscale_attributes_json(struct strbuf* sb,
+                                uint8_t rank,
+                                int nlod,
+                                const struct dimension* const* level_dims,
+                                const struct ngff_axis* axes,
+                                const struct attr_set* extras);

--- a/src/ngff/ngff_multiscale.c
+++ b/src/ngff/ngff_multiscale.c
@@ -64,7 +64,8 @@ struct ngff_multiscale
 // --- Group metadata ---
 
 static int
-write_ngff_group_metadata(struct ngff_multiscale* ms)
+write_ngff_group_metadata(struct ngff_multiscale* ms,
+                          const struct io_event* after)
 {
   const struct dimension* level_ptrs[LOD_MAX_LEVELS];
   for (int lv = 0; lv < ms->nlod; ++lv)
@@ -73,6 +74,10 @@ write_ngff_group_metadata(struct ngff_multiscale* ms)
   struct strbuf key = { 0 };
   struct strbuf json = { 0 };
   int rc = 1;
+
+  // Older queued group snapshots must land before a synchronous rewrite.
+  if (!after && ms->pool->put_after && ms->pool->flush(ms->pool))
+    goto done;
 
   if (ngff_multiscale_group_json(
         &json, ms->rank, ms->nlod, level_ptrs, ms->axes, &ms->attrs))
@@ -86,8 +91,15 @@ write_ngff_group_metadata(struct ngff_multiscale* ms)
       goto done;
   }
 
-  rc = ms->store->put(
-    ms->store, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
+  if (after)
+    rc = ms->pool->put_after(ms->pool,
+                             strbuf_cstr(&key),
+                             strbuf_cstr(&json),
+                             strbuf_len(&json),
+                             *after);
+  else
+    rc = ms->store->put(
+      ms->store, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
   if (rc == 0)
     ms->attrs.dirty = 0;
 
@@ -113,31 +125,61 @@ Fail:
 }
 
 static int
+update_append(struct ngff_multiscale* ms,
+              uint8_t level,
+              uint8_t n_append,
+              const uint64_t* append_sizes,
+              const struct io_event* after)
+{
+  if (level >= ms->nlod || n_append == 0 || n_append > ms->rank ||
+      !append_sizes)
+    return 1;
+
+  struct shard_sink* child = zarr_array_as_shard_sink(ms->levels[level]);
+  const struct dimension* dims = zarr_array_dimensions(ms->levels[level]);
+  int changed = 0;
+  for (uint8_t d = 0; d < n_append; ++d)
+    changed |= dims[d].size != append_sizes[d];
+
+  int rc =
+    after
+      ? child->update_append_after(child, level, n_append, append_sizes, *after)
+      : child->update_append(child, level, n_append, append_sizes);
+  if (rc)
+    return 1;
+
+  if (!changed)
+    return 0;
+
+  // The shared pool orders publications, so the child snapshot is visible
+  // before its group snapshot and earlier groups cannot replace later ones.
+  if (write_ngff_group_metadata(ms, after)) {
+    log_error("ngff_multiscale: failed to rewrite group zarr.json for %s",
+              strbuf_cstr(&ms->prefix));
+    return 1;
+  }
+  return 0;
+}
+
+static int
 ngff_multiscale_update_append(struct shard_sink* self,
                               uint8_t level,
                               uint8_t n_append,
                               const uint64_t* append_sizes)
 {
   struct ngff_multiscale* ms = container_of(self, struct ngff_multiscale, base);
-  if (level >= ms->nlod)
-    return 1;
+  return update_append(ms, level, n_append, append_sizes, NULL);
+}
 
-  struct shard_sink* child = zarr_array_as_shard_sink(ms->levels[level]);
-  const struct dimension* dims = zarr_array_dimensions(ms->levels[level]);
-  uint64_t old_dim0 = dims[0].size;
-
-  if (child->update_append(child, level, n_append, append_sizes))
-    return 1;
-
-  if (old_dim0 == append_sizes[0])
-    return 0;
-
-  if (write_ngff_group_metadata(ms)) {
-    log_error("ngff_multiscale: failed to rewrite group zarr.json for %s",
-              strbuf_cstr(&ms->prefix));
-    return 1;
-  }
-  return 0;
+static int
+ngff_multiscale_update_append_after(struct shard_sink* self,
+                                    uint8_t level,
+                                    uint8_t n_append,
+                                    const uint64_t* append_sizes,
+                                    struct io_event after)
+{
+  struct ngff_multiscale* ms = container_of(self, struct ngff_multiscale, base);
+  return update_append(ms, level, n_append, append_sizes, &after);
 }
 
 static struct io_event
@@ -188,8 +230,7 @@ ngff_multiscale_flush_fn(struct shard_sink* self)
     if (child && child->flush)
       rc |= child->flush(child);
   }
-  if (ms->attrs.dirty)
-    rc |= write_ngff_group_metadata(ms);
+  rc |= ngff_multiscale_flush_metadata(ms);
   return rc;
 }
 
@@ -220,6 +261,8 @@ ngff_multiscale_init(struct store* store,
 
   ms->base.open = ngff_multiscale_open;
   ms->base.update_append = ngff_multiscale_update_append;
+  ms->base.update_append_after =
+    pool->put_after ? ngff_multiscale_update_append_after : NULL;
   ms->base.record_fence = ngff_multiscale_record_fence_fn;
   ms->base.wait_fence = ngff_multiscale_wait_fence_fn;
   ms->base.flush = ngff_multiscale_flush_fn;
@@ -281,7 +324,7 @@ ngff_multiscale_init(struct store* store,
     slot_base += dims_compute_shard_geometry(lv_dims, cfg->rank, sc, cps);
   }
 
-  CHECK(Fail_levels, write_ngff_group_metadata(ms) == 0);
+  CHECK(Fail_levels, write_ngff_group_metadata(ms, NULL) == 0);
 
   lod_plan_free(plan);
   return ms;
@@ -380,7 +423,7 @@ ngff_multiscale_destroy(struct ngff_multiscale* ms)
 {
   if (!ms)
     return;
-  if (ms->attrs.dirty && write_ngff_group_metadata(ms))
+  if (ngff_multiscale_flush_fn(&ms->base))
     log_error("ngff_multiscale: metadata flush failed during destroy");
   for (int i = 0; i < ms->nlod; ++i)
     zarr_array_destroy(ms->levels[i]);
@@ -433,8 +476,8 @@ ngff_multiscale_flush_metadata(struct ngff_multiscale* ms)
 {
   CHECK(Fail, ms);
   if (!ms->attrs.dirty)
-    return 0;
-  return write_ngff_group_metadata(ms);
+    return ms->pool->put_after ? ms->pool->flush(ms->pool) : 0;
+  return write_ngff_group_metadata(ms, NULL);
 Fail:
   return 1;
 }

--- a/src/ngff/ngff_multiscale.c
+++ b/src/ngff/ngff_multiscale.c
@@ -64,8 +64,7 @@ struct ngff_multiscale
 // --- Group metadata ---
 
 static int
-write_ngff_group_metadata(struct ngff_multiscale* ms,
-                          const struct io_event* after)
+write_ngff_group_metadata(struct ngff_multiscale* ms, int queued)
 {
   const struct dimension* level_ptrs[LOD_MAX_LEVELS];
   for (int lv = 0; lv < ms->nlod; ++lv)
@@ -76,7 +75,7 @@ write_ngff_group_metadata(struct ngff_multiscale* ms,
   int rc = 1;
 
   // Older queued group snapshots must land before a synchronous rewrite.
-  if (!after && ms->pool->put_after && ms->pool->flush(ms->pool))
+  if (!queued && ms->pool->queue_metadata && ms->pool->flush(ms->pool))
     goto done;
 
   if (ngff_multiscale_group_json(
@@ -91,12 +90,9 @@ write_ngff_group_metadata(struct ngff_multiscale* ms,
       goto done;
   }
 
-  if (after)
-    rc = ms->pool->put_after(ms->pool,
-                             strbuf_cstr(&key),
-                             strbuf_cstr(&json),
-                             strbuf_len(&json),
-                             *after);
+  if (queued)
+    rc = ms->pool->queue_metadata(
+      ms->pool, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
   else
     rc = ms->store->put(
       ms->store, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
@@ -129,7 +125,7 @@ update_append(struct ngff_multiscale* ms,
               uint8_t level,
               uint8_t n_append,
               const uint64_t* append_sizes,
-              const struct io_event* after)
+              int queued)
 {
   if (level >= ms->nlod || n_append == 0 || n_append > ms->rank ||
       !append_sizes)
@@ -141,10 +137,8 @@ update_append(struct ngff_multiscale* ms,
   for (uint8_t d = 0; d < n_append; ++d)
     changed |= dims[d].size != append_sizes[d];
 
-  int rc =
-    after
-      ? child->update_append_after(child, level, n_append, append_sizes, *after)
-      : child->update_append(child, level, n_append, append_sizes);
+  int rc = queued ? child->queue_append(child, level, n_append, append_sizes)
+                  : child->update_append(child, level, n_append, append_sizes);
   if (rc)
     return 1;
 
@@ -153,7 +147,7 @@ update_append(struct ngff_multiscale* ms,
 
   // The shared pool orders publications, so the child snapshot is visible
   // before its group snapshot and earlier groups cannot replace later ones.
-  if (write_ngff_group_metadata(ms, after)) {
+  if (write_ngff_group_metadata(ms, queued)) {
     log_error("ngff_multiscale: failed to rewrite group zarr.json for %s",
               strbuf_cstr(&ms->prefix));
     return 1;
@@ -168,18 +162,17 @@ ngff_multiscale_update_append(struct shard_sink* self,
                               const uint64_t* append_sizes)
 {
   struct ngff_multiscale* ms = container_of(self, struct ngff_multiscale, base);
-  return update_append(ms, level, n_append, append_sizes, NULL);
+  return update_append(ms, level, n_append, append_sizes, 0);
 }
 
 static int
-ngff_multiscale_update_append_after(struct shard_sink* self,
-                                    uint8_t level,
-                                    uint8_t n_append,
-                                    const uint64_t* append_sizes,
-                                    struct io_event after)
+ngff_multiscale_queue_append(struct shard_sink* self,
+                             uint8_t level,
+                             uint8_t n_append,
+                             const uint64_t* append_sizes)
 {
   struct ngff_multiscale* ms = container_of(self, struct ngff_multiscale, base);
-  return update_append(ms, level, n_append, append_sizes, &after);
+  return update_append(ms, level, n_append, append_sizes, 1);
 }
 
 static struct io_event
@@ -261,8 +254,8 @@ ngff_multiscale_init(struct store* store,
 
   ms->base.open = ngff_multiscale_open;
   ms->base.update_append = ngff_multiscale_update_append;
-  ms->base.update_append_after =
-    pool->put_after ? ngff_multiscale_update_append_after : NULL;
+  ms->base.queue_append =
+    pool->queue_metadata ? ngff_multiscale_queue_append : NULL;
   ms->base.record_fence = ngff_multiscale_record_fence_fn;
   ms->base.wait_fence = ngff_multiscale_wait_fence_fn;
   ms->base.flush = ngff_multiscale_flush_fn;
@@ -324,7 +317,7 @@ ngff_multiscale_init(struct store* store,
     slot_base += dims_compute_shard_geometry(lv_dims, cfg->rank, sc, cps);
   }
 
-  CHECK(Fail_levels, write_ngff_group_metadata(ms, NULL) == 0);
+  CHECK(Fail_levels, write_ngff_group_metadata(ms, 0) == 0);
 
   lod_plan_free(plan);
   return ms;
@@ -476,8 +469,8 @@ ngff_multiscale_flush_metadata(struct ngff_multiscale* ms)
 {
   CHECK(Fail, ms);
   if (!ms->attrs.dirty)
-    return ms->pool->put_after ? ms->pool->flush(ms->pool) : 0;
-  return write_ngff_group_metadata(ms, NULL);
+    return ms->pool->queue_metadata ? ms->pool->flush(ms->pool) : 0;
+  return write_ngff_group_metadata(ms, 0);
 Fail:
   return 1;
 }

--- a/src/ngff/ngff_multiscale.c
+++ b/src/ngff/ngff_multiscale.c
@@ -6,7 +6,9 @@
 #include "ngff/ngff_metadata.h"
 #include "util/prelude.h"
 #include "zarr/attr_set.h"
+#include "zarr/metadata_io.h"
 #include "zarr/zarr_array.h"
+#include "zarr/zarr_group.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -64,44 +66,26 @@ struct ngff_multiscale
 // --- Group metadata ---
 
 static int
-write_ngff_group_metadata(struct ngff_multiscale* ms, int queued)
+submit_ngff_group_metadata(struct ngff_multiscale* ms)
 {
   const struct dimension* level_ptrs[LOD_MAX_LEVELS];
   for (int lv = 0; lv < ms->nlod; ++lv)
     level_ptrs[lv] = zarr_array_dimensions(ms->levels[lv]);
 
-  struct strbuf key = { 0 };
-  struct strbuf json = { 0 };
+  struct strbuf attrs = { 0 };
   int rc = 1;
 
-  // Older queued group snapshots must land before a synchronous rewrite.
-  if (!queued && ms->pool->queue_metadata && ms->pool->flush(ms->pool))
+  if (ngff_multiscale_attributes_json(
+        &attrs, ms->rank, ms->nlod, level_ptrs, ms->axes, &ms->attrs))
     goto done;
 
-  if (ngff_multiscale_group_json(
-        &json, ms->rank, ms->nlod, level_ptrs, ms->axes, &ms->attrs))
-    goto done;
-
-  if (strbuf_len(&ms->prefix) > 0) {
-    if (strbuf_appendf(&key, "%s/zarr.json", strbuf_cstr(&ms->prefix)))
-      goto done;
-  } else {
-    if (strbuf_append_cstr(&key, "zarr.json"))
-      goto done;
-  }
-
-  if (queued)
-    rc = ms->pool->queue_metadata(
-      ms->pool, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
-  else
-    rc = ms->store->put(
-      ms->store, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
+  rc = zarr_group_submit(
+    ms->store, ms->pool, strbuf_cstr(&ms->prefix), strbuf_cstr(&attrs));
   if (rc == 0)
     ms->attrs.dirty = 0;
 
 done:
-  strbuf_free(&key);
-  strbuf_free(&json);
+  strbuf_free(&attrs);
   return rc;
 }
 
@@ -121,25 +105,21 @@ Fail:
 }
 
 static int
-update_append(struct ngff_multiscale* ms,
+submit_append(struct ngff_multiscale* ms,
               uint8_t level,
               uint8_t n_append,
-              const uint64_t* append_sizes,
-              int queued)
+              const uint64_t* append_sizes)
 {
   if (level >= ms->nlod || n_append == 0 || n_append > ms->rank ||
       !append_sizes)
     return 1;
 
-  struct shard_sink* child = zarr_array_as_shard_sink(ms->levels[level]);
   const struct dimension* dims = zarr_array_dimensions(ms->levels[level]);
   int changed = 0;
   for (uint8_t d = 0; d < n_append; ++d)
     changed |= dims[d].size != append_sizes[d];
 
-  int rc = queued ? child->queue_append(child, level, n_append, append_sizes)
-                  : child->update_append(child, level, n_append, append_sizes);
-  if (rc)
+  if (zarr_array_submit_append(ms->levels[level], n_append, append_sizes))
     return 1;
 
   if (!changed)
@@ -147,7 +127,7 @@ update_append(struct ngff_multiscale* ms,
 
   // The shared pool orders publications, so the child snapshot is visible
   // before its group snapshot and earlier groups cannot replace later ones.
-  if (write_ngff_group_metadata(ms, queued)) {
+  if (submit_ngff_group_metadata(ms)) {
     log_error("ngff_multiscale: failed to rewrite group zarr.json for %s",
               strbuf_cstr(&ms->prefix));
     return 1;
@@ -162,7 +142,9 @@ ngff_multiscale_update_append(struct shard_sink* self,
                               const uint64_t* append_sizes)
 {
   struct ngff_multiscale* ms = container_of(self, struct ngff_multiscale, base);
-  return update_append(ms, level, n_append, append_sizes, 0);
+  int rc = submit_append(ms, level, n_append, append_sizes);
+  rc |= zarr_metadata_wait(ms->pool);
+  return rc;
 }
 
 static int
@@ -172,7 +154,7 @@ ngff_multiscale_queue_append(struct shard_sink* self,
                              const uint64_t* append_sizes)
 {
   struct ngff_multiscale* ms = container_of(self, struct ngff_multiscale, base);
-  return update_append(ms, level, n_append, append_sizes, 1);
+  return submit_append(ms, level, n_append, append_sizes);
 }
 
 static struct io_event
@@ -317,7 +299,9 @@ ngff_multiscale_init(struct store* store,
     slot_base += dims_compute_shard_geometry(lv_dims, cfg->rank, sc, cps);
   }
 
-  CHECK(Fail_levels, write_ngff_group_metadata(ms, 0) == 0);
+  int rc = submit_ngff_group_metadata(ms);
+  rc |= zarr_metadata_wait(pool);
+  CHECK(Fail_levels, rc == 0);
 
   lod_plan_free(plan);
   return ms;
@@ -468,9 +452,9 @@ int
 ngff_multiscale_flush_metadata(struct ngff_multiscale* ms)
 {
   CHECK(Fail, ms);
-  if (!ms->attrs.dirty)
-    return ms->pool->queue_metadata ? ms->pool->flush(ms->pool) : 0;
-  return write_ngff_group_metadata(ms, 0);
+  int rc = ms->attrs.dirty ? submit_ngff_group_metadata(ms) : 0;
+  rc |= zarr_metadata_wait(ms->pool);
+  return rc;
 Fail:
   return 1;
 }

--- a/src/store.h
+++ b/src/store.h
@@ -14,6 +14,8 @@ struct store;
 
 // Create a filesystem store rooted at the given directory.
 // unbuffered: use O_DIRECT / FILE_FLAG_NO_BUFFERING for shard data writes.
+// Metadata writes create missing parent directories and atomically replace
+// files for readers. They remain buffered and do not add fsync.
 // Returns NULL on error.
 struct store*
 store_fs_create(const char* root, int unbuffered);

--- a/src/stream.cpu.h
+++ b/src/stream.cpu.h
@@ -7,6 +7,8 @@ struct tile_stream_layout;
 struct tile_stream_cpu;
 
 // Create a CPU streaming pipeline. Returns NULL on failure or f16 dtype.
+// Initializes supported sink metadata to an empty append extent. Configured
+// dimension sizes retain their meaning as the stream's input capacity.
 // The config->dimensions pointer must remain valid for the lifetime of the
 // stream.
 struct tile_stream_cpu*

--- a/src/stream.gpu.h
+++ b/src/stream.gpu.h
@@ -69,6 +69,8 @@ tile_stream_gpu_advise_layout(struct tile_stream_configuration* config,
 
 // Allocate and initialize a tile_stream_gpu. Returns pointer on success,
 // NULL on failure. Caller must free with tile_stream_gpu_destroy.
+// Initializes supported sink metadata to an empty append extent. Configured
+// dimension sizes retain their meaning as the stream's input capacity.
 // The config->dimensions pointer must remain valid for the lifetime of the
 // stream.
 struct tile_stream_gpu*

--- a/src/types.stream.h
+++ b/src/types.stream.h
@@ -127,6 +127,10 @@ struct stream_metrics
   // totals above are under-reported.
   uint64_t scatter_samples_lost;
   uint64_t lod_samples_lost;
+
+  // Separate work totals prevent sampling from understating copy volume.
+  uint64_t memcpy_calls;
+  uint64_t memcpy_bytes;
 };
 
 struct tile_stream_configuration
@@ -149,6 +153,7 @@ struct tile_stream_configuration
                                // staging buffer to the device when the sink
                                // reports more pending than this
   int max_threads;             // 0 = OpenMP default
+  int full_memcpy_timing;
 };
 
 struct tile_stream_status

--- a/src/writer.h
+++ b/src/writer.h
@@ -92,13 +92,25 @@ struct shard_sink
                                uint64_t shard_index);
 
   // Optional: update append dim extents in metadata (e.g. zarr.json shape).
-  // Called periodically during streaming and from the writer's close.
+  // Called with the empty extent at stream creation, periodically during
+  // streaming for synchronous sinks, and from the writer's close.
   // append_sizes has n_append elements (sizes for dims 0..n_append-1).
   // NULL means no-op (non-zarr sinks can ignore).
   int (*update_append)(struct shard_sink* self,
                        uint8_t level,
                        uint8_t n_append,
                        const uint64_t* append_sizes);
+
+  // Optional: queue a snapshot of the append metadata after all IO through
+  // after has completed successfully. Returning zero accepts the update;
+  // flush must report any later failure and wait for publication.
+  // Does not borrow append_sizes. Writers use synchronous publication if
+  // either this hook or flush is NULL.
+  int (*update_append_after)(struct shard_sink* self,
+                             uint8_t level,
+                             uint8_t n_append,
+                             const uint64_t* append_sizes,
+                             struct io_event after);
 
   // IO fence for backpressure. NULL = no async IO.
   struct io_event (*record_fence)(struct shard_sink* self);

--- a/src/writer.h
+++ b/src/writer.h
@@ -101,16 +101,15 @@ struct shard_sink
                        uint8_t n_append,
                        const uint64_t* append_sizes);
 
-  // Optional: queue a snapshot of the append metadata after all IO through
-  // after has completed successfully. Returning zero accepts the update;
-  // flush must report any later failure and wait for publication.
+  // Optional: queue a snapshot of append metadata behind prior sink IO.
+  // Publish only after those writes complete successfully. Returning zero
+  // accepts the update; flush waits for publication and reports later errors.
   // Does not borrow append_sizes. Writers use synchronous publication if
   // either this hook or flush is NULL.
-  int (*update_append_after)(struct shard_sink* self,
-                             uint8_t level,
-                             uint8_t n_append,
-                             const uint64_t* append_sizes,
-                             struct io_event after);
+  int (*queue_append)(struct shard_sink* self,
+                      uint8_t level,
+                      uint8_t n_append,
+                      const uint64_t* append_sizes);
 
   // IO fence for backpressure. NULL = no async IO.
   struct io_event (*record_fence)(struct shard_sink* self);

--- a/src/zarr.h
+++ b/src/zarr.h
@@ -51,7 +51,8 @@ zarr_array_has_error(const struct zarr_array* a);
 uint64_t
 zarr_array_pending_bytes(const struct zarr_array* a);
 
-// Access live dimensions (reflects append-dimension updates).
+// Access live dimensions (reflects accepted append-dimension updates).
+// With queued publication these may lead the visible metadata until flush.
 const struct dimension*
 zarr_array_dimensions(const struct zarr_array* a);
 

--- a/src/zarr.h
+++ b/src/zarr.h
@@ -23,8 +23,8 @@ struct zarr_array;
 
 // Create a zarr v3 array.
 // Writes {prefix}/zarr.json. Does NOT write root or intermediate groups.
-// The caller must ensure the prefix directory exists (via zarr_group_create
-// or the higher-level ngff/hcs layers).
+// The caller must satisfy the store's prefix-directory requirements;
+// filesystem stores create missing directories on demand.
 // prefix may be "" to write at the store root.
 // Returns NULL on error.
 struct zarr_array*
@@ -34,13 +34,14 @@ zarr_array_create(struct store* store,
 
 // Auto-flushes pending metadata best-effort; ignores flush errors. Call
 // writer_flush then writer_close on the owning stream before destroy if you
-// detect failures.
+// need to detect failures.
 void
 zarr_array_destroy(struct zarr_array* a);
 
 struct shard_sink*
 zarr_array_as_shard_sink(struct zarr_array* a);
 
+// Wait for pending I/O and report errors. Does not submit buffered attributes.
 int
 zarr_array_flush(struct zarr_array* a);
 
@@ -58,9 +59,10 @@ zarr_array_dimensions(const struct zarr_array* a);
 
 // Attach a custom JSON attribute to the array's zarr.json under
 // attributes.<attr_key>. Value is validated and copied. attr_key must be
-// non-empty and contain no quotes or control chars. Becomes visible on the
-// next metadata rewrite (shape advance, explicit flush, or destroy).
-// Replaces any prior value for the same key. Returns 0 on success.
+// non-empty and contain no quotes or control chars. Included in the next
+// metadata rewrite: shape advance, sink metadata flush (including
+// writer_close), or destroy. Queued snapshots become visible after their I/O
+// completes. Replaces any prior value for the same key. Returns 0 on success.
 int
 zarr_array_set_attribute(struct zarr_array* a,
                          const char* attr_key,

--- a/src/zarr/CMakeLists.txt
+++ b/src/zarr/CMakeLists.txt
@@ -10,6 +10,8 @@ add_src_lib(zarr_metadata SOURCES zarr_metadata.c zarr_metadata.h
     LINKS json_writer attr_set dimension dtype codec_types chucky_log
 )
 
+add_src_lib(zarr_metadata_io SOURCES metadata_io.c metadata_io.h LINKS strbuf)
+
 add_src_lib(shard_delivery SOURCES
     shard_delivery.c shard_delivery.h
     shard_write_plan.c shard_write_plan.h
@@ -33,11 +35,11 @@ add_src_lib(store_fs SOURCES store_fs.c store_fs.h store.h
 )
 
 add_src_lib(zarr_group SOURCES zarr_group.c zarr_group.h
-    LINKS zarr_metadata attr_set strbuf chucky_log
+    LINKS zarr_metadata zarr_metadata_io attr_set strbuf chucky_log
 )
 
 add_src_lib(zarr_array SOURCES zarr_array.c zarr_array.h
-    LINKS zarr_metadata attr_set lod_plan writer strbuf chucky_log
+    LINKS zarr_metadata zarr_metadata_io attr_set lod_plan writer strbuf chucky_log
 )
 
 add_src_lib(s3_client SOURCES s3_client.c s3_client.h

--- a/src/zarr/CMakeLists.txt
+++ b/src/zarr/CMakeLists.txt
@@ -31,7 +31,7 @@ add_src_lib(shard_pool_fs SOURCES shard_pool_fs.c shard_pool_fs.h shard_pool.h
 )
 
 add_src_lib(store_fs SOURCES store_fs.c store_fs.h store.h
-    LINKS shard_pool_fs platform platform_io strbuf chucky_log
+    LINKS shard_pool_fs io_backend_fs platform platform_io strbuf chucky_log
 )
 
 add_src_lib(zarr_group SOURCES zarr_group.c zarr_group.h

--- a/src/zarr/io_backend.fs.c
+++ b/src/zarr/io_backend.fs.c
@@ -203,40 +203,47 @@ execute_open(struct io_backend_fs* b, const struct io_request* req)
   platform_mutex_unlock(b->mutex);
 }
 
-static void
-execute_replace(struct io_backend_fs* b, const struct io_request* req)
+int
+io_backend_fs_replace(const char* path, const void* data, size_t len)
 {
-  // A completed dependency may contain a failed write. Never advertise its
-  // extent, even though the scheduler still retires failed jobs to drain.
-  if (atomic_load(b->io_error))
-    return;
-
   struct strbuf tmp_path = { 0 };
-  CHECK(Fail, req->path && (req->payload || req->nbytes == 0));
-  CHECK(Fail, req->nbytes <= SIZE_MAX);
+  CHECK(Fail, path && (data || len == 0));
+  // Each process uses its own sibling temporary name. Callers within a
+  // process serialize replacements of the same path.
   CHECK(Fail,
         strbuf_appendf(&tmp_path,
                        "%s.tmp.%llu",
-                       req->path,
+                       path,
                        (unsigned long long)platform_process_id()) == 0);
 
-  // Metadata remains buffered even when shard data uses direct I/O. As with
-  // store_fs.put, replacement is atomic for readers but does not add fsync.
+  // Metadata stays buffered even when shard data uses direct I/O. Neither is
+  // fsynced: making metadata outlive the data it describes would not help.
   const platform_fd fd = open_write(strbuf_cstr(&tmp_path), 0);
   CHECK(Fail, fd != PLATFORM_FD_INVALID);
-  const int written =
-    platform_write(fd, req->payload, (size_t)req->nbytes) == 0;
+  const int written = platform_write(fd, data, len) == 0;
   platform_close(fd);
-  if (!written || platform_rename_replace(strbuf_cstr(&tmp_path), req->path)) {
+  if (!written || platform_rename_replace(strbuf_cstr(&tmp_path), path)) {
     platform_remove_file(strbuf_cstr(&tmp_path));
     goto Fail;
   }
   strbuf_free(&tmp_path);
-  return;
+  return 0;
 
 Fail:
   strbuf_free(&tmp_path);
-  record_failure(b, "io_backend_fs: atomic replacement failed");
+  return 1;
+}
+
+static void
+execute_replace(struct io_backend_fs* b, const struct io_request* req)
+{
+  // The earlier queue prefix may contain a failed write. Never advertise its
+  // extent, even though the scheduler still retires failed jobs to drain.
+  if (atomic_load(b->io_error))
+    return;
+  if (req->nbytes > SIZE_MAX ||
+      io_backend_fs_replace(req->path, req->payload, (size_t)req->nbytes))
+    record_failure(b, "io_backend_fs: atomic replacement failed");
 }
 
 static void

--- a/src/zarr/io_backend.fs.c
+++ b/src/zarr/io_backend.fs.c
@@ -204,6 +204,42 @@ execute_open(struct io_backend_fs* b, const struct io_request* req)
 }
 
 static void
+execute_replace(struct io_backend_fs* b, const struct io_request* req)
+{
+  // A completed dependency may contain a failed write. Never advertise its
+  // extent, even though the scheduler still retires failed jobs to drain.
+  if (atomic_load(b->io_error))
+    return;
+
+  struct strbuf tmp_path = { 0 };
+  CHECK(Fail, req->path && (req->payload || req->nbytes == 0));
+  CHECK(Fail, req->nbytes <= SIZE_MAX);
+  CHECK(Fail,
+        strbuf_appendf(&tmp_path,
+                       "%s.tmp.%llu",
+                       req->path,
+                       (unsigned long long)platform_process_id()) == 0);
+
+  // Metadata remains buffered even when shard data uses direct I/O. As with
+  // store_fs.put, replacement is atomic for readers but does not add fsync.
+  const platform_fd fd = open_write(strbuf_cstr(&tmp_path), 0);
+  CHECK(Fail, fd != PLATFORM_FD_INVALID);
+  const int written =
+    platform_write(fd, req->payload, (size_t)req->nbytes) == 0;
+  platform_close(fd);
+  if (!written || platform_rename_replace(strbuf_cstr(&tmp_path), req->path)) {
+    platform_remove_file(strbuf_cstr(&tmp_path));
+    goto Fail;
+  }
+  strbuf_free(&tmp_path);
+  return;
+
+Fail:
+  strbuf_free(&tmp_path);
+  record_failure(b, "io_backend_fs: atomic replacement failed");
+}
+
+static void
 fs_execute(void* ctx, const struct io_request* req)
 {
   struct io_backend_fs* b = (struct io_backend_fs*)ctx;
@@ -211,6 +247,10 @@ fs_execute(void* ctx, const struct io_request* req)
     return;
   if (req->op == IO_OP_OPEN) {
     execute_open(b, req);
+    return;
+  }
+  if (req->op == IO_OP_REPLACE) {
+    execute_replace(b, req);
     return;
   }
 

--- a/src/zarr/io_backend.fs.h
+++ b/src/zarr/io_backend.fs.h
@@ -25,7 +25,8 @@ io_backend_fs_reserve_file(struct io_backend_fs* b);
 void
 io_backend_fs_cancel_file(struct io_backend_fs* b, struct io_file_token file);
 
-// Counts include open calls that have not returned yet.
+// Shard handle counts include open calls that have not returned yet.
+// Metadata replacement uses a separate short-lived buffered handle.
 uint32_t
 io_backend_fs_handle_count(const struct io_backend_fs* b);
 

--- a/src/zarr/io_backend.fs.h
+++ b/src/zarr/io_backend.fs.h
@@ -3,9 +3,18 @@
 #include "zarr/io_backend.h"
 
 #include <stdatomic.h>
+#include <stddef.h>
 #include <stdint.h>
 
 struct io_backend_fs;
+
+// Replace path atomically for readers, creating missing parent directories.
+// Writes a buffered sibling temporary file and renames it without fsync.
+// Inputs are borrowed until return; data may be NULL only when len is zero.
+// Callers must serialize replacements of the same path within a process.
+// Returns 0 on success, non-zero on error.
+int
+io_backend_fs_replace(const char* path, const void* data, size_t len);
 
 // io_error is the pool's flag; it is raised on any failure.
 struct io_backend_fs*

--- a/src/zarr/io_request.h
+++ b/src/zarr/io_request.h
@@ -11,6 +11,7 @@ enum io_op
   IO_OP_WRITE,    // payload to a file at an offset
   IO_OP_TRUNCATE, // barrier: set the file's size
   IO_OP_CLOSE,    // barrier: last request naming this token
+  IO_OP_REPLACE,  // buffered atomic replacement of path; no file token
 };
 
 // A token names one open of one shard file. A generation is never reused, so
@@ -36,6 +37,10 @@ struct io_request
   uint64_t offset;
 
   uint64_t logical_size; // truncate only
+
+  // Wait for completion of the posted prefix through this sequence. Zero
+  // means no dependency. The scheduler leaves workers free while it waits.
+  uint64_t after_seq;
 
   // The owned allocation is released before the request is reported complete.
   void* owned;

--- a/src/zarr/io_request.h
+++ b/src/zarr/io_request.h
@@ -11,7 +11,7 @@ enum io_op
   IO_OP_WRITE,    // payload to a file at an offset
   IO_OP_TRUNCATE, // barrier: set the file's size
   IO_OP_CLOSE,    // barrier: last request naming this token
-  IO_OP_REPLACE,  // buffered atomic replacement of path; no file token
+  IO_OP_REPLACE,  // atomic path replacement after all prior work; no file token
 };
 
 // A token names one open of one shard file. A generation is never reused, so
@@ -37,10 +37,6 @@ struct io_request
   uint64_t offset;
 
   uint64_t logical_size; // truncate only
-
-  // Wait for completion of the posted prefix through this sequence. Zero
-  // means no dependency. The scheduler leaves workers free while it waits.
-  uint64_t after_seq;
 
   // The owned allocation is released before the request is reported complete.
   void* owned;

--- a/src/zarr/io_scheduler.c
+++ b/src/zarr/io_scheduler.c
@@ -248,8 +248,6 @@ file_next_ready(struct io_scheduler* q, const struct file_pending* file)
   for (uint64_t seq = file->oldest_seq; seq != NO_SEQ;) {
     const struct io_job* job = job_at(q, seq);
     if (job->state == IO_JOB_WAITING) {
-      if (job->req.after_seq >= q->tail)
-        return NO_SEQ;
       if (is_barrier(&job->req))
         return file->oldest_seq == seq ? seq : NO_SEQ;
       return file->barrier_running ? NO_SEQ : seq;
@@ -264,7 +262,8 @@ next_ready_seq(struct io_scheduler* q)
 {
   for (uint64_t seq = q->nofile_oldest; seq != NO_SEQ;) {
     const struct io_job* job = job_at(q, seq);
-    if (job->state == IO_JOB_WAITING && job->req.after_seq < q->tail)
+    if (job->state == IO_JOB_WAITING &&
+        (job->req.op != IO_OP_REPLACE || seq == q->tail))
       return seq;
     seq = job->newer_on_file;
   }
@@ -482,11 +481,10 @@ int
 io_scheduler_post(struct io_scheduler* q, struct io_request req)
 {
   platform_mutex_lock(q->mutex);
-  // Refuse forward dependencies before queue backpressure can park a caller.
-  // Every accepted dependency then points strictly backwards, so draining the
-  // queue cannot leave its workers waiting on an unpostable request.
-  if (req.after_seq >= q->head) {
-    log_error("io_scheduler: refused a dependency on an unposted sequence");
+  // Replacements use the no-file queue, where readiness requires the entire
+  // earlier prefix to have retired. Refuse a token before parking the caller.
+  if (req.op == IO_OP_REPLACE && req.file.generation != 0) {
+    log_error("io_scheduler: a replacement cannot carry a file token");
     platform_mutex_unlock(q->mutex);
     return 1;
   }

--- a/src/zarr/io_scheduler.c
+++ b/src/zarr/io_scheduler.c
@@ -248,6 +248,8 @@ file_next_ready(struct io_scheduler* q, const struct file_pending* file)
   for (uint64_t seq = file->oldest_seq; seq != NO_SEQ;) {
     const struct io_job* job = job_at(q, seq);
     if (job->state == IO_JOB_WAITING) {
+      if (job->req.after_seq >= q->tail)
+        return NO_SEQ;
       if (is_barrier(&job->req))
         return file->oldest_seq == seq ? seq : NO_SEQ;
       return file->barrier_running ? NO_SEQ : seq;
@@ -262,7 +264,7 @@ next_ready_seq(struct io_scheduler* q)
 {
   for (uint64_t seq = q->nofile_oldest; seq != NO_SEQ;) {
     const struct io_job* job = job_at(q, seq);
-    if (job->state == IO_JOB_WAITING)
+    if (job->state == IO_JOB_WAITING && job->req.after_seq < q->tail)
       return seq;
     seq = job->newer_on_file;
   }
@@ -480,6 +482,14 @@ int
 io_scheduler_post(struct io_scheduler* q, struct io_request req)
 {
   platform_mutex_lock(q->mutex);
+  // Refuse forward dependencies before queue backpressure can park a caller.
+  // Every accepted dependency then points strictly backwards, so draining the
+  // queue cannot leave its workers waiting on an unpostable request.
+  if (req.after_seq >= q->head) {
+    log_error("io_scheduler: refused a dependency on an unposted sequence");
+    platform_mutex_unlock(q->mutex);
+    return 1;
+  }
   while (!has_room(q, req.nbytes) && !q->shutdown)
     queue_wait(q, q->room);
 

--- a/src/zarr/io_scheduler.h
+++ b/src/zarr/io_scheduler.h
@@ -32,7 +32,9 @@ uint64_t
 io_scheduler_parked_threads(const struct io_scheduler* q);
 
 // Zero is returned on success; on failure nothing is posted and the payload
-// is still yours. after_seq must name an already posted sequence (or zero).
+// is still yours. A REPLACE request has no file token and runs only after all
+// requests inserted before it have retired. Insertion after queue backpressure
+// defines this order; later independent work can run while replacement waits.
 int
 io_scheduler_post(struct io_scheduler* q, struct io_request req);
 

--- a/src/zarr/io_scheduler.h
+++ b/src/zarr/io_scheduler.h
@@ -32,7 +32,7 @@ uint64_t
 io_scheduler_parked_threads(const struct io_scheduler* q);
 
 // Zero is returned on success; on failure nothing is posted and the payload
-// is still yours.
+// is still yours. after_seq must name an already posted sequence (or zero).
 int
 io_scheduler_post(struct io_scheduler* q, struct io_request req);
 

--- a/src/zarr/metadata_io.c
+++ b/src/zarr/metadata_io.c
@@ -1,0 +1,31 @@
+#include "zarr/metadata_io.h"
+#include "util/strbuf.h"
+#include "zarr/shard_pool.h"
+#include "zarr/store.h"
+
+int
+zarr_metadata_submit(struct store* store,
+                     struct shard_pool* pool,
+                     const char* prefix,
+                     const struct strbuf* json)
+{
+  struct strbuf key = { 0 };
+  int rc = prefix && prefix[0] ? strbuf_appendf(&key, "%s/zarr.json", prefix)
+                               : strbuf_append_cstr(&key, "zarr.json");
+  if (rc == 0) {
+    if (pool && pool->queue_metadata)
+      rc = pool->queue_metadata(
+        pool, strbuf_cstr(&key), strbuf_cstr(json), strbuf_len(json));
+    else
+      rc = store->put(
+        store, strbuf_cstr(&key), strbuf_cstr(json), strbuf_len(json));
+  }
+  strbuf_free(&key);
+  return rc;
+}
+
+int
+zarr_metadata_wait(struct shard_pool* pool)
+{
+  return pool && pool->queue_metadata ? pool->flush(pool) : 0;
+}

--- a/src/zarr/metadata_io.h
+++ b/src/zarr/metadata_io.h
@@ -1,0 +1,23 @@
+// Private Zarr metadata submission over an injected store and optional pool.
+#pragma once
+
+struct shard_pool;
+struct store;
+struct strbuf;
+
+// Submit prefix/zarr.json (or zarr.json for an empty/NULL prefix). A pool with
+// queue_metadata copies the key and JSON before returning; other stores write
+// synchronously. Success means the snapshot was accepted, so its buffers may
+// be released immediately. A later queued IO failure is sticky on the pool.
+int
+zarr_metadata_submit(struct store* store,
+                     struct shard_pool* pool,
+                     const char* prefix,
+                     const struct strbuf* json);
+
+// Complete accepted queued metadata and report pool errors. This is a no-op
+// without queue_metadata: ordinary S3 metadata must not flush shard uploads.
+// Synchronous callers wait after submission; completion errors do not undo
+// accepted snapshots and remain sticky, just as for asynchronous publication.
+int
+zarr_metadata_wait(struct shard_pool* pool);

--- a/src/zarr/shard_delivery.c
+++ b/src/zarr/shard_delivery.c
@@ -284,10 +284,10 @@ shard_state_publish_append(struct shard_state* ss,
                            const uint64_t* cursor_elements,
                            struct stream_metrics* metrics)
 {
-  // An asynchronous sink owns the publication dependency. The producer only
-  // snapshots the finalized extent; workers publish it after its writes land.
+  // An asynchronous sink queues metadata behind prior writes. The producer
+  // snapshots only the finalized extent; workers publish it when IO succeeds.
   // Keep fence_pending truthful for any later synchronous readable query.
-  const int queued = sink->update_append_after && sink->flush;
+  const int queued = sink->queue_append && sink->flush;
   const uint64_t readable =
     queued ? ss->finalized_append_chunks
            : shard_state_readable_append_chunks(ss, sink, metrics);
@@ -298,12 +298,8 @@ shard_state_publish_append(struct shard_state* ss,
   else
     dim_info_decompose_append_sizes(dims, readable, append_sizes);
   if (queued)
-    return sink->update_append_after(
-      sink,
-      level,
-      dim_info_n_append(dims),
-      append_sizes,
-      ss->fence_pending ? ss->finalized_fence : (struct io_event){ 0 });
+    return sink->queue_append(
+      sink, level, dim_info_n_append(dims), append_sizes);
   return sink->update_append(
     sink, level, dim_info_n_append(dims), append_sizes);
 }

--- a/src/zarr/shard_delivery.c
+++ b/src/zarr/shard_delivery.c
@@ -243,6 +243,22 @@ record_finalized(struct shard_state* ss, struct shard_sink* sink)
   }
 }
 
+int
+shard_sink_init_append(struct shard_sink* sink,
+                       const struct dim_info* dims,
+                       int nlod)
+{
+  if (!sink || !sink->update_append)
+    return 0;
+  uint64_t append_sizes[HALF_MAX_RANK];
+  dim_info_decompose_append_sizes(dims, 0, append_sizes);
+  for (int lv = 0; lv < nlod; ++lv)
+    if (sink->update_append(
+          sink, (uint8_t)lv, dim_info_n_append(dims), append_sizes))
+      return 1;
+  return 0;
+}
+
 uint64_t
 shard_state_readable_append_chunks(struct shard_state* ss,
                                    struct shard_sink* sink,
@@ -268,13 +284,26 @@ shard_state_publish_append(struct shard_state* ss,
                            const uint64_t* cursor_elements,
                            struct stream_metrics* metrics)
 {
-  uint64_t readable = shard_state_readable_append_chunks(ss, sink, metrics);
+  // An asynchronous sink owns the publication dependency. The producer only
+  // snapshots the finalized extent; workers publish it after its writes land.
+  // Keep fence_pending truthful for any later synchronous readable query.
+  const int queued = sink->update_append_after && sink->flush;
+  const uint64_t readable =
+    queued ? ss->finalized_append_chunks
+           : shard_state_readable_append_chunks(ss, sink, metrics);
   uint64_t append_sizes[HALF_MAX_RANK];
   if (cursor_elements)
     dim_info_readable_append_sizes(
       dims, readable, *cursor_elements, level, append_sizes);
   else
     dim_info_decompose_append_sizes(dims, readable, append_sizes);
+  if (queued)
+    return sink->update_append_after(
+      sink,
+      level,
+      dim_info_n_append(dims),
+      append_sizes,
+      ss->fence_pending ? ss->finalized_fence : (struct io_event){ 0 });
   return sink->update_append(
     sink, level, dim_info_n_append(dims), append_sizes);
 }

--- a/src/zarr/shard_delivery.h
+++ b/src/zarr/shard_delivery.h
@@ -78,6 +78,13 @@ shard_state_destroy(struct shard_state* ss);
 size_t
 shard_state_heap_bytes(const struct level_layout_info* li);
 
+// A new stream advertises no appended data, independently of its configured
+// capacity. Called once during creation, before any array accepts input.
+int
+shard_sink_init_append(struct shard_sink* sink,
+                       const struct dim_info* dims,
+                       int nlod);
+
 // A reader can safely see up to this append-dim extent. The last finalize's
 // writes are waited on, and they have normally landed already. Pass metrics to
 // time that wait, or NULL.
@@ -86,7 +93,10 @@ shard_state_readable_append_chunks(struct shard_state* ss,
                                    struct shard_sink* sink,
                                    struct stream_metrics* metrics);
 
-// Publish one level's append extent through the sink. Pass cursor_elements to
+// Publish one level's append extent through the sink. Sinks supporting queued
+// publication snapshot the metadata now and publish only after the finalized
+// fence succeeds; other sinks wait here. Final close drains queued metadata.
+// Pass cursor_elements to
 // hold the extent down to what the caller appended, or NULL where the cursor
 // belongs to another thread. Returns non-zero if the sink rejected the update.
 //

--- a/src/zarr/shard_delivery.h
+++ b/src/zarr/shard_delivery.h
@@ -94,11 +94,11 @@ shard_state_readable_append_chunks(struct shard_state* ss,
                                    struct stream_metrics* metrics);
 
 // Publish one level's append extent through the sink. Sinks supporting queued
-// publication snapshot the metadata now and publish only after the finalized
-// fence succeeds; other sinks wait here. Final close drains queued metadata.
-// Pass cursor_elements to
-// hold the extent down to what the caller appended, or NULL where the cursor
-// belongs to another thread. Returns non-zero if the sink rejected the update.
+// publication snapshot the metadata now and publish after prior writes finish
+// successfully; other sinks wait here. Final close drains queued metadata.
+// Pass cursor_elements to hold the extent down to what the caller appended,
+// or NULL where the cursor belongs to another thread. Returns non-zero if the
+// sink rejected the update.
 //
 // The extent names only closed-out shards, so it stays truthful after a failed
 // flush, and is the only way a reader learns of shards written since the last

--- a/src/zarr/shard_pool.h
+++ b/src/zarr/shard_pool.h
@@ -22,6 +22,16 @@ struct shard_pool
   // Block until all I/O up to ev has completed.
   void (*wait_fence)(struct shard_pool* self, struct io_event ev);
 
+  // Optional metadata publication. Copies key/data before returning and
+  // atomically replaces the key after the dependency completes successfully.
+  // Updates are ordered within the pool. Errors are sticky and flush waits
+  // for these jobs as well as shard writes. NULL means synchronous-only.
+  int (*put_after)(struct shard_pool* self,
+                   const char* key,
+                   const void* data,
+                   size_t len,
+                   struct io_event after);
+
   // Wait for all pending I/O to complete. Returns non-zero on error.
   int (*flush)(struct shard_pool* self);
 

--- a/src/zarr/shard_pool.h
+++ b/src/zarr/shard_pool.h
@@ -23,14 +23,13 @@ struct shard_pool
   void (*wait_fence)(struct shard_pool* self, struct io_event ev);
 
   // Optional metadata publication. Copies key/data before returning and
-  // atomically replaces the key after the dependency completes successfully.
-  // Updates are ordered within the pool. Errors are sticky and flush waits
-  // for these jobs as well as shard writes. NULL means synchronous-only.
-  int (*put_after)(struct shard_pool* self,
-                   const char* key,
-                   const void* data,
-                   size_t len,
-                   struct io_event after);
+  // atomically replaces the key after all previously accepted IO succeeds.
+  // Queue insertion after backpressure defines the order. Errors are sticky
+  // and flush waits for metadata as well as shard writes. NULL = synchronous.
+  int (*queue_metadata)(struct shard_pool* self,
+                        const char* key,
+                        const void* data,
+                        size_t len);
 
   // Wait for all pending I/O to complete. Returns non-zero on error.
   int (*flush)(struct shard_pool* self);

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -21,7 +21,6 @@ struct shard_pool_fs
   struct shard_pool base;
   struct io_backend_fs* backend;
   struct io_scheduler* queue;
-  struct platform_mutex* metadata_mutex;
   struct fs_slot* slots;
   uint64_t nslots;
   int unbuffered;
@@ -266,11 +265,10 @@ pool_fs_wait_fence(struct shard_pool* self, struct io_event ev)
 }
 
 static int
-pool_fs_put_after(struct shard_pool* self,
-                  const char* key,
-                  const void* data,
-                  size_t len,
-                  struct io_event after)
+pool_fs_queue_metadata(struct shard_pool* self,
+                       const char* key,
+                       const void* data,
+                       size_t len)
 {
   struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
   struct strbuf path = { 0 };
@@ -286,29 +284,19 @@ pool_fs_put_after(struct shard_pool* self,
   if (len)
     memcpy(owned + path_bytes, data, len);
 
-  // Taking the current prefix under the posting lock also orders this update
-  // after earlier metadata updates. Later shard writes can still run while
-  // this request waits, and no worker parks on a prerequisite.
-  platform_mutex_lock(p->metadata_mutex);
-  const struct io_event prefix = io_scheduler_record(p->queue);
-  CHECK(Unlock, after.seq <= prefix.seq);
-  CHECK(Unlock,
+  CHECK(Fail,
         io_scheduler_post(p->queue,
                           (struct io_request){
                             .op = IO_OP_REPLACE,
                             .path = owned,
                             .payload = owned + path_bytes,
                             .nbytes = len,
-                            .after_seq = prefix.seq,
                             .owned = owned,
                             .owned_free = free,
                           }) == 0);
-  platform_mutex_unlock(p->metadata_mutex);
   strbuf_free(&path);
   return 0;
 
-Unlock:
-  platform_mutex_unlock(p->metadata_mutex);
 Fail:
   atomic_store(&p->io_error, 1);
   free(owned);
@@ -363,7 +351,6 @@ pool_fs_destroy(struct shard_pool* self)
   // The worker has to be gone before the backend holding its descriptors is.
   io_scheduler_destroy(p->queue);
   io_backend_fs_destroy(p->backend);
-  platform_mutex_free(p->metadata_mutex);
 
   free(p->slots);
   strbuf_free(&p->root);
@@ -417,7 +404,7 @@ shard_pool_fs_create_wrapped(const char* root,
   p->base.open = pool_fs_open;
   p->base.record_fence = pool_fs_record_fence;
   p->base.wait_fence = pool_fs_wait_fence;
-  p->base.put_after = pool_fs_put_after;
+  p->base.queue_metadata = pool_fs_queue_metadata;
   p->base.flush = pool_fs_flush;
   p->base.has_error = pool_fs_has_error;
   p->base.pending_bytes = pool_fs_pending_bytes;
@@ -425,8 +412,6 @@ shard_pool_fs_create_wrapped(const char* root,
   p->base.destroy = pool_fs_destroy;
   p->nslots = nslots;
   p->unbuffered = unbuffered;
-  p->metadata_mutex = platform_mutex_new();
-  CHECK(Fail_alloc, p->metadata_mutex);
   CHECK(Fail_alloc, strbuf_set(&p->root, root) == 0);
 
   p->backend = io_backend_fs_create(&p->io_error,
@@ -468,7 +453,6 @@ Fail_queue:
 Fail_backend:
   io_backend_fs_destroy(p->backend);
 Fail_alloc:
-  platform_mutex_free(p->metadata_mutex);
   strbuf_free(&p->root);
   free(p);
 Fail:

--- a/src/zarr/shard_pool_fs.c
+++ b/src/zarr/shard_pool_fs.c
@@ -21,6 +21,7 @@ struct shard_pool_fs
   struct shard_pool base;
   struct io_backend_fs* backend;
   struct io_scheduler* queue;
+  struct platform_mutex* metadata_mutex;
   struct fs_slot* slots;
   uint64_t nslots;
   int unbuffered;
@@ -265,6 +266,57 @@ pool_fs_wait_fence(struct shard_pool* self, struct io_event ev)
 }
 
 static int
+pool_fs_put_after(struct shard_pool* self,
+                  const char* key,
+                  const void* data,
+                  size_t len,
+                  struct io_event after)
+{
+  struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
+  struct strbuf path = { 0 };
+  char* owned = NULL;
+  CHECK(Fail, key && (data || len == 0));
+  CHECK(Fail, !atomic_load(&p->io_error));
+  CHECK(Fail, strbuf_appendf(&path, "%s/%s", strbuf_cstr(&p->root), key) == 0);
+  const size_t path_bytes = strbuf_len(&path) + 1;
+  CHECK(Fail, len <= SIZE_MAX - path_bytes);
+  owned = (char*)malloc(path_bytes + len);
+  CHECK(Fail, owned);
+  memcpy(owned, strbuf_cstr(&path), path_bytes);
+  if (len)
+    memcpy(owned + path_bytes, data, len);
+
+  // Taking the current prefix under the posting lock also orders this update
+  // after earlier metadata updates. Later shard writes can still run while
+  // this request waits, and no worker parks on a prerequisite.
+  platform_mutex_lock(p->metadata_mutex);
+  const struct io_event prefix = io_scheduler_record(p->queue);
+  CHECK(Unlock, after.seq <= prefix.seq);
+  CHECK(Unlock,
+        io_scheduler_post(p->queue,
+                          (struct io_request){
+                            .op = IO_OP_REPLACE,
+                            .path = owned,
+                            .payload = owned + path_bytes,
+                            .nbytes = len,
+                            .after_seq = prefix.seq,
+                            .owned = owned,
+                            .owned_free = free,
+                          }) == 0);
+  platform_mutex_unlock(p->metadata_mutex);
+  strbuf_free(&path);
+  return 0;
+
+Unlock:
+  platform_mutex_unlock(p->metadata_mutex);
+Fail:
+  atomic_store(&p->io_error, 1);
+  free(owned);
+  strbuf_free(&path);
+  return 1;
+}
+
+static int
 pool_fs_flush(struct shard_pool* self)
 {
   struct shard_pool_fs* p = container_of(self, struct shard_pool_fs, base);
@@ -311,6 +363,7 @@ pool_fs_destroy(struct shard_pool* self)
   // The worker has to be gone before the backend holding its descriptors is.
   io_scheduler_destroy(p->queue);
   io_backend_fs_destroy(p->backend);
+  platform_mutex_free(p->metadata_mutex);
 
   free(p->slots);
   strbuf_free(&p->root);
@@ -364,6 +417,7 @@ shard_pool_fs_create_wrapped(const char* root,
   p->base.open = pool_fs_open;
   p->base.record_fence = pool_fs_record_fence;
   p->base.wait_fence = pool_fs_wait_fence;
+  p->base.put_after = pool_fs_put_after;
   p->base.flush = pool_fs_flush;
   p->base.has_error = pool_fs_has_error;
   p->base.pending_bytes = pool_fs_pending_bytes;
@@ -371,6 +425,8 @@ shard_pool_fs_create_wrapped(const char* root,
   p->base.destroy = pool_fs_destroy;
   p->nslots = nslots;
   p->unbuffered = unbuffered;
+  p->metadata_mutex = platform_mutex_new();
+  CHECK(Fail_alloc, p->metadata_mutex);
   CHECK(Fail_alloc, strbuf_set(&p->root, root) == 0);
 
   p->backend = io_backend_fs_create(&p->io_error,
@@ -412,6 +468,7 @@ Fail_queue:
 Fail_backend:
   io_backend_fs_destroy(p->backend);
 Fail_alloc:
+  platform_mutex_free(p->metadata_mutex);
   strbuf_free(&p->root);
   free(p);
 Fail:

--- a/src/zarr/store_fs.c
+++ b/src/zarr/store_fs.c
@@ -1,8 +1,8 @@
 #include "zarr/store_fs.h"
-#include "platform/platform.h"
 #include "platform/platform_io.h"
 #include "util/prelude.h"
 #include "util/strbuf.h"
+#include "zarr/io_backend.fs.h"
 #include "zarr/shard_pool_fs.h"
 
 #include <stdlib.h>
@@ -22,44 +22,14 @@ fs_join(const struct store_fs* fs, const char* key, struct strbuf* out)
   return strbuf_appendf(out, "%s/%s", strbuf_cstr(&fs->root), key);
 }
 
-// Written to a sibling temporary file and renamed into place, so a reader
-// opening the key while a stream is running sees either the whole previous
-// contents or the whole new ones, never a truncated or half-written file.
-// Not flushed to the device first: shard data is not flushed either, so
-// forcing the metadata out would cost a journal commit mid-stream to make it
-// outlive the data it describes.
 static int
 fs_put(struct store* self, const char* key, const void* data, size_t len)
 {
   struct store_fs* fs = container_of(self, struct store_fs, base);
   struct strbuf path = { 0 };
-  struct strbuf tmp_path = { 0 };
-  int rc = 1;
-  if (fs_join(fs, key, &path))
-    goto done;
-
-  // The process id keeps two writers sharing a directory off the same
-  // temporary name, where each would otherwise rename the other's
-  // half-written file over the key.
-  if (strbuf_appendf(&tmp_path,
-                     "%s.tmp.%llu",
-                     strbuf_cstr(&path),
-                     (unsigned long long)platform_process_id()))
-    goto done;
-
-  platform_fd fd = platform_open_write(strbuf_cstr(&tmp_path), 0);
-  if (fd == PLATFORM_FD_INVALID)
-    goto done;
-  int written = platform_write(fd, data, len) == 0;
-  platform_close(fd);
-
-  if (written &&
-      platform_rename_replace(strbuf_cstr(&tmp_path), strbuf_cstr(&path)) == 0)
-    rc = 0;
-  else
-    platform_remove_file(strbuf_cstr(&tmp_path));
-done:
-  strbuf_free(&tmp_path);
+  int rc = fs_join(fs, key, &path);
+  if (rc == 0)
+    rc = io_backend_fs_replace(strbuf_cstr(&path), data, len);
   strbuf_free(&path);
   return rc;
 }

--- a/src/zarr/store_fs.h
+++ b/src/zarr/store_fs.h
@@ -5,6 +5,8 @@
 
 // Create a filesystem store rooted at the given directory.
 // unbuffered: use O_DIRECT / FILE_FLAG_NO_BUFFERING for shard pool writers.
+// Metadata writes create missing parent directories and atomically replace
+// files for readers. They remain buffered and do not add fsync.
 // Returns NULL on error.
 struct store*
 store_fs_create(const char* root, int unbuffered);

--- a/src/zarr/zarr_array.c
+++ b/src/zarr/zarr_array.c
@@ -5,6 +5,7 @@
 #include "util/prelude.h"
 #include "util/strbuf.h"
 #include "zarr/attr_set.h"
+#include "zarr/metadata_io.h"
 #include "zarr/zarr_metadata.h"
 
 #include <stdlib.h>
@@ -36,24 +37,10 @@ struct zarr_array
 // --- Metadata writing ---
 
 static int
-write_array_metadata(struct zarr_array* a, int queued)
+submit_array_metadata(struct zarr_array* a)
 {
-  struct strbuf key = { 0 };
   struct strbuf json = { 0 };
   int rc = 1;
-
-  // A synchronous rewrite must not be overwritten by an older queued
-  // snapshot. Failed IO must not expose the newer shape either.
-  if (!queued && a->pool->queue_metadata && a->pool->flush(a->pool))
-    goto done;
-
-  if (strbuf_len(&a->prefix) > 0) {
-    if (strbuf_appendf(&key, "%s/zarr.json", strbuf_cstr(&a->prefix)))
-      goto done;
-  } else {
-    if (strbuf_append_cstr(&key, "zarr.json"))
-      goto done;
-  }
 
   if (zarr_array_json(&json,
                       a->rank,
@@ -65,17 +52,11 @@ write_array_metadata(struct zarr_array* a, int queued)
                       &a->attrs))
     goto done;
 
-  if (queued)
-    rc = a->pool->queue_metadata(
-      a->pool, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
-  else
-    rc = a->store->put(
-      a->store, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
+  rc = zarr_metadata_submit(a->store, a->pool, strbuf_cstr(&a->prefix), &json);
   if (rc == 0)
     a->attrs.dirty = 0;
 
 done:
-  strbuf_free(&key);
   strbuf_free(&json);
   return rc;
 }
@@ -111,11 +92,10 @@ zarr_array_open(struct shard_sink* self, uint8_t level, uint64_t shard_index)
   return w;
 }
 
-static int
-update_append(struct zarr_array* a,
-              uint8_t n_append,
-              const uint64_t* append_sizes,
-              int queued)
+int
+zarr_array_submit_append(struct zarr_array* a,
+                         uint8_t n_append,
+                         const uint64_t* append_sizes)
 {
   if (n_append == 0 || n_append > a->rank || !append_sizes)
     return 1;
@@ -127,11 +107,8 @@ update_append(struct zarr_array* a,
       break;
     }
   }
-  if (!changed) {
-    // dimensions includes accepted snapshots that may still be queued.
-    // Keep update_append's synchronous visibility contract on this path.
-    return !queued && a->pool->queue_metadata ? a->pool->flush(a->pool) : 0;
-  }
+  if (!changed)
+    return 0;
 
   uint64_t old_sizes[MAX_ZARR_RANK];
   for (uint8_t d = 0; d < n_append; ++d) {
@@ -139,7 +116,7 @@ update_append(struct zarr_array* a,
     a->dimensions[d].size = append_sizes[d];
   }
 
-  if (write_array_metadata(a, queued)) {
+  if (submit_array_metadata(a)) {
     for (uint8_t d = 0; d < n_append; ++d)
       a->dimensions[d].size = old_sizes[d];
     log_error("zarr_array: failed to rewrite zarr.json for %s",
@@ -157,7 +134,10 @@ zarr_array_update_append(struct shard_sink* self,
 {
   (void)level;
   struct zarr_array* a = container_of(self, struct zarr_array, base);
-  return update_append(a, n_append, append_sizes, 0);
+  int rc = zarr_array_submit_append(a, n_append, append_sizes);
+  // Even an unchanged shape may refer to a snapshot still in the queue.
+  rc |= zarr_metadata_wait(a->pool);
+  return rc;
 }
 
 static int
@@ -170,7 +150,7 @@ zarr_array_queue_append(struct shard_sink* self,
   struct zarr_array* a = container_of(self, struct zarr_array, base);
   // Serialize while dimensions, attributes and prefix are stable. The pool
   // copies the resulting key and bytes; workers never borrow array state.
-  return update_append(a, n_append, append_sizes, 1);
+  return zarr_array_submit_append(a, n_append, append_sizes);
 }
 
 static struct io_event
@@ -260,8 +240,10 @@ zarr_array_init(struct store* store,
   a->base.pending_bytes = zarr_array_pending_bytes_fn;
   a->base.required_shard_alignment = zarr_array_required_shard_alignment_fn;
 
-  // Write array zarr.json
-  CHECK(Fail_alloc, write_array_metadata(a, 0) == 0);
+  // Creation returns only after the initial metadata is visible.
+  int rc = submit_array_metadata(a);
+  rc |= zarr_metadata_wait(pool);
+  CHECK(Fail_alloc, rc == 0);
 
   return a;
 
@@ -398,9 +380,9 @@ int
 zarr_array_flush_metadata(struct zarr_array* a)
 {
   CHECK(Fail, a);
-  if (!a->attrs.dirty)
-    return a->pool->queue_metadata ? a->pool->flush(a->pool) : 0;
-  return write_array_metadata(a, 0);
+  int rc = a->attrs.dirty ? submit_array_metadata(a) : 0;
+  rc |= zarr_metadata_wait(a->pool);
+  return rc;
 Fail:
   return 1;
 }

--- a/src/zarr/zarr_array.c
+++ b/src/zarr/zarr_array.c
@@ -36,15 +36,15 @@ struct zarr_array
 // --- Metadata writing ---
 
 static int
-write_array_metadata(struct zarr_array* a, const struct io_event* after)
+write_array_metadata(struct zarr_array* a, int queued)
 {
   struct strbuf key = { 0 };
   struct strbuf json = { 0 };
   int rc = 1;
 
   // A synchronous rewrite must not be overwritten by an older queued
-  // snapshot. A failed dependency must not expose the newer shape either.
-  if (!after && a->pool->put_after && a->pool->flush(a->pool))
+  // snapshot. Failed IO must not expose the newer shape either.
+  if (!queued && a->pool->queue_metadata && a->pool->flush(a->pool))
     goto done;
 
   if (strbuf_len(&a->prefix) > 0) {
@@ -65,12 +65,9 @@ write_array_metadata(struct zarr_array* a, const struct io_event* after)
                       &a->attrs))
     goto done;
 
-  if (after)
-    rc = a->pool->put_after(a->pool,
-                            strbuf_cstr(&key),
-                            strbuf_cstr(&json),
-                            strbuf_len(&json),
-                            *after);
+  if (queued)
+    rc = a->pool->queue_metadata(
+      a->pool, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
   else
     rc = a->store->put(
       a->store, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
@@ -118,7 +115,7 @@ static int
 update_append(struct zarr_array* a,
               uint8_t n_append,
               const uint64_t* append_sizes,
-              const struct io_event* after)
+              int queued)
 {
   if (n_append == 0 || n_append > a->rank || !append_sizes)
     return 1;
@@ -133,7 +130,7 @@ update_append(struct zarr_array* a,
   if (!changed) {
     // dimensions includes accepted snapshots that may still be queued.
     // Keep update_append's synchronous visibility contract on this path.
-    return !after && a->pool->put_after ? a->pool->flush(a->pool) : 0;
+    return !queued && a->pool->queue_metadata ? a->pool->flush(a->pool) : 0;
   }
 
   uint64_t old_sizes[MAX_ZARR_RANK];
@@ -142,7 +139,7 @@ update_append(struct zarr_array* a,
     a->dimensions[d].size = append_sizes[d];
   }
 
-  if (write_array_metadata(a, after)) {
+  if (write_array_metadata(a, queued)) {
     for (uint8_t d = 0; d < n_append; ++d)
       a->dimensions[d].size = old_sizes[d];
     log_error("zarr_array: failed to rewrite zarr.json for %s",
@@ -160,21 +157,20 @@ zarr_array_update_append(struct shard_sink* self,
 {
   (void)level;
   struct zarr_array* a = container_of(self, struct zarr_array, base);
-  return update_append(a, n_append, append_sizes, NULL);
+  return update_append(a, n_append, append_sizes, 0);
 }
 
 static int
-zarr_array_update_append_after(struct shard_sink* self,
-                               uint8_t level,
-                               uint8_t n_append,
-                               const uint64_t* append_sizes,
-                               struct io_event after)
+zarr_array_queue_append(struct shard_sink* self,
+                        uint8_t level,
+                        uint8_t n_append,
+                        const uint64_t* append_sizes)
 {
   (void)level;
   struct zarr_array* a = container_of(self, struct zarr_array, base);
   // Serialize while dimensions, attributes and prefix are stable. The pool
   // copies the resulting key and bytes; workers never borrow array state.
-  return update_append(a, n_append, append_sizes, &after);
+  return update_append(a, n_append, append_sizes, 1);
 }
 
 static struct io_event
@@ -256,8 +252,7 @@ zarr_array_init(struct store* store,
 
   a->base.open = zarr_array_open;
   a->base.update_append = zarr_array_update_append;
-  a->base.update_append_after =
-    pool->put_after ? zarr_array_update_append_after : NULL;
+  a->base.queue_append = pool->queue_metadata ? zarr_array_queue_append : NULL;
   a->base.record_fence = zarr_array_record_fence_fn;
   a->base.wait_fence = zarr_array_wait_fence_fn;
   a->base.flush = zarr_array_flush_fn;
@@ -266,7 +261,7 @@ zarr_array_init(struct store* store,
   a->base.required_shard_alignment = zarr_array_required_shard_alignment_fn;
 
   // Write array zarr.json
-  CHECK(Fail_alloc, write_array_metadata(a, NULL) == 0);
+  CHECK(Fail_alloc, write_array_metadata(a, 0) == 0);
 
   return a;
 
@@ -404,8 +399,8 @@ zarr_array_flush_metadata(struct zarr_array* a)
 {
   CHECK(Fail, a);
   if (!a->attrs.dirty)
-    return a->pool->put_after ? a->pool->flush(a->pool) : 0;
-  return write_array_metadata(a, NULL);
+    return a->pool->queue_metadata ? a->pool->flush(a->pool) : 0;
+  return write_array_metadata(a, 0);
 Fail:
   return 1;
 }

--- a/src/zarr/zarr_array.c
+++ b/src/zarr/zarr_array.c
@@ -36,11 +36,16 @@ struct zarr_array
 // --- Metadata writing ---
 
 static int
-write_array_metadata(struct zarr_array* a)
+write_array_metadata(struct zarr_array* a, const struct io_event* after)
 {
   struct strbuf key = { 0 };
   struct strbuf json = { 0 };
   int rc = 1;
+
+  // A synchronous rewrite must not be overwritten by an older queued
+  // snapshot. A failed dependency must not expose the newer shape either.
+  if (!after && a->pool->put_after && a->pool->flush(a->pool))
+    goto done;
 
   if (strbuf_len(&a->prefix) > 0) {
     if (strbuf_appendf(&key, "%s/zarr.json", strbuf_cstr(&a->prefix)))
@@ -60,8 +65,15 @@ write_array_metadata(struct zarr_array* a)
                       &a->attrs))
     goto done;
 
-  rc = a->store->put(
-    a->store, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
+  if (after)
+    rc = a->pool->put_after(a->pool,
+                            strbuf_cstr(&key),
+                            strbuf_cstr(&json),
+                            strbuf_len(&json),
+                            *after);
+  else
+    rc = a->store->put(
+      a->store, strbuf_cstr(&key), strbuf_cstr(&json), strbuf_len(&json));
   if (rc == 0)
     a->attrs.dirty = 0;
 
@@ -103,14 +115,12 @@ zarr_array_open(struct shard_sink* self, uint8_t level, uint64_t shard_index)
 }
 
 static int
-zarr_array_update_append(struct shard_sink* self,
-                         uint8_t level,
-                         uint8_t n_append,
-                         const uint64_t* append_sizes)
+update_append(struct zarr_array* a,
+              uint8_t n_append,
+              const uint64_t* append_sizes,
+              const struct io_event* after)
 {
-  (void)level;
-  struct zarr_array* a = container_of(self, struct zarr_array, base);
-  if (n_append == 0 || n_append > a->rank)
+  if (n_append == 0 || n_append > a->rank || !append_sizes)
     return 1;
 
   int changed = 0;
@@ -120,18 +130,51 @@ zarr_array_update_append(struct shard_sink* self,
       break;
     }
   }
-  if (!changed)
-    return 0;
+  if (!changed) {
+    // dimensions includes accepted snapshots that may still be queued.
+    // Keep update_append's synchronous visibility contract on this path.
+    return !after && a->pool->put_after ? a->pool->flush(a->pool) : 0;
+  }
 
-  for (uint8_t d = 0; d < n_append; ++d)
+  uint64_t old_sizes[MAX_ZARR_RANK];
+  for (uint8_t d = 0; d < n_append; ++d) {
+    old_sizes[d] = a->dimensions[d].size;
     a->dimensions[d].size = append_sizes[d];
+  }
 
-  if (write_array_metadata(a)) {
+  if (write_array_metadata(a, after)) {
+    for (uint8_t d = 0; d < n_append; ++d)
+      a->dimensions[d].size = old_sizes[d];
     log_error("zarr_array: failed to rewrite zarr.json for %s",
               strbuf_cstr(&a->prefix));
     return 1;
   }
   return 0;
+}
+
+static int
+zarr_array_update_append(struct shard_sink* self,
+                         uint8_t level,
+                         uint8_t n_append,
+                         const uint64_t* append_sizes)
+{
+  (void)level;
+  struct zarr_array* a = container_of(self, struct zarr_array, base);
+  return update_append(a, n_append, append_sizes, NULL);
+}
+
+static int
+zarr_array_update_append_after(struct shard_sink* self,
+                               uint8_t level,
+                               uint8_t n_append,
+                               const uint64_t* append_sizes,
+                               struct io_event after)
+{
+  (void)level;
+  struct zarr_array* a = container_of(self, struct zarr_array, base);
+  // Serialize while dimensions, attributes and prefix are stable. The pool
+  // copies the resulting key and bytes; workers never borrow array state.
+  return update_append(a, n_append, append_sizes, &after);
 }
 
 static struct io_event
@@ -173,9 +216,7 @@ static int
 zarr_array_flush_fn(struct shard_sink* self)
 {
   struct zarr_array* a = container_of(self, struct zarr_array, base);
-  if (!a->attrs.dirty)
-    return 0;
-  return write_array_metadata(a);
+  return zarr_array_flush_metadata(a);
 }
 
 // --- Core init (geometry already computed) ---
@@ -215,6 +256,8 @@ zarr_array_init(struct store* store,
 
   a->base.open = zarr_array_open;
   a->base.update_append = zarr_array_update_append;
+  a->base.update_append_after =
+    pool->put_after ? zarr_array_update_append_after : NULL;
   a->base.record_fence = zarr_array_record_fence_fn;
   a->base.wait_fence = zarr_array_wait_fence_fn;
   a->base.flush = zarr_array_flush_fn;
@@ -223,7 +266,7 @@ zarr_array_init(struct store* store,
   a->base.required_shard_alignment = zarr_array_required_shard_alignment_fn;
 
   // Write array zarr.json
-  CHECK(Fail_alloc, write_array_metadata(a) == 0);
+  CHECK(Fail_alloc, write_array_metadata(a, NULL) == 0);
 
   return a;
 
@@ -301,7 +344,7 @@ zarr_array_destroy(struct zarr_array* a)
     return;
   // Fallback for callers that didn't flush via the writer/sink — same shape
   // as the auto-flush log in stream destroys.
-  if (a->attrs.dirty && write_array_metadata(a))
+  if (zarr_array_flush_metadata(a))
     log_error("zarr_array: metadata flush failed during destroy");
   attr_set_destroy(&a->attrs);
   dims_free_names(a->dimensions, a->rank);
@@ -361,8 +404,8 @@ zarr_array_flush_metadata(struct zarr_array* a)
 {
   CHECK(Fail, a);
   if (!a->attrs.dirty)
-    return 0;
-  return write_array_metadata(a);
+    return a->pool->put_after ? a->pool->flush(a->pool) : 0;
+  return write_array_metadata(a, NULL);
 Fail:
   return 1;
 }

--- a/src/zarr/zarr_array.h
+++ b/src/zarr/zarr_array.h
@@ -17,6 +17,15 @@ zarr_array_create_with_pool(struct store* store,
                             const char* prefix,
                             const struct zarr_array_config* cfg);
 
+// Submit an append-shape snapshot without waiting for queued IO. Used by NGFF
+// to submit the child and group before one shared zarr_metadata_wait. Immediate
+// rejection restores dimensions; accepted snapshots remain the current state
+// even if completion later fails. Non-queue pools complete synchronously.
+int
+zarr_array_submit_append(struct zarr_array* a,
+                         uint8_t n_append,
+                         const uint64_t* append_sizes);
+
 // Private: force the array's zarr.json to be rewritten now with current shape
 // and buffered attributes. Production callers go through writer_close, which
 // drives the sink-level flush hook; this remains exposed for low-level tests

--- a/src/zarr/zarr_group.c
+++ b/src/zarr/zarr_group.c
@@ -4,26 +4,25 @@
 #include "zarr.h"
 #include "zarr/attr_set.h"
 #include "zarr/json_writer.h"
+#include "zarr/metadata_io.h"
 #include "zarr/zarr_metadata.h"
 
 #include <stdlib.h>
 
 int
-zarr_group_write_with_raw_attrs(struct store* store,
-                                const char* key,
-                                const char* attributes_json)
+zarr_group_submit(struct store* store,
+                  struct shard_pool* pool,
+                  const char* prefix,
+                  const char* attributes_json)
 {
   CHECK(Fail, store);
-  CHECK(Fail, key);
+  CHECK(Fail, prefix);
   CHECK(Fail, attributes_json);
 
   struct strbuf buf = { 0 };
-  int rc = strbuf_appendf(&buf,
-                          "{\"zarr_format\":3,\"node_type\":\"group\","
-                          "\"consolidated_metadata\":null,\"attributes\":%s}",
-                          attributes_json);
+  int rc = zarr_group_json(&buf, attributes_json);
   if (rc == 0)
-    rc = store->put(store, key, strbuf_cstr(&buf), strbuf_len(&buf));
+    rc = zarr_metadata_submit(store, pool, prefix, &buf);
   strbuf_free(&buf);
   return rc;
 
@@ -35,43 +34,34 @@ Fail:
 
 struct zarr_group
 {
-  struct store* store; // borrowed
-  struct strbuf key;   // owned
+  struct store* store;  // borrowed
+  struct strbuf prefix; // owned
   struct attr_set attrs;
 };
 
 static int
 zarr_group_write(struct zarr_group* g)
 {
-  struct strbuf json = { 0 };
+  struct strbuf attrs = { 0 };
   int rc = 1;
 
   struct json_writer jw;
-  jw_init(&jw, &json);
+  jw_init(&jw, &attrs);
 
   jw_object_begin(&jw);
-  jw_key(&jw, "zarr_format");
-  jw_int(&jw, 3);
-  jw_key(&jw, "node_type");
-  jw_string(&jw, "group");
-  jw_key(&jw, "consolidated_metadata");
-  jw_null(&jw);
-  jw_key(&jw, "attributes");
-  jw_object_begin(&jw);
   attr_set_emit(&g->attrs, &jw);
-  jw_object_end(&jw);
   jw_object_end(&jw);
 
   if (jw_error(&jw))
     goto done;
 
-  rc = g->store->put(
-    g->store, strbuf_cstr(&g->key), strbuf_cstr(&json), strbuf_len(&json));
+  rc = zarr_group_submit(
+    g->store, NULL, strbuf_cstr(&g->prefix), strbuf_cstr(&attrs));
   if (rc == 0)
     g->attrs.dirty = 0;
 
 done:
-  strbuf_free(&json);
+  strbuf_free(&attrs);
   return rc;
 }
 
@@ -85,11 +75,10 @@ zarr_group_create(struct store* store, const char* key)
   CHECK(Fail, g);
   g->store = store;
   attr_set_init(&g->attrs);
-  int rc = (key[0]) ? strbuf_appendf(&g->key, "%s/zarr.json", key)
-                    : strbuf_append_cstr(&g->key, "zarr.json");
+  int rc = strbuf_set(&g->prefix, key);
   if (rc || zarr_group_write(g) != 0) {
     attr_set_destroy(&g->attrs);
-    strbuf_free(&g->key);
+    strbuf_free(&g->prefix);
     free(g);
     return NULL;
   }
@@ -107,7 +96,7 @@ zarr_group_destroy(struct zarr_group* g)
   if (g->attrs.dirty)
     zarr_group_write(g);
   attr_set_destroy(&g->attrs);
-  strbuf_free(&g->key);
+  strbuf_free(&g->prefix);
   free(g);
 }
 

--- a/src/zarr/zarr_group.h
+++ b/src/zarr/zarr_group.h
@@ -3,11 +3,12 @@
 
 #include "zarr/store.h"
 
-// Internal: write a zarr v3 group zarr.json at the given key with the supplied
-// raw attributes JSON spliced in. attributes_json must be a valid JSON object
-// text (e.g. produced by hcs_*_attributes_json). Used by HCS plate/well group
-// writers. Returns 0 on success, non-zero on error.
+// Submit a group at prefix using a prevalidated attributes JSON object.
+// A queue-capable pool copies the snapshot; call zarr_metadata_wait for
+// synchronous visibility. NULL/non-queue pools write synchronously via store.
+// Returns 0 when accepted, non-zero on serialization/submission failure.
 int
-zarr_group_write_with_raw_attrs(struct store* store,
-                                const char* key,
-                                const char* attributes_json);
+zarr_group_submit(struct store* store,
+                  struct shard_pool* pool,
+                  const char* prefix,
+                  const char* attributes_json);

--- a/src/zarr/zarr_metadata.c
+++ b/src/zarr/zarr_metadata.c
@@ -34,7 +34,7 @@ dtype_zarr_string(enum dtype dt)
 }
 
 int
-zarr_root_json(struct strbuf* sb)
+zarr_group_json(struct strbuf* sb, const char* attributes_json)
 {
   struct json_writer jw;
   jw_init(&jw, sb);
@@ -47,11 +47,16 @@ zarr_root_json(struct strbuf* sb)
   jw_key(&jw, "consolidated_metadata");
   jw_null(&jw);
   jw_key(&jw, "attributes");
-  jw_object_begin(&jw);
-  jw_object_end(&jw);
+  jw_raw(&jw, attributes_json);
   jw_object_end(&jw);
 
   return jw_error(&jw) ? 1 : 0;
+}
+
+int
+zarr_root_json(struct strbuf* sb)
+{
+  return zarr_group_json(sb, "{}");
 }
 
 int

--- a/src/zarr/zarr_metadata.h
+++ b/src/zarr/zarr_metadata.h
@@ -10,6 +10,11 @@
 
 struct attr_set;
 
+// Append a zarr v3 group envelope around a prevalidated attributes JSON object.
+// Returns 0 on success.
+int
+zarr_group_json(struct strbuf* sb, const char* attributes_json);
+
 // Append zarr v3 root group JSON to sb. Returns 0 on success.
 int
 zarr_root_json(struct strbuf* sb);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,14 @@ add_test_exe(test_host_batch test_host_batch.c
     shard_delivery stream_config test_shard_sink chucky_log
 )
 
+add_gpu_test_exe(test_memcpy_sampling_gpu test_memcpy_sampling_gpu.c
+    LINKS multiarray_gpu stream test_shard_sink test_shard_verify
+          CUDA::cuda_driver CUDA::cudart_static
+)
+if(CHUCKY_ENABLE_GPU)
+    set_tests_properties(test-test_memcpy_sampling_gpu PROPERTIES TIMEOUT 60)
+endif()
+
 # CPU LOD test (no CUDA)
 add_test_exe(test_lod_cpu test_lod_cpu.c lod_cpu compress_cpu morton_util threadpool platform chucky_log)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -233,13 +233,21 @@ set_tests_properties(test-test_pending_bytes_fs PROPERTIES TIMEOUT 60)
 add_test_exe(test_shape_after_flush_cpu test_shape_after_flush_cpu.c stream_cpu test_shard_sink writer chucky_log)
 add_test_exe(test_stall_metrics_cpu test_stall_metrics_cpu.c stream_cpu test_shard_sink writer platform chucky_log)
 add_gpu_test_exe(test_shape_after_flush_gpu test_shape_after_flush_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink writer chucky_log)
-add_test_exe(test_stream_initial_shape_cpu test_stream_initial_shape.c
-    stream_cpu multiarray_cpu test_zarr_helpers test_shard_sink test_platform writer chucky_log)
-add_gpu_test_exe(test_stream_initial_shape_gpu test_stream_initial_shape.c
+add_test_exe(test_stream_publication_cpu test_stream_publication.c
+    stream_cpu multiarray_cpu test_zarr_helpers test_shard_sink test_io_faults
+    test_platform writer chucky_log
+)
+set_tests_properties(test-test_stream_publication_cpu PROPERTIES TIMEOUT 60)
+add_gpu_test_exe(test_stream_publication_gpu test_stream_publication.c
     LINKS CUDA::cuda_driver CUDA::cudart_static stream multiarray_gpu
-          test_zarr_helpers test_shard_sink test_platform writer chucky_log)
+          test_zarr_helpers test_shard_sink test_io_faults test_platform writer chucky_log
+)
 if(CHUCKY_ENABLE_GPU)
-    target_compile_definitions(test_stream_initial_shape_gpu PRIVATE TEST_INITIAL_SHAPE_GPU)
+    target_compile_definitions(
+        test_stream_publication_gpu
+        PRIVATE TEST_STREAM_PUBLICATION_GPU
+    )
+    set_tests_properties(test-test_stream_publication_gpu PROPERTIES TIMEOUT 60)
 endif()
 add_gpu_test_exe(test_multiarray_flush_mock  test_multiarray_flush_mock.c  LINKS CUDA::cuda_driver CUDA::cudart_static multiarray_gpu stream writer chucky_log)
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   test_zarr_helpers store_s3 platform_cmd)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,34 @@ target_link_libraries(
 add_test_lib(test_shard_sink test_shard_sink.c test_shard_sink.h)
 target_link_libraries(test_shard_sink PUBLIC writer)
 
+# A private build of the multiarray constructor lets the publication tests
+# fail its descriptor allocation without replacing the process allocator.
+add_test_lib(test_multiarray_cpu_fault ../src/multiarray/stream.c)
+target_include_directories(
+    test_multiarray_cpu_fault PRIVATE ${PROJECT_SOURCE_DIR}/src
+)
+target_compile_definitions(
+    test_multiarray_cpu_fault PRIVATE CHUCKY_TEST_MULTIARRAY_DESCRIPTOR_ALLOC
+)
+target_link_libraries(
+    test_multiarray_cpu_fault
+    PUBLIC stream_config transpose_cpu pipeline_cpu threadpool
+           dimension shard_delivery chucky_log
+)
+
+add_gpu_test_lib(
+    test_multiarray_gpu_fault ../src/multiarray/stream.gpu.c
+    LINKS stream chucky_log
+)
+if(CHUCKY_ENABLE_GPU)
+    target_include_directories(
+        test_multiarray_gpu_fault PRIVATE ${PROJECT_SOURCE_DIR}/src
+    )
+    target_compile_definitions(
+        test_multiarray_gpu_fault PRIVATE CHUCKY_TEST_MULTIARRAY_DESCRIPTOR_ALLOC
+    )
+endif()
+
 # Test-only counting sink shim (wraps a sink, counts copy vs zero-copy paths)
 add_test_lib(test_counting_sink test_counting_sink.c test_counting_sink.h)
 target_link_libraries(test_counting_sink PUBLIC writer)
@@ -242,12 +270,12 @@ add_test_exe(test_shape_after_flush_cpu test_shape_after_flush_cpu.c stream_cpu 
 add_test_exe(test_stall_metrics_cpu test_stall_metrics_cpu.c stream_cpu test_shard_sink writer platform chucky_log)
 add_gpu_test_exe(test_shape_after_flush_gpu test_shape_after_flush_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink writer chucky_log)
 add_test_exe(test_stream_publication_cpu test_stream_publication.c
-    stream_cpu multiarray_cpu test_zarr_helpers test_shard_sink test_io_faults
+    stream_cpu test_multiarray_cpu_fault test_zarr_helpers test_shard_sink test_io_faults
     test_platform writer chucky_log
 )
 set_tests_properties(test-test_stream_publication_cpu PROPERTIES TIMEOUT 60)
 add_gpu_test_exe(test_stream_publication_gpu test_stream_publication.c
-    LINKS CUDA::cuda_driver CUDA::cudart_static stream multiarray_gpu
+    LINKS CUDA::cuda_driver CUDA::cudart_static stream test_multiarray_gpu_fault
           test_zarr_helpers test_shard_sink test_io_faults test_platform writer chucky_log
 )
 if(CHUCKY_ENABLE_GPU)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,7 +181,7 @@ if(CHUCKY_ENABLE_GPU AND HAVE_BLOSC)
     )
 endif()
 
-add_test_exe(test_json_writer test_json_writer.c zarr_metadata ngff_metadata strbuf chucky_log)
+add_test_exe(test_json_writer test_json_writer.c zarr_metadata ngff_metadata attr_set json_validate strbuf chucky_log)
 add_test_exe(test_bench_memory test_bench_memory.c bench_memory)
 add_test_exe(test_io_scheduler test_io_scheduler.c io_scheduler test_io_backend_fake test_platform chucky_log)
 add_test_exe(test_filesystem_write test_filesystem_write.c filesystem_write chucky_log)
@@ -196,7 +196,7 @@ add_test_exe(test_ngff_attribute test_ngff_attribute.c ngff_multiscale store_fs 
 add_test_exe(test_hcs_attribute test_hcs_attribute.c hcs store_fs store_api test_platform chucky_log)
 add_test_exe(test_zarr_array  test_zarr_array.c  zarr_array zarr_group store_fs store_api test_platform chucky_log)
 add_test_exe(test_ngff_multiscale test_ngff_multiscale.c ngff_multiscale zarr_group store_fs store_api test_platform chucky_log)
-add_test_exe(test_metadata_publication test_metadata_publication.c ngff_multiscale zarr_array shard_delivery store_fs store_api test_platform chucky_log)
+add_test_exe(test_metadata_publication test_metadata_publication.c ngff_multiscale zarr_array shard_delivery store_fs store_api json_validate test_platform chucky_log)
 add_test_exe(test_hcs test_hcs.c hcs store_fs store_api test_platform chucky_log)
 
 # OME-NGFF validation via ome-zarr-models (requires uv)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -196,6 +196,7 @@ add_test_exe(test_ngff_attribute test_ngff_attribute.c ngff_multiscale store_fs 
 add_test_exe(test_hcs_attribute test_hcs_attribute.c hcs store_fs store_api test_platform chucky_log)
 add_test_exe(test_zarr_array  test_zarr_array.c  zarr_array zarr_group store_fs store_api test_platform chucky_log)
 add_test_exe(test_ngff_multiscale test_ngff_multiscale.c ngff_multiscale zarr_group store_fs store_api test_platform chucky_log)
+add_test_exe(test_metadata_publication test_metadata_publication.c ngff_multiscale zarr_array shard_delivery store_fs store_api test_platform chucky_log)
 add_test_exe(test_hcs test_hcs.c hcs store_fs store_api test_platform chucky_log)
 
 # OME-NGFF validation via ome-zarr-models (requires uv)
@@ -232,6 +233,14 @@ set_tests_properties(test-test_pending_bytes_fs PROPERTIES TIMEOUT 60)
 add_test_exe(test_shape_after_flush_cpu test_shape_after_flush_cpu.c stream_cpu test_shard_sink writer chucky_log)
 add_test_exe(test_stall_metrics_cpu test_stall_metrics_cpu.c stream_cpu test_shard_sink writer platform chucky_log)
 add_gpu_test_exe(test_shape_after_flush_gpu test_shape_after_flush_gpu.c LINKS CUDA::cuda_driver CUDA::cudart_static stream test_shard_sink writer chucky_log)
+add_test_exe(test_stream_initial_shape_cpu test_stream_initial_shape.c
+    stream_cpu multiarray_cpu test_zarr_helpers test_shard_sink test_platform writer chucky_log)
+add_gpu_test_exe(test_stream_initial_shape_gpu test_stream_initial_shape.c
+    LINKS CUDA::cuda_driver CUDA::cudart_static stream multiarray_gpu
+          test_zarr_helpers test_shard_sink test_platform writer chucky_log)
+if(CHUCKY_ENABLE_GPU)
+    target_compile_definitions(test_stream_initial_shape_gpu PRIVATE TEST_INITIAL_SHAPE_GPU)
+endif()
 add_gpu_test_exe(test_multiarray_flush_mock  test_multiarray_flush_mock.c  LINKS CUDA::cuda_driver CUDA::cudart_static multiarray_gpu stream writer chucky_log)
 add_test_exe(test_zarr_s3_sink   test_zarr_s3_sink.c   test_zarr_helpers store_s3 platform_cmd)
 add_test_exe(test_store_s3       test_store_s3.c       store_s3 store_api platform_cmd chucky_log)

--- a/tests/test_batch.c
+++ b/tests/test_batch.c
@@ -631,7 +631,7 @@ test_batch_failed_delivery_claims_nothing(void)
            css.update_append_count,
            css.finalize_count);
   CHECK(Fail2, fr.error != 0);
-  CHECK(Fail2, css.update_append_count == 1);
+  CHECK(Fail2, css.update_append_count == 2);
   CHECK(Fail2, css.last_append_size0 == 0);
 
   free(src);

--- a/tests/test_counting_sink.c
+++ b/tests/test_counting_sink.c
@@ -135,15 +135,13 @@ counting_required_shard_alignment(const struct shard_sink* self)
 }
 
 static int
-counting_update_append_after(struct shard_sink* self,
-                             uint8_t level,
-                             uint8_t n_append,
-                             const uint64_t* append_sizes,
-                             struct io_event after)
+counting_queue_append(struct shard_sink* self,
+                      uint8_t level,
+                      uint8_t n_append,
+                      const uint64_t* append_sizes)
 {
   struct counting_sink* s = (struct counting_sink*)self;
-  return s->inner->update_append_after(
-    s->inner, level, n_append, append_sizes, after);
+  return s->inner->queue_append(s->inner, level, n_append, append_sizes);
 }
 
 static int
@@ -160,7 +158,7 @@ counting_sink_init(struct counting_sink* cs, struct shard_sink* inner)
     .base = {
       .open = counting_open,
       .update_append = inner->update_append ? counting_update_append : NULL,
-      .update_append_after = inner->update_append_after ? counting_update_append_after : NULL,
+      .queue_append = inner->queue_append ? counting_queue_append : NULL,
       .flush = inner->flush ? counting_flush : NULL,
       .record_fence = inner->record_fence ? counting_record_fence : NULL,
       .wait_fence = inner->wait_fence ? counting_wait_fence : NULL,

--- a/tests/test_counting_sink.c
+++ b/tests/test_counting_sink.c
@@ -134,6 +134,25 @@ counting_required_shard_alignment(const struct shard_sink* self)
   return cs->inner->required_shard_alignment(cs->inner);
 }
 
+static int
+counting_update_append_after(struct shard_sink* self,
+                             uint8_t level,
+                             uint8_t n_append,
+                             const uint64_t* append_sizes,
+                             struct io_event after)
+{
+  struct counting_sink* s = (struct counting_sink*)self;
+  return s->inner->update_append_after(
+    s->inner, level, n_append, append_sizes, after);
+}
+
+static int
+counting_flush(struct shard_sink* self)
+{
+  struct counting_sink* s = (struct counting_sink*)self;
+  return s->inner->flush(s->inner);
+}
+
 void
 counting_sink_init(struct counting_sink* cs, struct shard_sink* inner)
 {
@@ -141,6 +160,8 @@ counting_sink_init(struct counting_sink* cs, struct shard_sink* inner)
     .base = {
       .open = counting_open,
       .update_append = inner->update_append ? counting_update_append : NULL,
+      .update_append_after = inner->update_append_after ? counting_update_append_after : NULL,
+      .flush = inner->flush ? counting_flush : NULL,
       .record_fence = inner->record_fence ? counting_record_fence : NULL,
       .wait_fence = inner->wait_fence ? counting_wait_fence : NULL,
       .has_error = inner->has_error ? counting_has_error : NULL,

--- a/tests/test_flush_drain_cpu.c
+++ b/tests/test_flush_drain_cpu.c
@@ -15,7 +15,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #define DRAIN_OBSERVE_MS 200
 #define POST_RELEASE_TIMEOUT_MS 5000
@@ -26,133 +25,6 @@ struct flush_args
   _Atomic int done;
   int error;
 };
-
-struct append_args
-{
-  struct writer* w;
-  struct slice input;
-  _Atomic int done;
-  int error;
-};
-
-static void
-append_thread_fn(void* arg)
-{
-  struct append_args* a = (struct append_args*)arg;
-  a->error = writer_append_wait(a->w, a->input).error;
-  atomic_store(&a->done, 1);
-}
-
-static int
-metadata_shape_is(const char* tmpdir, uint64_t frames)
-{
-  char path[4608], expected[96], json[16384];
-  snprintf(path, sizeof(path), "%s/0/zarr.json", tmpdir);
-  snprintf(expected,
-           sizeof(expected),
-           "\"shape\":[%llu,8,8]",
-           (unsigned long long)frames);
-  FILE* f = fopen(path, "rb");
-  if (!f)
-    return 0;
-  size_t n = fread(json, 1, sizeof(json) - 1, f);
-  int ok = !ferror(f) && feof(f);
-  fclose(f);
-  json[n] = '\0';
-  return ok && strstr(json, expected) != NULL;
-}
-
-// A closed generation queues its metadata behind a filesystem fence, without
-// parking append. Releasing that fence must publish even if input stops.
-static int
-test_publication_follows_io(const char* tmpdir, int fail_truncate)
-{
-  struct dimension dims[] = {
-    { .size = 8,
-      .chunk_size = 1,
-      .chunks_per_shard = 2,
-      .name = "t",
-      .storage_position = 0 },
-    { .size = 8,
-      .chunk_size = 8,
-      .chunks_per_shard = 1,
-      .name = "y",
-      .storage_position = 1 },
-    { .size = 8,
-      .chunk_size = 8,
-      .chunks_per_shard = 1,
-      .name = "x",
-      .storage_position = 2 },
-  };
-  struct io_faults faults;
-  struct test_zarr_sink z = { 0 };
-  struct tile_stream_cpu* s = NULL;
-  test_thread* thr = NULL;
-  uint16_t data[2 * 8 * 8] = { 0 };
-  _Atomic int gate = 0;
-  struct append_args a = { 0 };
-  int rc = 1;
-
-  CHECK(Cleanup,
-        test_zarr_sink_open_with_pool(
-          &z,
-          io_faults_store_create(&faults, tmpdir, 1, NULL),
-          "0",
-          dims,
-          3,
-          dtype_u16,
-          (struct codec_config){ .id = CODEC_NONE }) == 0);
-  const struct tile_stream_configuration cfg = {
-    .buffer_capacity_bytes = 4096,
-    .epochs_per_batch = 2,
-    .dtype = dtype_u16,
-    .rank = 3,
-    .dimensions = dims,
-    .codec = { .id = CODEC_NONE },
-    .metadata_update_interval_s = 0,
-    .max_threads = 2,
-  };
-  s = tile_stream_cpu_create(&cfg, test_zarr_sink_as_shard_sink(&z));
-  CHECK(Cleanup, s && metadata_shape_is(tmpdir, 0));
-  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
-  for (int i = 0; i < POST_RELEASE_TIMEOUT_MS && atomic_load(&faults.armed);
-       ++i)
-    platform_sleep_ns(1000000LL);
-  CHECK(Cleanup, atomic_load(&faults.armed) == 0);
-  if (fail_truncate)
-    io_faults_fail_next_truncate(&faults);
-
-  a.w = tile_stream_cpu_writer(s);
-  a.input = (struct slice){ .beg = data, .end = data + 2 * 8 * 8 };
-  CHECK(Cleanup, test_thread_start(&thr, append_thread_fn, &a) == 0);
-  CHECK(Cleanup, test_wait_flag(&a.done, POST_RELEASE_TIMEOUT_MS) == 0);
-  test_thread_join(thr);
-  thr = NULL;
-  CHECK(Cleanup, fail_truncate || a.error == 0);
-  CHECK(Cleanup, atomic_load(&gate) == 0 && metadata_shape_is(tmpdir, 0));
-
-  atomic_store(&gate, 1);
-  if (!fail_truncate) {
-    for (int i = 0;
-         i < POST_RELEASE_TIMEOUT_MS && !metadata_shape_is(tmpdir, 2);
-         ++i)
-      platform_sleep_ns(1000000LL);
-    CHECK(Cleanup, metadata_shape_is(tmpdir, 2));
-  }
-  struct writer_result fr = writer_flush(a.w);
-  struct writer_result cr = writer_close(a.w);
-  CHECK(Cleanup, (fr.error != 0) == fail_truncate);
-  CHECK(Cleanup, (cr.error != 0) == fail_truncate);
-  CHECK(Cleanup, metadata_shape_is(tmpdir, fail_truncate ? 0 : 2));
-  rc = 0;
-
-Cleanup:
-  atomic_store(&gate, 1);
-  test_thread_join(thr);
-  tile_stream_cpu_destroy(s);
-  test_zarr_sink_close(&z);
-  return rc;
-}
 
 static void
 flush_thread_fn(void* arg)
@@ -297,12 +169,6 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/flush_drain_cpu", tmpdir);
     test_mkdir(sub);
     ecode |= test_flush_waits_for_sink_io(sub);
-  }
-  for (int fail = 0; fail < 2; ++fail) {
-    char sub[4200];
-    snprintf(sub, sizeof(sub), "%s/publication_%d", tmpdir, fail);
-    test_mkdir(sub);
-    ecode |= test_publication_follows_io(sub, fail);
   }
 
   test_tmpdir_remove(tmpdir);

--- a/tests/test_flush_drain_cpu.c
+++ b/tests/test_flush_drain_cpu.c
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define DRAIN_OBSERVE_MS 200
 #define POST_RELEASE_TIMEOUT_MS 5000
@@ -25,6 +26,133 @@ struct flush_args
   _Atomic int done;
   int error;
 };
+
+struct append_args
+{
+  struct writer* w;
+  struct slice input;
+  _Atomic int done;
+  int error;
+};
+
+static void
+append_thread_fn(void* arg)
+{
+  struct append_args* a = (struct append_args*)arg;
+  a->error = writer_append_wait(a->w, a->input).error;
+  atomic_store(&a->done, 1);
+}
+
+static int
+metadata_shape_is(const char* tmpdir, uint64_t frames)
+{
+  char path[4608], expected[96], json[16384];
+  snprintf(path, sizeof(path), "%s/0/zarr.json", tmpdir);
+  snprintf(expected,
+           sizeof(expected),
+           "\"shape\":[%llu,8,8]",
+           (unsigned long long)frames);
+  FILE* f = fopen(path, "rb");
+  if (!f)
+    return 0;
+  size_t n = fread(json, 1, sizeof(json) - 1, f);
+  int ok = !ferror(f) && feof(f);
+  fclose(f);
+  json[n] = '\0';
+  return ok && strstr(json, expected) != NULL;
+}
+
+// A closed generation queues its metadata behind a filesystem fence, without
+// parking append. Releasing that fence must publish even if input stops.
+static int
+test_publication_follows_io(const char* tmpdir, int fail_truncate)
+{
+  struct dimension dims[] = {
+    { .size = 8,
+      .chunk_size = 1,
+      .chunks_per_shard = 2,
+      .name = "t",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  struct io_faults faults;
+  struct test_zarr_sink z = { 0 };
+  struct tile_stream_cpu* s = NULL;
+  test_thread* thr = NULL;
+  uint16_t data[2 * 8 * 8] = { 0 };
+  _Atomic int gate = 0;
+  struct append_args a = { 0 };
+  int rc = 1;
+
+  CHECK(Cleanup,
+        test_zarr_sink_open_with_pool(
+          &z,
+          io_faults_store_create(&faults, tmpdir, 1, NULL),
+          "0",
+          dims,
+          3,
+          dtype_u16,
+          (struct codec_config){ .id = CODEC_NONE }) == 0);
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = 4096,
+    .epochs_per_batch = 2,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .metadata_update_interval_s = 0,
+    .max_threads = 2,
+  };
+  s = tile_stream_cpu_create(&cfg, test_zarr_sink_as_shard_sink(&z));
+  CHECK(Cleanup, s && metadata_shape_is(tmpdir, 0));
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
+  for (int i = 0; i < POST_RELEASE_TIMEOUT_MS && atomic_load(&faults.armed);
+       ++i)
+    platform_sleep_ns(1000000LL);
+  CHECK(Cleanup, atomic_load(&faults.armed) == 0);
+  if (fail_truncate)
+    io_faults_fail_next_truncate(&faults);
+
+  a.w = tile_stream_cpu_writer(s);
+  a.input = (struct slice){ .beg = data, .end = data + 2 * 8 * 8 };
+  CHECK(Cleanup, test_thread_start(&thr, append_thread_fn, &a) == 0);
+  CHECK(Cleanup, test_wait_flag(&a.done, POST_RELEASE_TIMEOUT_MS) == 0);
+  test_thread_join(thr);
+  thr = NULL;
+  CHECK(Cleanup, fail_truncate || a.error == 0);
+  CHECK(Cleanup, atomic_load(&gate) == 0 && metadata_shape_is(tmpdir, 0));
+
+  atomic_store(&gate, 1);
+  if (!fail_truncate) {
+    for (int i = 0;
+         i < POST_RELEASE_TIMEOUT_MS && !metadata_shape_is(tmpdir, 2);
+         ++i)
+      platform_sleep_ns(1000000LL);
+    CHECK(Cleanup, metadata_shape_is(tmpdir, 2));
+  }
+  struct writer_result fr = writer_flush(a.w);
+  struct writer_result cr = writer_close(a.w);
+  CHECK(Cleanup, (fr.error != 0) == fail_truncate);
+  CHECK(Cleanup, (cr.error != 0) == fail_truncate);
+  CHECK(Cleanup, metadata_shape_is(tmpdir, fail_truncate ? 0 : 2));
+  rc = 0;
+
+Cleanup:
+  atomic_store(&gate, 1);
+  test_thread_join(thr);
+  tile_stream_cpu_destroy(s);
+  test_zarr_sink_close(&z);
+  return rc;
+}
 
 static void
 flush_thread_fn(void* arg)
@@ -169,6 +297,12 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/flush_drain_cpu", tmpdir);
     test_mkdir(sub);
     ecode |= test_flush_waits_for_sink_io(sub);
+  }
+  for (int fail = 0; fail < 2; ++fail) {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/publication_%d", tmpdir, fail);
+    test_mkdir(sub);
+    ecode |= test_publication_follows_io(sub, fail);
   }
 
   test_tmpdir_remove(tmpdir);

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -3,7 +3,6 @@
 // reported (#218).
 
 #include "gpu/prelude.cuda.h"
-#include "gpu/stream.internal.h"
 #include "platform/platform.h"
 #include "store.h"
 #include "stream.gpu.h"
@@ -17,7 +16,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <cuda.h>
 
@@ -30,143 +28,6 @@ struct flush_args
   _Atomic int done;
   int error;
 };
-
-struct append_args
-{
-  struct writer* w;
-  struct slice input;
-  _Atomic int done;
-  int error;
-};
-
-static void
-append_thread_fn(void* arg)
-{
-  struct append_args* a = (struct append_args*)arg;
-  a->error = writer_append_wait(a->w, a->input).error;
-  atomic_store(&a->done, 1);
-}
-
-static int
-metadata_shape_is(const char* tmpdir, uint64_t frames)
-{
-  char path[4608], expected[96], json[16384];
-  snprintf(path, sizeof(path), "%s/0/zarr.json", tmpdir);
-  snprintf(expected,
-           sizeof(expected),
-           "\"shape\":[%llu,8,8]",
-           (unsigned long long)frames);
-  FILE* f = fopen(path, "rb");
-  if (!f)
-    return 0;
-  size_t n = fread(json, 1, sizeof(json) - 1, f);
-  int ok = !ferror(f) && feof(f);
-  fclose(f);
-  json[n] = '\0';
-  return ok && strstr(json, expected) != NULL;
-}
-
-// A closed generation queues its metadata behind a filesystem fence, without
-// parking append. Releasing that fence must publish even if input stops.
-static int
-test_publication_follows_io(const char* tmpdir, int fail_truncate)
-{
-  struct dimension dims[] = {
-    { .size = 8,
-      .chunk_size = 1,
-      .chunks_per_shard = 2,
-      .name = "t",
-      .storage_position = 0 },
-    { .size = 8,
-      .chunk_size = 8,
-      .chunks_per_shard = 1,
-      .name = "y",
-      .storage_position = 1 },
-    { .size = 8,
-      .chunk_size = 8,
-      .chunks_per_shard = 1,
-      .name = "x",
-      .storage_position = 2 },
-  };
-  struct io_faults faults;
-  struct test_zarr_sink z = { 0 };
-  struct tile_stream_gpu* s = NULL;
-  test_thread* thr = NULL;
-  uint16_t data[2 * 8 * 8] = { 0 };
-  _Atomic int gate = 0;
-  struct append_args a = { 0 };
-  int rc = 1;
-
-  CHECK(Cleanup,
-        test_zarr_sink_open_with_pool(
-          &z,
-          io_faults_store_create(&faults, tmpdir, 1, NULL),
-          "0",
-          dims,
-          3,
-          dtype_u16,
-          (struct codec_config){ .id = CODEC_NONE }) == 0);
-  const struct tile_stream_configuration cfg = {
-    .buffer_capacity_bytes = 4096,
-    .epochs_per_batch = 2,
-    .dtype = dtype_u16,
-    .rank = 3,
-    .dimensions = dims,
-    .codec = { .id = CODEC_NONE },
-    .metadata_update_interval_s = 0,
-    .max_threads = 2,
-  };
-  s = tile_stream_gpu_create(&cfg, test_zarr_sink_as_shard_sink(&z));
-  CHECK(Cleanup, s && metadata_shape_is(tmpdir, 0));
-  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
-  for (int i = 0; i < POST_RELEASE_TIMEOUT_MS && atomic_load(&faults.armed);
-       ++i)
-    platform_sleep_ns(1000000LL);
-  CHECK(Cleanup, atomic_load(&faults.armed) == 0);
-  if (fail_truncate)
-    io_faults_fail_next_truncate(&faults);
-
-  a.w = tile_stream_gpu_writer(s);
-  a.input = (struct slice){ .beg = data, .end = data + 2 * 8 * 8 };
-  CHECK(Cleanup, test_thread_start(&thr, append_thread_fn, &a) == 0);
-  CHECK(Cleanup, test_wait_flag(&a.done, POST_RELEASE_TIMEOUT_MS) == 0);
-  test_thread_join(thr);
-  thr = NULL;
-  CHECK(Cleanup, fail_truncate || a.error == 0);
-  if (!fail_truncate && s->engine.delivery.thread) {
-    for (int i = 0; i < POST_RELEASE_TIMEOUT_MS &&
-                    gpu_delivery_job_state(&s->engine.delivery, 0, NULL) !=
-                      DELIVERY_JOB_DONE;
-         ++i)
-      platform_sleep_ns(1000000LL);
-    CHECK(Cleanup,
-          gpu_delivery_job_state(&s->engine.delivery, 0, NULL) ==
-            DELIVERY_JOB_DONE);
-  }
-  CHECK(Cleanup, atomic_load(&gate) == 0 && metadata_shape_is(tmpdir, 0));
-
-  atomic_store(&gate, 1);
-  if (!fail_truncate) {
-    for (int i = 0;
-         i < POST_RELEASE_TIMEOUT_MS && !metadata_shape_is(tmpdir, 2);
-         ++i)
-      platform_sleep_ns(1000000LL);
-    CHECK(Cleanup, metadata_shape_is(tmpdir, 2));
-  }
-  struct writer_result fr = writer_flush(a.w);
-  struct writer_result cr = writer_close(a.w);
-  CHECK(Cleanup, (fr.error != 0) == fail_truncate);
-  CHECK(Cleanup, (cr.error != 0) == fail_truncate);
-  CHECK(Cleanup, metadata_shape_is(tmpdir, fail_truncate ? 0 : 2));
-  rc = 0;
-
-Cleanup:
-  atomic_store(&gate, 1);
-  test_thread_join(thr);
-  tile_stream_gpu_destroy(s);
-  test_zarr_sink_close(&z);
-  return rc;
-}
 
 static void
 flush_thread_fn(void* arg)
@@ -534,13 +395,6 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/foreign_context", tmpdir);
     test_mkdir(sub);
     ecode |= test_writes_from_a_foreign_context(sub, dev);
-  }
-
-  for (int fail = 0; fail < 2; ++fail) {
-    char sub[4200];
-    snprintf(sub, sizeof(sub), "%s/publication_%d", tmpdir, fail);
-    test_mkdir(sub);
-    ecode |= test_publication_follows_io(sub, fail);
   }
 
 Cleanup:

--- a/tests/test_flush_drain_gpu.c
+++ b/tests/test_flush_drain_gpu.c
@@ -1,8 +1,9 @@
 // Regression test: a flush on the GPU stream drains sink IO before returning,
-// so when it returns every queued write is durable and any that failed is
+// so when it returns every queued write has completed and any that failed is
 // reported (#218).
 
 #include "gpu/prelude.cuda.h"
+#include "gpu/stream.internal.h"
 #include "platform/platform.h"
 #include "store.h"
 #include "stream.gpu.h"
@@ -16,6 +17,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <cuda.h>
 
@@ -28,6 +30,143 @@ struct flush_args
   _Atomic int done;
   int error;
 };
+
+struct append_args
+{
+  struct writer* w;
+  struct slice input;
+  _Atomic int done;
+  int error;
+};
+
+static void
+append_thread_fn(void* arg)
+{
+  struct append_args* a = (struct append_args*)arg;
+  a->error = writer_append_wait(a->w, a->input).error;
+  atomic_store(&a->done, 1);
+}
+
+static int
+metadata_shape_is(const char* tmpdir, uint64_t frames)
+{
+  char path[4608], expected[96], json[16384];
+  snprintf(path, sizeof(path), "%s/0/zarr.json", tmpdir);
+  snprintf(expected,
+           sizeof(expected),
+           "\"shape\":[%llu,8,8]",
+           (unsigned long long)frames);
+  FILE* f = fopen(path, "rb");
+  if (!f)
+    return 0;
+  size_t n = fread(json, 1, sizeof(json) - 1, f);
+  int ok = !ferror(f) && feof(f);
+  fclose(f);
+  json[n] = '\0';
+  return ok && strstr(json, expected) != NULL;
+}
+
+// A closed generation queues its metadata behind a filesystem fence, without
+// parking append. Releasing that fence must publish even if input stops.
+static int
+test_publication_follows_io(const char* tmpdir, int fail_truncate)
+{
+  struct dimension dims[] = {
+    { .size = 8,
+      .chunk_size = 1,
+      .chunks_per_shard = 2,
+      .name = "t",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  struct io_faults faults;
+  struct test_zarr_sink z = { 0 };
+  struct tile_stream_gpu* s = NULL;
+  test_thread* thr = NULL;
+  uint16_t data[2 * 8 * 8] = { 0 };
+  _Atomic int gate = 0;
+  struct append_args a = { 0 };
+  int rc = 1;
+
+  CHECK(Cleanup,
+        test_zarr_sink_open_with_pool(
+          &z,
+          io_faults_store_create(&faults, tmpdir, 1, NULL),
+          "0",
+          dims,
+          3,
+          dtype_u16,
+          (struct codec_config){ .id = CODEC_NONE }) == 0);
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = 4096,
+    .epochs_per_batch = 2,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .metadata_update_interval_s = 0,
+    .max_threads = 2,
+  };
+  s = tile_stream_gpu_create(&cfg, test_zarr_sink_as_shard_sink(&z));
+  CHECK(Cleanup, s && metadata_shape_is(tmpdir, 0));
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
+  for (int i = 0; i < POST_RELEASE_TIMEOUT_MS && atomic_load(&faults.armed);
+       ++i)
+    platform_sleep_ns(1000000LL);
+  CHECK(Cleanup, atomic_load(&faults.armed) == 0);
+  if (fail_truncate)
+    io_faults_fail_next_truncate(&faults);
+
+  a.w = tile_stream_gpu_writer(s);
+  a.input = (struct slice){ .beg = data, .end = data + 2 * 8 * 8 };
+  CHECK(Cleanup, test_thread_start(&thr, append_thread_fn, &a) == 0);
+  CHECK(Cleanup, test_wait_flag(&a.done, POST_RELEASE_TIMEOUT_MS) == 0);
+  test_thread_join(thr);
+  thr = NULL;
+  CHECK(Cleanup, fail_truncate || a.error == 0);
+  if (!fail_truncate && s->engine.delivery.thread) {
+    for (int i = 0; i < POST_RELEASE_TIMEOUT_MS &&
+                    gpu_delivery_job_state(&s->engine.delivery, 0, NULL) !=
+                      DELIVERY_JOB_DONE;
+         ++i)
+      platform_sleep_ns(1000000LL);
+    CHECK(Cleanup,
+          gpu_delivery_job_state(&s->engine.delivery, 0, NULL) ==
+            DELIVERY_JOB_DONE);
+  }
+  CHECK(Cleanup, atomic_load(&gate) == 0 && metadata_shape_is(tmpdir, 0));
+
+  atomic_store(&gate, 1);
+  if (!fail_truncate) {
+    for (int i = 0;
+         i < POST_RELEASE_TIMEOUT_MS && !metadata_shape_is(tmpdir, 2);
+         ++i)
+      platform_sleep_ns(1000000LL);
+    CHECK(Cleanup, metadata_shape_is(tmpdir, 2));
+  }
+  struct writer_result fr = writer_flush(a.w);
+  struct writer_result cr = writer_close(a.w);
+  CHECK(Cleanup, (fr.error != 0) == fail_truncate);
+  CHECK(Cleanup, (cr.error != 0) == fail_truncate);
+  CHECK(Cleanup, metadata_shape_is(tmpdir, fail_truncate ? 0 : 2));
+  rc = 0;
+
+Cleanup:
+  atomic_store(&gate, 1);
+  test_thread_join(thr);
+  tile_stream_gpu_destroy(s);
+  test_zarr_sink_close(&z);
+  return rc;
+}
 
 static void
 flush_thread_fn(void* arg)
@@ -395,6 +534,13 @@ main(int ac, char* av[])
     snprintf(sub, sizeof(sub), "%s/foreign_context", tmpdir);
     test_mkdir(sub);
     ecode |= test_writes_from_a_foreign_context(sub, dev);
+  }
+
+  for (int fail = 0; fail < 2; ++fail) {
+    char sub[4200];
+    snprintf(sub, sizeof(sub), "%s/publication_%d", tmpdir, fail);
+    test_mkdir(sub);
+    ecode |= test_publication_follows_io(sub, fail);
   }
 
 Cleanup:

--- a/tests/test_io_scheduler.c
+++ b/tests/test_io_scheduler.c
@@ -487,6 +487,160 @@ Fail:
   return 1;
 }
 
+struct dependency_backend
+{
+  _Atomic int gates[4];
+  _Atomic int started[4];
+  _Atomic int completed[4];
+  _Atomic int ran_early;
+};
+
+static void
+dependency_execute(void* ctx, const struct io_request* req)
+{
+  struct dependency_backend* backend = (struct dependency_backend*)ctx;
+  const uint64_t index = req->offset;
+  if (index == 2 && (!atomic_load(&backend->completed[0]) ||
+                     !atomic_load(&backend->completed[1])))
+    atomic_store(&backend->ran_early, 1);
+  atomic_store(&backend->started[index], 1);
+  while (!atomic_load(&backend->gates[index]))
+    platform_sleep_ns(1000000LL);
+}
+
+static void
+dependency_finished(void* ctx)
+{
+  atomic_store((_Atomic int*)ctx, 1);
+}
+
+static int
+test_dependency_workers(uint64_t workers, int dependent_has_file)
+{
+  struct dependency_backend backend = { 0 };
+  atomic_store(&backend.gates[2], 1);
+  atomic_store(&backend.gates[3], 1);
+  struct io_scheduler* scheduler = io_scheduler_create(
+    (struct io_backend){ .ctx = &backend, .execute = dependency_execute },
+    (struct io_scheduler_limits){ .workers = workers });
+  CHECK(Fail, scheduler);
+
+  struct io_request requests[4] = {
+    { .op = IO_OP_NOOP },
+    file_write(1, 0),
+    dependent_has_file ? file_write(2, 1)
+                       : (struct io_request){ .op = IO_OP_REPLACE },
+    file_write(3, 2),
+  };
+  for (uint64_t i = 0; i < 4; ++i) {
+    requests[i].offset = i;
+    requests[i].finished_ctx = &backend.completed[i];
+    requests[i].finished = dependency_finished;
+  }
+
+  // Hold the first worker so the dependent job is already queued when the
+  // prerequisite file becomes runnable. With one worker, executing the
+  // dependent job before the file would deadlock an executor-side wait.
+  CHECK(Cleanup, io_scheduler_post(scheduler, requests[0]) == 0);
+  CHECK(Cleanup, test_wait_flag(&backend.started[0], WAIT_MS) == 0);
+  CHECK(Cleanup, io_scheduler_post(scheduler, requests[1]) == 0);
+  requests[2].after_seq = io_scheduler_record(scheduler).seq;
+  CHECK(Cleanup, io_scheduler_post(scheduler, requests[2]) == 0);
+  CHECK(Cleanup, io_scheduler_post(scheduler, requests[3]) == 0);
+  if (workers > 1) {
+    // Two workers hold the prerequisites. The remaining worker must skip
+    // the dependency and run a later, unrelated file request.
+    CHECK(Cleanup, test_wait_flag(&backend.started[1], WAIT_MS) == 0);
+    CHECK(Cleanup, test_wait_flag(&backend.completed[3], WAIT_MS) == 0);
+    CHECK(Cleanup, atomic_load(&backend.started[2]) == 0);
+  }
+
+  atomic_store(&backend.gates[1], 1);
+  atomic_store(&backend.gates[0], 1);
+  io_event_wait(scheduler, io_scheduler_record(scheduler));
+  CHECK(Cleanup, atomic_load(&backend.ran_early) == 0);
+  for (uint64_t i = 0; i < 4; ++i)
+    CHECK(Cleanup, atomic_load(&backend.completed[i]) == 1);
+  io_scheduler_destroy(scheduler);
+  return 0;
+
+Cleanup:
+  for (uint64_t i = 0; i < 4; ++i)
+    atomic_store(&backend.gates[i], 1);
+  io_scheduler_destroy(scheduler);
+Fail:
+  return 1;
+}
+
+static int
+test_dependencies(void)
+{
+  int err = 0;
+  for (int with_file = 0; with_file <= 1; ++with_file) {
+    err |= test_dependency_workers(1, with_file);
+    err |= test_dependency_workers(3, with_file);
+  }
+  return err;
+}
+
+static int
+test_invalid_dependencies(void)
+{
+  struct io_backend_fake fake;
+  io_backend_fake_init(&fake);
+  _Atomic int gate = 0;
+  _Atomic int released = 0;
+  io_backend_fake_hold(&fake, &gate);
+  test_thread* poster = NULL;
+  struct owned_payload* payload = NULL;
+  struct io_scheduler* scheduler = io_scheduler_create(
+    io_backend_fake_as_backend(&fake),
+    (struct io_scheduler_limits){ .max_requests = 1, .workers = 1 });
+  CHECK(Fail, scheduler);
+
+  CHECK(Cleanup,
+        io_scheduler_post(scheduler, (struct io_request){ .after_seq = 1 }) !=
+          0);
+  CHECK(Cleanup,
+        io_scheduler_post(scheduler,
+                          (struct io_request){ .after_seq = UINT64_MAX }) != 0);
+  CHECK(Cleanup, io_scheduler_record(scheduler).seq == 0);
+
+  CHECK(Cleanup, io_scheduler_post(scheduler, (struct io_request){ 0 }) == 0);
+  CHECK(Cleanup, wait_for_started(&fake, 1, WAIT_MS) == 0);
+  payload = (struct owned_payload*)calloc(1, sizeof(*payload));
+  CHECK(Cleanup, payload);
+  payload->released = &released;
+  struct post_call call = {
+    .scheduler = scheduler,
+    .request = { .after_seq = 2,
+                 .owned = payload,
+                 .owned_free = release_owned },
+  };
+  CHECK(Cleanup, test_thread_start(&poster, post_main, &call) == 0);
+  // An invalid dependency is refused even while the request ring is full.
+  CHECK(Cleanup, test_wait_flag(&call.done, WAIT_MS) == 0);
+  CHECK(Cleanup, call.result != 0);
+  CHECK(Cleanup, atomic_load(&released) == 0);
+  CHECK(Cleanup, io_scheduler_record(scheduler).seq == 1);
+  test_thread_join(poster);
+  poster = NULL;
+  atomic_store(&gate, 1);
+  io_scheduler_destroy(scheduler);
+  free(payload);
+  return 0;
+
+Cleanup:
+  atomic_store(&gate, 1);
+  if (poster)
+    test_thread_join(poster);
+  io_scheduler_destroy(scheduler);
+  if (!atomic_load(&released))
+    free(payload);
+Fail:
+  return 1;
+}
+
 struct wait_call
 {
   struct io_scheduler* scheduler;
@@ -604,6 +758,8 @@ main(void)
     { "file_barriers", test_file_barriers },
     { "file_opens_overlap", test_file_opens_overlap },
     { "file_generation_reuse", test_file_generation_reuse },
+    { "dependencies", test_dependencies },
+    { "invalid_dependencies", test_invalid_dependencies },
     { "destroy_releases_waiters_and_drains",
       test_destroy_releases_waiters_and_drains },
   };

--- a/tests/test_io_scheduler.c
+++ b/tests/test_io_scheduler.c
@@ -487,85 +487,87 @@ Fail:
   return 1;
 }
 
-struct dependency_backend
+struct replacement_backend
 {
-  _Atomic int gates[4];
-  _Atomic int started[4];
-  _Atomic int completed[4];
+  _Atomic int gates[6];
+  _Atomic int started[6];
+  _Atomic int completed[6];
   _Atomic int ran_early;
 };
 
 static void
-dependency_execute(void* ctx, const struct io_request* req)
+replacement_execute(void* ctx, const struct io_request* req)
 {
-  struct dependency_backend* backend = (struct dependency_backend*)ctx;
+  struct replacement_backend* backend = (struct replacement_backend*)ctx;
   const uint64_t index = req->offset;
-  if (index == 2 && (!atomic_load(&backend->completed[0]) ||
-                     !atomic_load(&backend->completed[1])))
-    atomic_store(&backend->ran_early, 1);
+  if (req->op == IO_OP_REPLACE)
+    for (uint64_t i = 0; i < index; ++i)
+      if (!atomic_load(&backend->completed[i]))
+        atomic_store(&backend->ran_early, 1);
   atomic_store(&backend->started[index], 1);
   while (!atomic_load(&backend->gates[index]))
     platform_sleep_ns(1000000LL);
 }
 
 static void
-dependency_finished(void* ctx)
+replacement_finished(void* ctx)
 {
   atomic_store((_Atomic int*)ctx, 1);
 }
 
 static int
-test_dependency_workers(uint64_t workers, int dependent_has_file)
+test_replacement_workers(uint64_t workers, int later_has_file)
 {
-  struct dependency_backend backend = { 0 };
-  atomic_store(&backend.gates[2], 1);
-  atomic_store(&backend.gates[3], 1);
+  struct replacement_backend backend = { 0 };
+  for (uint64_t i = 2; i < 6; ++i)
+    atomic_store(&backend.gates[i], 1);
   struct io_scheduler* scheduler = io_scheduler_create(
-    (struct io_backend){ .ctx = &backend, .execute = dependency_execute },
+    (struct io_backend){ .ctx = &backend, .execute = replacement_execute },
     (struct io_scheduler_limits){ .workers = workers });
   CHECK(Fail, scheduler);
 
-  struct io_request requests[4] = {
+  struct io_request requests[6] = {
     { .op = IO_OP_NOOP },
     file_write(1, 0),
-    dependent_has_file ? file_write(2, 1)
-                       : (struct io_request){ .op = IO_OP_REPLACE },
-    file_write(3, 2),
+    { .op = IO_OP_REPLACE },
+    later_has_file ? file_write(2, 1) : (struct io_request){ .op = IO_OP_NOOP },
+    { .op = IO_OP_REPLACE },
+    { .op = IO_OP_NOOP },
   };
-  for (uint64_t i = 0; i < 4; ++i) {
+  for (uint64_t i = 0; i < 6; ++i) {
     requests[i].offset = i;
     requests[i].finished_ctx = &backend.completed[i];
-    requests[i].finished = dependency_finished;
+    requests[i].finished = replacement_finished;
   }
 
-  // Hold the first worker so the dependent job is already queued when the
-  // prerequisite file becomes runnable. With one worker, executing the
-  // dependent job before the file would deadlock an executor-side wait.
+  // Hold the first worker until the queue contains both replacements. With
+  // one worker, replacement priority must not bypass the prerequisite file.
   CHECK(Cleanup, io_scheduler_post(scheduler, requests[0]) == 0);
   CHECK(Cleanup, test_wait_flag(&backend.started[0], WAIT_MS) == 0);
   CHECK(Cleanup, io_scheduler_post(scheduler, requests[1]) == 0);
-  requests[2].after_seq = io_scheduler_record(scheduler).seq;
-  CHECK(Cleanup, io_scheduler_post(scheduler, requests[2]) == 0);
-  CHECK(Cleanup, io_scheduler_post(scheduler, requests[3]) == 0);
+  for (uint64_t i = 2; i < 6; ++i)
+    CHECK(Cleanup, io_scheduler_post(scheduler, requests[i]) == 0);
   if (workers > 1) {
     // Two workers hold the prerequisites. The remaining worker must skip
-    // the dependency and run a later, unrelated file request.
+    // the replacements and run later, independent file/no-file requests.
     CHECK(Cleanup, test_wait_flag(&backend.started[1], WAIT_MS) == 0);
     CHECK(Cleanup, test_wait_flag(&backend.completed[3], WAIT_MS) == 0);
+    CHECK(Cleanup, test_wait_flag(&backend.completed[5], WAIT_MS) == 0);
     CHECK(Cleanup, atomic_load(&backend.started[2]) == 0);
+    CHECK(Cleanup, atomic_load(&backend.started[4]) == 0);
   }
 
   atomic_store(&backend.gates[1], 1);
   atomic_store(&backend.gates[0], 1);
   io_event_wait(scheduler, io_scheduler_record(scheduler));
   CHECK(Cleanup, atomic_load(&backend.ran_early) == 0);
-  for (uint64_t i = 0; i < 4; ++i)
+  for (uint64_t i = 0; i < 6; ++i)
     CHECK(Cleanup, atomic_load(&backend.completed[i]) == 1);
   io_scheduler_destroy(scheduler);
   return 0;
 
 Cleanup:
-  for (uint64_t i = 0; i < 4; ++i)
+  for (uint64_t i = 0; i < 6; ++i)
     atomic_store(&backend.gates[i], 1);
   io_scheduler_destroy(scheduler);
 Fail:
@@ -573,18 +575,94 @@ Fail:
 }
 
 static int
-test_dependencies(void)
+test_replacements(void)
 {
   int err = 0;
   for (int with_file = 0; with_file <= 1; ++with_file) {
-    err |= test_dependency_workers(1, with_file);
-    err |= test_dependency_workers(3, with_file);
+    err |= test_replacement_workers(1, with_file);
+    err |= test_replacement_workers(3, with_file);
   }
   return err;
 }
 
 static int
-test_invalid_dependencies(void)
+test_replacement_order_after_backpressure(void)
+{
+  struct replacement_backend backend = { 0 };
+  atomic_store(&backend.gates[2], 1);
+  atomic_store(&backend.gates[3], 1);
+  test_thread* poster = NULL;
+  struct io_scheduler* scheduler = io_scheduler_create(
+    (struct io_backend){ .ctx = &backend, .execute = replacement_execute },
+    (struct io_scheduler_limits){ .max_bytes = 64, .workers = 3 });
+  CHECK(Fail, scheduler);
+
+  CHECK(Cleanup,
+        io_scheduler_post(scheduler,
+                          (struct io_request){
+                            .op = IO_OP_NOOP,
+                            .nbytes = 64,
+                            .offset = 0,
+                            .finished = replacement_finished,
+                            .finished_ctx = &backend.completed[0],
+                          }) == 0);
+  CHECK(Cleanup, test_wait_flag(&backend.started[0], WAIT_MS) == 0);
+  struct post_call call = {
+    .scheduler = scheduler,
+    .request = { .op = IO_OP_REPLACE,
+                 .nbytes = 8,
+                 .offset = 2,
+                 .finished = replacement_finished,
+                 .finished_ctx = &backend.completed[2] },
+  };
+  CHECK(Cleanup, test_thread_start(&poster, post_main, &call) == 0);
+  CHECK(Cleanup, wait_for_parked(scheduler, 1, WAIT_MS) == 0);
+
+  // This zero-byte open fits while the metadata caller is parked. It is
+  // inserted first, so metadata must also wait for it to complete.
+  CHECK(Cleanup,
+        io_scheduler_post(scheduler,
+                          (struct io_request){
+                            .op = IO_OP_OPEN,
+                            .file = { .generation = 1 },
+                            .offset = 1,
+                            .finished = replacement_finished,
+                            .finished_ctx = &backend.completed[1],
+                          }) == 0);
+  CHECK(Cleanup, test_wait_flag(&backend.started[1], WAIT_MS) == 0);
+  atomic_store(&backend.gates[0], 1);
+  CHECK(Cleanup, test_wait_flag(&call.done, WAIT_MS) == 0);
+  CHECK(Cleanup, call.result == 0);
+  CHECK(Cleanup,
+        io_scheduler_post(scheduler,
+                          (struct io_request){
+                            .op = IO_OP_NOOP,
+                            .offset = 3,
+                            .finished = replacement_finished,
+                            .finished_ctx = &backend.completed[3],
+                          }) == 0);
+  CHECK(Cleanup, test_wait_flag(&backend.completed[3], WAIT_MS) == 0);
+  CHECK(Cleanup, atomic_load(&backend.started[2]) == 0);
+  atomic_store(&backend.gates[1], 1);
+  io_event_wait(scheduler, io_scheduler_record(scheduler));
+  CHECK(Cleanup, atomic_load(&backend.completed[2]) == 1);
+  CHECK(Cleanup, atomic_load(&backend.ran_early) == 0);
+  test_thread_join(poster);
+  io_scheduler_destroy(scheduler);
+  return 0;
+
+Cleanup:
+  for (uint64_t i = 0; i < 6; ++i)
+    atomic_store(&backend.gates[i], 1);
+  if (poster)
+    test_thread_join(poster);
+  io_scheduler_destroy(scheduler);
+Fail:
+  return 1;
+}
+
+static int
+test_replacement_file_token_refused(void)
 {
   struct io_backend_fake fake;
   io_backend_fake_init(&fake);
@@ -599,11 +677,11 @@ test_invalid_dependencies(void)
   CHECK(Fail, scheduler);
 
   CHECK(Cleanup,
-        io_scheduler_post(scheduler, (struct io_request){ .after_seq = 1 }) !=
-          0);
-  CHECK(Cleanup,
         io_scheduler_post(scheduler,
-                          (struct io_request){ .after_seq = UINT64_MAX }) != 0);
+                          (struct io_request){
+                            .op = IO_OP_REPLACE,
+                            .file = { .generation = 1 },
+                          }) != 0);
   CHECK(Cleanup, io_scheduler_record(scheduler).seq == 0);
 
   CHECK(Cleanup, io_scheduler_post(scheduler, (struct io_request){ 0 }) == 0);
@@ -613,12 +691,13 @@ test_invalid_dependencies(void)
   payload->released = &released;
   struct post_call call = {
     .scheduler = scheduler,
-    .request = { .after_seq = 2,
+    .request = { .op = IO_OP_REPLACE,
+                 .file = { .generation = 1 },
                  .owned = payload,
                  .owned_free = release_owned },
   };
   CHECK(Cleanup, test_thread_start(&poster, post_main, &call) == 0);
-  // An invalid dependency is refused even while the request ring is full.
+  // A replacement with a file token is refused even while the ring is full.
   CHECK(Cleanup, test_wait_flag(&call.done, WAIT_MS) == 0);
   CHECK(Cleanup, call.result != 0);
   CHECK(Cleanup, atomic_load(&released) == 0);
@@ -758,8 +837,10 @@ main(void)
     { "file_barriers", test_file_barriers },
     { "file_opens_overlap", test_file_opens_overlap },
     { "file_generation_reuse", test_file_generation_reuse },
-    { "dependencies", test_dependencies },
-    { "invalid_dependencies", test_invalid_dependencies },
+    { "replacements", test_replacements },
+    { "replacement_order_after_backpressure",
+      test_replacement_order_after_backpressure },
+    { "replacement_file_token_refused", test_replacement_file_token_refused },
     { "destroy_releases_waiters_and_drains",
       test_destroy_releases_waiters_and_drains },
   };

--- a/tests/test_json_writer.c
+++ b/tests/test_json_writer.c
@@ -3,6 +3,8 @@
 #include "ngff/ngff_metadata.h"
 #include "util/prelude.h"
 #include "util/strbuf.h"
+#include "zarr/attr_set.h"
+#include "zarr/json_validate.h"
 #include "zarr/json_writer.h"
 #include "zarr/zarr_metadata.h"
 
@@ -286,7 +288,27 @@ Fail:
 }
 
 static int
-test_zarr_multiscale_group_json(void)
+test_zarr_group_json(void)
+{
+  struct strbuf sb = { 0 };
+  CHECK(Fail,
+        zarr_group_json(
+          &sb, "{\"label\":\"camera\",\"settings\":{\"gain\":0.5}}") == 0);
+  const char* expected =
+    "{\"zarr_format\":3,\"node_type\":\"group\","
+    "\"consolidated_metadata\":null,\"attributes\":{\"label\":\"camera\","
+    "\"settings\":{\"gain\":0.5}}}";
+  CHECK(Fail, strcmp(strbuf_cstr(&sb), expected) == 0);
+  strbuf_free(&sb);
+  return 0;
+Fail:
+  log_error("  got: %s", strbuf_cstr(&sb));
+  strbuf_free(&sb);
+  return 1;
+}
+
+static int
+test_ngff_attributes_and_group_json(void)
 {
   // 3-dim config (t/y/x) with 2 LOD levels
   struct dimension l0_dims[3] = {
@@ -317,22 +339,56 @@ test_zarr_multiscale_group_json(void)
   };
 
   const struct dimension* levels[2] = { l0_dims, l1_dims };
+  const struct ngff_axis axes[] = {
+    { .type = ngff_axis_time, .unit = "second", .scale = 0.25 },
+    { .unit = "micrometer", .scale = 0.5 },
+    { .unit = "micrometer", .scale = 0.125 },
+  };
 
   struct strbuf sb = { 0 };
-  CHECK(Fail, ngff_multiscale_group_json(&sb, 3, 2, levels, NULL, NULL) == 0);
+  struct strbuf group = { 0 };
+  struct attr_set extras = { 0 };
+  CHECK(Fail,
+        attr_set_upsert(&extras,
+                        "custom",
+                        "{\"exposure\":0.25,\"labels\":[\"fast\",2]}") == 0);
+  CHECK(Fail,
+        ngff_multiscale_attributes_json(&sb, 3, 2, levels, axes, &extras) == 0);
 
   const char* s = strbuf_cstr(&sb);
+  CHECK(Fail, json_value_is_valid(s, strbuf_len(&sb)));
+  CHECK(Fail, strncmp(s, "{\"ome\":", 7) == 0);
+  CHECK(Fail, !strstr(s, "\"zarr_format\"") && !strstr(s, "\"attributes\""));
   CHECK(Fail, strstr(s, "\"version\":\"0.5\""));
-  CHECK(Fail, strstr(s, "\"axes\""));
+  CHECK(Fail,
+        strstr(s, "\"name\":\"t\",\"type\":\"time\",\"unit\":\"second\""));
+  CHECK(Fail, strstr(s, "\"unit\":\"micrometer\""));
   CHECK(Fail, strstr(s, "\"datasets\""));
   CHECK(Fail, strstr(s, "\"coordinateTransformations\""));
-  CHECK(Fail, strstr(s, "\"attributes\":{\"ome\""));
+  CHECK(Fail, strstr(s, "\"scale\":[0.25,0.5,0.125]"));
+  CHECK(Fail, strstr(s, "\"scale\":[0.25,1.0,0.25]"));
+  CHECK(Fail,
+        strstr(s, "\"custom\":{\"exposure\":0.25,\"labels\":[\"fast\",2]}"));
 
+  // Zarr supplies exactly one group envelope around the complete attributes.
+  CHECK(Fail, zarr_group_json(&group, s) == 0);
+  const char* root = strbuf_cstr(&group);
+  CHECK(Fail, json_value_is_valid(root, strbuf_len(&group)));
+  const char* prefix = "{\"zarr_format\":3,\"node_type\":\"group\","
+                       "\"consolidated_metadata\":null,\"attributes\":";
+  CHECK(Fail, strncmp(root, prefix, strlen(prefix)) == 0);
+  CHECK(Fail, strbuf_len(&group) == strlen(prefix) + strbuf_len(&sb) + 1);
+  CHECK(Fail, memcmp(root + strlen(prefix), s, strbuf_len(&sb)) == 0);
+
+  attr_set_destroy(&extras);
+  strbuf_free(&group);
   strbuf_free(&sb);
   return 0;
 
 Fail:
   log_error("  got: %s", strbuf_cstr(&sb));
+  attr_set_destroy(&extras);
+  strbuf_free(&group);
   strbuf_free(&sb);
   return 1;
 }
@@ -362,7 +418,8 @@ test_scale_clamped_dim(void)
   const struct dimension* levels[3] = { l0, l1, l2 };
 
   struct strbuf sb = { 0 };
-  CHECK(Fail, ngff_multiscale_group_json(&sb, 3, 3, levels, NULL, NULL) == 0);
+  CHECK(Fail,
+        ngff_multiscale_attributes_json(&sb, 3, 3, levels, NULL, NULL) == 0);
 
   const char* s = strbuf_cstr(&sb);
   // L0: scale=[1.0, 1.0, 1.0]
@@ -493,7 +550,8 @@ main(void)
     { "uint", test_uint },
     { "zarr_metadata", test_zarr_metadata },
     { "zarr_root_json", test_zarr_root_json },
-    { "zarr_multiscale_group_json", test_zarr_multiscale_group_json },
+    { "zarr_group_json", test_zarr_group_json },
+    { "ngff_attributes_and_group_json", test_ngff_attributes_and_group_json },
     { "scale_clamped_dim", test_scale_clamped_dim },
     { "zarr_array_json_lz4", test_zarr_array_json_lz4 },
     { "zarr_array_json_zstd", test_zarr_array_json_zstd },

--- a/tests/test_memcpy_sampling_gpu.c
+++ b/tests/test_memcpy_sampling_gpu.c
@@ -1,0 +1,184 @@
+#include "multiarray.gpu.h"
+#include "stream.gpu.h"
+#include "stream/layouts.h"
+#include "test_runner.h"
+#include "test_shard_sink.h"
+#include "test_shard_verify.h"
+
+#include <stdlib.h>
+
+static int
+run_copies(int full, int mixed, int finite)
+{
+  enum
+  {
+    CHUNK = 4096,
+    CPS = 16,
+    STAGING = 32768,
+    BATCH = 12 * CHUNK
+  };
+  const size_t total = 2 * 1024 * 1024 + 123;
+  uint8_t* input = malloc(total);
+  struct test_shard_sink sink;
+  struct tile_stream_gpu* stream = NULL;
+  int result = 1;
+  test_sink_init(&sink, 33, 128 * 1024);
+  CHECK(Fail, input);
+  for (size_t i = 0; i < total; ++i)
+    input[i] = (uint8_t)((i * 137) ^ (i >> 9));
+  struct dimension dim = { .size = finite ? total : 0,
+                           .chunk_size = CHUNK,
+                           .chunks_per_shard = CPS };
+  const struct tile_stream_configuration cfg = {
+    .buffer_capacity_bytes = STAGING,
+    .dtype = dtype_u8,
+    .rank = 1,
+    .dimensions = &dim,
+    .codec = { .id = CODEC_NONE },
+    .epochs_per_batch = 12,
+    .full_memcpy_timing = full,
+  };
+  stream = tile_stream_gpu_create(&cfg, &sink.base);
+  CHECK(Fail, stream);
+  CHECK(Fail, tile_stream_gpu_layout(stream)->epoch_elements == CHUNK);
+  struct writer* w = tile_stream_gpu_writer(stream);
+  const size_t offers[] = { 511, 8191, 8192, 8193, 131072 };
+  uint64_t copies = 0, small = 0, timed = 0, timed_bytes = 0, appends = 0;
+  size_t accepted = 0;
+  while (accepted < total) {
+    size_t offer = mixed ? offers[appends % countof(offers)] : 512;
+    if (offer > total - accepted)
+      offer = total - accepted;
+    size_t remaining = offer;
+    while (remaining) {
+      const size_t batch_offset = accepted % BATCH;
+      size_t n = STAGING - batch_offset % STAGING;
+      if (n > BATCH - batch_offset)
+        n = BATCH - batch_offset;
+      if (n > remaining)
+        n = remaining;
+      copies++;
+      int measure = full || n >= 8192;
+      if (!measure) {
+        measure = small % 64 == (small / 64) % 64;
+        small++;
+      }
+      if (measure) {
+        timed++;
+        timed_bytes += n;
+      }
+      accepted += n;
+      remaining -= n;
+    }
+    struct writer_result r = writer_append(
+      w, (struct slice){ input + accepted - offer, input + accepted });
+    CHECK(Fail, r.error == 0 && r.rest.beg == r.rest.end);
+    appends++;
+  }
+  CHECK(Fail, writer_flush(w).error == 0);
+  CHECK(Fail, writer_flush(w).error == 0);
+  CHECK(Fail, writer_close(w).error == 0);
+  const struct stream_metrics m = tile_stream_gpu_get_metrics(stream);
+  CHECK(Fail, m.memcpy_calls == copies);
+  CHECK(Fail, m.memcpy_bytes == total);
+  CHECK(Fail, (uint64_t)m.memcpy.count == timed);
+  CHECK(Fail, m.memcpy.input_bytes == (double)timed_bytes);
+  CHECK(Fail, m.memcpy.output_bytes == (double)timed_bytes);
+  CHECK(Fail, m.append_count == appends);
+  CHECK(Fail, m.scatter_samples_lost == 0);
+  CHECK(Fail, full || timed < copies);
+  CHECK(Fail, m.memcpy.max_ms <= m.max_append_ms);
+  const struct writer_result refused =
+    writer_append(w, (struct slice){ input, input + 512 });
+  CHECK(Fail, refused.error == writer_error_finished);
+  CHECK(Fail, refused.rest.beg == input);
+  CHECK(Fail, tile_stream_gpu_get_metrics(stream).memcpy_calls == copies);
+
+  for (size_t sh = 0; sh < 33; ++sh) {
+    const struct test_shard_writer* sw = &sink.writers[0][sh];
+    uint64_t offsets[CPS], sizes[CPS];
+    CHECK(Fail, sw->finalized && sw->size);
+    CHECK(Fail, shard_index_parse(sw->buf, sw->size, CPS, offsets, sizes) == 0);
+    CHECK(Fail, shard_index_check_crc(sw->buf, sw->size, CPS) == 0);
+    for (size_t c = 0; c < CPS; ++c) {
+      const size_t start = (sh * CPS + c) * CHUNK;
+      if (start >= total)
+        break;
+      CHECK(Fail, sizes[c] == CHUNK);
+      CHECK(Fail, offsets[c] <= sw->size - CHUNK);
+      for (size_t j = 0; j < CHUNK; ++j)
+        CHECK(Fail,
+              sw->buf[offsets[c] + j] ==
+                (start + j < total ? input[start + j] : 0));
+    }
+  }
+  result = 0;
+Fail:
+  tile_stream_gpu_destroy(stream);
+  test_sink_free(&sink);
+  free(input);
+  return result;
+}
+
+static int
+test_copy_modes(void)
+{
+  for (int full = 0; full < 2; ++full)
+    for (int mixed = 0; mixed < 2; ++mixed)
+      for (int finite = 0; finite < 2; ++finite)
+        if (run_copies(full, mixed, finite))
+          return 1;
+  return 0;
+}
+
+static int
+test_per_array_phase(void)
+{
+  struct dimension dim = { .size = 0,
+                           .chunk_size = 4096,
+                           .chunks_per_shard = 16 };
+  struct tile_stream_configuration cfg[3];
+  struct test_shard_sink sinks[3];
+  struct shard_sink* bases[3];
+  struct multiarray_tile_stream_gpu* stream = NULL;
+  int result = 1;
+  for (int a = 0; a < 3; ++a) {
+    test_sink_init(&sinks[a], 1, 128 * 1024);
+    bases[a] = &sinks[a].base;
+    cfg[a] = (struct tile_stream_configuration){
+      .buffer_capacity_bytes = 32768,
+      .dtype = dtype_u8,
+      .rank = 1,
+      .dimensions = &dim,
+      .codec = { .id = CODEC_NONE },
+      .epochs_per_batch = 12,
+      .full_memcpy_timing = a == 2,
+    };
+  }
+  stream = multiarray_tile_stream_gpu_create(3, cfg, bases, 0);
+  CHECK(Fail, stream);
+  struct multiarray_writer* w = multiarray_tile_stream_gpu_writer(stream);
+  const uint8_t input[512] = { 0 };
+  for (int round = 0; round < 2; ++round)
+    for (int a = 0; a < 3; ++a)
+      for (int i = 0; i < 8; ++i) {
+        struct multiarray_writer_result r =
+          w->update(w, a, (struct slice){ input, input + sizeof(input) });
+        CHECK(Fail, r.error == 0 && r.rest.beg == r.rest.end);
+      }
+  CHECK(Fail, w->flush(w).error == 0);
+  const struct stream_metrics m =
+    multiarray_tile_stream_gpu_get_metrics(stream);
+  CHECK(Fail, m.memcpy_calls == 48 && m.memcpy_bytes == 48 * 512);
+  CHECK(Fail, m.memcpy.count == 18 && m.memcpy.input_bytes == 18 * 512);
+  CHECK(Fail, m.append_count == 0);
+  result = 0;
+Fail:
+  multiarray_tile_stream_gpu_destroy(stream);
+  for (int a = 0; a < 3; ++a)
+    test_sink_free(&sinks[a]);
+  return result;
+}
+
+RUN_GPU_TESTS({ "copy modes and readback", test_copy_modes },
+              { "per-array sampling phase", test_per_array_phase })

--- a/tests/test_metadata_publication.c
+++ b/tests/test_metadata_publication.c
@@ -18,7 +18,6 @@ struct pending_metadata
 {
   struct strbuf key;
   struct strbuf json;
-  struct io_event after;
   uint64_t seq;
 };
 
@@ -44,7 +43,7 @@ progress(struct deferred_pool* p)
 {
   while (p->head < p->count) {
     struct pending_metadata* job = &p->jobs[p->head];
-    if (job->after.seq > p->ready)
+    if (job->seq - 1 > p->ready)
       break;
     if (p->fail_completion)
       p->error = 1;
@@ -62,11 +61,10 @@ progress(struct deferred_pool* p)
 }
 
 static int
-deferred_put(struct shard_pool* self,
-             const char* key,
-             const void* data,
-             size_t len,
-             struct io_event after)
+deferred_queue_metadata(struct shard_pool* self,
+                        const char* key,
+                        const void* data,
+                        size_t len)
 {
   struct deferred_pool* p = container_of(self, struct deferred_pool, base);
   if (p->reject || p->error || p->count == countof(p->jobs)) {
@@ -80,7 +78,8 @@ deferred_put(struct shard_pool* self,
     p->error = 1;
     return 1;
   }
-  job->after = after;
+  // The pool orders metadata after its current prefix; no caller supplies
+  // or owns the dependency.
   job->seq = ++p->submitted;
   ++p->count;
   return 0;
@@ -123,7 +122,7 @@ static void
 deferred_init(struct deferred_pool* p, struct store* store)
 {
   *p = (struct deferred_pool){
-    .base = { .put_after = deferred_put,
+    .base = { .queue_metadata = deferred_queue_metadata,
               .record_fence = deferred_record,
               .wait_fence = deferred_wait,
               .flush = deferred_flush,
@@ -180,25 +179,25 @@ test_array_snapshots(void)
   struct zarr_array* a = create_array(store, &pool, "array");
   CHECK(Fail_store, a);
   struct shard_sink* sink = zarr_array_as_shard_sink(a);
-  CHECK(Fail_array, sink->update_append_after);
+  CHECK(Fail_array, sink->queue_append);
   unsigned initial_flushes = pool.flushes;
 
   CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"first\"") == 0);
   uint64_t size = 4;
   struct io_event first = data_fence(&pool);
-  CHECK(Fail_array, sink->update_append_after(sink, 0, 1, &size, first) == 0);
+  CHECK(Fail_array, sink->queue_append(sink, 0, 1, &size) == 0);
   CHECK(Fail_array, pool.flushes == initial_flushes);
   CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[0,64]"));
 
   CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"second\"") == 0);
   size = 8;
   struct io_event second = data_fence(&pool);
-  CHECK(Fail_array, sink->update_append_after(sink, 0, 1, &size, second) == 0);
+  CHECK(Fail_array, sink->queue_append(sink, 0, 1, &size) == 0);
   size = 999; // Neither the caller's extent nor mutable attrs are borrowed.
   CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"latest\"") == 0);
   CHECK(Fail_array, pool.count == 2 && pool.head == 0);
-  CHECK(Fail_array, pool.jobs[0].after.seq == first.seq);
-  CHECK(Fail_array, pool.jobs[1].after.seq == second.seq);
+  CHECK(Fail_array, pool.jobs[0].seq == first.seq + 1);
+  CHECK(Fail_array, pool.jobs[1].seq == second.seq + 1);
   CHECK(Fail_array,
         strstr(strbuf_cstr(&pool.jobs[0].json), "\"shape\":[4,64]"));
   CHECK(Fail_array,
@@ -222,22 +221,22 @@ test_array_snapshots(void)
   CHECK(Fail_array, metadata_contains("array/zarr.json", "\"tag\":\"latest\""));
 
   size = 12;
-  CHECK(Fail_array,
-        sink->update_append_after(sink, 0, 1, &size, data_fence(&pool)) == 0);
+  data_fence(&pool);
+  CHECK(Fail_array, sink->queue_append(sink, 0, 1, &size) == 0);
   // Even an unchanged synchronous update must wait for its queued shape.
   CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) == 0);
   CHECK(Fail_array, pool.head == pool.count);
   CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[12,64]"));
 
   size = 16;
-  CHECK(Fail_array,
-        sink->update_append_after(sink, 0, 1, &size, data_fence(&pool)) == 0);
+  data_fence(&pool);
+  CHECK(Fail_array, sink->queue_append(sink, 0, 1, &size) == 0);
   CHECK(Fail_array, sink->flush(sink) == 0); // No dirty attributes.
   CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[16,64]"));
 
   size = 20;
-  CHECK(Fail_array,
-        sink->update_append_after(sink, 0, 1, &size, data_fence(&pool)) == 0);
+  data_fence(&pool);
+  CHECK(Fail_array, sink->queue_append(sink, 0, 1, &size) == 0);
   CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"destroyed\"") == 0);
   zarr_array_destroy(a);
   a = NULL;
@@ -270,7 +269,8 @@ test_array_failure(int reject)
   pool.reject = reject;
   pool.fail_completion = !reject;
   uint64_t size = 4;
-  int rc = sink->update_append_after(sink, 0, 1, &size, data_fence(&pool));
+  data_fence(&pool);
+  int rc = sink->queue_append(sink, 0, 1, &size);
   CHECK(Fail_array, reject ? rc != 0 : rc == 0);
   if (reject)
     CHECK(Fail_array, zarr_array_dimensions(a)[0].size == 0);
@@ -301,11 +301,11 @@ test_synchronous_pool(void)
   CHECK(Fail, store);
   struct deferred_pool pool;
   deferred_init(&pool, store);
-  pool.base.put_after = NULL;
+  pool.base.queue_metadata = NULL;
   struct zarr_array* a = create_array(store, &pool, "synchronous");
   CHECK(Fail_store, a);
   struct shard_sink* sink = zarr_array_as_shard_sink(a);
-  CHECK(Fail_array, !sink->update_append_after);
+  CHECK(Fail_array, !sink->queue_append);
   uint64_t size = 4;
   CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) == 0);
   CHECK(Fail_array,
@@ -332,7 +332,7 @@ test_async_hook_without_flush(void)
   struct zarr_array* a = create_array(store, &pool, "no-flush");
   CHECK(Fail_store, a);
   struct shard_sink* sink = zarr_array_as_shard_sink(a);
-  CHECK(Fail_array, sink->update_append_after);
+  CHECK(Fail_array, sink->queue_append);
   sink->flush = NULL;
 
   const struct dimension dim = { .size = 0,
@@ -395,17 +395,19 @@ test_ngff_snapshots(void)
     ngff_multiscale_create_with_pool(store, &pool.base, "ms", &cfg);
   CHECK(Fail_store, ms);
   struct shard_sink* sink = ngff_multiscale_as_shard_sink(ms);
-  CHECK(Fail_ms, sink->update_append_after);
+  CHECK(Fail_ms, sink->queue_append);
   unsigned initial_flushes = pool.flushes;
 
   CHECK(Fail_ms, ngff_multiscale_set_attribute(ms, "tag", "\"first\"") == 0);
   uint64_t size = 4;
   struct io_event first = data_fence(&pool);
-  CHECK(Fail_ms, sink->update_append_after(sink, 0, 1, &size, first) == 0);
+  CHECK(Fail_ms, sink->queue_append(sink, 0, 1, &size) == 0);
   CHECK(Fail_ms, ngff_multiscale_set_attribute(ms, "tag", "\"second\"") == 0);
   struct io_event second = data_fence(&pool);
-  CHECK(Fail_ms, sink->update_append_after(sink, 1, 1, &size, second) == 0);
+  CHECK(Fail_ms, sink->queue_append(sink, 1, 1, &size) == 0);
   CHECK(Fail_ms, pool.flushes == initial_flushes && pool.count == 4);
+  CHECK(Fail_ms, pool.jobs[0].seq == first.seq + 1);
+  CHECK(Fail_ms, pool.jobs[2].seq == second.seq + 1);
   CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[0].key), "ms/0/zarr.json") == 0);
   CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[1].key), "ms/zarr.json") == 0);
   CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[2].key), "ms/1/zarr.json") == 0);
@@ -427,8 +429,8 @@ test_ngff_snapshots(void)
   CHECK(Fail_ms, metadata_contains("ms/zarr.json", "\"tag\":\"latest\""));
 
   size = 8;
-  CHECK(Fail_ms,
-        sink->update_append_after(sink, 0, 1, &size, data_fence(&pool)) == 0);
+  data_fence(&pool);
+  CHECK(Fail_ms, sink->queue_append(sink, 0, 1, &size) == 0);
   CHECK(Fail_ms,
         ngff_multiscale_set_attribute(ms, "tag", "\"destroyed\"") == 0);
   CHECK(Fail_ms,

--- a/tests/test_metadata_publication.c
+++ b/tests/test_metadata_publication.c
@@ -5,6 +5,7 @@
 #include "test_platform.h"
 #include "util/prelude.h"
 #include "util/strbuf.h"
+#include "zarr/json_validate.h"
 #include "zarr/shard_delivery.h"
 #include "zarr/zarr_array.h"
 
@@ -147,9 +148,10 @@ metadata_contains(const char* key, const char* needle)
     return 0;
   char json[8192];
   size_t len = fread(json, 1, sizeof(json) - 1, f);
+  int ok = !ferror(f) && feof(f);
   fclose(f);
   json[len] = '\0';
-  return strstr(json, needle) != NULL;
+  return ok && json_value_is_valid(json, len) && strstr(json, needle) != NULL;
 }
 
 static struct zarr_array*
@@ -181,6 +183,8 @@ test_array_snapshots(void)
   struct shard_sink* sink = zarr_array_as_shard_sink(a);
   CHECK(Fail_array, sink->queue_append);
   unsigned initial_flushes = pool.flushes;
+  const size_t first_job = pool.count;
+  CHECK(Fail_array, pool.head == first_job);
 
   CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"first\"") == 0);
   uint64_t size = 4;
@@ -195,22 +199,25 @@ test_array_snapshots(void)
   CHECK(Fail_array, sink->queue_append(sink, 0, 1, &size) == 0);
   size = 999; // Neither the caller's extent nor mutable attrs are borrowed.
   CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"latest\"") == 0);
-  CHECK(Fail_array, pool.count == 2 && pool.head == 0);
-  CHECK(Fail_array, pool.jobs[0].seq == first.seq + 1);
-  CHECK(Fail_array, pool.jobs[1].seq == second.seq + 1);
+  CHECK(Fail_array, pool.count == first_job + 2 && pool.head == first_job);
+  CHECK(Fail_array, pool.flushes == initial_flushes);
+  CHECK(Fail_array, pool.jobs[first_job].seq == first.seq + 1);
+  CHECK(Fail_array, pool.jobs[first_job + 1].seq == second.seq + 1);
   CHECK(Fail_array,
-        strstr(strbuf_cstr(&pool.jobs[0].json), "\"shape\":[4,64]"));
+        strstr(strbuf_cstr(&pool.jobs[first_job].json), "\"shape\":[4,64]"));
   CHECK(Fail_array,
-        strstr(strbuf_cstr(&pool.jobs[0].json), "\"tag\":\"first\""));
-  CHECK(Fail_array,
-        strstr(strbuf_cstr(&pool.jobs[1].json), "\"shape\":[8,64]"));
-  CHECK(Fail_array,
-        strstr(strbuf_cstr(&pool.jobs[1].json), "\"tag\":\"second\""));
+        strstr(strbuf_cstr(&pool.jobs[first_job].json), "\"tag\":\"first\""));
+  CHECK(
+    Fail_array,
+    strstr(strbuf_cstr(&pool.jobs[first_job + 1].json), "\"shape\":[8,64]"));
+  CHECK(
+    Fail_array,
+    strstr(strbuf_cstr(&pool.jobs[first_job + 1].json), "\"tag\":\"second\""));
 
   // Completing the first dependency publishes without another append.
   pool.ready = first.seq;
   progress(&pool);
-  CHECK(Fail_array, pool.head == 1);
+  CHECK(Fail_array, pool.head == first_job + 1);
   CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[4,64]"));
   CHECK(Fail_array, metadata_contains("array/zarr.json", "\"tag\":\"first\""));
 
@@ -219,14 +226,6 @@ test_array_snapshots(void)
   CHECK(Fail_array, pool.head == pool.count);
   CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[8,64]"));
   CHECK(Fail_array, metadata_contains("array/zarr.json", "\"tag\":\"latest\""));
-
-  size = 12;
-  data_fence(&pool);
-  CHECK(Fail_array, sink->queue_append(sink, 0, 1, &size) == 0);
-  // Even an unchanged synchronous update must wait for its queued shape.
-  CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) == 0);
-  CHECK(Fail_array, pool.head == pool.count);
-  CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[12,64]"));
 
   size = 16;
   data_fence(&pool);
@@ -257,7 +256,66 @@ Fail:
 }
 
 static int
-test_array_failure(int reject)
+test_array_synchronous_updates(void)
+{
+  struct store* store = store_fs_create(tmpdir, 0);
+  CHECK(Fail, store);
+  struct deferred_pool pool;
+  deferred_init(&pool, store);
+  struct zarr_array* a = create_array(store, &pool, "sync-updates");
+  CHECK(Fail_store, a);
+  struct shard_sink* sink = zarr_array_as_shard_sink(a);
+  CHECK(Fail_array, pool.count > 0 && pool.head == pool.count);
+  CHECK(Fail_array,
+        metadata_contains("sync-updates/zarr.json", "\"shape\":[0,64]"));
+  const size_t initial_jobs = pool.count;
+  unsigned initial_flushes = pool.flushes;
+
+  CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"earlier\"") == 0);
+  uint64_t size = 4;
+  data_fence(&pool);
+  CHECK(Fail_array, sink->queue_append(sink, 0, 1, &size) == 0);
+  CHECK(Fail_array,
+        metadata_contains("sync-updates/zarr.json", "\"shape\":[0,64]"));
+
+  // A changed synchronous update joins the same ordered queue and waits for
+  // its own snapshot, so the older snapshot cannot overwrite it afterward.
+  CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"latest\"") == 0);
+  size = 8;
+  CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) == 0);
+  CHECK(Fail_array, pool.count == initial_jobs + 2);
+  CHECK(Fail_array, pool.head == pool.count && pool.flushes > initial_flushes);
+  CHECK(Fail_array,
+        metadata_contains("sync-updates/zarr.json", "\"shape\":[8,64]"));
+  CHECK(Fail_array,
+        metadata_contains("sync-updates/zarr.json", "\"tag\":\"latest\""));
+
+  // Equal in-memory shape does not mean the accepted snapshot is visible.
+  size = 12;
+  data_fence(&pool);
+  CHECK(Fail_array, sink->queue_append(sink, 0, 1, &size) == 0);
+  CHECK(Fail_array,
+        metadata_contains("sync-updates/zarr.json", "\"shape\":[8,64]"));
+  initial_flushes = pool.flushes;
+  CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) == 0);
+  CHECK(Fail_array, pool.head == pool.count && pool.flushes > initial_flushes);
+  CHECK(Fail_array,
+        metadata_contains("sync-updates/zarr.json", "\"shape\":[12,64]"));
+
+  zarr_array_destroy(a);
+  store_destroy(store);
+  return 0;
+Fail_array:
+  zarr_array_destroy(a);
+Fail_store:
+  deferred_flush(&pool.base);
+  store_destroy(store);
+Fail:
+  return 1;
+}
+
+static int
+test_array_failure(int reject, int synchronous)
 {
   struct store* store = store_fs_create(tmpdir, 0);
   CHECK(Fail, store);
@@ -270,14 +328,18 @@ test_array_failure(int reject)
   pool.fail_completion = !reject;
   uint64_t size = 4;
   data_fence(&pool);
-  int rc = sink->queue_append(sink, 0, 1, &size);
-  CHECK(Fail_array, reject ? rc != 0 : rc == 0);
+  int rc = synchronous ? sink->update_append(sink, 0, 1, &size)
+                       : sink->queue_append(sink, 0, 1, &size);
+  CHECK(Fail_array, (reject || synchronous) ? rc != 0 : rc == 0);
   if (reject)
     CHECK(Fail_array, zarr_array_dimensions(a)[0].size == 0);
   CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"unsafe\"") == 0);
   CHECK(Fail_array, sink->flush(sink) != 0);
   CHECK(Fail_array, zarr_array_has_error(a) != 0);
-  // A synchronous rewrite or destroy must not expose the failed extent.
+  // Clearing the injected fault does not clear the sticky IO error. A later
+  // synchronous rewrite or destroy must not expose the failed extent.
+  pool.reject = 0;
+  pool.fail_completion = 0;
   CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) != 0);
   zarr_array_destroy(a);
   a = NULL;
@@ -304,16 +366,54 @@ test_synchronous_pool(void)
   pool.base.queue_metadata = NULL;
   struct zarr_array* a = create_array(store, &pool, "synchronous");
   CHECK(Fail_store, a);
+  struct ngff_multiscale* ms = NULL;
   struct shard_sink* sink = zarr_array_as_shard_sink(a);
   CHECK(Fail_array, !sink->queue_append);
+  const struct io_event outstanding = data_fence(&pool);
   uint64_t size = 4;
   CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) == 0);
   CHECK(Fail_array,
         metadata_contains("synchronous/zarr.json", "\"shape\":[4,64]"));
+  // S3/custom synchronous metadata must not flush active uploads, even when
+  // there is outstanding shard IO or the requested shape is unchanged.
+  CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) == 0);
+  CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"direct\"") == 0);
+  CHECK(Fail_array, zarr_array_flush_metadata(a) == 0);
+  CHECK(Fail_array,
+        metadata_contains("synchronous/zarr.json", "\"tag\":\"direct\""));
   CHECK(Fail_array, pool.flushes == 0 && pool.count == 0);
+  CHECK(Fail_array, pool.ready < outstanding.seq);
+
+  struct dimension dims[] = {
+    { .size = 0, .chunk_size = 1, .chunks_per_shard = 4, .name = "t" },
+    { .size = 64,
+      .chunk_size = 8,
+      .name = "x",
+      .downsample = 1,
+      .storage_position = 1 },
+  };
+  const struct ngff_multiscale_config cfg = {
+    .data_type = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+    .nlod = 2,
+  };
+  ms = ngff_multiscale_create_with_pool(store, &pool.base, "direct-ms", &cfg);
+  CHECK(Fail_array, ms);
+  CHECK(Fail_ms, ngff_multiscale_set_attribute(ms, "tag", "\"direct\"") == 0);
+  CHECK(Fail_ms, ngff_multiscale_flush_metadata(ms) == 0);
+  CHECK(Fail_ms,
+        metadata_contains("direct-ms/zarr.json", "\"tag\":\"direct\""));
+  CHECK(Fail_ms, pool.flushes == 0 && pool.count == 0);
+  CHECK(Fail_ms, pool.ready < outstanding.seq);
+  ngff_multiscale_destroy(ms);
+  ms = NULL;
   zarr_array_destroy(a);
+  CHECK(Fail_store, pool.flushes == 0);
   store_destroy(store);
   return 0;
+Fail_ms:
+  ngff_multiscale_destroy(ms);
 Fail_array:
   zarr_array_destroy(a);
 Fail_store:
@@ -349,7 +449,7 @@ test_async_hook_without_flush(void)
         shard_state_publish_append(&state, sink, &info, 0, NULL, NULL) == 0);
   // Close cannot drain this sink's queued metadata. Publication must use
   // the synchronous callback and consume its data fence before returning.
-  CHECK(Fail_array, pool.count == 0 && state.fence_pending == 0);
+  CHECK(Fail_array, pool.head == pool.count && state.fence_pending == 0);
   CHECK(Fail_array, pool.ready >= state.finalized_fence.seq);
   CHECK(Fail_array,
         metadata_contains("no-flush/zarr.json", "\"shape\":[4,64]"));
@@ -397,6 +497,9 @@ test_ngff_snapshots(void)
   struct shard_sink* sink = ngff_multiscale_as_shard_sink(ms);
   CHECK(Fail_ms, sink->queue_append);
   unsigned initial_flushes = pool.flushes;
+  const size_t first_job = pool.count;
+  CHECK(Fail_ms, pool.head == first_job);
+  CHECK(Fail_ms, metadata_contains("ms/zarr.json", "\"attributes\":{\"ome\""));
 
   CHECK(Fail_ms, ngff_multiscale_set_attribute(ms, "tag", "\"first\"") == 0);
   uint64_t size = 4;
@@ -405,20 +508,32 @@ test_ngff_snapshots(void)
   CHECK(Fail_ms, ngff_multiscale_set_attribute(ms, "tag", "\"second\"") == 0);
   struct io_event second = data_fence(&pool);
   CHECK(Fail_ms, sink->queue_append(sink, 1, 1, &size) == 0);
-  CHECK(Fail_ms, pool.flushes == initial_flushes && pool.count == 4);
-  CHECK(Fail_ms, pool.jobs[0].seq == first.seq + 1);
-  CHECK(Fail_ms, pool.jobs[2].seq == second.seq + 1);
-  CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[0].key), "ms/0/zarr.json") == 0);
-  CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[1].key), "ms/zarr.json") == 0);
-  CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[2].key), "ms/1/zarr.json") == 0);
-  CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[3].key), "ms/zarr.json") == 0);
-  CHECK(Fail_ms, strstr(strbuf_cstr(&pool.jobs[1].json), "\"tag\":\"first\""));
-  CHECK(Fail_ms, strstr(strbuf_cstr(&pool.jobs[3].json), "\"tag\":\"second\""));
+  CHECK(Fail_ms,
+        pool.flushes == initial_flushes && pool.count == first_job + 4);
+  CHECK(Fail_ms, pool.jobs[first_job].seq == first.seq + 1);
+  CHECK(Fail_ms, pool.jobs[first_job + 2].seq == second.seq + 1);
+  CHECK(Fail_ms,
+        strcmp(strbuf_cstr(&pool.jobs[first_job].key), "ms/0/zarr.json") == 0);
+  CHECK(Fail_ms,
+        strcmp(strbuf_cstr(&pool.jobs[first_job + 1].key), "ms/zarr.json") ==
+          0);
+  CHECK(Fail_ms,
+        strcmp(strbuf_cstr(&pool.jobs[first_job + 2].key), "ms/1/zarr.json") ==
+          0);
+  CHECK(Fail_ms,
+        strcmp(strbuf_cstr(&pool.jobs[first_job + 3].key), "ms/zarr.json") ==
+          0);
+  CHECK(
+    Fail_ms,
+    strstr(strbuf_cstr(&pool.jobs[first_job + 1].json), "\"tag\":\"first\""));
+  CHECK(
+    Fail_ms,
+    strstr(strbuf_cstr(&pool.jobs[first_job + 3].json), "\"tag\":\"second\""));
   CHECK(Fail_ms, metadata_contains("ms/0/zarr.json", "\"shape\":[0,64]"));
 
   pool.ready = first.seq;
   progress(&pool);
-  CHECK(Fail_ms, pool.head == 2);
+  CHECK(Fail_ms, pool.head == first_job + 2);
   CHECK(Fail_ms, metadata_contains("ms/0/zarr.json", "\"shape\":[4,64]"));
   CHECK(Fail_ms, metadata_contains("ms/1/zarr.json", "\"shape\":[0,32]"));
   CHECK(Fail_ms, metadata_contains("ms/zarr.json", "\"tag\":\"first\""));
@@ -426,6 +541,18 @@ test_ngff_snapshots(void)
   CHECK(Fail_ms, ngff_multiscale_flush_metadata(ms) == 0);
   CHECK(Fail_ms, pool.head == pool.count);
   CHECK(Fail_ms, metadata_contains("ms/1/zarr.json", "\"shape\":[4,32]"));
+  CHECK(Fail_ms, metadata_contains("ms/zarr.json", "\"tag\":\"latest\""));
+
+  // Synchronous publication uses the same child-before-group order and does
+  // not return until both snapshots are visible.
+  const size_t before_sync = pool.count;
+  initial_flushes = pool.flushes;
+  size = 6;
+  data_fence(&pool);
+  CHECK(Fail_ms, sink->update_append(sink, 0, 1, &size) == 0);
+  CHECK(Fail_ms, pool.count == before_sync + 2 && pool.head == pool.count);
+  CHECK(Fail_ms, pool.flushes > initial_flushes);
+  CHECK(Fail_ms, metadata_contains("ms/0/zarr.json", "\"shape\":[6,64]"));
   CHECK(Fail_ms, metadata_contains("ms/zarr.json", "\"tag\":\"latest\""));
 
   size = 8;
@@ -460,8 +587,11 @@ main(void)
     return 1;
   int err = 0;
   err |= test_array_snapshots();
-  err |= test_array_failure(0);
-  err |= test_array_failure(1);
+  err |= test_array_synchronous_updates();
+  err |= test_array_failure(0, 0);
+  err |= test_array_failure(1, 0);
+  err |= test_array_failure(0, 1);
+  err |= test_array_failure(1, 1);
   err |= test_synchronous_pool();
   err |= test_async_hook_without_flush();
   err |= test_ngff_snapshots();

--- a/tests/test_metadata_publication.c
+++ b/tests/test_metadata_publication.c
@@ -1,0 +1,468 @@
+#include "dimension.h"
+#include "ngff.h"
+#include "ngff/ngff_multiscale.h"
+#include "store.h"
+#include "test_platform.h"
+#include "util/prelude.h"
+#include "util/strbuf.h"
+#include "zarr/shard_delivery.h"
+#include "zarr/zarr_array.h"
+
+#include <stdio.h>
+#include <string.h>
+
+// Deterministically hold publication dependencies without worker timing.
+// The real scheduler tests cover executing these jobs after IO completion;
+// these tests cover immutable metadata, ordering and the sink flush hooks.
+struct pending_metadata
+{
+  struct strbuf key;
+  struct strbuf json;
+  struct io_event after;
+  uint64_t seq;
+};
+
+struct deferred_pool
+{
+  struct shard_pool base;
+  struct store* store;
+  struct pending_metadata jobs[16];
+  size_t head;
+  size_t count;
+  uint64_t submitted;
+  uint64_t ready;
+  unsigned flushes;
+  int error;
+  int reject;
+  int fail_completion;
+};
+
+static char tmpdir[512];
+
+static void
+progress(struct deferred_pool* p)
+{
+  while (p->head < p->count) {
+    struct pending_metadata* job = &p->jobs[p->head];
+    if (job->after.seq > p->ready)
+      break;
+    if (p->fail_completion)
+      p->error = 1;
+    if (!p->error && p->store->put(p->store,
+                                   strbuf_cstr(&job->key),
+                                   strbuf_cstr(&job->json),
+                                   strbuf_len(&job->json)))
+      p->error = 1;
+    if (job->seq > p->ready)
+      p->ready = job->seq;
+    strbuf_free(&job->key);
+    strbuf_free(&job->json);
+    ++p->head;
+  }
+}
+
+static int
+deferred_put(struct shard_pool* self,
+             const char* key,
+             const void* data,
+             size_t len,
+             struct io_event after)
+{
+  struct deferred_pool* p = container_of(self, struct deferred_pool, base);
+  if (p->reject || p->error || p->count == countof(p->jobs)) {
+    p->error = 1;
+    return 1;
+  }
+  struct pending_metadata* job = &p->jobs[p->count];
+  if (strbuf_set(&job->key, key) || strbuf_append(&job->json, data, len)) {
+    strbuf_free(&job->key);
+    strbuf_free(&job->json);
+    p->error = 1;
+    return 1;
+  }
+  job->after = after;
+  job->seq = ++p->submitted;
+  ++p->count;
+  return 0;
+}
+
+static struct io_event
+deferred_record(struct shard_pool* self)
+{
+  struct deferred_pool* p = container_of(self, struct deferred_pool, base);
+  return (struct io_event){ p->submitted };
+}
+
+static void
+deferred_wait(struct shard_pool* self, struct io_event ev)
+{
+  struct deferred_pool* p = container_of(self, struct deferred_pool, base);
+  if (ev.seq > p->ready)
+    p->ready = ev.seq;
+  progress(p);
+}
+
+static int
+deferred_flush(struct shard_pool* self)
+{
+  struct deferred_pool* p = container_of(self, struct deferred_pool, base);
+  ++p->flushes;
+  deferred_wait(self, deferred_record(self));
+  return p->error;
+}
+
+static int
+deferred_error(const struct shard_pool* self)
+{
+  const struct deferred_pool* p =
+    container_of(self, struct deferred_pool, base);
+  return p->error;
+}
+
+static void
+deferred_init(struct deferred_pool* p, struct store* store)
+{
+  *p = (struct deferred_pool){
+    .base = { .put_after = deferred_put,
+              .record_fence = deferred_record,
+              .wait_fence = deferred_wait,
+              .flush = deferred_flush,
+              .has_error = deferred_error },
+    .store = store,
+  };
+}
+
+static struct io_event
+data_fence(struct deferred_pool* p)
+{
+  return (struct io_event){ ++p->submitted };
+}
+
+static int
+metadata_contains(const char* key, const char* needle)
+{
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/%s", tmpdir, key);
+  FILE* f = fopen(path, "rb");
+  if (!f)
+    return 0;
+  char json[8192];
+  size_t len = fread(json, 1, sizeof(json) - 1, f);
+  fclose(f);
+  json[len] = '\0';
+  return strstr(json, needle) != NULL;
+}
+
+static struct zarr_array*
+create_array(struct store* store, struct deferred_pool* p, const char* key)
+{
+  struct dimension dims[] = {
+    { .size = 0, .chunk_size = 1, .chunks_per_shard = 4, .name = "t" },
+    { .size = 64, .chunk_size = 16, .name = "x" },
+  };
+  struct zarr_array_config cfg = {
+    .data_type = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+  };
+  if (store->mkdirs(store, key))
+    return NULL;
+  return zarr_array_create_with_pool(store, &p->base, 0, key, &cfg);
+}
+
+static int
+test_array_snapshots(void)
+{
+  struct store* store = store_fs_create(tmpdir, 0);
+  CHECK(Fail, store);
+  struct deferred_pool pool;
+  deferred_init(&pool, store);
+  struct zarr_array* a = create_array(store, &pool, "array");
+  CHECK(Fail_store, a);
+  struct shard_sink* sink = zarr_array_as_shard_sink(a);
+  CHECK(Fail_array, sink->update_append_after);
+  unsigned initial_flushes = pool.flushes;
+
+  CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"first\"") == 0);
+  uint64_t size = 4;
+  struct io_event first = data_fence(&pool);
+  CHECK(Fail_array, sink->update_append_after(sink, 0, 1, &size, first) == 0);
+  CHECK(Fail_array, pool.flushes == initial_flushes);
+  CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[0,64]"));
+
+  CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"second\"") == 0);
+  size = 8;
+  struct io_event second = data_fence(&pool);
+  CHECK(Fail_array, sink->update_append_after(sink, 0, 1, &size, second) == 0);
+  size = 999; // Neither the caller's extent nor mutable attrs are borrowed.
+  CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"latest\"") == 0);
+  CHECK(Fail_array, pool.count == 2 && pool.head == 0);
+  CHECK(Fail_array, pool.jobs[0].after.seq == first.seq);
+  CHECK(Fail_array, pool.jobs[1].after.seq == second.seq);
+  CHECK(Fail_array,
+        strstr(strbuf_cstr(&pool.jobs[0].json), "\"shape\":[4,64]"));
+  CHECK(Fail_array,
+        strstr(strbuf_cstr(&pool.jobs[0].json), "\"tag\":\"first\""));
+  CHECK(Fail_array,
+        strstr(strbuf_cstr(&pool.jobs[1].json), "\"shape\":[8,64]"));
+  CHECK(Fail_array,
+        strstr(strbuf_cstr(&pool.jobs[1].json), "\"tag\":\"second\""));
+
+  // Completing the first dependency publishes without another append.
+  pool.ready = first.seq;
+  progress(&pool);
+  CHECK(Fail_array, pool.head == 1);
+  CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[4,64]"));
+  CHECK(Fail_array, metadata_contains("array/zarr.json", "\"tag\":\"first\""));
+
+  // A manual attribute rewrite must drain the older second snapshot first.
+  CHECK(Fail_array, zarr_array_flush_metadata(a) == 0);
+  CHECK(Fail_array, pool.head == pool.count);
+  CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[8,64]"));
+  CHECK(Fail_array, metadata_contains("array/zarr.json", "\"tag\":\"latest\""));
+
+  size = 12;
+  CHECK(Fail_array,
+        sink->update_append_after(sink, 0, 1, &size, data_fence(&pool)) == 0);
+  // Even an unchanged synchronous update must wait for its queued shape.
+  CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) == 0);
+  CHECK(Fail_array, pool.head == pool.count);
+  CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[12,64]"));
+
+  size = 16;
+  CHECK(Fail_array,
+        sink->update_append_after(sink, 0, 1, &size, data_fence(&pool)) == 0);
+  CHECK(Fail_array, sink->flush(sink) == 0); // No dirty attributes.
+  CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[16,64]"));
+
+  size = 20;
+  CHECK(Fail_array,
+        sink->update_append_after(sink, 0, 1, &size, data_fence(&pool)) == 0);
+  CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"destroyed\"") == 0);
+  zarr_array_destroy(a);
+  a = NULL;
+  CHECK(Fail_array, pool.head == pool.count);
+  CHECK(Fail_array, metadata_contains("array/zarr.json", "\"shape\":[20,64]"));
+  CHECK(Fail_array,
+        metadata_contains("array/zarr.json", "\"tag\":\"destroyed\""));
+
+  store_destroy(store);
+  return 0;
+Fail_array:
+  zarr_array_destroy(a);
+Fail_store:
+  deferred_flush(&pool.base);
+  store_destroy(store);
+Fail:
+  return 1;
+}
+
+static int
+test_array_failure(int reject)
+{
+  struct store* store = store_fs_create(tmpdir, 0);
+  CHECK(Fail, store);
+  struct deferred_pool pool;
+  deferred_init(&pool, store);
+  struct zarr_array* a = create_array(store, &pool, "failure");
+  CHECK(Fail_store, a);
+  struct shard_sink* sink = zarr_array_as_shard_sink(a);
+  pool.reject = reject;
+  pool.fail_completion = !reject;
+  uint64_t size = 4;
+  int rc = sink->update_append_after(sink, 0, 1, &size, data_fence(&pool));
+  CHECK(Fail_array, reject ? rc != 0 : rc == 0);
+  if (reject)
+    CHECK(Fail_array, zarr_array_dimensions(a)[0].size == 0);
+  CHECK(Fail_array, zarr_array_set_attribute(a, "tag", "\"unsafe\"") == 0);
+  CHECK(Fail_array, sink->flush(sink) != 0);
+  CHECK(Fail_array, zarr_array_has_error(a) != 0);
+  // A synchronous rewrite or destroy must not expose the failed extent.
+  CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) != 0);
+  zarr_array_destroy(a);
+  a = NULL;
+  CHECK(Fail_array, metadata_contains("failure/zarr.json", "\"shape\":[0,64]"));
+  CHECK(Fail_array, !metadata_contains("failure/zarr.json", "unsafe"));
+  store_destroy(store);
+  return 0;
+Fail_array:
+  zarr_array_destroy(a);
+Fail_store:
+  deferred_flush(&pool.base);
+  store_destroy(store);
+Fail:
+  return 1;
+}
+
+static int
+test_synchronous_pool(void)
+{
+  struct store* store = store_fs_create(tmpdir, 0);
+  CHECK(Fail, store);
+  struct deferred_pool pool;
+  deferred_init(&pool, store);
+  pool.base.put_after = NULL;
+  struct zarr_array* a = create_array(store, &pool, "synchronous");
+  CHECK(Fail_store, a);
+  struct shard_sink* sink = zarr_array_as_shard_sink(a);
+  CHECK(Fail_array, !sink->update_append_after);
+  uint64_t size = 4;
+  CHECK(Fail_array, sink->update_append(sink, 0, 1, &size) == 0);
+  CHECK(Fail_array,
+        metadata_contains("synchronous/zarr.json", "\"shape\":[4,64]"));
+  CHECK(Fail_array, pool.flushes == 0 && pool.count == 0);
+  zarr_array_destroy(a);
+  store_destroy(store);
+  return 0;
+Fail_array:
+  zarr_array_destroy(a);
+Fail_store:
+  store_destroy(store);
+Fail:
+  return 1;
+}
+
+static int
+test_async_hook_without_flush(void)
+{
+  struct store* store = store_fs_create(tmpdir, 0);
+  CHECK(Fail, store);
+  struct deferred_pool pool;
+  deferred_init(&pool, store);
+  struct zarr_array* a = create_array(store, &pool, "no-flush");
+  CHECK(Fail_store, a);
+  struct shard_sink* sink = zarr_array_as_shard_sink(a);
+  CHECK(Fail_array, sink->update_append_after);
+  sink->flush = NULL;
+
+  const struct dimension dim = { .size = 0,
+                                 .chunk_size = 1,
+                                 .chunks_per_shard = 4 };
+  struct dim_info info;
+  CHECK(Fail_array, dim_info_init(&info, &dim, 1) == 0);
+  struct shard_state state = {
+    .finalized_append_chunks = 4,
+    .finalized_fence = data_fence(&pool),
+    .fence_pending = 1,
+  };
+  CHECK(Fail_array,
+        shard_state_publish_append(&state, sink, &info, 0, NULL, NULL) == 0);
+  // Close cannot drain this sink's queued metadata. Publication must use
+  // the synchronous callback and consume its data fence before returning.
+  CHECK(Fail_array, pool.count == 0 && state.fence_pending == 0);
+  CHECK(Fail_array, pool.ready >= state.finalized_fence.seq);
+  CHECK(Fail_array,
+        metadata_contains("no-flush/zarr.json", "\"shape\":[4,64]"));
+
+  zarr_array_destroy(a);
+  store_destroy(store);
+  return 0;
+Fail_array:
+  zarr_array_destroy(a);
+Fail_store:
+  deferred_flush(&pool.base);
+  store_destroy(store);
+Fail:
+  return 1;
+}
+
+static int
+test_ngff_snapshots(void)
+{
+  struct store* store = store_fs_create(tmpdir, 0);
+  CHECK(Fail, store);
+  struct deferred_pool pool;
+  deferred_init(&pool, store);
+  struct dimension dims[] = {
+    { .size = 0,
+      .chunk_size = 1,
+      .chunks_per_shard = 4,
+      .name = "t",
+      .storage_position = 0 },
+    { .size = 64,
+      .chunk_size = 8,
+      .name = "x",
+      .storage_position = 1,
+      .downsample = 1 },
+  };
+  struct ngff_multiscale_config cfg = {
+    .data_type = dtype_u16,
+    .rank = 2,
+    .dimensions = dims,
+    .nlod = 2,
+  };
+  struct ngff_multiscale* ms =
+    ngff_multiscale_create_with_pool(store, &pool.base, "ms", &cfg);
+  CHECK(Fail_store, ms);
+  struct shard_sink* sink = ngff_multiscale_as_shard_sink(ms);
+  CHECK(Fail_ms, sink->update_append_after);
+  unsigned initial_flushes = pool.flushes;
+
+  CHECK(Fail_ms, ngff_multiscale_set_attribute(ms, "tag", "\"first\"") == 0);
+  uint64_t size = 4;
+  struct io_event first = data_fence(&pool);
+  CHECK(Fail_ms, sink->update_append_after(sink, 0, 1, &size, first) == 0);
+  CHECK(Fail_ms, ngff_multiscale_set_attribute(ms, "tag", "\"second\"") == 0);
+  struct io_event second = data_fence(&pool);
+  CHECK(Fail_ms, sink->update_append_after(sink, 1, 1, &size, second) == 0);
+  CHECK(Fail_ms, pool.flushes == initial_flushes && pool.count == 4);
+  CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[0].key), "ms/0/zarr.json") == 0);
+  CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[1].key), "ms/zarr.json") == 0);
+  CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[2].key), "ms/1/zarr.json") == 0);
+  CHECK(Fail_ms, strcmp(strbuf_cstr(&pool.jobs[3].key), "ms/zarr.json") == 0);
+  CHECK(Fail_ms, strstr(strbuf_cstr(&pool.jobs[1].json), "\"tag\":\"first\""));
+  CHECK(Fail_ms, strstr(strbuf_cstr(&pool.jobs[3].json), "\"tag\":\"second\""));
+  CHECK(Fail_ms, metadata_contains("ms/0/zarr.json", "\"shape\":[0,64]"));
+
+  pool.ready = first.seq;
+  progress(&pool);
+  CHECK(Fail_ms, pool.head == 2);
+  CHECK(Fail_ms, metadata_contains("ms/0/zarr.json", "\"shape\":[4,64]"));
+  CHECK(Fail_ms, metadata_contains("ms/1/zarr.json", "\"shape\":[0,32]"));
+  CHECK(Fail_ms, metadata_contains("ms/zarr.json", "\"tag\":\"first\""));
+  CHECK(Fail_ms, ngff_multiscale_set_attribute(ms, "tag", "\"latest\"") == 0);
+  CHECK(Fail_ms, ngff_multiscale_flush_metadata(ms) == 0);
+  CHECK(Fail_ms, pool.head == pool.count);
+  CHECK(Fail_ms, metadata_contains("ms/1/zarr.json", "\"shape\":[4,32]"));
+  CHECK(Fail_ms, metadata_contains("ms/zarr.json", "\"tag\":\"latest\""));
+
+  size = 8;
+  CHECK(Fail_ms,
+        sink->update_append_after(sink, 0, 1, &size, data_fence(&pool)) == 0);
+  CHECK(Fail_ms,
+        ngff_multiscale_set_attribute(ms, "tag", "\"destroyed\"") == 0);
+  CHECK(Fail_ms,
+        zarr_array_set_attribute(ngff_multiscale_level(ms, 0), "child", "1") ==
+          0);
+  ngff_multiscale_destroy(ms);
+  ms = NULL;
+  CHECK(Fail_ms, pool.head == pool.count);
+  CHECK(Fail_ms, metadata_contains("ms/0/zarr.json", "\"shape\":[8,64]"));
+  CHECK(Fail_ms, metadata_contains("ms/0/zarr.json", "\"child\":1"));
+  CHECK(Fail_ms, metadata_contains("ms/zarr.json", "\"tag\":\"destroyed\""));
+  store_destroy(store);
+  return 0;
+Fail_ms:
+  ngff_multiscale_destroy(ms);
+Fail_store:
+  deferred_flush(&pool.base);
+  store_destroy(store);
+Fail:
+  return 1;
+}
+
+int
+main(void)
+{
+  if (test_tmpdir_create(tmpdir, sizeof(tmpdir)))
+    return 1;
+  int err = 0;
+  err |= test_array_snapshots();
+  err |= test_array_failure(0);
+  err |= test_array_failure(1);
+  err |= test_synchronous_pool();
+  err |= test_async_hook_without_flush();
+  err |= test_ngff_snapshots();
+  test_tmpdir_remove(tmpdir);
+  return err;
+}

--- a/tests/test_multiarray_cpu.c
+++ b/tests/test_multiarray_cpu.c
@@ -1134,15 +1134,16 @@ test_close_before_flush(void)
   // Nothing is queued yet, so close publishes nothing and leaves the array
   // open to the flush that follows.
   CHECK(Fail, w->close(w).error == multiarray_writer_ok);
-  CHECK(Fail, sink.update_append_count == 0);
+  CHECK(Fail, sink.update_append_count == 1);
+  CHECK(Fail, sink.last_append_size0 == 0);
 
   CHECK(Fail, w->flush(w).error == multiarray_writer_ok);
   CHECK(Fail, w->close(w).error == multiarray_writer_ok);
-  CHECK(Fail, sink.update_append_count == 1);
+  CHECK(Fail, sink.update_append_count == 2);
   CHECK(Fail, sink.last_append_size0 == 1);
 
   multiarray_tile_stream_cpu_destroy(ms);
-  CHECK(Fail2, sink.update_append_count == 1);
+  CHECK(Fail2, sink.update_append_count == 2);
   test_sink_free(&sink);
   log_info("  PASS");
   return 0;

--- a/tests/test_shape_after_flush_cpu.c
+++ b/tests/test_shape_after_flush_cpu.c
@@ -86,8 +86,7 @@ run_shape_case(const struct shape_case* c)
       .storage_position = 2 },
   };
 
-  // A long interval keeps the periodic update from firing, so every recorded
-  // update is one the flush wrote.
+  // A long interval leaves only initialization and final close publication.
   struct tile_stream_configuration config = {
     .buffer_capacity_bytes = 4096,
     .dtype = dtype_u16,
@@ -111,7 +110,8 @@ run_shape_case(const struct shape_case* c)
     data[i] = PLANE_FILL;
 
   struct writer* w = tile_stream_cpu_writer(s);
-  CHECK(Fail, sink.update_append_count == 0);
+  CHECK(Fail, sink.update_append_count == 1);
+  CHECK(Fail, sink.last_append_size0 == 0);
 
   for (int i = 0; i < c->planes; ++i) {
     struct slice sl = { .beg = data, .end = (const char*)data + plane_bytes };
@@ -129,7 +129,7 @@ run_shape_case(const struct shape_case* c)
            sink.update_append_count,
            (unsigned long long)sink.last_append_size0);
   CHECK(Fail, (fr.error != 0) == c->expect_flush_error);
-  CHECK(Fail, sink.update_append_count == 1);
+  CHECK(Fail, sink.update_append_count == 2);
   CHECK(Fail, sink.last_append_size0 == c->expect_shape0);
 
   // The flush finalized the stream: no more input, and the shape it published
@@ -141,7 +141,7 @@ run_shape_case(const struct shape_case* c)
     CHECK(Fail, r.rest.beg == sl.beg && r.rest.end == sl.end);
   }
   // Finalizing again reports the same outcome without writing anything more.
-  CHECK(Fail, sink.update_append_count == 1);
+  CHECK(Fail, sink.update_append_count == 2);
   CHECK(Fail, sink.last_append_size0 == c->expect_shape0);
 
   if (c->expect_padding_planes)

--- a/tests/test_shape_after_flush_gpu.c
+++ b/tests/test_shape_after_flush_gpu.c
@@ -45,8 +45,7 @@ run_shape_case(const struct shape_case* c)
       .storage_position = 2 },
   };
 
-  // A long interval keeps the periodic update from firing, so every recorded
-  // update is one the flush wrote.
+  // A long interval leaves only initialization and final close publication.
   struct tile_stream_configuration config = {
     .buffer_capacity_bytes = 4096,
     .dtype = dtype_u16,
@@ -65,7 +64,8 @@ run_shape_case(const struct shape_case* c)
   CHECK(Fail, data);
 
   struct writer* w = tile_stream_gpu_writer(s);
-  CHECK(Fail, sink.update_append_count == 0);
+  CHECK(Fail, sink.update_append_count == 1);
+  CHECK(Fail, sink.last_append_size0 == 0);
 
   for (int i = 0; i < c->planes; ++i) {
     struct slice sl = { .beg = data, .end = data + PLANE_ELEMS };
@@ -78,7 +78,7 @@ run_shape_case(const struct shape_case* c)
   log_info("  updates=%d shape0=%llu",
            sink.update_append_count,
            (unsigned long long)sink.last_append_size0);
-  CHECK(Fail, sink.update_append_count == 1);
+  CHECK(Fail, sink.update_append_count == 2);
   CHECK(Fail, sink.last_append_size0 == c->expect_shape0);
 
   // The flush finalized the stream: no more input, and the shape it published
@@ -91,7 +91,7 @@ run_shape_case(const struct shape_case* c)
   }
   CHECK(Fail, writer_flush(w).error == 0);
   CHECK(Fail, writer_close(w).error == 0);
-  CHECK(Fail, sink.update_append_count == 1);
+  CHECK(Fail, sink.update_append_count == 2);
   CHECK(Fail, sink.last_append_size0 == c->expect_shape0);
 
   free(data);

--- a/tests/test_store_fs.c
+++ b/tests/test_store_fs.c
@@ -1041,6 +1041,91 @@ metadata_file_matches(const char* path, const char* expected)
 }
 
 static int
+test_metadata_creates_parents(int queued)
+{
+  log_info("=== test_metadata_creates_parents (queued=%d) ===", queued);
+  char root[4096];
+  snprintf(root, sizeof(root), "%s/metadata-parents-%d", tmpdir, queued);
+  struct store* store = store_fs_create(root, 1);
+  struct shard_pool* pool = NULL;
+  CHECK(Cleanup, store);
+  if (queued) {
+    pool = store->create_pool(store, 1);
+    CHECK(Cleanup, pool && pool->queue_metadata);
+  }
+  CHECK(Cleanup, platform_path_exists(root) == 0);
+
+  // Short unaligned data and empty metadata both create missing parents,
+  // including the store root. Empty replacement must also remove old bytes.
+  const char* keys[] = {
+    "short/nested/zarr.json",
+    "empty/nested/zarr.json",
+    "short/nested/zarr.json",
+  };
+  const char* data[] = { "abc", NULL, NULL };
+  for (size_t i = 0; i < countof(keys); ++i) {
+    size_t len = data[i] ? strlen(data[i]) : 0;
+    int rc = pool ? pool->queue_metadata(pool, keys[i], data[i], len)
+                  : store->put(store, keys[i], data[i], len);
+    if (pool)
+      rc |= pool->flush(pool);
+    CHECK(Cleanup, rc == 0);
+    char path[4200];
+    snprintf(path, sizeof(path), "%s/%s", root, keys[i]);
+    CHECK(Cleanup, metadata_file_matches(path, data[i] ? data[i] : ""));
+  }
+
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return 0;
+
+Cleanup:
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return 1;
+}
+
+static int
+test_store_replace_failure_cleanup(void)
+{
+  log_info("=== test_store_replace_failure_cleanup ===");
+  struct store* store = store_fs_create(tmpdir, 0);
+  CHECK(Cleanup, store);
+  const char* key = "direct-failed-replace/zarr.json";
+  CHECK(Cleanup, store->mkdirs(store, key) == 0);
+  CHECK(Cleanup,
+        store->put(store, "direct-failed-replace/zarr.json/keep", "old", 3) ==
+          0);
+
+  // Rename cannot replace the directory. Its contents must survive and the
+  // completed temporary write must be removed.
+  CHECK(Cleanup, store->put(store, key, "{}", 2) != 0);
+  char path[4200];
+  snprintf(path, sizeof(path), "%s/%s/keep", tmpdir, key);
+  CHECK(Cleanup, metadata_file_matches(path, "old"));
+  snprintf(path,
+           sizeof(path),
+           "%s/%s.tmp.%llu",
+           tmpdir,
+           key,
+           (unsigned long long)platform_process_id());
+  CHECK(Cleanup, platform_path_exists(path) == 0);
+
+  // Direct store calls report their own errors; pool errors remain the queued
+  // executor's responsibility.
+  CHECK(Cleanup,
+        store->put(store, "direct-failed-replace/next.json", "ok", 2) == 0);
+  snprintf(path, sizeof(path), "%s/direct-failed-replace/next.json", tmpdir);
+  CHECK(Cleanup, metadata_file_matches(path, "ok"));
+  store_destroy(store);
+  return 0;
+
+Cleanup:
+  store_destroy(store);
+  return 1;
+}
+
+static int
 wait_for_fault_taken(struct io_faults* faults)
 {
   for (int i = 0; i < 2000; ++i) {
@@ -1348,6 +1433,9 @@ main(void)
 
   int err = 0;
   err |= test_store_put();
+  err |= test_metadata_creates_parents(0);
+  err |= test_metadata_creates_parents(1);
+  err |= test_store_replace_failure_cleanup();
   err |= test_put_is_atomic_for_readers(0);
   err |= test_put_is_atomic_for_readers(1);
   err |= test_store_mkdirs();

--- a/tests/test_store_fs.c
+++ b/tests/test_store_fs.c
@@ -635,10 +635,8 @@ test_put_is_atomic_for_readers(int queued)
   for (int i = 0; i < PUT_ROUNDS && !put_err; ++i) {
     const char* doc = i % 2 ? shortdoc : longdoc;
     const size_t len = i % 2 ? strlen(shortdoc) : PUT_LONG_BYTES;
-    put_err =
-      pool
-        ? pool->put_after(pool, "zarr.json", doc, len, (struct io_event){ 0 })
-        : s->put(s, "zarr.json", doc, len);
+    put_err = pool ? pool->queue_metadata(pool, "zarr.json", doc, len)
+                   : s->put(s, "zarr.json", doc, len);
   }
   if (pool)
     put_err |= pool->flush(pool);
@@ -1060,7 +1058,7 @@ metadata_probe_finished(void* ctx)
 }
 
 static int
-test_put_after_owns_data_and_progresses(void)
+test_queued_metadata_owns_data_and_progresses(void)
 {
   _Atomic int gate = 0;
   struct io_faults faults;
@@ -1076,11 +1074,9 @@ test_put_after_owns_data_and_progresses(void)
   // An unbuffered shard pool must still accept this unaligned metadata.
   const struct io_scheduler_limits limits = { .workers = 4 };
   pool = io_faults_pool_create(&faults, tmpdir, 1, 1, &limits);
-  CHECK(Cleanup, pool && pool->put_after);
+  CHECK(Cleanup, pool && pool->queue_metadata);
   CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
-  CHECK(Cleanup,
-        pool->put_after(
-          pool, key, data, strlen(data), pool->record_fence(pool)) == 0);
+  CHECK(Cleanup, pool->queue_metadata(pool, key, data, strlen(data)) == 0);
   memset(key, 'x', sizeof(key) - 1);
   memset(data, 'x', sizeof(data) - 1);
   CHECK(Cleanup, metadata_file_matches(path, "{}"));
@@ -1107,7 +1103,7 @@ Cleanup:
 }
 
 static int
-test_put_after_preserves_order(void)
+test_queued_metadata_preserves_order(void)
 {
   _Atomic int gate = 0;
   _Atomic int probe_done = 0;
@@ -1121,18 +1117,16 @@ test_put_after_preserves_order(void)
   CHECK(Cleanup, store->put(store, key, "old", 3) == 0);
   const struct io_scheduler_limits limits = { .workers = 2 };
   pool = io_faults_pool_create(&faults, tmpdir, 1, 0, &limits);
-  CHECK(Cleanup, pool && pool->put_after);
+  CHECK(Cleanup, pool && pool->queue_metadata);
 
   // Hold the first replacement itself; a second free worker must not let a
-  // later extent overtake it, even when the caller passes an empty fence.
+  // later extent overtake it. Later independent work must still progress.
   faults.block_gate = &gate;
   atomic_store(&faults.armed,
                (uint16_t)((IO_OP_REPLACE << 8) | IO_FAULT_BLOCK));
-  CHECK(Cleanup,
-        pool->put_after(pool, key, "first", 5, (struct io_event){ 0 }) == 0);
+  CHECK(Cleanup, pool->queue_metadata(pool, key, "first", 5) == 0);
   CHECK(Cleanup, wait_for_fault_taken(&faults) == 0);
-  CHECK(Cleanup,
-        pool->put_after(pool, key, "second", 6, (struct io_event){ 0 }) == 0);
+  CHECK(Cleanup, pool->queue_metadata(pool, key, "second", 6) == 0);
   CHECK(Cleanup,
         io_scheduler_post(faults.queue,
                           (struct io_request){
@@ -1159,7 +1153,7 @@ Cleanup:
 }
 
 static int
-test_put_after_failed_write_keeps_extent(void)
+test_queued_metadata_failed_write_keeps_extent(void)
 {
   _Atomic int gate = 0;
   struct io_faults faults;
@@ -1172,7 +1166,7 @@ test_put_after_failed_write_keeps_extent(void)
   CHECK(Cleanup, store->put(store, key, "old", 3) == 0);
   const struct io_scheduler_limits limits = { .workers = 1 };
   pool = io_faults_pool_create(&faults, tmpdir, 1, 0, &limits);
-  CHECK(Cleanup, pool && pool->put_after);
+  CHECK(Cleanup, pool && pool->queue_metadata);
   CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
   CHECK(Cleanup, wait_for_fault_taken(&faults) == 0);
 
@@ -1183,14 +1177,12 @@ test_put_after_failed_write_keeps_extent(void)
   const char byte = 'x';
   CHECK(Cleanup, writer->write(writer, 0, &byte, &byte + 1) == 0);
   CHECK(Cleanup, writer->finalize(writer) == 0);
-  CHECK(Cleanup,
-        pool->put_after(pool, key, "new", 3, pool->record_fence(pool)) == 0);
+  CHECK(Cleanup, pool->queue_metadata(pool, key, "new", 3) == 0);
   atomic_store(&gate, 1);
   CHECK(Cleanup, pool->flush(pool) != 0);
   CHECK(Cleanup, pool->has_error(pool) != 0);
   CHECK(Cleanup, metadata_file_matches(path, "old"));
-  CHECK(Cleanup,
-        pool->put_after(pool, key, "later", 5, (struct io_event){ 0 }) != 0);
+  CHECK(Cleanup, pool->queue_metadata(pool, key, "later", 5) != 0);
   CHECK(Cleanup, pool->flush(pool) != 0);
   CHECK(Cleanup, metadata_file_matches(path, "old"));
   shard_pool_destroy(pool);
@@ -1205,7 +1197,7 @@ Cleanup:
 }
 
 static int
-test_put_after_replace_failure_is_sticky(void)
+test_queued_metadata_replace_failure_is_sticky(void)
 {
   _Atomic int gate = 0;
   struct io_faults faults;
@@ -1217,14 +1209,11 @@ test_put_after_replace_failure_is_sticky(void)
   CHECK(Cleanup, store->mkdirs(store, key) == 0);
   const struct io_scheduler_limits limits = { .workers = 1 };
   pool = io_faults_pool_create(&faults, tmpdir, 1, 0, &limits);
-  CHECK(Cleanup, pool && pool->put_after);
+  CHECK(Cleanup, pool && pool->queue_metadata);
   CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
+  CHECK(Cleanup, pool->queue_metadata(pool, key, "{}", 2) == 0);
   CHECK(Cleanup,
-        pool->put_after(pool, key, "{}", 2, (struct io_event){ 0 }) == 0);
-  CHECK(Cleanup,
-        pool->put_after(
-          pool, "failed-replace/next.json", "new", 3, (struct io_event){ 0 }) ==
-          0);
+        pool->queue_metadata(pool, "failed-replace/next.json", "new", 3) == 0);
   atomic_store(&gate, 1);
   CHECK(Cleanup, pool->flush(pool) != 0);
   CHECK(Cleanup, pool->has_error(pool) != 0);
@@ -1239,11 +1228,8 @@ test_put_after_replace_failure_is_sticky(void)
            key,
            (unsigned long long)platform_process_id());
   CHECK(Cleanup, platform_path_exists(path) == 0);
-  CHECK(
-    Cleanup,
-    pool->put_after(
-      pool, "failed-replace/later.json", "new", 3, (struct io_event){ 0 }) !=
-      0);
+  CHECK(Cleanup,
+        pool->queue_metadata(pool, "failed-replace/later.json", "new", 3) != 0);
   CHECK(Cleanup, pool->flush(pool) != 0);
   shard_pool_destroy(pool);
   store_destroy(store);
@@ -1379,10 +1365,10 @@ main(void)
   err |= test_shard_pool_handle_bound(3, 16);
   err |= test_backend_open_failure_cleanup();
   err |= test_shard_pool_owns_open_paths();
-  err |= test_put_after_owns_data_and_progresses();
-  err |= test_put_after_preserves_order();
-  err |= test_put_after_failed_write_keeps_extent();
-  err |= test_put_after_replace_failure_is_sticky();
+  err |= test_queued_metadata_owns_data_and_progresses();
+  err |= test_queued_metadata_preserves_order();
+  err |= test_queued_metadata_failed_write_keeps_extent();
+  err |= test_queued_metadata_replace_failure_is_sticky();
   err |= test_stale_file_token_refused();
   err |= test_has_existing_data();
   err |= test_has_existing_data_unrelated_files();

--- a/tests/test_store_fs.c
+++ b/tests/test_store_fs.c
@@ -602,16 +602,18 @@ put_reader_fn(void* arg)
 }
 
 static int
-test_put_is_atomic_for_readers(void)
+test_put_is_atomic_for_readers(int queued)
 {
-  log_info("=== test_put_is_atomic_for_readers ===");
+  log_info("=== test_put_is_atomic_for_readers (queued=%d) ===", queued);
 
   char root[4096];
-  snprintf(root, sizeof(root), "%s/atomic_put", tmpdir);
+  snprintf(root, sizeof(root), "%s/atomic_put_%d", tmpdir, queued);
   CHECK(Fail, test_mkdir(root) == 0);
 
   struct store* s = store_fs_create(root, 0);
   CHECK(Fail, s);
+  struct shard_pool* pool = queued ? s->create_pool(s, 1) : NULL;
+  CHECK(Fail2, !queued || pool);
 
   char* longdoc = (char*)malloc(PUT_LONG_BYTES);
   CHECK(Fail2, longdoc);
@@ -631,9 +633,15 @@ test_put_is_atomic_for_readers(void)
 
   int put_err = 0;
   for (int i = 0; i < PUT_ROUNDS && !put_err; ++i) {
-    put_err = (i % 2) ? s->put(s, "zarr.json", shortdoc, strlen(shortdoc))
-                      : s->put(s, "zarr.json", longdoc, PUT_LONG_BYTES);
+    const char* doc = i % 2 ? shortdoc : longdoc;
+    const size_t len = i % 2 ? strlen(shortdoc) : PUT_LONG_BYTES;
+    put_err =
+      pool
+        ? pool->put_after(pool, "zarr.json", doc, len, (struct io_event){ 0 })
+        : s->put(s, "zarr.json", doc, len);
   }
+  if (pool)
+    put_err |= pool->flush(pool);
 
   atomic_store(&reader.stop, 1);
   CHECK(Fail3, test_thread_join(t) == 0);
@@ -653,6 +661,7 @@ test_put_is_atomic_for_readers(void)
   CHECK(Fail3, memcmp(final_doc, shortdoc, final_len) == 0);
 
   free(longdoc);
+  shard_pool_destroy(pool);
   store_destroy(s);
   log_info("  PASS");
   return 0;
@@ -660,6 +669,7 @@ test_put_is_atomic_for_readers(void)
 Fail3:
   free(longdoc);
 Fail2:
+  shard_pool_destroy(pool);
   store_destroy(s);
 Fail:
   log_error("  FAIL");
@@ -1018,6 +1028,234 @@ Fail:
   return 1;
 }
 
+static int
+metadata_file_matches(const char* path, const char* expected)
+{
+  FILE* file = fopen(path, "rb");
+  if (!file)
+    return 0;
+  char actual[256];
+  const size_t nread = fread(actual, 1, sizeof(actual), file);
+  const int end = fgetc(file);
+  fclose(file);
+  return nread == strlen(expected) && end == EOF &&
+         memcmp(actual, expected, nread) == 0;
+}
+
+static int
+wait_for_fault_taken(struct io_faults* faults)
+{
+  for (int i = 0; i < 2000; ++i) {
+    if (!atomic_load(&faults->armed))
+      return 0;
+    platform_sleep_ns(1000000LL);
+  }
+  return 1;
+}
+
+static void
+metadata_probe_finished(void* ctx)
+{
+  atomic_store((_Atomic int*)ctx, 1);
+}
+
+static int
+test_put_after_owns_data_and_progresses(void)
+{
+  _Atomic int gate = 0;
+  struct io_faults faults;
+  struct store* store = store_fs_create(tmpdir, 0);
+  struct shard_pool* pool = NULL;
+  CHECK(Cleanup, store);
+  char key[] = "owned-metadata.json";
+  char data[] = "{\"shape\":[16]}";
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/%s", tmpdir, key);
+  CHECK(Cleanup, store->put(store, key, "{}", 2) == 0);
+
+  // An unbuffered shard pool must still accept this unaligned metadata.
+  const struct io_scheduler_limits limits = { .workers = 4 };
+  pool = io_faults_pool_create(&faults, tmpdir, 1, 1, &limits);
+  CHECK(Cleanup, pool && pool->put_after);
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
+  CHECK(Cleanup,
+        pool->put_after(
+          pool, key, data, strlen(data), pool->record_fence(pool)) == 0);
+  memset(key, 'x', sizeof(key) - 1);
+  memset(data, 'x', sizeof(data) - 1);
+  CHECK(Cleanup, metadata_file_matches(path, "{}"));
+
+  atomic_store(&gate, 1);
+  int published = 0;
+  for (int i = 0; i < 2000 && !published; ++i) {
+    published = metadata_file_matches(path, "{\"shape\":[16]}");
+    if (!published)
+      platform_sleep_ns(1000000LL);
+  }
+  // Publication must advance even if the producer makes no further calls.
+  CHECK(Cleanup, published);
+  CHECK(Cleanup, pool->flush(pool) == 0);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return 0;
+
+Cleanup:
+  atomic_store(&gate, 1);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return 1;
+}
+
+static int
+test_put_after_preserves_order(void)
+{
+  _Atomic int gate = 0;
+  _Atomic int probe_done = 0;
+  struct io_faults faults;
+  struct store* store = store_fs_create(tmpdir, 0);
+  struct shard_pool* pool = NULL;
+  CHECK(Cleanup, store);
+  const char* key = "ordered-metadata.json";
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/%s", tmpdir, key);
+  CHECK(Cleanup, store->put(store, key, "old", 3) == 0);
+  const struct io_scheduler_limits limits = { .workers = 2 };
+  pool = io_faults_pool_create(&faults, tmpdir, 1, 0, &limits);
+  CHECK(Cleanup, pool && pool->put_after);
+
+  // Hold the first replacement itself; a second free worker must not let a
+  // later extent overtake it, even when the caller passes an empty fence.
+  faults.block_gate = &gate;
+  atomic_store(&faults.armed,
+               (uint16_t)((IO_OP_REPLACE << 8) | IO_FAULT_BLOCK));
+  CHECK(Cleanup,
+        pool->put_after(pool, key, "first", 5, (struct io_event){ 0 }) == 0);
+  CHECK(Cleanup, wait_for_fault_taken(&faults) == 0);
+  CHECK(Cleanup,
+        pool->put_after(pool, key, "second", 6, (struct io_event){ 0 }) == 0);
+  CHECK(Cleanup,
+        io_scheduler_post(faults.queue,
+                          (struct io_request){
+                            .op = IO_OP_NOOP,
+                            .finished = metadata_probe_finished,
+                            .finished_ctx = &probe_done,
+                          }) == 0);
+  CHECK(Cleanup, test_wait_flag(&probe_done, 2000) == 0);
+  CHECK(Cleanup, metadata_file_matches(path, "old"));
+
+  atomic_store(&gate, 1);
+  // Destruction itself must drain the dependent replacements in order.
+  shard_pool_destroy(pool);
+  pool = NULL;
+  CHECK(Cleanup, metadata_file_matches(path, "second"));
+  store_destroy(store);
+  return 0;
+
+Cleanup:
+  atomic_store(&gate, 1);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return 1;
+}
+
+static int
+test_put_after_failed_write_keeps_extent(void)
+{
+  _Atomic int gate = 0;
+  struct io_faults faults;
+  struct store* store = store_fs_create(tmpdir, 0);
+  struct shard_pool* pool = NULL;
+  CHECK(Cleanup, store);
+  const char* key = "failed-write-metadata.json";
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/%s", tmpdir, key);
+  CHECK(Cleanup, store->put(store, key, "old", 3) == 0);
+  const struct io_scheduler_limits limits = { .workers = 1 };
+  pool = io_faults_pool_create(&faults, tmpdir, 1, 0, &limits);
+  CHECK(Cleanup, pool && pool->put_after);
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
+  CHECK(Cleanup, wait_for_fault_taken(&faults) == 0);
+
+  io_faults_fail_next_write(&faults);
+  struct shard_writer* writer =
+    pool->open(pool, 0, "failed-metadata-prerequisite.bin");
+  CHECK(Cleanup, writer);
+  const char byte = 'x';
+  CHECK(Cleanup, writer->write(writer, 0, &byte, &byte + 1) == 0);
+  CHECK(Cleanup, writer->finalize(writer) == 0);
+  CHECK(Cleanup,
+        pool->put_after(pool, key, "new", 3, pool->record_fence(pool)) == 0);
+  atomic_store(&gate, 1);
+  CHECK(Cleanup, pool->flush(pool) != 0);
+  CHECK(Cleanup, pool->has_error(pool) != 0);
+  CHECK(Cleanup, metadata_file_matches(path, "old"));
+  CHECK(Cleanup,
+        pool->put_after(pool, key, "later", 5, (struct io_event){ 0 }) != 0);
+  CHECK(Cleanup, pool->flush(pool) != 0);
+  CHECK(Cleanup, metadata_file_matches(path, "old"));
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return 0;
+
+Cleanup:
+  atomic_store(&gate, 1);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return 1;
+}
+
+static int
+test_put_after_replace_failure_is_sticky(void)
+{
+  _Atomic int gate = 0;
+  struct io_faults faults;
+  struct store* store = store_fs_create(tmpdir, 0);
+  struct shard_pool* pool = NULL;
+  CHECK(Cleanup, store);
+  // Renaming a file over a directory fails on every supported filesystem.
+  const char* key = "failed-replace/zarr.json";
+  CHECK(Cleanup, store->mkdirs(store, key) == 0);
+  const struct io_scheduler_limits limits = { .workers = 1 };
+  pool = io_faults_pool_create(&faults, tmpdir, 1, 0, &limits);
+  CHECK(Cleanup, pool && pool->put_after);
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
+  CHECK(Cleanup,
+        pool->put_after(pool, key, "{}", 2, (struct io_event){ 0 }) == 0);
+  CHECK(Cleanup,
+        pool->put_after(
+          pool, "failed-replace/next.json", "new", 3, (struct io_event){ 0 }) ==
+          0);
+  atomic_store(&gate, 1);
+  CHECK(Cleanup, pool->flush(pool) != 0);
+  CHECK(Cleanup, pool->has_error(pool) != 0);
+
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/failed-replace/next.json", tmpdir);
+  CHECK(Cleanup, platform_path_exists(path) == 0);
+  snprintf(path,
+           sizeof(path),
+           "%s/%s.tmp.%llu",
+           tmpdir,
+           key,
+           (unsigned long long)platform_process_id());
+  CHECK(Cleanup, platform_path_exists(path) == 0);
+  CHECK(
+    Cleanup,
+    pool->put_after(
+      pool, "failed-replace/later.json", "new", 3, (struct io_event){ 0 }) !=
+      0);
+  CHECK(Cleanup, pool->flush(pool) != 0);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return 0;
+
+Cleanup:
+  atomic_store(&gate, 1);
+  shard_pool_destroy(pool);
+  store_destroy(store);
+  return 1;
+}
+
 // --- stale file token ---
 
 // A pool slot's token is private and is cleared on finalize, so a retired
@@ -1124,7 +1362,8 @@ main(void)
 
   int err = 0;
   err |= test_store_put();
-  err |= test_put_is_atomic_for_readers();
+  err |= test_put_is_atomic_for_readers(0);
+  err |= test_put_is_atomic_for_readers(1);
   err |= test_store_mkdirs();
   err |= test_shard_pool_write();
   err |= test_shard_pool_fence();
@@ -1140,6 +1379,10 @@ main(void)
   err |= test_shard_pool_handle_bound(3, 16);
   err |= test_backend_open_failure_cleanup();
   err |= test_shard_pool_owns_open_paths();
+  err |= test_put_after_owns_data_and_progresses();
+  err |= test_put_after_preserves_order();
+  err |= test_put_after_failed_write_keeps_extent();
+  err |= test_put_after_replace_failure_is_sticky();
   err |= test_stale_file_token_refused();
   err |= test_has_existing_data();
   err |= test_has_existing_data_unrelated_files();

--- a/tests/test_stream_initial_shape.c
+++ b/tests/test_stream_initial_shape.c
@@ -1,0 +1,301 @@
+// A stream starts empty even when its configured capacity is finite. Array
+// creation by itself retains its fixed shape; attaching a stream publishes the
+// empty readable extent synchronously without changing that capacity.
+
+#include "defs.limits.h"
+#include "ngff/ngff_multiscale.h"
+#include "test_platform.h"
+#include "test_shard_sink.h"
+#include "test_zarr_helpers.h"
+#include "util/prelude.h"
+
+#ifdef TEST_INITIAL_SHAPE_GPU
+#include "multiarray.gpu.h"
+#include "stream.gpu.h"
+#include "test_runner.h"
+typedef struct tile_stream_gpu test_stream;
+typedef struct multiarray_tile_stream_gpu test_multiarray;
+#define stream_create tile_stream_gpu_create
+#define stream_destroy tile_stream_gpu_destroy
+#define stream_writer tile_stream_gpu_writer
+#define multiarray_create multiarray_tile_stream_gpu_create
+#define multiarray_destroy multiarray_tile_stream_gpu_destroy
+#define get_multiarray_writer multiarray_tile_stream_gpu_writer
+#else
+#include "multiarray.cpu.h"
+#include "stream.cpu.h"
+typedef struct tile_stream_cpu test_stream;
+typedef struct multiarray_tile_stream_cpu test_multiarray;
+#define stream_create tile_stream_cpu_create
+#define stream_destroy tile_stream_cpu_destroy
+#define stream_writer tile_stream_cpu_writer
+#define multiarray_create multiarray_tile_stream_cpu_create
+#define multiarray_destroy multiarray_tile_stream_cpu_destroy
+#define get_multiarray_writer multiarray_tile_stream_cpu_writer
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+static int
+metadata_has_shape(const char* root, const char* key, const char* shape)
+{
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/%s", root, key);
+  FILE* f = fopen(path, "rb");
+  if (!f)
+    return 0;
+  char json[16384];
+  size_t n = fread(json, 1, sizeof(json) - 1, f);
+  int ok = !ferror(f) && feof(f);
+  fclose(f);
+  json[n] = '\0';
+  return ok && strstr(json, shape) != NULL;
+}
+
+static void
+finite_dims(struct dimension dims[4], uint64_t capacity)
+{
+  dims_create(dims, "tzyx", (uint64_t[]){ capacity, 2, 4, 4 });
+  dims_set_chunk_sizes(dims, 4, (uint64_t[]){ 1, 1, 4, 4 });
+  dims[0].chunks_per_shard = 2;
+  dims[1].chunks_per_shard = 2;
+  dims[2].chunks_per_shard = 1;
+  dims[3].chunks_per_shard = 1;
+}
+
+static struct tile_stream_configuration
+finite_config(struct dimension* dims, uint8_t rank)
+{
+  return (struct tile_stream_configuration){
+    .buffer_capacity_bytes = 4096,
+    .dtype = dtype_u16,
+    .rank = rank,
+    .dimensions = dims,
+    .codec = { .id = CODEC_NONE },
+    .epochs_per_batch = 2,
+    .metadata_update_interval_s = 3600,
+    .max_threads = 2,
+  };
+}
+
+static int
+test_finite_shape_and_capacity(void)
+{
+  char tmpdir[512] = { 0 };
+  struct test_zarr_sink z = { 0 };
+  test_stream* s = NULL;
+  struct dimension dims[4];
+  finite_dims(dims, 4);
+  struct tile_stream_configuration cfg = finite_config(dims, 4);
+  uint16_t data[4 * 2 * 4 * 4] = { 0 };
+  int rc = 1;
+
+  CHECK(Cleanup, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  CHECK(Cleanup,
+        test_zarr_sink_open(
+          &z, tmpdir, "array", dims, 4, dtype_u16, 0, cfg.codec, 0) == 0);
+  CHECK(Cleanup,
+        metadata_has_shape(tmpdir, "array/zarr.json", "\"shape\":[4,2,4,4]"));
+  s = stream_create(&cfg, test_zarr_sink_as_shard_sink(&z));
+  CHECK(Cleanup, s);
+  CHECK(Cleanup,
+        metadata_has_shape(tmpdir, "array/zarr.json", "\"shape\":[0,2,4,4]"));
+  CHECK(Cleanup, dims[0].size == 4 && dims[1].size == 2);
+
+  struct writer* w = stream_writer(s);
+  struct slice all = { .beg = data,
+                       .end = data + sizeof(data) / sizeof(*data) };
+  struct writer_result r = writer_append_wait(w, all);
+  CHECK(Cleanup, r.error == 0);
+  struct slice extra = { .beg = data, .end = data + 1 };
+  r = writer_append(w, extra);
+  CHECK(Cleanup, r.error == writer_error_finished && r.rest.beg == extra.beg);
+  CHECK(Cleanup, writer_flush(w).error == 0);
+  CHECK(Cleanup, writer_close(w).error == 0);
+  CHECK(Cleanup,
+        metadata_has_shape(tmpdir, "array/zarr.json", "\"shape\":[4,2,4,4]"));
+  rc = 0;
+
+Cleanup:
+  stream_destroy(s);
+  test_zarr_sink_close(&z);
+  if (tmpdir[0])
+    test_tmpdir_remove(tmpdir);
+  return rc;
+}
+
+static int
+test_multiscale_initial_shape(void)
+{
+  char tmpdir[512] = { 0 };
+  struct test_zarr_multiscale z = { 0 };
+  test_stream* s = NULL;
+  struct dimension dims[3];
+  dims_create(dims, "tyx", (uint64_t[]){ 4, 8, 8 });
+  dims_set_chunk_sizes(dims, 3, (uint64_t[]){ 1, 4, 4 });
+  for (int d = 0; d < 3; ++d) {
+    dims[d].chunks_per_shard = 1;
+    dims[d].downsample = 1;
+  }
+  struct tile_stream_configuration cfg = finite_config(dims, 3);
+  uint64_t before[LOD_MAX_LEVELS][3] = { 0 };
+  int nlod = 0;
+  int rc = 1;
+
+  CHECK(Cleanup, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  CHECK(Cleanup,
+        test_zarr_multiscale_open(
+          &z, tmpdir, "multi", dims, 3, dtype_u16, 0, cfg.codec, NULL, 0) == 0);
+  while (nlod < LOD_MAX_LEVELS) {
+    struct zarr_array* a = ngff_multiscale_level(z.ms, nlod);
+    if (!a)
+      break;
+    const struct dimension* level = zarr_array_dimensions(a);
+    for (int d = 0; d < 3; ++d)
+      before[nlod][d] = level[d].size;
+    CHECK(Cleanup, before[nlod][0] > 0);
+    ++nlod;
+  }
+  CHECK(Cleanup, nlod > 1);
+  s = stream_create(&cfg, test_zarr_multiscale_as_shard_sink(&z));
+  CHECK(Cleanup, s);
+  for (int lv = 0; lv < nlod; ++lv) {
+    const struct dimension* level =
+      zarr_array_dimensions(ngff_multiscale_level(z.ms, lv));
+    CHECK(Cleanup, level[0].size == 0);
+    CHECK(Cleanup,
+          level[1].size == before[lv][1] && level[2].size == before[lv][2]);
+    char key[64], shape[128];
+    snprintf(key, sizeof(key), "multi/%d/zarr.json", lv);
+    snprintf(shape,
+             sizeof(shape),
+             "\"shape\":[0,%llu,%llu]",
+             (unsigned long long)before[lv][1],
+             (unsigned long long)before[lv][2]);
+    CHECK(Cleanup, metadata_has_shape(tmpdir, key, shape));
+  }
+  CHECK(Cleanup, dims[0].size == 4);
+  rc = 0;
+
+Cleanup:
+  stream_destroy(s);
+  test_zarr_multiscale_close(&z);
+  if (tmpdir[0])
+    test_tmpdir_remove(tmpdir);
+  return rc;
+}
+
+static int
+test_multiarray_initial_shape(void)
+{
+  char roots[2][512] = { { 0 } };
+  struct test_zarr_sink z[2] = { { 0 } };
+  test_multiarray* ms = NULL;
+  struct dimension dims[2][4];
+  struct tile_stream_configuration cfg[2];
+  struct shard_sink* sinks[2];
+  uint16_t plane[2 * 4 * 4] = { 0 };
+  int rc = 1;
+  for (int a = 0; a < 2; ++a) {
+    finite_dims(dims[a], (uint64_t)(4 + a));
+    cfg[a] = finite_config(dims[a], 4);
+    CHECK(Cleanup, test_tmpdir_create(roots[a], sizeof(roots[a])) == 0);
+    CHECK(
+      Cleanup,
+      test_zarr_sink_open(
+        &z[a], roots[a], "array", dims[a], 4, dtype_u16, 0, cfg[a].codec, 0) ==
+        0);
+    sinks[a] = test_zarr_sink_as_shard_sink(&z[a]);
+  }
+  ms = multiarray_create(2, cfg, sinks, 0);
+  CHECK(Cleanup, ms);
+  for (int a = 0; a < 2; ++a)
+    CHECK(
+      Cleanup,
+      metadata_has_shape(roots[a], "array/zarr.json", "\"shape\":[0,2,4,4]"));
+
+  struct multiarray_writer* w = get_multiarray_writer(ms);
+  struct slice input = { .beg = plane, .end = plane + 2 * 4 * 4 };
+  CHECK(Cleanup, w->update(w, 0, input).error == 0);
+  CHECK(Cleanup, w->flush(w).error == 0);
+  CHECK(Cleanup, w->close(w).error == 0);
+  CHECK(Cleanup,
+        metadata_has_shape(roots[0], "array/zarr.json", "\"shape\":[1,2,4,4]"));
+  CHECK(Cleanup,
+        metadata_has_shape(roots[1], "array/zarr.json", "\"shape\":[0,2,4,4]"));
+  CHECK(Cleanup, dims[0][0].size == 4 && dims[1][0].size == 5);
+  rc = 0;
+
+Cleanup:
+  multiarray_destroy(ms);
+  for (int a = 0; a < 2; ++a) {
+    test_zarr_sink_close(&z[a]);
+    if (roots[a][0])
+      test_tmpdir_remove(roots[a]);
+  }
+  return rc;
+}
+
+static int
+reject_update(struct shard_sink* self,
+              uint8_t level,
+              uint8_t n_append,
+              const uint64_t* sizes)
+{
+  (void)level;
+  (void)n_append;
+  struct test_shard_sink* sink =
+    container_of(self, struct test_shard_sink, base);
+  ++sink->update_append_count;
+  sink->last_append_size0 = sizes[0];
+  return 1;
+}
+
+static int
+test_initial_publication_failure(void)
+{
+  struct test_shard_sink sinks[2];
+  for (int a = 0; a < 2; ++a)
+    test_sink_init(&sinks[a], 1, 4096);
+  sinks[1].base.update_append = reject_update;
+  struct dimension dims[4];
+  finite_dims(dims, 4);
+  struct tile_stream_configuration cfg[2] = {
+    finite_config(dims, 4),
+    finite_config(dims, 4),
+  };
+  struct shard_sink* ptrs[2] = { &sinks[0].base, &sinks[1].base };
+  test_stream* s = stream_create(&cfg[1], ptrs[1]);
+  test_multiarray* ms = NULL;
+  int rc = 1;
+  CHECK(Cleanup, !s && sinks[1].update_append_count == 1);
+  CHECK(Cleanup, sinks[1].last_append_size0 == 0);
+  sinks[1].update_append_count = 0;
+  ms = multiarray_create(2, cfg, ptrs, 0);
+  CHECK(Cleanup, !ms);
+  CHECK(Cleanup,
+        sinks[0].update_append_count == 1 && sinks[1].update_append_count == 1);
+  rc = 0;
+Cleanup:
+  stream_destroy(s);
+  multiarray_destroy(ms);
+  for (int a = 0; a < 2; ++a)
+    test_sink_free(&sinks[a]);
+  return rc;
+}
+
+#ifdef TEST_INITIAL_SHAPE_GPU
+RUN_GPU_TESTS({ "finite_shape_and_capacity", test_finite_shape_and_capacity },
+              { "multiscale_initial_shape", test_multiscale_initial_shape },
+              { "multiarray_initial_shape", test_multiarray_initial_shape },
+              { "initial_publication_failure",
+                test_initial_publication_failure }, )
+#else
+int
+main(void)
+{
+  return test_finite_shape_and_capacity() | test_multiscale_initial_shape() |
+         test_multiarray_initial_shape() | test_initial_publication_failure();
+}
+#endif

--- a/tests/test_stream_publication.c
+++ b/tests/test_stream_publication.c
@@ -1,15 +1,19 @@
 // A stream starts empty even when its configured capacity is finite. Array
 // creation by itself retains its fixed shape; attaching a stream publishes the
-// empty readable extent synchronously without changing that capacity.
+// empty readable extent synchronously without changing that capacity. Later
+// publication follows completed IO without blocking append or requiring input.
 
 #include "defs.limits.h"
 #include "ngff/ngff_multiscale.h"
+#include "platform/platform.h"
+#include "test_io_faults.h"
 #include "test_platform.h"
 #include "test_shard_sink.h"
 #include "test_zarr_helpers.h"
 #include "util/prelude.h"
 
-#ifdef TEST_INITIAL_SHAPE_GPU
+#ifdef TEST_STREAM_PUBLICATION_GPU
+#include "gpu/stream.internal.h"
 #include "multiarray.gpu.h"
 #include "stream.gpu.h"
 #include "test_runner.h"
@@ -34,6 +38,7 @@ typedef struct multiarray_tile_stream_cpu test_multiarray;
 #define get_multiarray_writer multiarray_tile_stream_cpu_writer
 #endif
 
+#include <stdatomic.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -285,17 +290,159 @@ Cleanup:
   return rc;
 }
 
-#ifdef TEST_INITIAL_SHAPE_GPU
+#define PUBLICATION_TIMEOUT_MS 5000
+
+struct append_args
+{
+  struct writer* w;
+  struct slice input;
+  _Atomic int done;
+  int error;
+};
+
+static void
+append_thread_fn(void* arg)
+{
+  struct append_args* a = (struct append_args*)arg;
+  a->error = writer_append_wait(a->w, a->input).error;
+  atomic_store(&a->done, 1);
+}
+
+// A closed generation queues its metadata behind a filesystem fence, without
+// parking append. Releasing that fence must publish even if input stops.
+static int
+check_publication_follows_io(int fail_truncate)
+{
+  char tmpdir[512] = { 0 };
+  struct dimension dims[] = {
+    { .size = 8,
+      .chunk_size = 1,
+      .chunks_per_shard = 2,
+      .name = "t",
+      .storage_position = 0 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "y",
+      .storage_position = 1 },
+    { .size = 8,
+      .chunk_size = 8,
+      .chunks_per_shard = 1,
+      .name = "x",
+      .storage_position = 2 },
+  };
+  struct io_faults faults;
+  struct test_zarr_sink z = { 0 };
+  test_stream* s = NULL;
+  test_thread* thr = NULL;
+  uint16_t data[2 * 8 * 8] = { 0 };
+  _Atomic int gate = 0;
+  struct append_args a = { 0 };
+  int rc = 1;
+
+  CHECK(Cleanup, test_tmpdir_create(tmpdir, sizeof(tmpdir)) == 0);
+  CHECK(Cleanup,
+        test_zarr_sink_open_with_pool(
+          &z,
+          io_faults_store_create(&faults, tmpdir, 1, NULL),
+          "0",
+          dims,
+          3,
+          dtype_u16,
+          (struct codec_config){ .id = CODEC_NONE }) == 0);
+  struct tile_stream_configuration cfg = finite_config(dims, 3);
+  cfg.metadata_update_interval_s = 0;
+  s = stream_create(&cfg, test_zarr_sink_as_shard_sink(&z));
+  CHECK(Cleanup,
+        s && metadata_has_shape(tmpdir, "0/zarr.json", "\"shape\":[0,8,8]"));
+  CHECK(Cleanup, io_faults_inject_blocking_job(&faults, &gate) == 0);
+  for (int i = 0; i < PUBLICATION_TIMEOUT_MS && atomic_load(&faults.armed); ++i)
+    platform_sleep_ns(1000000LL);
+  CHECK(Cleanup, atomic_load(&faults.armed) == 0);
+  if (fail_truncate)
+    io_faults_fail_next_truncate(&faults);
+
+  a.w = stream_writer(s);
+  a.input = (struct slice){ .beg = data, .end = data + 2 * 8 * 8 };
+  CHECK(Cleanup, test_thread_start(&thr, append_thread_fn, &a) == 0);
+  CHECK(Cleanup, test_wait_flag(&a.done, PUBLICATION_TIMEOUT_MS) == 0);
+  test_thread_join(thr);
+  thr = NULL;
+  CHECK(Cleanup, fail_truncate || a.error == 0);
+#ifdef TEST_STREAM_PUBLICATION_GPU
+  if (!fail_truncate && s->engine.delivery.thread) {
+    for (int i = 0; i < PUBLICATION_TIMEOUT_MS &&
+                    gpu_delivery_job_state(&s->engine.delivery, 0, NULL) !=
+                      DELIVERY_JOB_DONE;
+         ++i)
+      platform_sleep_ns(1000000LL);
+    CHECK(Cleanup,
+          gpu_delivery_job_state(&s->engine.delivery, 0, NULL) ==
+            DELIVERY_JOB_DONE);
+  }
+#endif
+  CHECK(Cleanup, atomic_load(&gate) == 0);
+  CHECK(Cleanup,
+        metadata_has_shape(tmpdir, "0/zarr.json", "\"shape\":[0,8,8]"));
+
+  atomic_store(&gate, 1);
+  if (!fail_truncate) {
+    for (int i = 0;
+         i < PUBLICATION_TIMEOUT_MS &&
+         !metadata_has_shape(tmpdir, "0/zarr.json", "\"shape\":[2,8,8]");
+         ++i)
+      platform_sleep_ns(1000000LL);
+    CHECK(Cleanup,
+          metadata_has_shape(tmpdir, "0/zarr.json", "\"shape\":[2,8,8]"));
+  }
+  struct writer_result fr = writer_flush(a.w);
+  struct writer_result cr = writer_close(a.w);
+  CHECK(Cleanup, (fr.error != 0) == fail_truncate);
+  CHECK(Cleanup, (cr.error != 0) == fail_truncate);
+  CHECK(Cleanup,
+        metadata_has_shape(tmpdir,
+                           "0/zarr.json",
+                           fail_truncate ? "\"shape\":[0,8,8]"
+                                         : "\"shape\":[2,8,8]"));
+  rc = 0;
+
+Cleanup:
+  atomic_store(&gate, 1);
+  test_thread_join(thr);
+  stream_destroy(s);
+  test_zarr_sink_close(&z);
+  if (tmpdir[0])
+    test_tmpdir_remove(tmpdir);
+  return rc;
+}
+
+static int
+test_publication_follows_io(void)
+{
+  return check_publication_follows_io(0);
+}
+
+static int
+test_publication_withholds_failed_io(void)
+{
+  return check_publication_follows_io(1);
+}
+
+#ifdef TEST_STREAM_PUBLICATION_GPU
 RUN_GPU_TESTS({ "finite_shape_and_capacity", test_finite_shape_and_capacity },
               { "multiscale_initial_shape", test_multiscale_initial_shape },
               { "multiarray_initial_shape", test_multiarray_initial_shape },
               { "initial_publication_failure",
-                test_initial_publication_failure }, )
+                test_initial_publication_failure },
+              { "publication_follows_io", test_publication_follows_io },
+              { "publication_withholds_failed_io",
+                test_publication_withholds_failed_io }, )
 #else
 int
 main(void)
 {
   return test_finite_shape_and_capacity() | test_multiscale_initial_shape() |
-         test_multiarray_initial_shape() | test_initial_publication_failure();
+         test_multiarray_initial_shape() | test_initial_publication_failure() |
+         test_publication_follows_io() | test_publication_withholds_failed_io();
 }
 #endif

--- a/tests/test_stream_publication.c
+++ b/tests/test_stream_publication.c
@@ -40,7 +40,20 @@ typedef struct multiarray_tile_stream_cpu test_multiarray;
 
 #include <stdatomic.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+static int descriptor_alloc_calls;
+static int fail_descriptor_alloc;
+
+void*
+chucky_test_multiarray_descriptor_alloc(size_t count, size_t size)
+{
+  ++descriptor_alloc_calls;
+  if (fail_descriptor_alloc)
+    return NULL;
+  return calloc(count, size);
+}
 
 static int
 metadata_has_shape(const char* root, const char* key, const char* shape)
@@ -257,36 +270,100 @@ reject_update(struct shard_sink* self,
   return 1;
 }
 
+struct construction_sink
+{
+  struct test_shard_sink inner;
+  int flush_count;
+};
+
+static int
+count_flush(struct shard_sink* self)
+{
+  struct test_shard_sink* inner =
+    container_of(self, struct test_shard_sink, base);
+  struct construction_sink* sink =
+    container_of(inner, struct construction_sink, inner);
+  ++sink->flush_count;
+  return 0;
+}
+
+static void
+construction_sink_init(struct construction_sink* sink)
+{
+  *sink = (struct construction_sink){ 0 };
+  test_sink_init(&sink->inner, 1, 4096);
+  sink->inner.base.flush = count_flush;
+}
+
 static int
 test_initial_publication_failure(void)
 {
-  struct test_shard_sink sinks[2];
+  struct construction_sink sinks[2];
   for (int a = 0; a < 2; ++a)
-    test_sink_init(&sinks[a], 1, 4096);
-  sinks[1].base.update_append = reject_update;
+    construction_sink_init(&sinks[a]);
+  sinks[1].inner.base.update_append = reject_update;
   struct dimension dims[4];
   finite_dims(dims, 4);
   struct tile_stream_configuration cfg[2] = {
     finite_config(dims, 4),
     finite_config(dims, 4),
   };
-  struct shard_sink* ptrs[2] = { &sinks[0].base, &sinks[1].base };
+  struct shard_sink* ptrs[2] = { &sinks[0].inner.base, &sinks[1].inner.base };
   test_stream* s = stream_create(&cfg[1], ptrs[1]);
   test_multiarray* ms = NULL;
   int rc = 1;
-  CHECK(Cleanup, !s && sinks[1].update_append_count == 1);
-  CHECK(Cleanup, sinks[1].last_append_size0 == 0);
-  sinks[1].update_append_count = 0;
+  CHECK(Cleanup, !s && sinks[1].inner.update_append_count == 1);
+  CHECK(Cleanup, sinks[1].inner.last_append_size0 == 0);
+  CHECK(Cleanup,
+        sinks[1].inner.open_count == 0 && sinks[1].inner.finalize_count == 0 &&
+          sinks[1].flush_count == 0);
+  sinks[1].inner.update_append_count = 0;
   ms = multiarray_create(2, cfg, ptrs, 0);
   CHECK(Cleanup, !ms);
   CHECK(Cleanup,
-        sinks[0].update_append_count == 1 && sinks[1].update_append_count == 1);
+        sinks[0].inner.update_append_count == 1 &&
+          sinks[1].inner.update_append_count == 1);
+  for (int a = 0; a < 2; ++a)
+    CHECK(Cleanup,
+          sinks[a].inner.open_count == 0 &&
+            sinks[a].inner.finalize_count == 0 && sinks[a].flush_count == 0);
   rc = 0;
 Cleanup:
   stream_destroy(s);
   multiarray_destroy(ms);
   for (int a = 0; a < 2; ++a)
-    test_sink_free(&sinks[a]);
+    test_sink_free(&sinks[a].inner);
+  return rc;
+}
+
+static int
+test_descriptor_allocation_failure(void)
+{
+  struct construction_sink sink;
+  construction_sink_init(&sink);
+  struct dimension dims[4];
+  finite_dims(dims, 4);
+  struct tile_stream_configuration cfg = finite_config(dims, 4);
+  struct shard_sink* ptr = &sink.inner.base;
+  test_multiarray* ms = NULL;
+  int rc = 1;
+
+  descriptor_alloc_calls = 0;
+  fail_descriptor_alloc = 1;
+  ms = multiarray_create(1, &cfg, &ptr, 0);
+  fail_descriptor_alloc = 0;
+
+  CHECK(Cleanup, !ms);
+  CHECK(Cleanup, descriptor_alloc_calls == 1);
+  CHECK(Cleanup,
+        sink.inner.update_append_count == 0 && sink.inner.open_count == 0 &&
+          sink.inner.finalize_count == 0 && sink.flush_count == 0);
+  rc = 0;
+
+Cleanup:
+  fail_descriptor_alloc = 0;
+  multiarray_destroy(ms);
+  test_sink_free(&sink.inner);
   return rc;
 }
 
@@ -429,20 +506,21 @@ test_publication_withholds_failed_io(void)
 }
 
 #ifdef TEST_STREAM_PUBLICATION_GPU
-RUN_GPU_TESTS({ "finite_shape_and_capacity", test_finite_shape_and_capacity },
-              { "multiscale_initial_shape", test_multiscale_initial_shape },
-              { "multiarray_initial_shape", test_multiarray_initial_shape },
-              { "initial_publication_failure",
-                test_initial_publication_failure },
-              { "publication_follows_io", test_publication_follows_io },
-              { "publication_withholds_failed_io",
-                test_publication_withholds_failed_io }, )
+RUN_GPU_TESTS(
+  { "finite_shape_and_capacity", test_finite_shape_and_capacity },
+  { "multiscale_initial_shape", test_multiscale_initial_shape },
+  { "multiarray_initial_shape", test_multiarray_initial_shape },
+  { "initial_publication_failure", test_initial_publication_failure },
+  { "descriptor_allocation_failure", test_descriptor_allocation_failure },
+  { "publication_follows_io", test_publication_follows_io },
+  { "publication_withholds_failed_io", test_publication_withholds_failed_io }, )
 #else
 int
 main(void)
 {
   return test_finite_shape_and_capacity() | test_multiscale_initial_shape() |
          test_multiarray_initial_shape() | test_initial_publication_failure() |
-         test_publication_follows_io() | test_publication_withholds_failed_io();
+         test_descriptor_allocation_failure() | test_publication_follows_io() |
+         test_publication_withholds_failed_io();
 }
 #endif

--- a/tests/test_zarr_fs_sink.c
+++ b/tests/test_zarr_fs_sink.c
@@ -950,8 +950,8 @@ test_midstream_metadata_update(const char* tmpdir)
         test_zarr_sink_open(&z, tmpdir, "0", dims, 3, dtype_u16, 0, codec, 1) ==
           0);
 
-  // Enable periodic metadata updates with a tiny interval.
-  // Force epochs_per_batch=1 so each epoch triggers a flush (and timer check).
+  // Each epoch is a batch, and interval zero requests publication whenever
+  // that batch reaches delivery.
   const struct tile_stream_configuration config = {
     .buffer_capacity_bytes = 4096,
     .dtype = dtype_u16,
@@ -967,51 +967,42 @@ test_midstream_metadata_update(const char* tmpdir)
         (s = tile_stream_gpu_create(&config,
                                     test_zarr_sink_as_shard_sink(&z))) != NULL);
 
-  // Feed several epochs of data (enough to trigger timer-based update)
-  const size_t total = 6 * tile_stream_gpu_layout(s)->epoch_elements;
+  // Five epochs fill one three-epoch shard and leave another shard partial.
+  // Even after the delivery worker catches up, only the first is readable.
+  const size_t total = 5 * tile_stream_gpu_layout(s)->epoch_elements;
   uint16_t* src = (uint16_t*)malloc(total * sizeof(uint16_t));
   CHECK(Fail3, src);
   for (size_t i = 0; i < total; ++i)
     src[i] = (uint16_t)(i % 65536);
 
-  // Feed in two batches; the 1e-9 interval fires the timer on every
-  // wait_and_deliver
-  size_t half = 3 * tile_stream_gpu_layout(s)->epoch_elements;
+  // Feed two appends without flushing or waiting for filesystem completion.
+  size_t first = 3 * tile_stream_gpu_layout(s)->epoch_elements;
   {
-    struct slice input = { .beg = src, .end = src + half };
+    struct slice input = { .beg = src, .end = src + first };
     struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
     CHECK(Fail4, r.error == 0);
   }
 
   {
-    struct slice input = { .beg = src + half, .end = src + total };
+    struct slice input = { .beg = src + first, .end = src + total };
     struct writer_result r = writer_append(tile_stream_gpu_writer(s), input);
     CHECK(Fail4, r.error == 0);
   }
 
-  // The timer-based update_append fired during the second append batch,
-  // writing zarr.json synchronously. Verify shape[0] > 0 before writer_flush.
+  // Publication follows queued filesystem completion. Observe it as a reader,
+  // without another append or a flush/drain call driving the update.
   {
     char path[4096];
     snprintf(path, sizeof(path), "%s/0/zarr.json", tmpdir);
 
-    uint8_t* data;
-    size_t len;
-    CHECK(Fail4, read_file_all(path, &data, &len) == 0);
-    data[len < 4095 ? len : 4095] = '\0';
-    log_info("  midstream metadata: %s", (char*)data);
-
-    // Of the 6 epochs kicked, the two still sitting in their slots have not
-    // been delivered, and a slot is always drained before it is refilled, so
-    // the delivered count is exact. Of those, only the chunks filling a whole
-    // shard may be advertised: the remainder sits in a shard that has no
-    // index on disk yet (#123).
+    // The worker may deliver every kicked epoch independently of append.
+    // Only whole shards may be advertised; the remaining chunks have no
+    // completed shard index yet (#123).
     const uint64_t epochs_kicked =
       total / tile_stream_gpu_layout(s)->epoch_elements;
-    const uint64_t chunks_delivered = epochs_kicked - 2;
     const uint64_t finalized_chunks =
-      (chunks_delivered / dims[0].chunks_per_shard) * dims[0].chunks_per_shard;
-    CHECK(Fail4, finalized_chunks < chunks_delivered); // else nothing is gated
+      (epochs_kicked / dims[0].chunks_per_shard) * dims[0].chunks_per_shard;
+    CHECK(Fail4, finalized_chunks < epochs_kicked); // else nothing is gated
 
     char expected_shape[64];
     snprintf(expected_shape,
@@ -1021,12 +1012,24 @@ test_midstream_metadata_update(const char* tmpdir)
              (unsigned long long)dims[1].size,
              (unsigned long long)dims[2].size);
 
-    int has_shape = strstr((char*)data, expected_shape) != NULL;
-    int is_array = strstr((char*)data, "\"node_type\":\"array\"") != NULL;
-    free(data);
-
+    const int64_t deadline_ns = platform_monotonic_ns() + 5000000000LL;
+    int has_shape = 0;
+    for (;;) {
+      uint8_t* data;
+      size_t len;
+      CHECK(Fail4, read_file_all(path, &data, &len) == 0);
+      data[len] = '\0';
+      has_shape = strstr((char*)data, expected_shape) != NULL;
+      int is_array = strstr((char*)data, "\"node_type\":\"array\"") != NULL;
+      if (has_shape)
+        log_info("  midstream metadata: %s", (char*)data);
+      free(data);
+      CHECK(Fail4, is_array);
+      if (has_shape || platform_monotonic_ns() >= deadline_ns)
+        break;
+      platform_sleep_ns(1000000LL);
+    }
     CHECK(Fail4, has_shape);
-    CHECK(Fail4, is_array);
 
     // Follow the advertised extent into the shard files the way a reader
     // would. Every shard it names must carry a real index; a shard still
@@ -1061,14 +1064,15 @@ test_midstream_metadata_update(const char* tmpdir)
              (unsigned long long)(append_shards * x_shards));
   }
 
-  // Now flush and verify final state
+  // Now finalize and publish the partial shard as well.
   {
     struct writer_result r = writer_flush(tile_stream_gpu_writer(s));
     CHECK(Fail4, r.error == 0);
   }
+  CHECK(Fail4, writer_close(tile_stream_gpu_writer(s)).error == 0);
   CHECK(Fail4, test_zarr_sink_flush(&z) == 0);
 
-  // Verify final shape after flush: 6 epochs * chunk_size 2 = 12
+  // Verify final shape after close: 5 epochs * chunk_size 2 = 10.
   {
     char path[4096];
     snprintf(path, sizeof(path), "%s/0/zarr.json", tmpdir);
@@ -1077,10 +1081,10 @@ test_midstream_metadata_update(const char* tmpdir)
     size_t len;
     CHECK(Fail4, read_file_all(path, &data, &len) == 0);
     data[len < 4095 ? len : 4095] = '\0';
-    int has_shape = strstr((char*)data, "\"shape\":[12,8,12]") != NULL;
+    int has_shape = strstr((char*)data, "\"shape\":[10,8,12]") != NULL;
     free(data);
     CHECK(Fail4, has_shape);
-    log_info("  final metadata shape: [12,8,12] OK");
+    log_info("  final metadata shape: [10,8,12] OK");
   }
 
   free(src);


### PR DESCRIPTION
Publishing a closed shard's readable extent waits for filesystem I/O on
the CPU append path or GPU delivery worker. Metadata snapshots now use
the existing scheduler, allowing both paths to continue while publication
waits for earlier writes to succeed.

Metadata replacement is atomic. Flush and close report queued I/O
failures; close waits for publication. New streams advertise an
empty extent while retaining input capacity. Failed constructors release
resources without finalizing sinks.

Small GPU host-copy timings are sampled while preserving copy totals and
append latency metrics. Single-stream benchmark timing includes final
close.

CPU tests, Zarr/NGFF readback, and sweep/report tests pass. CI passes on
CPU, CUDA 12/13, macOS, and Windows.

Closes #268.
