### PR TITLE
bench: add sustained append throughput and boundary latency measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,48 @@ multiscale, and multiscale-with-dim0-downsampling modes.
 | `--blosc-block-bytes` | e.g. `16K`, `64K`, `4097` | Required for Blosc | Internal Blosc block size in bytes |
 | `--blosc-shuffle` | `none`, `byte`, `bit` | `none` | Blosc filter; recorded with the level in benchmark JSON |
 | `--reduce` | `mean`, `min`, `max`, `median`, `max_sup`, `min_sup` | `mean` | LOD reduction method |
+| `--duration` | seconds, > 0 | off | Sustained measurement window; single-stream, single-scale discard only |
+| `--warmup` | seconds, >= 0 | 0 | Unmeasured streaming before `--duration` |
+| `--no-boundary-timing` | flag | off | Disable full-API samples to check their observer overhead |
+| `--append-elements` | element count | bulk | In sustained mode, append bytes must divide the fixed 64 MiB source ring |
 | `--full-memcpy-timing` | flag | off | GPU profiling: time every host copy instead of sampling small copies |
 | `-o path` | output directory | omit to discard | Write Zarr output to disk |
 
 Benchmarks report per-stage throughput and latency, compression ratio, memory
 breakdown, and overall pipeline GiB/s.
+
+For sustained append comparisons, hold the reference frame count, chunk size,
+memory budget, and source pattern fixed. For example:
+
+```sh
+./build/bench/bench_stream_smallepoch_single --backend gpu --codec none \
+  --fill xor --dtype u16 --frames 65536 --chunk-bytes 1M --memory-budget 5G \
+  --append-elements 256 --warmup 5 --duration 20 --json
+```
+
+Here `--frames` fits the layout; streaming then continues without a frame limit.
+Preparation and stream creation precede warmup. The measurement window does not
+flush at either endpoint. Its completed-output rate counts physical discard
+bytes (including padding and footers), not accepted input or queued writes.
+Final flush and close are timed separately as drain. Top-level JSON throughput
+and pipeline metrics cover the whole run; the optional `sustained` object holds
+window-only throughput and full-API latency samples.
+
+Latency samples cover calls crossing input batch/generation boundaries, a
+possible staging-boundary grid, and the next 16 calls after each. The grid is
+the greatest common divisor of input batch bytes and staging capacity. These
+are overlapping input-position groups, not internal flush event timestamps;
+they do not establish a maximum for unsampled calls. The GPU's existing
+whole-run append histogram is also retained.
+Use a paired `--no-boundary-timing` run to check sampling's throughput cost;
+this does not disable the library's existing timers.
+
+Compare 256, 1024, 4096, and 33554432 elements for 512 B, 2 KiB, 8 KiB, and
+64 MiB offers at `u16`; use 30 seconds for bulk. Repeat in reverse order and
+include `orca2_single --frames 200` and `--backend cpu` controls. Check actual
+elapsed time and delivered batch counts: short windows can have substantial
+endpoint/backlog error. The fixed-frame sweep runner is unchanged; do not mix
+these window rates into historical fixed-frame throughput comparisons.
 
 ## Architecture
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -96,4 +96,17 @@ if(Python3_Interpreter_FOUND)
             ${CMAKE_CURRENT_SOURCE_DIR}/test_bench_report.py
             $<TARGET_FILE:test_bench_report>
     )
+    set(SUSTAINED_BACKENDS cpu)
+    if(CHUCKY_ENABLE_GPU)
+        list(APPEND SUSTAINED_BACKENDS gpu)
+    endif()
+    foreach(backend IN LISTS SUSTAINED_BACKENDS)
+        add_test(
+            NAME test-bench_sustained_${backend}
+            COMMAND
+                ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/test_bench_sustained.py
+                $<TARGET_FILE:bench_stream_smallepoch_single> ${backend}
+        )
+    endforeach()
 endif()

--- a/bench/bench_report.c
+++ b/bench/bench_report.c
@@ -680,6 +680,123 @@ json_duration_stats(struct json_writer* jw,
   jw_object_end(jw);
 }
 
+static const char* const boundary_names[] = { "Batch",
+                                              "Generation",
+                                              "Staging grid" };
+static const char* const boundary_keys[] = { "batch",
+                                             "generation",
+                                             "staging_grid" };
+
+void
+print_sustained_report(const struct bench_sustained* run)
+{
+  char source[32], append[32];
+  format_bytes(source, sizeof(source), run->source_bytes);
+  format_bytes(append, sizeof(append), run->append_bytes);
+  print_report("\n--- Sustained window ---");
+  print_report("  Source: %s    Append: %s", source, append);
+  print_report(
+    "  Source prep: %8.3f s    Warmup: %8.3f s", run->prep_s, run->warmup_s);
+  print_report(
+    "  Measurement: %8.3f s    Drain:  %8.3f s", run->elapsed_s, run->drain_s);
+  print_report("  Accepted:    %8.3f GiB/s",
+               gb_per_s(run->input_bytes, run->elapsed_s * 1000));
+  print_report("  Completed:   %8.3f GiB/s (physical discard bytes)",
+               gb_per_s(run->output_bytes, run->elapsed_s * 1000));
+  if (!run->boundary_timing) {
+    print_report("  Full API boundary sampling: disabled");
+    return;
+  }
+  print_report(
+    "\n  Full API samples at input boundaries and the next 16 calls:");
+  print_report("  %-15s %-9s %10s %10s %10s %10s",
+               "Boundary",
+               "Calls",
+               "Samples",
+               "avg ms",
+               "max ms",
+               ">=100 ms");
+  for (int i = 0; i < 3; ++i) {
+    for (int after = 0; after < 2; ++after) {
+      const struct bench_append_sample* sample =
+        after ? &run->following[i] : &run->boundary[i];
+      char count[32], avg[32] = "-", max[32] = "-", over[32];
+      format_count(count, sample->calls);
+      format_count(over, sample->over_100ms);
+      if (sample->calls) {
+        format_measurement(avg, sample->total_ms / sample->calls, 3);
+        format_measurement(max, sample->max_ms, 3);
+      }
+      print_report("  %-15s %-9s %10s %10s %10s %10s",
+                   boundary_names[i],
+                   after ? "+1..16" : "Crossing",
+                   count,
+                   avg,
+                   max,
+                   over);
+    }
+  }
+  print_report(
+    "  Groups may overlap; these are not internal flush event timestamps.");
+}
+
+static void
+json_sustained(struct json_writer* jw, const struct bench_sustained* run)
+{
+  jw_key(jw, "sustained");
+  jw_object_begin(jw);
+  jw_key(jw, "boundary_timing");
+  jw_bool(jw, run->boundary_timing);
+  jw_key(jw, "reference_frames");
+  jw_uint(jw, run->reference_frames);
+  jw_key(jw, "source_bytes");
+  jw_uint(jw, run->source_bytes);
+  jw_key(jw, "append_bytes");
+  jw_uint(jw, run->append_bytes);
+  jw_key(jw, "prep_s");
+  jw_float(jw, run->prep_s);
+  jw_key(jw, "warmup_s");
+  jw_float(jw, run->warmup_s);
+  jw_key(jw, "elapsed_s");
+  jw_float(jw, run->elapsed_s);
+  jw_key(jw, "drain_s");
+  jw_float(jw, run->drain_s);
+  jw_key(jw, "input_bytes");
+  jw_uint(jw, run->input_bytes);
+  jw_key(jw, "output_bytes");
+  jw_uint(jw, run->output_bytes);
+  jw_key(jw, "throughput_in_gibs");
+  jw_float(jw, gb_per_s(run->input_bytes, run->elapsed_s * 1000));
+  jw_key(jw, "throughput_out_gibs");
+  jw_float(jw, gb_per_s(run->output_bytes, run->elapsed_s * 1000));
+  jw_key(jw, "boundaries");
+  jw_object_begin(jw);
+  for (int i = 0; i < 3; ++i) {
+    jw_key(jw, boundary_keys[i]);
+    jw_object_begin(jw);
+    jw_key(jw, "bytes");
+    jw_uint(jw, run->boundary_bytes[i]);
+    for (int after = 0; after < 2; ++after) {
+      const struct bench_append_sample* sample =
+        after ? &run->following[i] : &run->boundary[i];
+      jw_key(jw, after ? "following" : "crossing");
+      jw_object_begin(jw);
+      jw_key(jw, "calls");
+      jw_uint(jw, sample->calls);
+      jw_key(jw, "over_100ms");
+      jw_uint(jw, sample->over_100ms);
+      jw_key(jw, "total_ms");
+      jw_float(jw, sample->total_ms);
+      jw_key(jw, "max_ms");
+      jw_float(jw, sample->max_ms);
+      jw_object_end(jw);
+    }
+    jw_object_end(jw);
+  }
+  jw_object_end(jw);
+  jw_object_end(jw);
+}
+
 static void
 json_delivery_timing(struct json_writer* jw,
                      const struct delivery_timing* timing)
@@ -720,7 +837,8 @@ print_bench_json_pass(const struct stream_metrics* m,
                       float init_s,
                       float flush_s,
                       const struct bench_memory* mem,
-                      int worker_threads)
+                      int worker_threads,
+                      const struct bench_sustained* sustained)
 {
   const size_t chunk_bytes = layout->chunk_stride * dtype_bpe(dtype);
   const size_t num_epochs =
@@ -745,6 +863,8 @@ print_bench_json_pass(const struct stream_metrics* m,
   jw_object_begin(&jw);
   jw_key(&jw, "status");
   jw_string(&jw, "pass");
+  if (sustained)
+    json_sustained(&jw, sustained);
   if (codec_is_blosc(codec.id)) {
     jw_key(&jw, "blosc_block_bytes");
     jw_uint(&jw, codec.blosc_block_bytes);

--- a/bench/bench_report.h
+++ b/bench/bench_report.h
@@ -19,6 +19,27 @@ struct sink_stats
   uint64_t total_chunks; // all LOD levels, per epoch
 };
 
+struct bench_append_sample
+{
+  uint64_t calls;
+  uint64_t over_100ms;
+  double total_ms;
+  double max_ms;
+};
+
+struct bench_sustained
+{
+  int boundary_timing;
+  double prep_s, warmup_s, elapsed_s, drain_s;
+  uint64_t reference_frames, source_bytes, append_bytes;
+  uint64_t input_bytes, output_bytes;
+  uint64_t boundary_bytes[3];
+  struct bench_append_sample boundary[3], following[3];
+};
+
+void
+print_sustained_report(const struct bench_sustained* run);
+
 void
 print_memory_report(const struct bench_memory* mem);
 
@@ -70,7 +91,8 @@ print_bench_json_pass(const struct stream_metrics* metrics,
                       float init_s,
                       float flush_s,
                       const struct bench_memory* mem,
-                      int worker_threads);
+                      int worker_threads,
+                      const struct bench_sustained* sustained);
 
 // Emit a minimal error JSON (`{"status":"error"}`) to stdout.
 void

--- a/bench/bench_util.c
+++ b/bench/bench_util.c
@@ -17,6 +17,7 @@
 #include "zarr/json_writer.h"
 #include "zarr/shard_pool_fs.h"
 
+#include <math.h>
 #include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -334,12 +335,87 @@ free_fill_pattern(fill_fn fill)
     rand_pattern_free();
 }
 
-// --- Reusable bench driver ---
-//
-// Runs a single benchmark with the given dimensions and fill function.
-// When output_path is NULL, data is discarded. Otherwise:
-//   - single-scale: writes to <output_path>/<array_name>/
-//   - multiscale:   writes to <output_path>/multiscale/0/, .../1/, etc.
+static void
+append_sample_add(struct bench_append_sample* sample, double ms)
+{
+  sample->calls++;
+  sample->over_100ms += ms >= 100;
+  sample->total_ms += ms;
+  if (ms > sample->max_ms)
+    sample->max_ms = ms;
+}
+
+static int
+pump_sustained(struct writer* writer,
+               const unsigned char* source,
+               const _Atomic uint64_t* completed,
+               const struct bench_config* cfg,
+               struct bench_sustained* run,
+               size_t* total_bytes)
+{
+  uint64_t accepted = 0, checked = 0, warm_input = 0, warm_output = 0;
+  uint64_t next[3];
+  int following[3] = { 0 };
+  memcpy(next, run->boundary_bytes, sizeof(next));
+  const int64_t start = platform_monotonic_ns();
+  int64_t measure_start = start;
+  int measuring = cfg->warmup_s == 0;
+  while (1) {
+    const size_t offset = accepted & (run->source_bytes - 1);
+    const uint64_t end = accepted + run->append_bytes;
+    int crossing[3], active = 0;
+    if (run->boundary_timing) {
+      for (int i = 0; i < 3; ++i) {
+        crossing[i] = end >= next[i];
+        active |= crossing[i] || following[i];
+      }
+    }
+    const int timed = active && measuring;
+    const int64_t before = timed ? platform_monotonic_ns() : 0;
+    struct writer_result result = writer_append_wait(
+      writer,
+      (struct slice){ source + offset, source + offset + run->append_bytes });
+    const double ms = timed ? (platform_monotonic_ns() - before) * 1e-6 : 0;
+    if (result.error)
+      return 1;
+    if (active) {
+      for (int i = 0; i < 3; ++i) {
+        if (timed && crossing[i])
+          append_sample_add(&run->boundary[i], ms);
+        if (timed && following[i])
+          append_sample_add(&run->following[i], ms);
+        if (following[i])
+          --following[i];
+        if (crossing[i]) {
+          next[i] = (end / run->boundary_bytes[i] + 1) * run->boundary_bytes[i];
+          following[i] = 16;
+        }
+      }
+    }
+    accepted = end;
+    // Per-append clock reads would dominate the smallest offers.
+    if (accepted - checked < (4u << 20))
+      continue;
+    checked = accepted;
+    const int64_t now = platform_monotonic_ns();
+    const uint64_t output =
+      atomic_load_explicit(completed, memory_order_relaxed);
+    if (!measuring && (now - start) * 1e-9 >= cfg->warmup_s) {
+      measure_start = now;
+      warm_input = accepted;
+      warm_output = output;
+      measuring = 1;
+    }
+    if (measuring && (now - measure_start) * 1e-9 >= cfg->duration_s) {
+      run->warmup_s = (measure_start - start) * 1e-9;
+      run->elapsed_s = (now - measure_start) * 1e-9;
+      run->input_bytes = accepted - warm_input;
+      run->output_bytes = output - warm_output;
+      *total_bytes = accepted;
+      return 0;
+    }
+  }
+}
 
 int
 run_bench(const struct bench_config* cfg)
@@ -361,6 +437,24 @@ run_bench(const struct bench_config* cfg)
   }
 
   const enum dtype dtype = cfg->dtype ? cfg->dtype : dtype_u16;
+  const size_t bpe = dtype_bpe(dtype);
+  struct bench_sustained sustained = {
+    .boundary_timing = !cfg->no_boundary_timing,
+    .reference_frames = dims[0].size,
+    .source_bytes = 64u << 20,
+    .append_bytes =
+      cfg->append_elements ? cfg->append_elements * bpe : 64u << 20,
+  };
+  if (cfg->duration_s > 0 &&
+      (is_multiscale || output_path || cfg->s3_bucket || cfg->io_bw_mbps ||
+       cfg->io_latency_us || !sustained.append_bytes ||
+       cfg->append_elements > sustained.source_bytes / bpe ||
+       sustained.source_bytes % sustained.append_bytes)) {
+    log_error(
+      "Sustained runs require single-scale discard output and an append "
+      "size that divides 64 MiB");
+    return bench_failed(cfg->json_output);
+  }
   uint32_t chosen_epochs_per_batch = 0; // 0 = auto; set by advise_layout on fit
 
   if (resolve_chunk_sizing(
@@ -370,10 +464,12 @@ run_bench(const struct bench_config* cfg)
   dims_print(dims, rank);
   print_shard_summary(dims, rank, dtype_bpe(dtype));
 
+  const int64_t prep_start = platform_monotonic_ns();
   init_fill_pattern(fill, dims, rank);
 
-  const size_t total_elements = dim_total_elements(dims, rank);
-  const size_t total_bytes = total_elements * dtype_bpe(dtype);
+  size_t total_elements = dim_total_elements(dims, rank);
+  size_t total_bytes = total_elements * bpe;
+  unsigned char* source = NULL;
 
   struct discard_shard_sink dss;
   discard_shard_sink_init(&dss);
@@ -384,6 +480,22 @@ run_bench(const struct bench_config* cfg)
   int use_throttled = 0;
   struct shard_sink* sink = &dss.base;
   struct bench_handle h = { .backend = cfg->backend };
+
+  if (cfg->duration_s > 0) {
+    CHECK(Fail, chosen_epochs_per_batch > 0);
+    const size_t elements = sustained.source_bytes / bpe;
+    source = calloc(elements, bpe > 2 ? bpe : 2);
+    CHECK(Fail, source);
+    fill((uint16_t*)source, elements, 0, elements);
+    free_fill_pattern(fill);
+    sustained.prep_s = (platform_monotonic_ns() - prep_start) * 1e-9;
+    sustained.boundary_bytes[1] =
+      dims[0].chunk_size * dims[0].chunks_per_shard * bpe;
+    for (uint8_t d = 1; d < rank; ++d)
+      sustained.boundary_bytes[1] *= dims[d].size;
+    // Duration and append size must not change the fitted geometry.
+    dims[0].size = 0;
+  }
 
   if (cfg->s3_bucket) {
     CHECK(Fail,
@@ -498,6 +610,17 @@ run_bench(const struct bench_config* cfg)
   float init_s = platform_toc(&init_clock);
 
   const struct tile_stream_layout* layout = bench_layout(&h);
+  if (cfg->duration_s > 0) {
+    sustained.boundary_bytes[0] =
+      layout->epoch_elements * bpe * chosen_epochs_per_batch;
+    uint64_t a = sustained.boundary_bytes[0], b = config.buffer_capacity_bytes;
+    while (b) {
+      const uint64_t remainder = a % b;
+      a = b;
+      b = remainder;
+    }
+    sustained.boundary_bytes[2] = a;
+  }
   size_t max_compressed_size = 0;
   size_t codec_batch_size = 0;
   int nlod = 0;
@@ -508,6 +631,8 @@ run_bench(const struct bench_config* cfg)
     nlod = st.nlod;
   }
 
+  if (cfg->duration_s > 0)
+    print_report("  Reference extent below fits geometry, not run length:");
   log_bench_header(layout,
                    config.dtype,
                    config.codec,
@@ -528,12 +653,26 @@ run_bench(const struct bench_config* cfg)
 
   struct platform_clock clock = { 0 };
   platform_toc(&clock);
-  CHECK(Fail,
-        pump_data_prefill_blocked(bench_writer(&h),
-                                  total_elements,
-                                  fill,
-                                  dtype_bpe(dtype),
-                                  cfg->append_elements) == 0);
+  if (cfg->duration_s > 0) {
+    CHECK(Fail,
+          pump_sustained(bench_writer(&h),
+                         source,
+                         &dss.total_bytes,
+                         cfg,
+                         &sustained,
+                         &total_bytes) == 0);
+    total_elements = total_bytes / bpe;
+  } else {
+    CHECK(
+      Fail,
+      pump_data_prefill_blocked(
+        bench_writer(&h), total_elements, fill, bpe, cfg->append_elements) ==
+        0);
+  }
+
+  const int64_t drain_start = platform_monotonic_ns();
+  if (cfg->duration_s > 0)
+    CHECK(Fail, writer_flush(bench_writer(&h)).error == 0);
 
   // Final metadata publication belongs to the measured operation too.
   CHECK(Fail, writer_close(bench_writer(&h)).error == 0);
@@ -548,6 +687,7 @@ run_bench(const struct bench_config* cfg)
   }
   float flush_s = platform_toc(&flush_clock);
   float wall_s = platform_toc(&clock);
+  sustained.drain_s = (platform_monotonic_ns() - drain_start) * 1e-9;
 
   if (platform_peak_resident_memory(&mem_used.host_peak_bytes) != 0) {
     log_warn("  host peak memory reading unavailable");
@@ -584,6 +724,10 @@ run_bench(const struct bench_config* cfg)
       sink_total_bytes = dss.total_bytes;
     struct sink_stats ss = { .total_bytes = sink_total_bytes,
                              .total_chunks = est_total_chunks };
+    if (cfg->duration_s > 0) {
+      print_sustained_report(&sustained);
+      print_report("\n--- Whole run (warmup, measurement, drain) ---");
+    }
     print_bench_report(&m,
                        layout,
                        config.dtype,
@@ -611,7 +755,8 @@ run_bench(const struct bench_config* cfg)
                             init_s,
                             flush_s,
                             &mem_used,
-                            bench_worker_threads(&h));
+                            bench_worker_threads(&h),
+                            cfg->duration_s > 0 ? &sustained : NULL);
     }
   }
 
@@ -631,6 +776,8 @@ Cleanup:
   if (use_throttled)
     throttled_shard_sink_teardown(&tss);
   free_fill_pattern(fill);
+  free(source);
+  dims[0].size = sustained.reference_frames;
   return rc;
 }
 
@@ -660,6 +807,9 @@ struct bench_cli_args
   uint64_t backpressure_bytes;
   int max_threads;
   int full_memcpy_timing;
+  double warmup_s;
+  double duration_s;
+  int no_boundary_timing;
 };
 
 static int
@@ -739,7 +889,26 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
     } else if (strcmp(av[i], "--frames") == 0 && i + 1 < ac) {
       out->frames = (uint64_t)strtoull(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--append-elements") == 0 && i + 1 < ac) {
-      out->append_elements = (size_t)strtoull(av[++i], NULL, 10);
+      char* end;
+      const char* value = av[++i];
+      out->append_elements = (size_t)strtoull(value, &end, 10);
+      if (end == value || *end || *value == '-') {
+        fprintf(stderr, "Invalid --append-elements: %s\n", value);
+        return 1;
+      }
+    } else if ((strcmp(av[i], "--duration") == 0 ||
+                strcmp(av[i], "--warmup") == 0) &&
+               i + 1 < ac) {
+      char* end;
+      const int duration = strcmp(av[i], "--duration") == 0;
+      double seconds = strtod(av[i + 1], &end);
+      if (end == av[i + 1] || *end || !isfinite(seconds) || seconds < 0 ||
+          (duration && seconds == 0)) {
+        fprintf(stderr, "Invalid %s: %s\n", av[i], av[i + 1]);
+        return 1;
+      }
+      *(duration ? &out->duration_s : &out->warmup_s) = seconds;
+      ++i;
     } else if (strcmp(av[i], "--json") == 0) {
       out->json_output = 1;
     } else if (strcmp(av[i], "--chunk-bytes") == 0 && i + 1 < ac) {
@@ -778,6 +947,8 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
       out->max_threads = (int)strtol(av[++i], NULL, 10);
     } else if (strcmp(av[i], "--full-memcpy-timing") == 0) {
       out->full_memcpy_timing = 1;
+    } else if (strcmp(av[i], "--no-boundary-timing") == 0) {
+      out->no_boundary_timing = 1;
     } else {
       fprintf(stderr, "Unknown option: %s\n", av[i]);
       fprintf(stderr,
@@ -787,7 +958,9 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
               "[--blosc-shuffle none|byte|bit] "
               "[--reduce mean|min|max|median|max_sup|min_sup] "
               "[--backend gpu|cpu] [--dtype u8|u16|...] [--frames N] "
-              "[--json] [--chunk-bytes N] [--batch-bytes N] "
+              "[--json] [--append-elements N] [--duration S [--warmup S]] "
+              "[--no-boundary-timing] "
+              "[--chunk-bytes N] [--batch-bytes N] "
               "[--memory-budget N] [-o path] "
               "[--s3-bucket B --s3-region R --s3-endpoint E [--s3-prefix P] "
               "[--s3-throughput-gbps N]] "
@@ -798,6 +971,10 @@ parse_bench_cli_args(int ac, char* av[], struct bench_cli_args* out)
               av[0]);
       return 1;
     }
+  }
+  if (out->warmup_s > 0 && out->duration_s == 0) {
+    fprintf(stderr, "--warmup requires --duration\n");
+    return 1;
   }
   return codec_config_validate_blosc(out->codec);
 }
@@ -850,6 +1027,9 @@ bench_stream_main(int ac, char* av[], struct bench_spec spec)
     .backpressure_bytes = a.backpressure_bytes,
     .max_threads = a.max_threads,
     .full_memcpy_timing = a.full_memcpy_timing,
+    .warmup_s = a.warmup_s,
+    .duration_s = a.duration_s,
+    .no_boundary_timing = a.no_boundary_timing,
   };
   int ecode = run_bench(&cfg);
 
@@ -1150,6 +1330,10 @@ bench_two_streams_main(int ac, char* av[], struct bench_spec spec)
   struct bench_cli_args a = { 0 };
   if (parse_bench_cli_args(ac, av, &a))
     return 1;
+  if (a.duration_s > 0) {
+    print_report("--duration requires a single-stream benchmark");
+    return bench_failed(a.json_output);
+  }
 
   struct dimension* dims = spec.dims;
   if (a.frames > 0)

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -56,6 +56,9 @@ struct bench_config
   uint64_t backpressure_bytes; // 0 = disabled; >0 = stall when pending > N
   int max_threads;             // 0 = OpenMP default (omp_get_max_threads)
   int full_memcpy_timing;
+  double warmup_s;
+  double duration_s;
+  int no_boundary_timing;
 };
 
 int

--- a/bench/sink_discard.c
+++ b/bench/sink_discard.c
@@ -11,7 +11,8 @@ discard_shard_write(struct shard_writer* self,
   (void)offset;
   struct discard_shard_writer* w = (struct discard_shard_writer*)self;
   size_t nbytes = (size_t)((const char*)end - (const char*)beg);
-  w->parent->total_bytes += nbytes;
+  atomic_fetch_add_explicit(
+    &w->parent->total_bytes, nbytes, memory_order_relaxed);
   return 0;
 }
 
@@ -50,6 +51,7 @@ discard_shard_sink_init(struct discard_shard_sink* s)
     .base = { .open = discard_shard_open,
               .required_shard_alignment = discard_required_shard_alignment },
   };
+  atomic_init(&s->total_bytes, 0);
   s->writer = (struct discard_shard_writer){
     .base = { .write = discard_shard_write,
               .finalize = discard_shard_finalize },

--- a/bench/sink_discard.h
+++ b/bench/sink_discard.h
@@ -2,6 +2,7 @@
 
 #include "writer.h"
 
+#include <stdatomic.h>
 #include <stddef.h>
 
 struct discard_shard_writer
@@ -14,7 +15,7 @@ struct discard_shard_sink
 {
   struct shard_sink base;
   struct discard_shard_writer writer;
-  size_t total_bytes;
+  _Atomic uint64_t total_bytes;
   size_t shards_finalized;
 };
 

--- a/bench/test_bench_report.c
+++ b/bench/test_bench_report.c
@@ -118,6 +118,22 @@ main(int argc, char** argv)
                      empty ? 0 : 0.2f,
                      empty ? 0 : 65536);
   print_memory_report(&mem);
+  struct bench_sustained window = {
+    .boundary_timing = 1,
+    .elapsed_s = 1,
+    .source_bytes = 64u << 20,
+    .append_bytes = 512,
+  };
+  if (large) {
+    window.boundary[0] = (struct bench_append_sample){
+      .calls = UINT64_MAX,
+      .over_100ms = UINT64_MAX,
+      .total_ms = 1e20,
+      .max_ms = 1e20,
+    };
+  }
+  if (large || empty)
+    print_sustained_report(&window);
   print_bench_json_pass(&m,
                         &m.sink,
                         &layout,
@@ -130,6 +146,7 @@ main(int argc, char** argv)
                         0.1f,
                         empty ? 0 : 0.2f,
                         &mem,
-                        1);
+                        1,
+                        large || empty ? &window : NULL);
   return 0;
 }

--- a/bench/test_bench_report.py
+++ b/bench/test_bench_report.py
@@ -30,6 +30,17 @@ for mode in ("sampled", "full", "copy", "large", "empty"):
     assert "GB/s" not in p.stderr
     assert "backend_internal_name" not in p.stderr
     assert stage_header in lines
+    if mode in ("large", "empty"):
+        window = report["sustained"]
+        assert window["throughput_in_gibs"] == window["throughput_out_gibs"] == 0
+        samples = window["boundaries"]["batch"]["crossing"]
+        assert samples["calls"] == samples["over_100ms"] == (2**64 - 1 if mode == "large" else 0)
+        rows = [line for line in lines
+                if line[2:17].rstrip() in ("Batch", "Generation", "Staging grid")]
+        assert len(rows) == 6 and all(len(row) == 71 for row in rows), rows
+        assert rows[-1].split()[-4:] == ["0", "-", "-", "0"]
+    else:
+        assert "sustained" not in report
     if mode == "empty":
         assert "Host memory:      unavailable" in p.stderr
         assert "Append latency" not in p.stderr

--- a/bench/test_bench_sustained.py
+++ b/bench/test_bench_sustained.py
@@ -1,0 +1,95 @@
+import json
+import math
+from pathlib import Path
+import subprocess
+import sys
+
+
+exe, backend = sys.argv[1:]
+base = [exe, "--backend", backend, "--codec", "none", "--frames", "65536",
+        "--chunk-bytes", "1M", "--batch-bytes", "1M",
+        "--memory-budget", "1G", "--json"]
+
+
+def run(*args):
+    return subprocess.run([*base, *args], capture_output=True, text=True, timeout=60)
+
+
+geometry = None
+for append, warmup in ((256, 0), (4096, 0.05), (33554432, 0)):
+    p = run("--duration", "0.15", "--warmup", str(warmup),
+            "--append-elements", str(append))
+    assert p.returncode == 0, p.stderr
+    report = json.loads(p.stdout)
+    assert report["status"] == "pass"
+    window = report["sustained"]
+    assert window["boundary_timing"] is True
+    assert window["reference_frames"] == 65536
+    assert window["source_bytes"] == 64 << 20
+    assert window["append_bytes"] == append * 2
+    assert window["warmup_s"] >= warmup
+    assert window["elapsed_s"] >= 0.15
+    assert window["drain_s"] > 0
+    assert window["input_bytes"] % (append * 2) == 0
+    assert window["output_bytes"] > 0
+    for direction, key in (("in", "input"), ("out", "output")):
+        expected = window[f"{key}_bytes"] / 2**30 / window["elapsed_s"]
+        assert math.isclose(window[f"throughput_{direction}_gibs"], expected, rel_tol=1e-5)
+    total = round(report["input_gib"] * 2**30)
+    if warmup == 0:
+        assert math.isclose(total, window["input_bytes"], rel_tol=1e-5)
+    else:
+        assert total > window["input_bytes"]
+    assert report["wall_s"] >= window["warmup_s"] + window["elapsed_s"]
+    boundaries = window["boundaries"]
+    sizes = {key: value["bytes"] for key, value in boundaries.items()}
+    assert geometry is None or geometry == sizes
+    geometry = sizes
+    for group in boundaries.values():
+        assert group["crossing"]["calls"] > 0
+        for key in ("crossing", "following"):
+            sample = group[key]
+            assert 0 <= sample["over_100ms"] <= sample["calls"]
+            assert 0 <= sample["max_ms"] <= sample["total_ms"]
+            if sample["calls"]:
+                assert sample["max_ms"] > 0
+        if warmup == 0:
+            calls = window["input_bytes"] // window["append_bytes"]
+            expected = min(calls, window["input_bytes"] // group["bytes"])
+            assert group["crossing"]["calls"] == expected
+    section = p.stderr.split("--- Sustained window ---")[1].split("--- Whole run")[0]
+    assert all(len(line) <= 80 for line in section.splitlines()), section
+    assert "Full API samples" in section and "internal flush" in section
+
+p = run()
+assert p.returncode == 0, p.stderr
+assert "sustained" not in json.loads(p.stdout)
+
+p = run("--duration", "0.01", "--no-boundary-timing")
+assert p.returncode == 0, p.stderr
+window = json.loads(p.stdout)["sustained"]
+assert window["boundary_timing"] is False
+assert "Full API boundary sampling: disabled" in p.stderr
+assert all(group["crossing"]["calls"] == group["following"]["calls"] == 0
+           for group in window["boundaries"].values())
+
+for args in (("--duration", "0"), ("--duration", "nan"), ("--duration", "inf"),
+             ("--duration", "-1"), ("--duration", "1x"), ("--warmup", "1"),
+             ("--duration", "1", "--warmup", "-1"),
+             ("--duration", "1", "--append-elements", "3"),
+             ("--duration", "1", "--append-elements", "bad"),
+             ("--duration", "1", "--append-elements", "67108864"),
+             ("--duration", "1", "-o", "/unused-sustained-output"),
+             ("--duration", "1", "--s3-bucket", "unused"),
+             ("--duration", "1", "--io-bw-mbps", "100")):
+    p = run(*args)
+    assert p.returncode != 0, args
+
+for scenario in ("256cube_multiscale", "256cube_two_streams"):
+    other = Path(exe).with_name("bench_stream_" + scenario + Path(exe).suffix)
+    if other.exists():
+        p = subprocess.run([str(other), "--backend", backend, "--duration", "1"],
+                           capture_output=True, text=True, timeout=60)
+        assert p.returncode != 0, p.stderr
+
+print(f"Sustained accounting, geometry, CLI and TTY checks passed ({backend})")


### PR DESCRIPTION
## Summary

Add `--duration` and `--warmup` to the existing single-stream, single-scale
discard benchmarks. Fixed-frame runs, pipeline code, and sweep schema remain unchanged.

- Fit geometry from the reference frame count, then stream from a fixed 64 MiB source ring.
- Separate preparation, warmup, measured accepted/completed throughput, and final drain.
- Sample full API calls at batch/generation input boundaries, possible staging boundaries, and the next 16 calls. Label these as input-position groups, not internal event traces.
- Keep whole-run pipeline metrics separate. `--no-boundary-timing` provides an observer-overhead control.
- Retain 80-column text output and add accounting, geometry, CLI, and formatting regression coverage.

No experimental harnesses, result files, or logs are added to the repository.

## Validation

Release builds with and without GPU support. Non-S3 suites: 67 GPU-enabled
tests and 42 CPU-only tests. Boundary timing on/off and fixed-frame compatibility
are covered by the new benchmark integration tests; TTY fixtures cover empty
and very large sample counts.

32 serialized Auk runs at this commit: 5 s warmup, 20 s measured (30 s bulk),
reverse-order repeats, fixed source/layout/budget, none/discard/xor/u16,
performance-core affinity and four workers. Paired mean completed GiB/s:

| Append | smallepoch_single | orca2_single |
|---|---:|---:|
| 512 B | 7.579 | 7.383 |
| 2 KiB | 7.128 | 7.046 |
| 8 KiB | 9.655 | 8.719 |
| 64 MiB | 9.838 | 9.824 |

512 B sampling-on/off mean differences were -0.33% / +0.38%, with pair
differences changing sign on reversal; bulk differences were below 0.003%.

GPU: 3.63 billion recorded append-body calls, maximum 14.93 ms; full-API
boundary maximum 14.85 ms; final-drain maximum 88.04 ms. CPU boundary maximum
59.16 ms. No recorded >=100 ms append events. CPU small-call full-API samples
and GPU wrapper samples do not establish bounds on unsampled calls.

This establishes a sustained baseline, not a production performance change.
The residual small-offer deficit is real in both geometries; the bulk
small-epoch versus Orca gap does not persist.

Stacked on #267, after #270.
