### PR TITLE
writer: add optional bounded input buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ the library handles all tiling, padding, and shard assembly internally. See
 [docs/design.md][docs-design-md] for a detailed walkthrough, or
 [docs/guide.md][docs-guide-md] for a quick orientation to the module structure.
 
+Paced producers can opt into the [bounded input-buffering writer](docs/buffered-writer.md).
+
 For writing directly to S3 (or S3-compatible stores), see the
 [S3 storage guide][s3-storage-guide].
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -86,6 +86,8 @@ foreach(src IN LISTS BENCH_STREAM_SOURCES)
     add_bench(${target} ${src} bench_util Zstd::Zstd)
 endforeach()
 
+add_bench(bench_buffered_writer bench_buffered_writer.c bench_util)
+
 find_package(Python3 COMPONENTS Interpreter QUIET)
 if(Python3_Interpreter_FOUND AND HAVE_BLOSC)
     add_test(

--- a/bench/bench_buffered_writer.c
+++ b/bench/bench_buffered_writer.c
@@ -18,11 +18,14 @@ struct observed_writer
   int64_t* submitted;
   double* downstream_ms;
   double* completion_ms;
+  double* submission_to_forward_ms;
   size_t frame_bytes;
   size_t frames;
   size_t frame;
   size_t calls;
-  size_t max_batch_frames;
+  size_t call_capacity;
+  size_t bytes;
+  size_t max_batch_bytes;
 };
 
 static struct writer_result
@@ -31,17 +34,35 @@ observed_append(struct writer* self, struct slice input)
   struct observed_writer* o = (struct observed_writer*)self;
   const size_t bytes =
     (const unsigned char*)input.end - (const unsigned char*)input.beg;
-  const size_t frames = bytes / o->frame_bytes;
-  if (!frames || bytes % o->frame_bytes || frames > o->frames - o->frame)
+  if (!bytes || bytes > o->frames * o->frame_bytes - o->bytes)
     return writer_error_at(input.beg, input.end);
+  if (o->calls == o->call_capacity) {
+    if (o->call_capacity > SIZE_MAX / 2 / sizeof(*o->downstream_ms))
+      return writer_error_at(input.beg, input.end);
+    size_t capacity = o->call_capacity * 2;
+    double* values = realloc(o->downstream_ms, capacity * sizeof(*values));
+    if (!values)
+      return writer_error_at(input.beg, input.end);
+    o->downstream_ms = values;
+    o->call_capacity = capacity;
+  }
   const int64_t start = platform_monotonic_ns();
   struct writer_result r = writer_append_wait(o->downstream, input);
   const int64_t end = platform_monotonic_ns();
   o->downstream_ms[o->calls++] = (end - start) * 1e-6;
-  if (frames > o->max_batch_frames)
-    o->max_batch_frames = frames;
-  // A combined call gives one completion observation for all its frames.
-  for (size_t i = 0; i < frames; ++i, ++o->frame)
+  if (r.error)
+    return r;
+  // A byte-limited call may start or end inside a benchmark frame. Record its
+  // first byte's start once, and completion only when its last byte returns.
+  const size_t first =
+    o->bytes / o->frame_bytes + (o->bytes % o->frame_bytes != 0);
+  const size_t last = (o->bytes + bytes - 1) / o->frame_bytes;
+  for (size_t frame = first; frame <= last; ++frame)
+    o->submission_to_forward_ms[frame] = (start - o->submitted[frame]) * 1e-6;
+  if (bytes > o->max_batch_bytes)
+    o->max_batch_bytes = bytes;
+  o->bytes += bytes;
+  for (; o->frame < o->bytes / o->frame_bytes; ++o->frame)
     o->completion_ms[o->frame] = (end - o->submitted[o->frame]) * 1e-6;
   return r;
 }
@@ -95,8 +116,8 @@ main(int argc, char** argv)
   int gpu = 0;
   struct codec_config codec = { .id = CODEC_NONE };
   const char* codec_name = "none";
-  size_t frames = 2048, fps = 0, slots = 0, side = 1024, threads = 4;
-  size_t drain_slots = 0;
+  size_t frames = 2048, fps = 0, side = 1024, threads = 4;
+  size_t buffer_bytes = 0, drain_bytes = 0;
   for (int i = 1; i < argc; ++i) {
     if (i + 1 >= argc)
       goto usage;
@@ -112,36 +133,50 @@ main(int argc, char** argv)
       codec_name = value;
       codec.id = !strcmp(value, "none") ? CODEC_NONE : CODEC_ZSTD;
     } else {
-      size_t* out = !strcmp(key, "--frames")        ? &frames
-                    : !strcmp(key, "--fps")         ? &fps
-                    : !strcmp(key, "--slots")       ? &slots
-                    : !strcmp(key, "--drain-slots") ? &drain_slots
-                    : !strcmp(key, "--side")        ? &side
-                    : !strcmp(key, "--threads")     ? &threads
-                                                    : NULL;
+      size_t* out = !strcmp(key, "--frames")         ? &frames
+                    : !strcmp(key, "--fps")          ? &fps
+                    : !strcmp(key, "--buffer-bytes") ? &buffer_bytes
+                    : !strcmp(key, "--drain-bytes")  ? &drain_bytes
+                    : !strcmp(key, "--side")         ? &side
+                    : !strcmp(key, "--threads")      ? &threads
+                                                     : NULL;
       if (!out || number(value, out))
         goto usage;
     }
   }
   if (!frames || frames > 10000000 || !threads || threads > 1024 ||
       side < 256 || side > 4096 || side % 256 || fps > 1000000 ||
-      drain_slots > slots)
+      drain_bytes > buffer_bytes || buffer_bytes % sizeof(uint16_t) ||
+      drain_bytes % sizeof(uint16_t))
     goto usage;
 
   const size_t frame_bytes = side * side * sizeof(uint16_t);
+  if (frames > SIZE_MAX / frame_bytes)
+    goto usage;
   const size_t pattern_frames = 64;
   uint16_t* pattern = malloc(pattern_frames * frame_bytes);
   int64_t* submitted = calloc(frames, sizeof(*submitted));
   double* caller = calloc(frames, sizeof(*caller));
-  double* downstream = calloc(frames, sizeof(*downstream));
   double* completion = calloc(frames, sizeof(*completion));
+  double* submission_to_forward =
+    calloc(frames, sizeof(*submission_to_forward));
   double* lateness = calloc(frames, sizeof(*lateness));
   struct tile_stream_cpu* cpu = NULL;
   struct tile_stream_gpu* device = NULL;
   struct buffered_writer* buffered = NULL;
   int error = 1;
-  if (!pattern || !submitted || !caller || !downstream || !completion ||
-      !lateness)
+  struct observed_writer observed = {
+    .writer = { observed_append, observed_flush, observed_close },
+    .submitted = submitted,
+    .downstream_ms = calloc(frames, sizeof(double)),
+    .completion_ms = completion,
+    .submission_to_forward_ms = submission_to_forward,
+    .frame_bytes = frame_bytes,
+    .frames = frames,
+    .call_capacity = frames,
+  };
+  if (!pattern || !submitted || !caller || !observed.downstream_ms ||
+      !completion || !submission_to_forward || !lateness)
     goto cleanup;
   // A deterministic spatial/temporal pattern; generation stays outside timing.
   for (size_t t = 0; t < pattern_frames; ++t)
@@ -176,20 +211,12 @@ main(int argc, char** argv)
     if (!cpu)
       goto cleanup;
   }
-  struct observed_writer observed = {
-    .writer = { observed_append, observed_flush, observed_close },
-    .downstream = gpu ? bench_gpu_writer(device) : tile_stream_cpu_writer(cpu),
-    .submitted = submitted,
-    .downstream_ms = downstream,
-    .completion_ms = completion,
-    .frame_bytes = frame_bytes,
-    .frames = frames,
-  };
+  observed.downstream =
+    gpu ? bench_gpu_writer(device) : tile_stream_cpu_writer(cpu);
   struct writer* writer = &observed.writer;
-  if (slots) {
+  if (buffer_bytes) {
     buffered = buffered_writer_create(
-      writer,
-      &(struct buffered_writer_config){ frame_bytes, slots, drain_slots });
+      writer, &(struct buffered_writer_config){ buffer_bytes, drain_bytes });
     if (!buffered)
       goto cleanup;
     writer = buffered_writer_as_writer(buffered);
@@ -228,45 +255,40 @@ main(int argc, char** argv)
   buffered = NULL;
   if (destroy_error || observed.frame != frames)
     goto cleanup;
-  printf(
-    "{\"backend\":\"%s\",\"codec\":\"%s\",\"frames\":%zu,\"fps\":%zu,"
-    "\"frame_bytes\":%zu,\"slots\":%zu,\"drain_slots\":%zu,\"threads\":%zu,"
-    "\"wall_s\":%.6f,\"gib_s\":%.6f,\"second_half_gib_s\":%.6f,"
-    "\"flush_ms\":%.6f,",
-    gpu ? "gpu" : "cpu",
-    codec_name,
-    frames,
-    fps,
-    frame_bytes,
-    slots,
-    drain_slots ? drain_slots : slots,
-    threads,
-    (done - start) * 1e-9,
-    (double)frames * frame_bytes / (done - start) * (1e9 / 1073741824.0),
-    (double)(frames - frames / 2) * frame_bytes / (done - halfway) *
-      (1e9 / 1073741824.0),
-    (done - appended) * 1e-6);
+  printf("{\"backend\":\"%s\",\"codec\":\"%s\",\"frames\":%zu,\"fps\":%zu,"
+         "\"frame_bytes\":%zu,\"capacity_bytes\":%zu,\"max_drain_bytes\":%zu,"
+         "\"threads\":%zu,"
+         "\"wall_s\":%.6f,\"gib_s\":%.6f,\"second_half_gib_s\":%.6f,"
+         "\"flush_ms\":%.6f,",
+         gpu ? "gpu" : "cpu",
+         codec_name,
+         frames,
+         fps,
+         frame_bytes,
+         buffer_bytes,
+         drain_bytes ? drain_bytes : buffer_bytes,
+         threads,
+         (done - start) * 1e-9,
+         (double)frames * frame_bytes / (done - start) * (1e9 / 1073741824.0),
+         (double)(frames - frames / 2) * frame_bytes / (done - halfway) *
+           (1e9 / 1073741824.0),
+         (done - appended) * 1e-6);
   distribution("caller", caller, frames);
   printf(",");
-  distribution("downstream", downstream, observed.calls);
+  distribution("downstream", observed.downstream_ms, observed.calls);
   printf(",");
   distribution("completion", completion, frames);
   printf(",");
+  distribution("submission_to_forward", submission_to_forward, frames);
+  printf(",");
   distribution("lateness", lateness, frames);
-  printf(",\"downstream_calls\":%zu,\"max_batch_frames\":%zu,"
-         "\"buffer_payload_bytes\":%zu,"
-         "\"peak_occupied_slots\":%zu,\"peak_pending_bytes\":%zu,"
-         "\"backpressure_ms\":%.6f,\"queue_mean_ms\":%.6f,"
-         "\"queue_max_ms\":%.6f,\"abandoned_bytes\":%llu}\n",
+  printf(",\"downstream_calls\":%zu,\"max_batch_bytes\":%zu,"
+         "\"peak_pending_bytes\":%zu,"
+         "\"backpressure_ms\":%.6f,\"abandoned_bytes\":%llu}\n",
          observed.calls,
-         observed.max_batch_frames,
-         slots * frame_bytes,
-         stats.peak_occupied_slots,
+         observed.max_batch_bytes,
          stats.peak_pending_bytes,
          stats.backpressure_ns * 1e-6,
-         stats.completed_slots ? stats.queue_ns * 1e-6 / stats.completed_slots
-                               : 0,
-         stats.max_queue_ns * 1e-6,
          (unsigned long long)stats.abandoned_bytes);
   error = 0;
 cleanup:
@@ -279,18 +301,21 @@ cleanup:
     bench_gpu_context_destroy();
   free(lateness);
   free(completion);
-  free(downstream);
+  free(submission_to_forward);
+  free(observed.downstream_ms);
   free(caller);
   free(submitted);
   free(pattern);
   return error;
 usage:
-  fprintf(stderr,
-          "Usage: %s [--backend cpu|gpu] [--codec none|zstd] "
-          "[--frames N] [--fps N] [--slots N] [--drain-slots N] "
-          "[--side N] [--threads N]\n"
-          "fps=0: unpaced; slots=0: direct; drain-slots=0: up to all slots.\n"
-          "side: multiple of 256, 256..4096.\n",
-          argv[0]);
+  fprintf(
+    stderr,
+    "Usage: %s [--backend cpu|gpu] [--codec none|zstd] "
+    "[--frames N] [--fps N] [--buffer-bytes N] [--drain-bytes N] "
+    "[--side N] [--threads N]\n"
+    "fps=0: unpaced; buffer-bytes=0: direct; drain-bytes=0: up to capacity.\n"
+    "Buffer and drain sizes must be multiples of sizeof(uint16_t).\n"
+    "side: multiple of 256, 256..4096.\n",
+    argv[0]);
   return 2;
 }

--- a/bench/bench_buffered_writer.c
+++ b/bench/bench_buffered_writer.c
@@ -1,0 +1,270 @@
+// Compare direct and buffered frame appends using the same tile-stream layout.
+#include "bench_gpu.h"
+#include "dimension.h"
+#include "platform/platform.h"
+#include "sink_discard.h"
+#include "stream.cpu.h"
+#include "writer.buffered.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct observed_writer
+{
+  struct writer writer;
+  struct writer* downstream;
+  int64_t* submitted;
+  double* downstream_ms;
+  double* completion_ms;
+  size_t frame;
+};
+
+static struct writer_result
+observed_append(struct writer* self, struct slice input)
+{
+  struct observed_writer* o = (struct observed_writer*)self;
+  const int64_t start = platform_monotonic_ns();
+  struct writer_result r = writer_append_wait(o->downstream, input);
+  const int64_t end = platform_monotonic_ns();
+  o->downstream_ms[o->frame] = (end - start) * 1e-6;
+  o->completion_ms[o->frame] = (end - o->submitted[o->frame]) * 1e-6;
+  ++o->frame;
+  return r;
+}
+
+static struct writer_result
+observed_flush(struct writer* self)
+{
+  return writer_flush(((struct observed_writer*)self)->downstream);
+}
+
+static struct writer_result
+observed_close(struct writer* self)
+{
+  return writer_close(((struct observed_writer*)self)->downstream);
+}
+
+static int
+compare(const void* a, const void* b)
+{
+  const double x = *(const double*)a, y = *(const double*)b;
+  return (x > y) - (x < y);
+}
+
+static void
+distribution(const char* name, double* values, size_t n)
+{
+  qsort(values, n, sizeof(*values), compare);
+  printf("\"%s_ms\":{\"p50\":%.6f,\"p95\":%.6f,\"p99\":%.6f,\"max\":%.6f}",
+         name,
+         values[n / 2],
+         values[(n - 1) * 95 / 100],
+         values[(n - 1) * 99 / 100],
+         values[n - 1]);
+}
+
+static int
+number(const char* text, size_t* value)
+{
+  char* end;
+  errno = 0;
+  unsigned long long n = strtoull(text, &end, 10);
+  if (errno || *text < '0' || *text > '9' || *end || n > SIZE_MAX)
+    return 1;
+  *value = (size_t)n;
+  return 0;
+}
+
+int
+main(int argc, char** argv)
+{
+  int gpu = 0;
+  struct codec_config codec = { .id = CODEC_NONE };
+  const char* codec_name = "none";
+  size_t frames = 2048, fps = 0, slots = 0, side = 1024, threads = 4;
+  for (int i = 1; i < argc; ++i) {
+    if (i + 1 >= argc)
+      goto usage;
+    const char* key = argv[i];
+    const char* value = argv[++i];
+    if (!strcmp(key, "--backend")) {
+      if (strcmp(value, "cpu") && strcmp(value, "gpu"))
+        goto usage;
+      gpu = !strcmp(value, "gpu");
+    } else if (!strcmp(key, "--codec")) {
+      if (strcmp(value, "none") && strcmp(value, "zstd"))
+        goto usage;
+      codec_name = value;
+      codec.id = !strcmp(value, "none") ? CODEC_NONE : CODEC_ZSTD;
+    } else {
+      size_t* out = !strcmp(key, "--frames")    ? &frames
+                    : !strcmp(key, "--fps")     ? &fps
+                    : !strcmp(key, "--slots")   ? &slots
+                    : !strcmp(key, "--side")    ? &side
+                    : !strcmp(key, "--threads") ? &threads
+                                                : NULL;
+      if (!out || number(value, out))
+        goto usage;
+    }
+  }
+  if (!frames || frames > 10000000 || !threads || threads > 1024 ||
+      side < 256 || side > 4096 || side % 256 || fps > 1000000)
+    goto usage;
+
+  const size_t frame_bytes = side * side * sizeof(uint16_t);
+  const size_t pattern_frames = 64;
+  uint16_t* pattern = malloc(pattern_frames * frame_bytes);
+  int64_t* submitted = calloc(frames, sizeof(*submitted));
+  double* caller = calloc(frames, sizeof(*caller));
+  double* downstream = calloc(frames, sizeof(*downstream));
+  double* completion = calloc(frames, sizeof(*completion));
+  double* lateness = calloc(frames, sizeof(*lateness));
+  struct tile_stream_cpu* cpu = NULL;
+  struct tile_stream_gpu* device = NULL;
+  struct buffered_writer* buffered = NULL;
+  int error = 1;
+  if (!pattern || !submitted || !caller || !downstream || !completion ||
+      !lateness)
+    goto cleanup;
+  // A deterministic spatial/temporal pattern; generation stays outside timing.
+  for (size_t t = 0; t < pattern_frames; ++t)
+    for (size_t y = 0; y < side; ++y)
+      for (size_t x = 0; x < side; ++x)
+        pattern[(t * side + y) * side + x] = (uint16_t)(x ^ y ^ (t * 127));
+
+  struct dimension dims[3];
+  dims_create(dims, "tyx", (uint64_t[]){ 0, side, side });
+  dims_set_chunk_sizes(dims, 3, (uint64_t[]){ 1, 256, 256 });
+  dims[0].chunks_per_shard = 32;
+  dims_set_shard_counts(dims, 3, (uint64_t[]){ 0, 1, 1 });
+  const struct tile_stream_configuration config = {
+    .buffer_capacity_bytes = 8 * frame_bytes,
+    .dtype = dtype_u16,
+    .rank = 3,
+    .dimensions = dims,
+    .codec = codec,
+    .epochs_per_batch = 32,
+    .max_threads = (int)threads,
+  };
+  struct discard_shard_sink sink;
+  discard_shard_sink_init(&sink);
+  if (gpu) {
+    if (!bench_gpu_enabled() || bench_gpu_context_create())
+      goto cleanup;
+    device = bench_gpu_create(&config, &sink.base);
+    if (!device)
+      goto cleanup;
+  } else {
+    cpu = tile_stream_cpu_create(&config, &sink.base);
+    if (!cpu)
+      goto cleanup;
+  }
+  struct observed_writer observed = {
+    .writer = { observed_append, observed_flush, observed_close },
+    .downstream = gpu ? bench_gpu_writer(device) : tile_stream_cpu_writer(cpu),
+    .submitted = submitted,
+    .downstream_ms = downstream,
+    .completion_ms = completion,
+  };
+  struct writer* writer = &observed.writer;
+  if (slots) {
+    buffered = buffered_writer_create(
+      writer, &(struct buffered_writer_config){ frame_bytes, slots });
+    if (!buffered)
+      goto cleanup;
+    writer = buffered_writer_as_writer(buffered);
+  }
+  const int64_t start = platform_monotonic_ns();
+  int64_t halfway = start;
+  for (size_t frame = 0; frame < frames; ++frame) {
+    const int64_t due =
+      start + (fps ? (int64_t)(frame * 1000000000ull / fps) : 0);
+    int64_t now = platform_monotonic_ns();
+    while (fps && now < due) {
+      platform_sleep_ns(due - now);
+      now = platform_monotonic_ns();
+    }
+    submitted[frame] = now;
+    lateness[frame] = fps ? (now - due) * 1e-6 : 0;
+    const unsigned char* data =
+      (const unsigned char*)pattern + (frame % pattern_frames) * frame_bytes;
+    struct writer_result r =
+      writer_append_wait(writer, (struct slice){ data, data + frame_bytes });
+    const int64_t end = platform_monotonic_ns();
+    caller[frame] = (end - now) * 1e-6;
+    if (r.error)
+      goto cleanup;
+    if (frame + 1 == frames / 2)
+      halfway = end;
+  }
+  const int64_t appended = platform_monotonic_ns();
+  if (writer_flush(writer).error || writer_close(writer).error)
+    goto cleanup;
+  const int64_t done = platform_monotonic_ns();
+  struct buffered_writer_stats stats = { 0 };
+  if (buffered)
+    stats = buffered_writer_get_stats(buffered);
+  int destroy_error = buffered_writer_destroy(buffered);
+  buffered = NULL;
+  if (destroy_error || observed.frame != frames)
+    goto cleanup;
+  printf("{\"backend\":\"%s\",\"codec\":\"%s\",\"frames\":%zu,\"fps\":%zu,"
+         "\"frame_bytes\":%zu,\"slots\":%zu,\"threads\":%zu,"
+         "\"wall_s\":%.6f,\"gib_s\":%.6f,\"second_half_gib_s\":%.6f,"
+         "\"flush_ms\":%.6f,",
+         gpu ? "gpu" : "cpu",
+         codec_name,
+         frames,
+         fps,
+         frame_bytes,
+         slots,
+         threads,
+         (done - start) * 1e-9,
+         (double)frames * frame_bytes / (done - start) * (1e9 / 1073741824.0),
+         (double)(frames - frames / 2) * frame_bytes / (done - halfway) *
+           (1e9 / 1073741824.0),
+         (done - appended) * 1e-6);
+  distribution("caller", caller, frames);
+  printf(",");
+  distribution("downstream", downstream, frames);
+  printf(",");
+  distribution("completion", completion, frames);
+  printf(",");
+  distribution("lateness", lateness, frames);
+  printf(",\"peak_occupied_slots\":%zu,\"peak_pending_bytes\":%zu,"
+         "\"backpressure_ms\":%.6f,\"queue_mean_ms\":%.6f,"
+         "\"queue_max_ms\":%.6f,\"abandoned_bytes\":%llu}\n",
+         stats.peak_occupied_slots,
+         stats.peak_pending_bytes,
+         stats.backpressure_ns * 1e-6,
+         stats.completed_slots ? stats.queue_ns * 1e-6 / stats.completed_slots
+                               : 0,
+         stats.max_queue_ns * 1e-6,
+         (unsigned long long)stats.abandoned_bytes);
+  error = 0;
+cleanup:
+  error |= buffered_writer_destroy(buffered);
+  if (cpu)
+    tile_stream_cpu_destroy(cpu);
+  if (device)
+    bench_gpu_destroy(device);
+  if (gpu)
+    bench_gpu_context_destroy();
+  free(lateness);
+  free(completion);
+  free(downstream);
+  free(caller);
+  free(submitted);
+  free(pattern);
+  return error;
+usage:
+  fprintf(
+    stderr,
+    "Usage: %s [--backend cpu|gpu] [--codec none|zstd] "
+    "[--frames N] [--fps N] [--slots N] [--side N] [--threads N]\n"
+    "fps=0: unpaced; slots=0: direct; side: multiple of 256, 256..4096.\n",
+    argv[0]);
+  return 2;
+}

--- a/bench/bench_buffered_writer.c
+++ b/bench/bench_buffered_writer.c
@@ -96,6 +96,7 @@ main(int argc, char** argv)
   struct codec_config codec = { .id = CODEC_NONE };
   const char* codec_name = "none";
   size_t frames = 2048, fps = 0, slots = 0, side = 1024, threads = 4;
+  size_t drain_slots = 0;
   for (int i = 1; i < argc; ++i) {
     if (i + 1 >= argc)
       goto usage;
@@ -111,18 +112,20 @@ main(int argc, char** argv)
       codec_name = value;
       codec.id = !strcmp(value, "none") ? CODEC_NONE : CODEC_ZSTD;
     } else {
-      size_t* out = !strcmp(key, "--frames")    ? &frames
-                    : !strcmp(key, "--fps")     ? &fps
-                    : !strcmp(key, "--slots")   ? &slots
-                    : !strcmp(key, "--side")    ? &side
-                    : !strcmp(key, "--threads") ? &threads
-                                                : NULL;
+      size_t* out = !strcmp(key, "--frames")        ? &frames
+                    : !strcmp(key, "--fps")         ? &fps
+                    : !strcmp(key, "--slots")       ? &slots
+                    : !strcmp(key, "--drain-slots") ? &drain_slots
+                    : !strcmp(key, "--side")        ? &side
+                    : !strcmp(key, "--threads")     ? &threads
+                                                    : NULL;
       if (!out || number(value, out))
         goto usage;
     }
   }
   if (!frames || frames > 10000000 || !threads || threads > 1024 ||
-      side < 256 || side > 4096 || side % 256 || fps > 1000000)
+      side < 256 || side > 4096 || side % 256 || fps > 1000000 ||
+      drain_slots > slots)
     goto usage;
 
   const size_t frame_bytes = side * side * sizeof(uint16_t);
@@ -185,7 +188,8 @@ main(int argc, char** argv)
   struct writer* writer = &observed.writer;
   if (slots) {
     buffered = buffered_writer_create(
-      writer, &(struct buffered_writer_config){ frame_bytes, slots });
+      writer,
+      &(struct buffered_writer_config){ frame_bytes, slots, drain_slots });
     if (!buffered)
       goto cleanup;
     writer = buffered_writer_as_writer(buffered);
@@ -224,22 +228,24 @@ main(int argc, char** argv)
   buffered = NULL;
   if (destroy_error || observed.frame != frames)
     goto cleanup;
-  printf("{\"backend\":\"%s\",\"codec\":\"%s\",\"frames\":%zu,\"fps\":%zu,"
-         "\"frame_bytes\":%zu,\"slots\":%zu,\"threads\":%zu,"
-         "\"wall_s\":%.6f,\"gib_s\":%.6f,\"second_half_gib_s\":%.6f,"
-         "\"flush_ms\":%.6f,",
-         gpu ? "gpu" : "cpu",
-         codec_name,
-         frames,
-         fps,
-         frame_bytes,
-         slots,
-         threads,
-         (done - start) * 1e-9,
-         (double)frames * frame_bytes / (done - start) * (1e9 / 1073741824.0),
-         (double)(frames - frames / 2) * frame_bytes / (done - halfway) *
-           (1e9 / 1073741824.0),
-         (done - appended) * 1e-6);
+  printf(
+    "{\"backend\":\"%s\",\"codec\":\"%s\",\"frames\":%zu,\"fps\":%zu,"
+    "\"frame_bytes\":%zu,\"slots\":%zu,\"drain_slots\":%zu,\"threads\":%zu,"
+    "\"wall_s\":%.6f,\"gib_s\":%.6f,\"second_half_gib_s\":%.6f,"
+    "\"flush_ms\":%.6f,",
+    gpu ? "gpu" : "cpu",
+    codec_name,
+    frames,
+    fps,
+    frame_bytes,
+    slots,
+    drain_slots ? drain_slots : slots,
+    threads,
+    (done - start) * 1e-9,
+    (double)frames * frame_bytes / (done - start) * (1e9 / 1073741824.0),
+    (double)(frames - frames / 2) * frame_bytes / (done - halfway) *
+      (1e9 / 1073741824.0),
+    (done - appended) * 1e-6);
   distribution("caller", caller, frames);
   printf(",");
   distribution("downstream", downstream, observed.calls);
@@ -279,11 +285,12 @@ cleanup:
   free(pattern);
   return error;
 usage:
-  fprintf(
-    stderr,
-    "Usage: %s [--backend cpu|gpu] [--codec none|zstd] "
-    "[--frames N] [--fps N] [--slots N] [--side N] [--threads N]\n"
-    "fps=0: unpaced; slots=0: direct; side: multiple of 256, 256..4096.\n",
-    argv[0]);
+  fprintf(stderr,
+          "Usage: %s [--backend cpu|gpu] [--codec none|zstd] "
+          "[--frames N] [--fps N] [--slots N] [--drain-slots N] "
+          "[--side N] [--threads N]\n"
+          "fps=0: unpaced; slots=0: direct; drain-slots=0: up to all slots.\n"
+          "side: multiple of 256, 256..4096.\n",
+          argv[0]);
   return 2;
 }

--- a/bench/bench_buffered_writer.c
+++ b/bench/bench_buffered_writer.c
@@ -18,19 +18,31 @@ struct observed_writer
   int64_t* submitted;
   double* downstream_ms;
   double* completion_ms;
+  size_t frame_bytes;
+  size_t frames;
   size_t frame;
+  size_t calls;
+  size_t max_batch_frames;
 };
 
 static struct writer_result
 observed_append(struct writer* self, struct slice input)
 {
   struct observed_writer* o = (struct observed_writer*)self;
+  const size_t bytes =
+    (const unsigned char*)input.end - (const unsigned char*)input.beg;
+  const size_t frames = bytes / o->frame_bytes;
+  if (!frames || bytes % o->frame_bytes || frames > o->frames - o->frame)
+    return writer_error_at(input.beg, input.end);
   const int64_t start = platform_monotonic_ns();
   struct writer_result r = writer_append_wait(o->downstream, input);
   const int64_t end = platform_monotonic_ns();
-  o->downstream_ms[o->frame] = (end - start) * 1e-6;
-  o->completion_ms[o->frame] = (end - o->submitted[o->frame]) * 1e-6;
-  ++o->frame;
+  o->downstream_ms[o->calls++] = (end - start) * 1e-6;
+  if (frames > o->max_batch_frames)
+    o->max_batch_frames = frames;
+  // A combined call gives one completion observation for all its frames.
+  for (size_t i = 0; i < frames; ++i, ++o->frame)
+    o->completion_ms[o->frame] = (end - o->submitted[o->frame]) * 1e-6;
   return r;
 }
 
@@ -167,6 +179,8 @@ main(int argc, char** argv)
     .submitted = submitted,
     .downstream_ms = downstream,
     .completion_ms = completion,
+    .frame_bytes = frame_bytes,
+    .frames = frames,
   };
   struct writer* writer = &observed.writer;
   if (slots) {
@@ -228,14 +242,19 @@ main(int argc, char** argv)
          (done - appended) * 1e-6);
   distribution("caller", caller, frames);
   printf(",");
-  distribution("downstream", downstream, frames);
+  distribution("downstream", downstream, observed.calls);
   printf(",");
   distribution("completion", completion, frames);
   printf(",");
   distribution("lateness", lateness, frames);
-  printf(",\"peak_occupied_slots\":%zu,\"peak_pending_bytes\":%zu,"
+  printf(",\"downstream_calls\":%zu,\"max_batch_frames\":%zu,"
+         "\"buffer_payload_bytes\":%zu,"
+         "\"peak_occupied_slots\":%zu,\"peak_pending_bytes\":%zu,"
          "\"backpressure_ms\":%.6f,\"queue_mean_ms\":%.6f,"
          "\"queue_max_ms\":%.6f,\"abandoned_bytes\":%llu}\n",
+         observed.calls,
+         observed.max_batch_frames,
+         slots * frame_bytes,
          stats.peak_occupied_slots,
          stats.peak_pending_bytes,
          stats.backpressure_ns * 1e-6,

--- a/docs/buffered-writer.md
+++ b/docs/buffered-writer.md
@@ -7,41 +7,36 @@ adapter does not change the underlying pipeline or its output format.
 
 ## Capacity and acceptance
 
-Choose `slot_bytes` and `slot_count` explicitly. At most `slot_count` appends are
-accepted across the queued and active downstream batches. A short append still
-occupies one slot until its batch returns. Choose a slot size matching normal
-producer appends, and a count covering the temporary backlog your workload can
-tolerate. Both slot size and input sizes must respect downstream granularity.
+Configure **`capacity_bytes`** and **`max_drain_bytes`**. The adapter treats input
+as a byte stream: capacity, backpressure and drains do not depend on how callers
+partition that stream into appends. Capacity must be nonzero. A zero drain cap
+uses the full capacity; a cap greater than capacity is invalid. Capacity, cap
+and input sizes must respect downstream granularity, such as whole elements.
 
-The **`slot_bytes * slot_count`** payload allocation is a shared ring, plus one
-bookkeeping entry per slot and one worker thread and stack. The producer packs
-input directly into the ring while the worker drains an older prefix. Active
-drains pin only their own slots: with one slot active in a 64-slot ring, the
-producer can fill the other 63. Each completed drain frees its slots immediately.
-There are no append-path allocations or extra copies to assemble a batch.
+The payload allocation is exactly `capacity_bytes` in a shared ring, plus fixed
+bookkeeping and one worker thread and stack. The producer copies directly into
+free space while the worker drains an older prefix. Active drains pin only their
+own bytes. There are no per-append descriptors, allocations or packing copies.
 
-Set **`max_drain_slots`** independently of total capacity. A drain submits the
-contiguous backlog prefix up to that many slots in one downstream append. Zero
-uses `slot_count`, and values greater than `slot_count` are invalid. A drain also
-stops at the physical end of the ring. Short appends are packed without gaps;
-original append boundaries are not preserved. Partial downstream acceptance or
-stalls can require retries of the remaining suffix.
+Each drain submits up to `max_drain_bytes` of the contiguous queued prefix in
+one downstream append, stopping at the physical end of the ring. The byte cap
+can split a producer append or combine several appends, regardless of their
+sizes. Partial downstream acceptance or stalls can require retries of the
+remaining suffix.
 
-The worker starts immediately when input is available, without waiting to fill
-a batch. After each drain it immediately starts another if a backlog remains.
-For example, 64 slots with an eight-slot cap lets each drain catch up by up to
-eight producer appends while retaining the other 56 slots for waiting input.
-The cap bounds bytes held by one drain (`max_drain_slots * slot_bytes`), not its
-duration: a single frame can still trigger downstream startup or flush work.
+The worker starts as soon as input is available, without waiting to fill a
+batch. On return, that batch's bytes are reusable and the worker immediately
+starts another if a backlog remains. For example, a 128 MiB capacity with a
+16 MiB cap leaves at least 112 MiB outside the active drain for queued or new
+input. A size cap does not bound call duration: downstream startup or flush work
+can occur even for a small append.
 
-An append waits until one slot is free, copies up to `slot_bytes` or the end of
-the ring, and returns the unaccepted suffix in `writer_result.rest`. The accepted
-prefix is owned by the adapter, so the caller can immediately overwrite or free
-that prefix.
-`writer_append_wait` handles inputs larger than one slot. An empty input consumes
-no slot. When full, the queue blocks; it does not overwrite old data or drop new
-input. A bounded queue cannot compensate for sustained overload, and cannot
-bound an append's duration if downstream stops returning.
+An append waits for free capacity, copies as much input as fits up to the ring
+boundary, and returns the unaccepted suffix in `writer_result.rest`. The caller
+can immediately overwrite or free the accepted prefix. `writer_append_wait`
+retries any suffix. An empty input consumes no capacity. A full queue blocks
+without dropping or overwriting input. A bounded queue cannot compensate for
+sustained overload or bound a call's duration if downstream stops returning.
 
 Acceptance means the copy is queued, not that downstream consumed or persisted
 it. Always check flush and close, even if all appends succeeded.
@@ -52,7 +47,7 @@ it. Always check flush and close, even if all appends succeeded.
 | --- | --- | --- |
 | Normal flush | Forward every accepted byte, then flush downstream | Success only if draining and downstream flush succeed |
 | Downstream append fails or stops making progress | Stop forwarding; abandon the unconsumed accepted suffix | Sticky failure, including on later flush/close |
-| Downstream returns `finished` with accepted bytes left | Abandon its unconsumed suffix and later queued slots | Sticky failure; `abandoned_bytes` counts the loss |
+| Downstream returns `finished` with accepted bytes left | Abandon its unconsumed suffix and later queued bytes | Sticky failure; `abandoned_bytes` counts the loss |
 | Downstream returns `finished` after consuming all accepted bytes | Nothing remains | Future appends return `finished`; flush still runs |
 | Close after flush | Publish through downstream close | Wait for completion and report failures |
 | Close before flush | Continue accepting | No-op, matching tile-stream writers |
@@ -90,12 +85,11 @@ Downstream callbacks must not call back into the adapter.
 #include "writer.buffered.h"
 
 int write_buffered(struct writer* downstream, struct slice input,
-                   size_t slot_bytes, size_t slot_count)
+                   size_t capacity_bytes, size_t max_drain_bytes)
 {
   struct buffered_writer_config config = {
-    .slot_bytes = slot_bytes,
-    .slot_count = slot_count,
-    .max_drain_slots = slot_count < 8 ? slot_count : 8,
+    .capacity_bytes = capacity_bytes,
+    .max_drain_bytes = max_drain_bytes,
   };
   struct buffered_writer* buffered = buffered_writer_create(downstream, &config);
   if (!buffered)
@@ -113,17 +107,14 @@ int write_buffered(struct writer* downstream, struct slice input,
 ## Measurement
 
 Stats distinguish accepted, forwarded, abandoned and pending bytes. Pending
-bytes and occupied slots include the active downstream append, but exclude
-downstream asynchronous work after that append returns. Peaks capture brief
-occupancy spikes even if the observer samples infrequently.
+bytes include the active downstream append, but exclude downstream asynchronous
+work after that append returns. The peak captures brief occupancy spikes even
+if the observer samples infrequently.
 
-`backpressure_ns` measures caller time waiting for capacity. Queue time runs from
-acceptance (after the copy) until the worker starts forwarding. Downstream time
-includes partial-append retries. Completion time ends when downstream append
-returns, not when the data reaches storage. Queue time is summed per accepted
-slot; downstream time is summed once per drained batch. `completed_batches` and
-`max_batch_bytes` report batching separately from `completed_slots`. These clocks
-exclude caller copy time from queue time.
+`backpressure_ns` measures caller time waiting for capacity. `downstream_ns` and
+`max_downstream_ns` measure drained batches, including partial-append retries.
+`completed_batches` and `max_batch_bytes` describe batching without preserving
+producer append boundaries or retaining timing records per append.
 
 `bench_buffered_writer` compares direct and buffered appends using identical
 1024 x 1024 uint16 frames, 256 x 256 chunks, 32 epochs per batch, four processing
@@ -135,27 +126,33 @@ GPU readback tests, including metadata and immediate input reuse.
 
 ```sh
 # Repeat in alternating order for both cpu/gpu and none/zstd.
-build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --slots 0
-build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --slots 64 --drain-slots 8
+build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --buffer-bytes 0
+build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --buffer-bytes 134217728 --drain-bytes 16777216
 
-# Paced arrival: fps=0 disables pacing; slots=0 selects direct appends.
-build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --slots 0
-build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --slots 64 --drain-slots 8
+# Paced arrival: fps=0 disables pacing; buffer-bytes=0 selects direct appends.
+build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --buffer-bytes 0
+build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --buffer-bytes 134217728 --drain-bytes 16777216
 ```
 
-JSON reports caller latency per frame and downstream latency per batch, together
-with downstream call count, maximum frames per batch and reserved payload bytes.
-`drain_slots` reports the effective cap; `--drain-slots 0` uses all configured
-slots. Compare different caps at the same total capacity to distinguish batching
-from the queue's ability to absorb stalls. The eight-slot example is a tunable
-starting point, not a measured universal optimum.
-Submission-to-downstream completion delay is per frame: all frames in a combined
-call use that call's return time, since intermediate consumption is not observed.
-It also reports lateness against scheduled frame arrival, peak queue occupancy,
-queue delay and backpressure. The unpaced second-half byte rate
-includes the final drain, so accepted backlog is never counted as completed
-work. Compare several capacities and include an overloaded paced run. Smaller
-queues may reduce copying/cache overhead but absorb shorter stalls.
+JSON reports capacity, effective drain cap, maximum batch size and peak pending
+input in bytes. `--drain-bytes 0` uses the full configured capacity. Compare caps
+at the same capacity to distinguish batching from stall absorption. The 16 MiB
+example is a tunable starting point, not a universal optimum.
+
+Only the benchmark knows about frames. It reports caller latency per frame and
+downstream latency per batch. `submission_to_forward_ms` measures each frame's
+submission until its first byte reaches the downstream call; this includes
+copying and any preceding backpressure, rather than starting after acceptance.
+Completion delay ends when the call containing that frame's last byte returns.
+A drain may split a frame or combine parts of several frames. These observations
+measure downstream consumption, not persistence. The observer grows its timing
+array if a small byte cap produces more batches than frames.
+
+The benchmark also reports lateness against scheduled arrival and backpressure.
+The unpaced second-half byte rate includes the final drain, so accepted backlog
+is never counted as completed work. Compare several capacities and include an
+overloaded paced run. Smaller buffers may reduce copying/cache overhead but
+absorb shorter stalls.
 
 The extra copy consumes CPU and memory bandwidth. Buffering can reduce caller
 stalls while increasing downstream delay and reducing maximum throughput,

--- a/docs/buffered-writer.md
+++ b/docs/buffered-writer.md
@@ -7,13 +7,27 @@ adapter does not change the underlying pipeline or its output format.
 
 ## Capacity and acceptance
 
-Choose `slot_bytes` and `slot_count` explicitly. The payload allocation is their
-product; bookkeeping is fixed per slot, with one worker thread and its stack.
-The slot being forwarded counts toward capacity. There are no allocations in
-the adapter's append path. Slots are not combined: a short append occupies one
-slot until downstream consumes it. Choose a slot size matching normal producer
-appends, and a count covering the temporary backlog your workload can tolerate.
-Both slot size and input sizes must respect downstream element granularity.
+Choose `slot_bytes` and `slot_count` explicitly. At most `slot_count` appends are
+accepted across the queued and active downstream batches. A short append still
+occupies one slot until its batch returns. Choose a slot size matching normal
+producer appends, and a count covering the temporary backlog your workload can
+tolerate. Both slot size and input sizes must respect downstream granularity.
+
+The **`slot_bytes * slot_count`** payload allocation is split between two
+contiguous buffers, plus fixed bookkeeping and one worker thread and stack. The
+first buffer gets the extra slot for odd counts. The producer packs input
+directly into one buffer while the worker drains the other. When the producer
+buffer fills, it waits for the worker to swap buffers. Thus each queued backlog
+holds at most half the slots, rounded up. A one-slot allocation waits for each
+drain before refilling. There are no append-path allocations or extra copies to
+assemble a batch.
+
+Each drain snapshots the **entire queued backlog** and submits it in one
+downstream append. Short appends are packed without gaps; original append
+boundaries are not preserved. Input accepted while that call runs goes into
+the next buffer. Once the call returns, the worker immediately drains the new
+backlog. Partial downstream acceptance or stalls can require retries of the
+remaining suffix.
 
 An append waits until one slot is free, copies up to `slot_bytes`, and returns
 the unaccepted suffix in `writer_result.rest`. The accepted prefix is owned by
@@ -96,8 +110,10 @@ occupancy spikes even if the observer samples infrequently.
 `backpressure_ns` measures caller time waiting for capacity. Queue time runs from
 acceptance (after the copy) until the worker starts forwarding. Downstream time
 includes partial-append retries. Completion time ends when downstream append
-returns, not when the data reaches storage. Timing aggregates are per slot, not
-weighted by bytes. These clocks exclude caller copy time from queue time.
+returns, not when the data reaches storage. Queue time is summed per accepted
+slot; downstream time is summed once per drained batch. `completed_batches` and
+`max_batch_bytes` report batching separately from `completed_slots`. These clocks
+exclude caller copy time from queue time.
 
 `bench_buffered_writer` compares direct and buffered appends using identical
 1024 x 1024 uint16 frames, 256 x 256 chunks, 32 epochs per batch, four processing
@@ -117,9 +133,12 @@ build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps
 build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --slots 16
 ```
 
-JSON reports caller and downstream append latency, submission-to-downstream
-completion delay, lateness against scheduled frame arrival, peak queue
-occupancy, queue delay and backpressure. The unpaced second-half byte rate
+JSON reports caller latency per frame and downstream latency per batch, together
+with downstream call count, maximum frames per batch and reserved payload bytes.
+Submission-to-downstream completion delay is per frame: all frames in a combined
+call use that call's return time, since intermediate consumption is not observed.
+It also reports lateness against scheduled frame arrival, peak queue occupancy,
+queue delay and backpressure. The unpaced second-half byte rate
 includes the final drain, so accepted backlog is never counted as completed
 work. Compare several capacities and include an overloaded paced run. Smaller
 queues may reduce copying/cache overhead but absorb shorter stalls.

--- a/docs/buffered-writer.md
+++ b/docs/buffered-writer.md
@@ -1,0 +1,131 @@
+# Buffered input writer
+
+`writer.buffered.h` provides an optional copying adapter around `struct writer`.
+It can absorb temporary downstream stalls for a paced producer, including CPU
+and GPU tile streams. One worker forwards accepted input in order. Creating the
+adapter does not change the underlying pipeline or its output format.
+
+## Capacity and acceptance
+
+Choose `slot_bytes` and `slot_count` explicitly. The payload allocation is their
+product; bookkeeping is fixed per slot, with one worker thread and its stack.
+The slot being forwarded counts toward capacity. There are no allocations in
+the adapter's append path. Slots are not combined: a short append occupies one
+slot until downstream consumes it. Choose a slot size matching normal producer
+appends, and a count covering the temporary backlog your workload can tolerate.
+Both slot size and input sizes must respect downstream element granularity.
+
+An append waits until one slot is free, copies up to `slot_bytes`, and returns
+the unaccepted suffix in `writer_result.rest`. The accepted prefix is owned by
+the adapter, so the caller can immediately overwrite or free that prefix.
+`writer_append_wait` handles inputs larger than one slot. An empty input consumes
+no slot. When full, the queue blocks; it does not overwrite old data or drop new
+input. A bounded queue cannot compensate for sustained overload, and cannot
+bound an append's duration if downstream stops returning.
+
+Acceptance means the copy is queued, not that downstream consumed or persisted
+it. Always check flush and close, even if all appends succeeded.
+
+## Completion and errors
+
+| Event | Queued input | Result |
+| --- | --- | --- |
+| Normal flush | Forward every accepted byte, then flush downstream | Success only if draining and downstream flush succeed |
+| Downstream append fails or stops making progress | Stop forwarding; abandon the unconsumed accepted suffix | Sticky failure, including on later flush/close |
+| Downstream returns `finished` with accepted bytes left | Abandon its unconsumed suffix and later queued slots | Sticky failure; `abandoned_bytes` counts the loss |
+| Downstream returns `finished` after consuming all accepted bytes | Nothing remains | Future appends return `finished`; flush still runs |
+| Close after flush | Publish through downstream close | Wait for completion and report failures |
+| Close before flush | Continue accepting | No-op, matching tile-stream writers |
+
+After a terminal result, a later append returns its entire input unaccepted.
+`rest` always refers to that call's original input, never to internal copies.
+Previously accepted data cannot be recovered from the adapter. Inspect
+`abandoned_bytes` when deciding how to handle an acquisition failure.
+`forwarded_bytes` counts downstream consumption; a later I/O error may still
+prevent those bytes from reaching storage.
+
+Flush stops acceptance permanently. It calls downstream flush even after an
+append error, so already submitted work can drain. Flush and close are
+idempotent and preserve failures. Destroy runs both, joins the worker, frees the
+adapter, and returns an error if either failed. It never destroys downstream.
+Keep the sink alive through destruction of the underlying tile stream, too.
+
+## Ownership and concurrency
+
+The adapter borrows downstream. Its writer, configuration, sink, and GPU context
+must outlive the adapter. While the adapter exists, only its worker may access
+downstream, including downstream metrics/accessors. Destroy the adapter before
+reading those metrics or using downstream separately.
+
+The underlying writer must allow calls from a different thread and release its
+reference to consumed input before append returns. CPU and GPU tile-stream
+writers satisfy this contract; the GPU writer installs its own CUDA context
+around each operation. Other thread-affine writers require their own adaptation.
+
+Externally serialize calls to append, flush, close and destroy. A concurrent
+observer may call `buffered_writer_get_stats`; stop observers before destroy.
+Downstream callbacks must not call back into the adapter.
+
+```c
+#include "writer.buffered.h"
+
+int write_buffered(struct writer* downstream, struct slice input,
+                   size_t slot_bytes, size_t slot_count)
+{
+  struct buffered_writer_config config = { slot_bytes, slot_count };
+  struct buffered_writer* buffered = buffered_writer_create(downstream, &config);
+  if (!buffered)
+    return 1;
+  struct writer* writer = buffered_writer_as_writer(buffered);
+  int failed = writer_append_wait(writer, input).error != 0;
+  // The accepted prefix of input can be reused now. An error may leave a suffix.
+  failed |= writer_flush(writer).error != 0;
+  failed |= writer_close(writer).error != 0;
+  failed |= buffered_writer_destroy(buffered);
+  return failed;
+}
+```
+
+## Measurement
+
+Stats distinguish accepted, forwarded, abandoned and pending bytes. Pending
+bytes and occupied slots include the active downstream append, but exclude
+downstream asynchronous work after that append returns. Peaks capture brief
+occupancy spikes even if the observer samples infrequently.
+
+`backpressure_ns` measures caller time waiting for capacity. Queue time runs from
+acceptance (after the copy) until the worker starts forwarding. Downstream time
+includes partial-append retries. Completion time ends when downstream append
+returns, not when the data reaches storage. Timing aggregates are per slot, not
+weighted by bytes. These clocks exclude caller copy time from queue time.
+
+`bench_buffered_writer` compares direct and buffered appends using identical
+1024 x 1024 uint16 frames, 256 x 256 chunks, 32 epochs per batch, four processing
+threads, a 64-frame spatial/temporal XOR pattern, and a discard sink by default.
+The pattern is prepared before timing. Creation is excluded; first-append
+startup, append stalls, and final flush/close are included. The discard sink
+isolates pipeline capacity; filesystem output is checked separately by CPU and
+GPU readback tests, including metadata and immediate input reuse.
+
+```sh
+# Repeat in alternating order for both cpu/gpu and none/zstd.
+build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --slots 0
+build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --slots 16
+
+# Paced arrival: fps=0 disables pacing; slots=0 selects direct appends.
+build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --slots 0
+build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --slots 16
+```
+
+JSON reports caller and downstream append latency, submission-to-downstream
+completion delay, lateness against scheduled frame arrival, peak queue
+occupancy, queue delay and backpressure. The unpaced second-half byte rate
+includes the final drain, so accepted backlog is never counted as completed
+work. Compare several capacities and include an overloaded paced run. Smaller
+queues may reduce copying/cache overhead but absorb shorter stalls.
+
+The extra copy consumes CPU and memory bandwidth. Buffering can reduce caller
+stalls while increasing downstream delay and reducing maximum throughput,
+especially with codec `none`. Select capacity and decide whether to enable the
+adapter using measurements of the intended workload; there is no default
+capacity or general throughput-parity guarantee.

--- a/docs/buffered-writer.md
+++ b/docs/buffered-writer.md
@@ -1,161 +1,69 @@
 # Buffered input writer
 
-`writer.buffered.h` provides an optional copying adapter around `struct writer`.
-It can absorb temporary downstream stalls for a paced producer, including CPU
-and GPU tile streams. One worker forwards accepted input in order. Creating the
-adapter does not change the underlying pipeline or its output format.
+The [buffered writer](../src/writer.buffered.h) copies input into a bounded
+queue for CPU/GPU tile streams. Use it to absorb temporary downstream stalls
+when a paced producer needs to reuse input promptly. The extra copy can reduce
+sustained throughput.
 
-## Capacity and acceptance
+## Configure and use
 
-Configure **`capacity_bytes`** and **`max_drain_bytes`**. The adapter treats input
-as a byte stream: capacity, backpressure and drains do not depend on how callers
-partition that stream into appends. Capacity must be nonzero. A zero drain cap
-uses the full capacity; a cap greater than capacity is invalid. Capacity, cap
-and input sizes must respect downstream granularity, such as whole elements.
-
-The payload allocation is exactly `capacity_bytes` in a shared ring, plus fixed
-bookkeeping and one worker thread and stack. The producer copies directly into
-free space while the worker drains an older prefix. Active drains pin only their
-own bytes. There are no per-append descriptors, allocations or packing copies.
-
-Each drain submits up to `max_drain_bytes` of the contiguous queued prefix in
-one downstream append, stopping at the physical end of the ring. The byte cap
-can split a producer append or combine several appends, regardless of their
-sizes. Partial downstream acceptance or stalls can require retries of the
-remaining suffix.
-
-The worker starts as soon as input is available, without waiting to fill a
-batch. On return, that batch's bytes are reusable and the worker immediately
-starts another if a backlog remains. For example, a 128 MiB capacity with a
-16 MiB cap leaves at least 112 MiB outside the active drain for queued or new
-input. A size cap does not bound call duration: downstream startup or flush work
-can occur even for a small append.
-
-An append waits for free capacity, copies as much input as fits up to the ring
-boundary, and returns the unaccepted suffix in `writer_result.rest`. The caller
-can immediately overwrite or free the accepted prefix. `writer_append_wait`
-retries any suffix. An empty input consumes no capacity. A full queue blocks
-without dropping or overwriting input. A bounded queue cannot compensate for
-sustained overload or bound a call's duration if downstream stops returning.
-
-Acceptance means the copy is queued, not that downstream consumed or persisted
-it. Always check flush and close, even if all appends succeeded.
-
-## Completion and errors
-
-| Event | Queued input | Result |
-| --- | --- | --- |
-| Normal flush | Forward every accepted byte, then flush downstream | Success only if draining and downstream flush succeed |
-| Downstream append fails or stops making progress | Stop forwarding; abandon the unconsumed accepted suffix | Sticky failure, including on later flush/close |
-| Downstream returns `finished` with accepted bytes left | Abandon its unconsumed suffix and later queued bytes | Sticky failure; `abandoned_bytes` counts the loss |
-| Downstream returns `finished` after consuming all accepted bytes | Nothing remains | Future appends return `finished`; flush still runs |
-| Close after flush | Publish through downstream close | Wait for completion and report failures |
-| Close before flush | Continue accepting | No-op, matching tile-stream writers |
-
-After a terminal result, a later append returns its entire input unaccepted.
-`rest` always refers to that call's original input, never to internal copies.
-Previously accepted data cannot be recovered from the adapter. Inspect
-`abandoned_bytes` when deciding how to handle an acquisition failure.
-`forwarded_bytes` counts downstream consumption; a later I/O error may still
-prevent those bytes from reaching storage.
-
-Flush stops acceptance permanently. It calls downstream flush even after an
-append error, so already submitted work can drain. Flush and close are
-idempotent and preserve failures. Destroy runs both, joins the worker, frees the
-adapter, and returns an error if either failed. It never destroys downstream.
-Keep the sink alive through destruction of the underlying tile stream, too.
-
-## Ownership and concurrency
-
-The adapter borrows downstream. Its writer, configuration, sink, and GPU context
-must outlive the adapter. While the adapter exists, only its worker may access
-downstream, including downstream metrics/accessors. Destroy the adapter before
-reading those metrics or using downstream separately.
-
-The underlying writer must allow calls from a different thread and release its
-reference to consumed input before append returns. CPU and GPU tile-stream
-writers satisfy this contract; the GPU writer installs its own CUDA context
-around each operation. Other thread-affine writers require their own adaptation.
-
-Externally serialize calls to append, flush, close and destroy. A concurrent
-observer may call `buffered_writer_get_stats`; stop observers before destroy.
-Downstream callbacks must not call back into the adapter.
+`capacity_bytes` bounds queued and active input. `max_drain_bytes` limits each
+downstream batch; zero uses the full capacity. Capacity must be nonzero and the
+cap must not exceed it. Both values and input sizes must respect downstream
+granularity, such as whole elements. Tune these example sizes to your workload:
 
 ```c
 #include "writer.buffered.h"
 
-int write_buffered(struct writer* downstream, struct slice input,
-                   size_t capacity_bytes, size_t max_drain_bytes)
+int write_buffered(struct writer* downstream, struct slice input)
 {
-  struct buffered_writer_config config = {
-    .capacity_bytes = capacity_bytes,
-    .max_drain_bytes = max_drain_bytes,
+  const struct buffered_writer_config config = {
+    .capacity_bytes = 128u * 1024 * 1024,
+    .max_drain_bytes = 16u * 1024 * 1024,
   };
   struct buffered_writer* buffered = buffered_writer_create(downstream, &config);
   if (!buffered)
     return 1;
   struct writer* writer = buffered_writer_as_writer(buffered);
   int failed = writer_append_wait(writer, input).error != 0;
-  // The accepted prefix of input can be reused now. An error may leave a suffix.
-  failed |= writer_flush(writer).error != 0;
-  failed |= writer_close(writer).error != 0;
-  failed |= buffered_writer_destroy(buffered);
+  failed |= buffered_writer_destroy(buffered); // flush, close, and join
   return failed;
 }
 ```
 
-## Measurement
+## Input and ownership
 
-Stats distinguish accepted, forwarded, abandoned and pending bytes. Pending
-bytes include the active downstream append, but exclude downstream asynchronous
-work after that append returns. The peak captures brief occupancy spikes even
-if the observer samples infrequently.
+Append copies available input and returns the unaccepted suffix in `rest`.
+The accepted prefix can immediately be reused; `writer_append_wait` retries the
+suffix. A full queue blocks without dropping input.
 
-`backpressure_ns` measures caller time waiting for capacity. `downstream_ns` and
-`max_downstream_ns` measure drained batches, including partial-append retries.
-`completed_batches` and `max_batch_bytes` describe batching without preserving
-producer append boundaries or retaining timing records per append.
+The worker drains the contiguous queued prefix up to the cap or ring boundary.
+Drains can split or combine producer appends. The worker never waits to fill a
+batch: it releases each completed batch and immediately continues while input
+remains.
 
-`bench_buffered_writer` compares direct and buffered appends using identical
-1024 x 1024 uint16 frames, 256 x 256 chunks, 32 epochs per batch, four processing
-threads, a 64-frame spatial/temporal XOR pattern, and a discard sink by default.
-The pattern is prepared before timing. Creation is excluded; first-append
-startup, append stalls, and final flush/close are included. The discard sink
-isolates pipeline capacity; filesystem output is checked separately by CPU and
-GPU readback tests, including metadata and immediate input reuse.
+Keep downstream, its configuration, sink, and GPU context alive until adapter
+destruction. Only the worker may use downstream. Serialize append, flush, close,
+and destroy; stop concurrent stats readers before destroy. Custom writers must
+allow calls from another thread and release consumed input before returning.
 
-```sh
-# Repeat in alternating order for both cpu/gpu and none/zstd.
-build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --buffer-bytes 0
-build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --buffer-bytes 134217728 --drain-bytes 16777216
+## Finish and handle errors
 
-# Paced arrival: fps=0 disables pacing; buffer-bytes=0 selects direct appends.
-build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --buffer-bytes 0
-build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --buffer-bytes 134217728 --drain-bytes 16777216
-```
+Flush stops acceptance and drains queued input unless downstream has terminated.
+It still flushes downstream after failure. Close publishes metadata after flush;
+before flush it does nothing. Both are idempotent and preserve errors.
 
-JSON reports capacity, effective drain cap, maximum batch size and peak pending
-input in bytes. `--drain-bytes 0` uses the full configured capacity. Compare caps
-at the same capacity to distinguish batching from stall absorption. The 16 MiB
-example is a tunable starting point, not a universal optimum.
+A downstream failure or early completion stops forwarding. Remaining accepted
+input is counted in `abandoned_bytes` and makes finalization fail. Later appends
+accept nothing. Always check errors, including from destroy: it flushes, closes,
+joins, and frees the adapter without destroying downstream.
 
-Only the benchmark knows about frames. It reports caller latency per frame and
-downstream latency per batch. `submission_to_forward_ms` measures each frame's
-submission until its first byte reaches the downstream call; this includes
-copying and any preceding backpressure, rather than starting after acceptance.
-Completion delay ends when the call containing that frame's last byte returns.
-A drain may split a frame or combine parts of several frames. These observations
-measure downstream consumption, not persistence. The observer grows its timing
-array if a small byte cap produces more batches than frames.
+## Measure
 
-The benchmark also reports lateness against scheduled arrival and backpressure.
-The unpaced second-half byte rate includes the final drain, so accepted backlog
-is never counted as completed work. Compare several capacities and include an
-overloaded paced run. Smaller buffers may reduce copying/cache overhead but
-absorb shorter stalls.
+`buffered_writer_get_stats` reports byte occupancy, backpressure, and downstream
+batch timing. Forwarded bytes measure consumption, not storage persistence.
 
-The extra copy consumes CPU and memory bandwidth. Buffering can reduce caller
-stalls while increasing downstream delay and reducing maximum throughput,
-especially with codec `none`. Select capacity and decide whether to enable the
-adapter using measurements of the intended workload; there is no default
-capacity or general throughput-parity guarantee.
+Compare [bench_buffered_writer](../bench/bench_buffered_writer.c) with
+`--buffer-bytes 0` and your chosen capacity; vary `--drain-bytes` at fixed capacity.
+Test `--fps 0` and your expected frame rate. A cap limits bytes, not call
+duration, and buffering cannot absorb sustained overload.

--- a/docs/buffered-writer.md
+++ b/docs/buffered-writer.md
@@ -13,25 +13,31 @@ occupies one slot until its batch returns. Choose a slot size matching normal
 producer appends, and a count covering the temporary backlog your workload can
 tolerate. Both slot size and input sizes must respect downstream granularity.
 
-The **`slot_bytes * slot_count`** payload allocation is split between two
-contiguous buffers, plus fixed bookkeeping and one worker thread and stack. The
-first buffer gets the extra slot for odd counts. The producer packs input
-directly into one buffer while the worker drains the other. When the producer
-buffer fills, it waits for the worker to swap buffers. Thus each queued backlog
-holds at most half the slots, rounded up. A one-slot allocation waits for each
-drain before refilling. There are no append-path allocations or extra copies to
-assemble a batch.
+The **`slot_bytes * slot_count`** payload allocation is a shared ring, plus one
+bookkeeping entry per slot and one worker thread and stack. The producer packs
+input directly into the ring while the worker drains an older prefix. Active
+drains pin only their own slots: with one slot active in a 64-slot ring, the
+producer can fill the other 63. Each completed drain frees its slots immediately.
+There are no append-path allocations or extra copies to assemble a batch.
 
-Each drain snapshots the **entire queued backlog** and submits it in one
-downstream append. Short appends are packed without gaps; original append
-boundaries are not preserved. Input accepted while that call runs goes into
-the next buffer. Once the call returns, the worker immediately drains the new
-backlog. Partial downstream acceptance or stalls can require retries of the
-remaining suffix.
+Set **`max_drain_slots`** independently of total capacity. A drain submits the
+contiguous backlog prefix up to that many slots in one downstream append. Zero
+uses `slot_count`, and values greater than `slot_count` are invalid. A drain also
+stops at the physical end of the ring. Short appends are packed without gaps;
+original append boundaries are not preserved. Partial downstream acceptance or
+stalls can require retries of the remaining suffix.
 
-An append waits until one slot is free, copies up to `slot_bytes`, and returns
-the unaccepted suffix in `writer_result.rest`. The accepted prefix is owned by
-the adapter, so the caller can immediately overwrite or free that prefix.
+The worker starts immediately when input is available, without waiting to fill
+a batch. After each drain it immediately starts another if a backlog remains.
+For example, 64 slots with an eight-slot cap lets each drain catch up by up to
+eight producer appends while retaining the other 56 slots for waiting input.
+The cap bounds bytes held by one drain (`max_drain_slots * slot_bytes`), not its
+duration: a single frame can still trigger downstream startup or flush work.
+
+An append waits until one slot is free, copies up to `slot_bytes` or the end of
+the ring, and returns the unaccepted suffix in `writer_result.rest`. The accepted
+prefix is owned by the adapter, so the caller can immediately overwrite or free
+that prefix.
 `writer_append_wait` handles inputs larger than one slot. An empty input consumes
 no slot. When full, the queue blocks; it does not overwrite old data or drop new
 input. A bounded queue cannot compensate for sustained overload, and cannot
@@ -86,7 +92,11 @@ Downstream callbacks must not call back into the adapter.
 int write_buffered(struct writer* downstream, struct slice input,
                    size_t slot_bytes, size_t slot_count)
 {
-  struct buffered_writer_config config = { slot_bytes, slot_count };
+  struct buffered_writer_config config = {
+    .slot_bytes = slot_bytes,
+    .slot_count = slot_count,
+    .max_drain_slots = slot_count < 8 ? slot_count : 8,
+  };
   struct buffered_writer* buffered = buffered_writer_create(downstream, &config);
   if (!buffered)
     return 1;
@@ -126,15 +136,19 @@ GPU readback tests, including metadata and immediate input reuse.
 ```sh
 # Repeat in alternating order for both cpu/gpu and none/zstd.
 build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --slots 0
-build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --slots 16
+build/bench/bench_buffered_writer --backend cpu --codec none --frames 16384 --slots 64 --drain-slots 8
 
 # Paced arrival: fps=0 disables pacing; slots=0 selects direct appends.
 build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --slots 0
-build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --slots 16
+build/bench/bench_buffered_writer --backend gpu --codec zstd --frames 2048 --fps 500 --slots 64 --drain-slots 8
 ```
 
 JSON reports caller latency per frame and downstream latency per batch, together
 with downstream call count, maximum frames per batch and reserved payload bytes.
+`drain_slots` reports the effective cap; `--drain-slots 0` uses all configured
+slots. Compare different caps at the same total capacity to distinguish batching
+from the queue's ability to absorb stalls. The eight-slot example is a tunable
+starting point, not a measured universal optimum.
 Submission-to-downstream completion delay is per frame: all frames in a combined
 call use that call's return time, since intermediate consumption is not observed.
 It also reports lateness against scheduled frame arrival, peak queue occupancy,

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -3,6 +3,8 @@
 This document describes how chunks are tracked and their memory managed during
 streaming transpose of a D-dimensional tensor.
 
+For producer-side input buffering, see [Buffered input writer](buffered-writer.md).
+
 ## Setup
 
 Given input tensor shape $(s_{D-1}, \ldots, s_0)$ and chunk shape

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,8 @@ add_platform_sources(platform_io platform/platform_io)
 add_src_lib(platform_cmd SOURCES platform/platform_cmd.h)
 add_platform_sources(platform_cmd platform/platform_cmd)
 
-add_src_lib(writer SOURCES writer.c writer.h LINKS platform io_scheduler chucky_log)
+add_src_lib(writer SOURCES writer.c writer.h writer.buffered.c writer.buffered.h
+    LINKS platform io_scheduler chucky_log)
 
 add_src_lib(store_api SOURCES store.c store.h)
 

--- a/src/writer.buffered.c
+++ b/src/writer.buffered.c
@@ -5,14 +5,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct buffered_batch
+struct buffered_slot
 {
-  unsigned char* data;
-  size_t capacity_slots;
   size_t bytes;
-  size_t slots;
-  int64_t first_accepted_ns;
-  uint64_t acceptance_offsets_ns;
+  int64_t accepted_ns;
 };
 
 struct buffered_writer
@@ -22,10 +18,16 @@ struct buffered_writer
   struct platform_mutex* mutex;
   struct platform_cond* changed;
   struct platform_thread* worker;
-  struct buffered_batch buffers[2];
+  unsigned char* data;
+  struct buffered_slot* slots;
   size_t slot_bytes;
-  unsigned writing;
-  int copying; // the producer has an unpublished copy in the writing buffer
+  size_t slot_count;
+  size_t max_drain_slots;
+  size_t capacity_bytes;
+  size_t head;
+  size_t tail;
+  size_t read_offset;
+  size_t write_offset;
   struct buffered_writer_stats stats;
   int flush_requested;
   int flushed;
@@ -62,55 +64,55 @@ worker_main(void* arg)
   struct buffered_writer* b = arg;
   platform_mutex_lock(b->mutex);
   for (;;) {
-    if (b->buffers[b->writing].slots && !b->copying) {
-      // Freeze the complete backlog, including short appends packed without
-      // gaps. The producer switches to the other buffer while this one drains.
-      const struct buffered_batch batch = b->buffers[b->writing];
-      b->writing ^= 1;
-      b->buffers[b->writing].bytes = 0;
-      b->buffers[b->writing].slots = 0;
-      platform_cond_broadcast(b->changed); // the producer can refill now
-      const unsigned char* beg = batch.data;
+    if (b->stats.occupied_slots) {
+      // Snapshot a contiguous prefix of the backlog. Keep its slots occupied
+      // until downstream releases the input; the producer uses all other slots.
+      const int64_t first_accepted_ns = b->slots[b->head].accepted_ns;
+      uint64_t acceptance_offsets_ns = 0;
+      size_t bytes = 0, count = 0, next = b->head;
+      while (count < b->stats.occupied_slots && count < b->max_drain_slots &&
+             bytes < b->capacity_bytes - b->read_offset) {
+        bytes += b->slots[next].bytes;
+        acceptance_offsets_ns += b->slots[next].accepted_ns - first_accepted_ns;
+        ++count;
+        if (++next == b->slot_count)
+          next = 0;
+      }
+      const unsigned char* beg = b->data + b->read_offset;
       platform_mutex_unlock(b->mutex);
       const int64_t start = platform_monotonic_ns();
-      struct writer_result r = writer_append_wait(
-        b->downstream, (struct slice){ beg, beg + batch.bytes });
+      struct writer_result r =
+        writer_append_wait(b->downstream, (struct slice){ beg, beg + bytes });
       const int64_t end = platform_monotonic_ns();
-      size_t rest = remaining_bytes(&r, beg, beg + batch.bytes);
+      size_t rest = remaining_bytes(&r, beg, beg + bytes);
       platform_mutex_lock(b->mutex);
 
       struct buffered_writer_stats* s = &b->stats;
-      const uint64_t oldest_queue_ns = start - batch.first_accepted_ns;
-      s->queue_ns +=
-        batch.slots * oldest_queue_ns - batch.acceptance_offsets_ns;
+      const uint64_t oldest_queue_ns = start - first_accepted_ns;
+      s->queue_ns += count * oldest_queue_ns - acceptance_offsets_ns;
       if (oldest_queue_ns > s->max_queue_ns)
         s->max_queue_ns = oldest_queue_ns;
       record_time(&s->downstream_ns, &s->max_downstream_ns, end - start);
-      if ((uint64_t)(end - batch.first_accepted_ns) > s->max_completion_ns)
-        s->max_completion_ns = end - batch.first_accepted_ns;
-      s->completed_slots += batch.slots;
+      if ((uint64_t)(end - first_accepted_ns) > s->max_completion_ns)
+        s->max_completion_ns = end - first_accepted_ns;
+      s->completed_slots += count;
       ++s->completed_batches;
-      if (batch.bytes > s->max_batch_bytes)
-        s->max_batch_bytes = batch.bytes;
-      s->forwarded_bytes += batch.bytes - rest;
-      s->pending_bytes -= batch.bytes - rest;
+      if (bytes > s->max_batch_bytes)
+        s->max_batch_bytes = bytes;
+      s->forwarded_bytes += bytes - rest;
+      s->pending_bytes -= bytes - rest;
       if (r.error || rest) {
         s->downstream_finished = r.error == writer_error_finished;
         s->failed = r.error != writer_error_finished || s->pending_bytes != 0;
         s->abandoned_bytes += s->pending_bytes;
         s->pending_bytes = 0;
         s->occupied_slots = 0;
-        b->buffers[b->writing].bytes = 0;
-        b->buffers[b->writing].slots = 0;
       } else {
-        s->occupied_slots -= batch.slots;
-      }
-      // With a one-slot allocation, the second buffer has no capacity. Reuse
-      // the first only after downstream releases it.
-      if (!b->buffers[b->writing].capacity_slots) {
-        b->writing ^= 1;
-        b->buffers[b->writing].bytes = 0;
-        b->buffers[b->writing].slots = 0;
+        s->occupied_slots -= count;
+        b->head = next;
+        b->read_offset += bytes;
+        if (b->read_offset == b->capacity_bytes)
+          b->read_offset = 0;
       }
     } else if (b->flush_requested && !b->flushed) {
       platform_mutex_unlock(b->mutex);
@@ -152,43 +154,42 @@ buffered_append(struct writer* self, struct slice input)
   platform_mutex_lock(b->mutex);
   int status = append_status(b);
   if (!status && input.beg != input.end &&
-      b->buffers[b->writing].slots == b->buffers[b->writing].capacity_slots) {
+      b->stats.occupied_slots == b->slot_count) {
     const int64_t start = platform_monotonic_ns();
     do {
       platform_cond_wait(b->changed, b->mutex);
       status = append_status(b);
-    } while (!status && b->buffers[b->writing].slots ==
-                          b->buffers[b->writing].capacity_slots);
+    } while (!status && b->stats.occupied_slots == b->slot_count);
     b->stats.backpressure_ns += platform_monotonic_ns() - start;
   }
   if (status || input.beg == input.end) {
     platform_mutex_unlock(b->mutex);
     return (struct writer_result){ status, input };
   }
-  struct buffered_batch* batch = &b->buffers[b->writing];
-  const size_t offset = batch->bytes;
-  b->copying = 1;
-  platform_mutex_unlock(b->mutex);
-
   size_t bytes =
     (const unsigned char*)input.end - (const unsigned char*)input.beg;
   if (bytes > b->slot_bytes)
     bytes = b->slot_bytes;
-  // Do not swap buffers until this copy is published. The downstream call on
-  // the other buffer can proceed concurrently, without holding the mutex.
-  memcpy(batch->data + offset, input.beg, bytes);
+  if (bytes > b->capacity_bytes - b->write_offset)
+    bytes = b->capacity_bytes - b->write_offset;
+  const size_t offset = b->write_offset;
+  platform_mutex_unlock(b->mutex);
+
+  // Every occupied slot holds at most slot_bytes, so a free slot guarantees
+  // room for this copy. Stop at the ring boundary to keep each slot contiguous.
+  // The worker cannot see this slot until publication, and never moves data.
+  memcpy(b->data + offset, input.beg, bytes);
 
   platform_mutex_lock(b->mutex);
   status = append_status(b); // downstream may have terminated during the copy
   if (!status) {
-    const int64_t accepted_ns = platform_monotonic_ns();
-    if (!batch->slots) {
-      batch->first_accepted_ns = accepted_ns;
-      batch->acceptance_offsets_ns = 0;
-    }
-    batch->acceptance_offsets_ns += accepted_ns - batch->first_accepted_ns;
-    batch->bytes += bytes;
-    ++batch->slots;
+    b->slots[b->tail] =
+      (struct buffered_slot){ bytes, platform_monotonic_ns() };
+    if (++b->tail == b->slot_count)
+      b->tail = 0;
+    b->write_offset += bytes;
+    if (b->write_offset == b->capacity_bytes)
+      b->write_offset = 0;
     b->stats.accepted_bytes += bytes;
     b->stats.pending_bytes += bytes;
     ++b->stats.occupied_slots;
@@ -198,7 +199,6 @@ buffered_append(struct writer* self, struct slice input)
       b->stats.peak_occupied_slots = b->stats.occupied_slots;
     input.beg = (const unsigned char*)input.beg + bytes;
   }
-  b->copying = 0;
   platform_cond_broadcast(b->changed);
   platform_mutex_unlock(b->mutex);
   return (struct writer_result){ status, input };
@@ -239,7 +239,8 @@ release(struct buffered_writer* b)
 {
   platform_cond_free(b->changed);
   platform_mutex_free(b->mutex);
-  free(b->buffers[0].data);
+  free(b->slots);
+  free(b->data);
   free(b);
 }
 
@@ -249,7 +250,9 @@ buffered_writer_create(struct writer* downstream,
 {
   if (!downstream || !downstream->append || !downstream->flush || !config ||
       !config->slot_bytes || !config->slot_count ||
-      config->slot_count > SIZE_MAX / config->slot_bytes)
+      config->slot_count > SIZE_MAX / config->slot_bytes ||
+      config->slot_count > SIZE_MAX / sizeof(struct buffered_slot) ||
+      config->max_drain_slots > config->slot_count)
     return NULL;
   struct buffered_writer* b = calloc(1, sizeof(*b));
   if (!b)
@@ -258,16 +261,16 @@ buffered_writer_create(struct writer* downstream,
     (struct writer){ buffered_append, buffered_flush, buffered_close };
   b->downstream = downstream;
   b->slot_bytes = config->slot_bytes;
-  b->buffers[0].capacity_slots =
-    config->slot_count / 2 + config->slot_count % 2;
-  b->buffers[1].capacity_slots = config->slot_count / 2;
-  b->buffers[0].data = malloc(config->slot_count * b->slot_bytes);
+  b->slot_count = config->slot_count;
+  b->max_drain_slots =
+    config->max_drain_slots ? config->max_drain_slots : config->slot_count;
+  b->capacity_bytes = config->slot_count * b->slot_bytes;
+  b->data = malloc(b->capacity_bytes);
+  b->slots = calloc(config->slot_count, sizeof(*b->slots));
   b->mutex = platform_mutex_new();
   b->changed = platform_cond_new();
-  if (!b->buffers[0].data || !b->mutex || !b->changed)
+  if (!b->data || !b->slots || !b->mutex || !b->changed)
     goto fail;
-  b->buffers[1].data =
-    b->buffers[0].data + b->buffers[0].capacity_slots * b->slot_bytes;
   b->worker = platform_thread_start(worker_main, b);
   if (!b->worker)
     goto fail;

--- a/src/writer.buffered.c
+++ b/src/writer.buffered.c
@@ -5,12 +5,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct buffered_slot
-{
-  size_t bytes;
-  int64_t accepted_ns;
-};
-
 struct buffered_writer
 {
   struct writer writer;
@@ -19,13 +13,8 @@ struct buffered_writer
   struct platform_cond* changed;
   struct platform_thread* worker;
   unsigned char* data;
-  struct buffered_slot* slots;
-  size_t slot_bytes;
-  size_t slot_count;
-  size_t max_drain_slots;
   size_t capacity_bytes;
-  size_t head;
-  size_t tail;
+  size_t max_drain_bytes;
   size_t read_offset;
   size_t write_offset;
   struct buffered_writer_stats stats;
@@ -64,20 +53,14 @@ worker_main(void* arg)
   struct buffered_writer* b = arg;
   platform_mutex_lock(b->mutex);
   for (;;) {
-    if (b->stats.occupied_slots) {
-      // Snapshot a contiguous prefix of the backlog. Keep its slots occupied
-      // until downstream releases the input; the producer uses all other slots.
-      const int64_t first_accepted_ns = b->slots[b->head].accepted_ns;
-      uint64_t acceptance_offsets_ns = 0;
-      size_t bytes = 0, count = 0, next = b->head;
-      while (count < b->stats.occupied_slots && count < b->max_drain_slots &&
-             bytes < b->capacity_bytes - b->read_offset) {
-        bytes += b->slots[next].bytes;
-        acceptance_offsets_ns += b->slots[next].accepted_ns - first_accepted_ns;
-        ++count;
-        if (++next == b->slot_count)
-          next = 0;
-      }
+    if (b->stats.pending_bytes) {
+      // Snapshot a contiguous byte prefix, independent of producer appends.
+      // It remains pending until downstream releases the input.
+      size_t bytes = b->stats.pending_bytes;
+      if (bytes > b->max_drain_bytes)
+        bytes = b->max_drain_bytes;
+      if (bytes > b->capacity_bytes - b->read_offset)
+        bytes = b->capacity_bytes - b->read_offset;
       const unsigned char* beg = b->data + b->read_offset;
       platform_mutex_unlock(b->mutex);
       const int64_t start = platform_monotonic_ns();
@@ -88,14 +71,7 @@ worker_main(void* arg)
       platform_mutex_lock(b->mutex);
 
       struct buffered_writer_stats* s = &b->stats;
-      const uint64_t oldest_queue_ns = start - first_accepted_ns;
-      s->queue_ns += count * oldest_queue_ns - acceptance_offsets_ns;
-      if (oldest_queue_ns > s->max_queue_ns)
-        s->max_queue_ns = oldest_queue_ns;
       record_time(&s->downstream_ns, &s->max_downstream_ns, end - start);
-      if ((uint64_t)(end - first_accepted_ns) > s->max_completion_ns)
-        s->max_completion_ns = end - first_accepted_ns;
-      s->completed_slots += count;
       ++s->completed_batches;
       if (bytes > s->max_batch_bytes)
         s->max_batch_bytes = bytes;
@@ -106,10 +82,7 @@ worker_main(void* arg)
         s->failed = r.error != writer_error_finished || s->pending_bytes != 0;
         s->abandoned_bytes += s->pending_bytes;
         s->pending_bytes = 0;
-        s->occupied_slots = 0;
       } else {
-        s->occupied_slots -= count;
-        b->head = next;
         b->read_offset += bytes;
         if (b->read_offset == b->capacity_bytes)
           b->read_offset = 0;
@@ -154,12 +127,12 @@ buffered_append(struct writer* self, struct slice input)
   platform_mutex_lock(b->mutex);
   int status = append_status(b);
   if (!status && input.beg != input.end &&
-      b->stats.occupied_slots == b->slot_count) {
+      b->stats.pending_bytes == b->capacity_bytes) {
     const int64_t start = platform_monotonic_ns();
     do {
       platform_cond_wait(b->changed, b->mutex);
       status = append_status(b);
-    } while (!status && b->stats.occupied_slots == b->slot_count);
+    } while (!status && b->stats.pending_bytes == b->capacity_bytes);
     b->stats.backpressure_ns += platform_monotonic_ns() - start;
   }
   if (status || input.beg == input.end) {
@@ -168,35 +141,27 @@ buffered_append(struct writer* self, struct slice input)
   }
   size_t bytes =
     (const unsigned char*)input.end - (const unsigned char*)input.beg;
-  if (bytes > b->slot_bytes)
-    bytes = b->slot_bytes;
+  if (bytes > b->capacity_bytes - b->stats.pending_bytes)
+    bytes = b->capacity_bytes - b->stats.pending_bytes;
   if (bytes > b->capacity_bytes - b->write_offset)
     bytes = b->capacity_bytes - b->write_offset;
   const size_t offset = b->write_offset;
   platform_mutex_unlock(b->mutex);
 
-  // Every occupied slot holds at most slot_bytes, so a free slot guarantees
-  // room for this copy. Stop at the ring boundary to keep each slot contiguous.
-  // The worker cannot see this slot until publication, and never moves data.
+  // The single producer owns the free suffix. The worker cannot see this copy
+  // until publication and never moves data; active drains can run concurrently.
   memcpy(b->data + offset, input.beg, bytes);
 
   platform_mutex_lock(b->mutex);
   status = append_status(b); // downstream may have terminated during the copy
   if (!status) {
-    b->slots[b->tail] =
-      (struct buffered_slot){ bytes, platform_monotonic_ns() };
-    if (++b->tail == b->slot_count)
-      b->tail = 0;
     b->write_offset += bytes;
     if (b->write_offset == b->capacity_bytes)
       b->write_offset = 0;
     b->stats.accepted_bytes += bytes;
     b->stats.pending_bytes += bytes;
-    ++b->stats.occupied_slots;
     if (b->stats.pending_bytes > b->stats.peak_pending_bytes)
       b->stats.peak_pending_bytes = b->stats.pending_bytes;
-    if (b->stats.occupied_slots > b->stats.peak_occupied_slots)
-      b->stats.peak_occupied_slots = b->stats.occupied_slots;
     input.beg = (const unsigned char*)input.beg + bytes;
   }
   platform_cond_broadcast(b->changed);
@@ -239,7 +204,6 @@ release(struct buffered_writer* b)
 {
   platform_cond_free(b->changed);
   platform_mutex_free(b->mutex);
-  free(b->slots);
   free(b->data);
   free(b);
 }
@@ -249,10 +213,8 @@ buffered_writer_create(struct writer* downstream,
                        const struct buffered_writer_config* config)
 {
   if (!downstream || !downstream->append || !downstream->flush || !config ||
-      !config->slot_bytes || !config->slot_count ||
-      config->slot_count > SIZE_MAX / config->slot_bytes ||
-      config->slot_count > SIZE_MAX / sizeof(struct buffered_slot) ||
-      config->max_drain_slots > config->slot_count)
+      !config->capacity_bytes ||
+      config->max_drain_bytes > config->capacity_bytes)
     return NULL;
   struct buffered_writer* b = calloc(1, sizeof(*b));
   if (!b)
@@ -260,16 +222,13 @@ buffered_writer_create(struct writer* downstream,
   b->writer =
     (struct writer){ buffered_append, buffered_flush, buffered_close };
   b->downstream = downstream;
-  b->slot_bytes = config->slot_bytes;
-  b->slot_count = config->slot_count;
-  b->max_drain_slots =
-    config->max_drain_slots ? config->max_drain_slots : config->slot_count;
-  b->capacity_bytes = config->slot_count * b->slot_bytes;
+  b->capacity_bytes = config->capacity_bytes;
+  b->max_drain_bytes =
+    config->max_drain_bytes ? config->max_drain_bytes : config->capacity_bytes;
   b->data = malloc(b->capacity_bytes);
-  b->slots = calloc(config->slot_count, sizeof(*b->slots));
   b->mutex = platform_mutex_new();
   b->changed = platform_cond_new();
-  if (!b->data || !b->slots || !b->mutex || !b->changed)
+  if (!b->data || !b->mutex || !b->changed)
     goto fail;
   b->worker = platform_thread_start(worker_main, b);
   if (!b->worker)

--- a/src/writer.buffered.c
+++ b/src/writer.buffered.c
@@ -5,10 +5,14 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct buffered_slot
+struct buffered_batch
 {
+  unsigned char* data;
+  size_t capacity_slots;
   size_t bytes;
-  int64_t accepted_ns;
+  size_t slots;
+  int64_t first_accepted_ns;
+  uint64_t acceptance_offsets_ns;
 };
 
 struct buffered_writer
@@ -18,12 +22,10 @@ struct buffered_writer
   struct platform_mutex* mutex;
   struct platform_cond* changed;
   struct platform_thread* worker;
-  unsigned char* data;
-  struct buffered_slot* slots;
+  struct buffered_batch buffers[2];
   size_t slot_bytes;
-  size_t slot_count;
-  size_t head;
-  size_t tail;
+  unsigned writing;
+  int copying; // the producer has an unpublished copy in the writing buffer
   struct buffered_writer_stats stats;
   int flush_requested;
   int flushed;
@@ -40,7 +42,7 @@ record_time(uint64_t* sum, uint64_t* peak, uint64_t ns)
     *peak = ns;
 }
 
-// Only accept a suffix of the submitted slot, or an empty rest. Treat a broken
+// Only accept a suffix of the submitted batch, or an empty rest. Treat a broken
 // downstream contract as failure without dereferencing its pointers.
 static size_t
 remaining_bytes(struct writer_result* r, const void* beg, const void* end)
@@ -60,34 +62,55 @@ worker_main(void* arg)
   struct buffered_writer* b = arg;
   platform_mutex_lock(b->mutex);
   for (;;) {
-    if (b->stats.occupied_slots) {
-      const struct buffered_slot slot = b->slots[b->head];
-      const unsigned char* beg = b->data + b->head * b->slot_bytes;
+    if (b->buffers[b->writing].slots && !b->copying) {
+      // Freeze the complete backlog, including short appends packed without
+      // gaps. The producer switches to the other buffer while this one drains.
+      const struct buffered_batch batch = b->buffers[b->writing];
+      b->writing ^= 1;
+      b->buffers[b->writing].bytes = 0;
+      b->buffers[b->writing].slots = 0;
+      platform_cond_broadcast(b->changed); // the producer can refill now
+      const unsigned char* beg = batch.data;
       platform_mutex_unlock(b->mutex);
       const int64_t start = platform_monotonic_ns();
       struct writer_result r = writer_append_wait(
-        b->downstream, (struct slice){ beg, beg + slot.bytes });
+        b->downstream, (struct slice){ beg, beg + batch.bytes });
       const int64_t end = platform_monotonic_ns();
-      size_t rest = remaining_bytes(&r, beg, beg + slot.bytes);
+      size_t rest = remaining_bytes(&r, beg, beg + batch.bytes);
       platform_mutex_lock(b->mutex);
 
       struct buffered_writer_stats* s = &b->stats;
-      record_time(&s->queue_ns, &s->max_queue_ns, start - slot.accepted_ns);
+      const uint64_t oldest_queue_ns = start - batch.first_accepted_ns;
+      s->queue_ns +=
+        batch.slots * oldest_queue_ns - batch.acceptance_offsets_ns;
+      if (oldest_queue_ns > s->max_queue_ns)
+        s->max_queue_ns = oldest_queue_ns;
       record_time(&s->downstream_ns, &s->max_downstream_ns, end - start);
-      if ((uint64_t)(end - slot.accepted_ns) > s->max_completion_ns)
-        s->max_completion_ns = end - slot.accepted_ns;
-      ++s->completed_slots;
-      s->forwarded_bytes += slot.bytes - rest;
-      s->pending_bytes -= slot.bytes - rest;
+      if ((uint64_t)(end - batch.first_accepted_ns) > s->max_completion_ns)
+        s->max_completion_ns = end - batch.first_accepted_ns;
+      s->completed_slots += batch.slots;
+      ++s->completed_batches;
+      if (batch.bytes > s->max_batch_bytes)
+        s->max_batch_bytes = batch.bytes;
+      s->forwarded_bytes += batch.bytes - rest;
+      s->pending_bytes -= batch.bytes - rest;
       if (r.error || rest) {
         s->downstream_finished = r.error == writer_error_finished;
         s->failed = r.error != writer_error_finished || s->pending_bytes != 0;
         s->abandoned_bytes += s->pending_bytes;
         s->pending_bytes = 0;
         s->occupied_slots = 0;
+        b->buffers[b->writing].bytes = 0;
+        b->buffers[b->writing].slots = 0;
       } else {
-        --s->occupied_slots;
-        b->head = (b->head + 1) % b->slot_count;
+        s->occupied_slots -= batch.slots;
+      }
+      // With a one-slot allocation, the second buffer has no capacity. Reuse
+      // the first only after downstream releases it.
+      if (!b->buffers[b->writing].capacity_slots) {
+        b->writing ^= 1;
+        b->buffers[b->writing].bytes = 0;
+        b->buffers[b->writing].slots = 0;
       }
     } else if (b->flush_requested && !b->flushed) {
       platform_mutex_unlock(b->mutex);
@@ -129,32 +152,43 @@ buffered_append(struct writer* self, struct slice input)
   platform_mutex_lock(b->mutex);
   int status = append_status(b);
   if (!status && input.beg != input.end &&
-      b->stats.occupied_slots == b->slot_count) {
+      b->buffers[b->writing].slots == b->buffers[b->writing].capacity_slots) {
     const int64_t start = platform_monotonic_ns();
     do {
       platform_cond_wait(b->changed, b->mutex);
       status = append_status(b);
-    } while (!status && b->stats.occupied_slots == b->slot_count);
+    } while (!status && b->buffers[b->writing].slots ==
+                          b->buffers[b->writing].capacity_slots);
     b->stats.backpressure_ns += platform_monotonic_ns() - start;
   }
-  platform_mutex_unlock(b->mutex);
-  if (status || input.beg == input.end)
+  if (status || input.beg == input.end) {
+    platform_mutex_unlock(b->mutex);
     return (struct writer_result){ status, input };
+  }
+  struct buffered_batch* batch = &b->buffers[b->writing];
+  const size_t offset = batch->bytes;
+  b->copying = 1;
+  platform_mutex_unlock(b->mutex);
 
   size_t bytes =
     (const unsigned char*)input.end - (const unsigned char*)input.beg;
   if (bytes > b->slot_bytes)
     bytes = b->slot_bytes;
-  // The single producer owns tail until publication. The worker still counts
-  // its active slot as occupied, so it cannot read or recycle this free slot.
-  memcpy(b->data + b->tail * b->slot_bytes, input.beg, bytes);
+  // Do not swap buffers until this copy is published. The downstream call on
+  // the other buffer can proceed concurrently, without holding the mutex.
+  memcpy(batch->data + offset, input.beg, bytes);
 
   platform_mutex_lock(b->mutex);
   status = append_status(b); // downstream may have terminated during the copy
   if (!status) {
-    b->slots[b->tail] =
-      (struct buffered_slot){ bytes, platform_monotonic_ns() };
-    b->tail = (b->tail + 1) % b->slot_count;
+    const int64_t accepted_ns = platform_monotonic_ns();
+    if (!batch->slots) {
+      batch->first_accepted_ns = accepted_ns;
+      batch->acceptance_offsets_ns = 0;
+    }
+    batch->acceptance_offsets_ns += accepted_ns - batch->first_accepted_ns;
+    batch->bytes += bytes;
+    ++batch->slots;
     b->stats.accepted_bytes += bytes;
     b->stats.pending_bytes += bytes;
     ++b->stats.occupied_slots;
@@ -163,8 +197,9 @@ buffered_append(struct writer* self, struct slice input)
     if (b->stats.occupied_slots > b->stats.peak_occupied_slots)
       b->stats.peak_occupied_slots = b->stats.occupied_slots;
     input.beg = (const unsigned char*)input.beg + bytes;
-    platform_cond_broadcast(b->changed);
   }
+  b->copying = 0;
+  platform_cond_broadcast(b->changed);
   platform_mutex_unlock(b->mutex);
   return (struct writer_result){ status, input };
 }
@@ -204,8 +239,7 @@ release(struct buffered_writer* b)
 {
   platform_cond_free(b->changed);
   platform_mutex_free(b->mutex);
-  free(b->slots);
-  free(b->data);
+  free(b->buffers[0].data);
   free(b);
 }
 
@@ -215,8 +249,7 @@ buffered_writer_create(struct writer* downstream,
 {
   if (!downstream || !downstream->append || !downstream->flush || !config ||
       !config->slot_bytes || !config->slot_count ||
-      config->slot_count > SIZE_MAX / config->slot_bytes ||
-      config->slot_count > SIZE_MAX / sizeof(struct buffered_slot))
+      config->slot_count > SIZE_MAX / config->slot_bytes)
     return NULL;
   struct buffered_writer* b = calloc(1, sizeof(*b));
   if (!b)
@@ -225,13 +258,16 @@ buffered_writer_create(struct writer* downstream,
     (struct writer){ buffered_append, buffered_flush, buffered_close };
   b->downstream = downstream;
   b->slot_bytes = config->slot_bytes;
-  b->slot_count = config->slot_count;
-  b->data = malloc(b->slot_count * b->slot_bytes);
-  b->slots = calloc(b->slot_count, sizeof(*b->slots));
+  b->buffers[0].capacity_slots =
+    config->slot_count / 2 + config->slot_count % 2;
+  b->buffers[1].capacity_slots = config->slot_count / 2;
+  b->buffers[0].data = malloc(config->slot_count * b->slot_bytes);
   b->mutex = platform_mutex_new();
   b->changed = platform_cond_new();
-  if (!b->data || !b->slots || !b->mutex || !b->changed)
+  if (!b->buffers[0].data || !b->mutex || !b->changed)
     goto fail;
+  b->buffers[1].data =
+    b->buffers[0].data + b->buffers[0].capacity_slots * b->slot_bytes;
   b->worker = platform_thread_start(worker_main, b);
   if (!b->worker)
     goto fail;

--- a/src/writer.buffered.c
+++ b/src/writer.buffered.c
@@ -1,0 +1,273 @@
+#include "writer.buffered.h"
+
+#include "platform/platform.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+struct buffered_slot
+{
+  size_t bytes;
+  int64_t accepted_ns;
+};
+
+struct buffered_writer
+{
+  struct writer writer;
+  struct writer* downstream;
+  struct platform_mutex* mutex;
+  struct platform_cond* changed;
+  struct platform_thread* worker;
+  unsigned char* data;
+  struct buffered_slot* slots;
+  size_t slot_bytes;
+  size_t slot_count;
+  size_t head;
+  size_t tail;
+  struct buffered_writer_stats stats;
+  int flush_requested;
+  int flushed;
+  int close_requested;
+  int closed;
+  int stop;
+};
+
+static void
+record_time(uint64_t* sum, uint64_t* peak, uint64_t ns)
+{
+  *sum += ns;
+  if (ns > *peak)
+    *peak = ns;
+}
+
+// Only accept a suffix of the submitted slot, or an empty rest. Treat a broken
+// downstream contract as failure without dereferencing its pointers.
+static size_t
+remaining_bytes(struct writer_result* r, const void* beg, const void* end)
+{
+  if (r->rest.beg == r->rest.end)
+    return 0;
+  if (r->rest.end == end && (uintptr_t)r->rest.beg >= (uintptr_t)beg &&
+      (uintptr_t)r->rest.beg <= (uintptr_t)end)
+    return (uintptr_t)end - (uintptr_t)r->rest.beg;
+  r->error = writer_error_fail;
+  return (uintptr_t)end - (uintptr_t)beg;
+}
+
+static void
+worker_main(void* arg)
+{
+  struct buffered_writer* b = arg;
+  platform_mutex_lock(b->mutex);
+  for (;;) {
+    if (b->stats.occupied_slots) {
+      const struct buffered_slot slot = b->slots[b->head];
+      const unsigned char* beg = b->data + b->head * b->slot_bytes;
+      platform_mutex_unlock(b->mutex);
+      const int64_t start = platform_monotonic_ns();
+      struct writer_result r = writer_append_wait(
+        b->downstream, (struct slice){ beg, beg + slot.bytes });
+      const int64_t end = platform_monotonic_ns();
+      size_t rest = remaining_bytes(&r, beg, beg + slot.bytes);
+      platform_mutex_lock(b->mutex);
+
+      struct buffered_writer_stats* s = &b->stats;
+      record_time(&s->queue_ns, &s->max_queue_ns, start - slot.accepted_ns);
+      record_time(&s->downstream_ns, &s->max_downstream_ns, end - start);
+      if ((uint64_t)(end - slot.accepted_ns) > s->max_completion_ns)
+        s->max_completion_ns = end - slot.accepted_ns;
+      ++s->completed_slots;
+      s->forwarded_bytes += slot.bytes - rest;
+      s->pending_bytes -= slot.bytes - rest;
+      if (r.error || rest) {
+        s->downstream_finished = r.error == writer_error_finished;
+        s->failed = r.error != writer_error_finished || s->pending_bytes != 0;
+        s->abandoned_bytes += s->pending_bytes;
+        s->pending_bytes = 0;
+        s->occupied_slots = 0;
+      } else {
+        --s->occupied_slots;
+        b->head = (b->head + 1) % b->slot_count;
+      }
+    } else if (b->flush_requested && !b->flushed) {
+      platform_mutex_unlock(b->mutex);
+      struct writer_result r = writer_flush(b->downstream);
+      platform_mutex_lock(b->mutex);
+      b->stats.failed |= r.error != writer_error_ok;
+      b->flushed = 1;
+    } else if (b->close_requested && !b->closed) {
+      platform_mutex_unlock(b->mutex);
+      struct writer_result r = writer_close(b->downstream);
+      platform_mutex_lock(b->mutex);
+      b->stats.failed |= r.error != writer_error_ok;
+      b->closed = 1;
+    } else if (b->stop) {
+      break;
+    } else {
+      platform_cond_wait(b->changed, b->mutex);
+      continue;
+    }
+    platform_cond_broadcast(b->changed);
+  }
+  platform_mutex_unlock(b->mutex);
+}
+
+static int
+append_status(const struct buffered_writer* b)
+{
+  if (b->stats.failed)
+    return writer_error_fail;
+  if (b->flush_requested || b->stats.downstream_finished)
+    return writer_error_finished;
+  return writer_error_ok;
+}
+
+static struct writer_result
+buffered_append(struct writer* self, struct slice input)
+{
+  struct buffered_writer* b = (struct buffered_writer*)self;
+  platform_mutex_lock(b->mutex);
+  int status = append_status(b);
+  if (!status && input.beg != input.end &&
+      b->stats.occupied_slots == b->slot_count) {
+    const int64_t start = platform_monotonic_ns();
+    do {
+      platform_cond_wait(b->changed, b->mutex);
+      status = append_status(b);
+    } while (!status && b->stats.occupied_slots == b->slot_count);
+    b->stats.backpressure_ns += platform_monotonic_ns() - start;
+  }
+  platform_mutex_unlock(b->mutex);
+  if (status || input.beg == input.end)
+    return (struct writer_result){ status, input };
+
+  size_t bytes =
+    (const unsigned char*)input.end - (const unsigned char*)input.beg;
+  if (bytes > b->slot_bytes)
+    bytes = b->slot_bytes;
+  // The single producer owns tail until publication. The worker still counts
+  // its active slot as occupied, so it cannot read or recycle this free slot.
+  memcpy(b->data + b->tail * b->slot_bytes, input.beg, bytes);
+
+  platform_mutex_lock(b->mutex);
+  status = append_status(b); // downstream may have terminated during the copy
+  if (!status) {
+    b->slots[b->tail] =
+      (struct buffered_slot){ bytes, platform_monotonic_ns() };
+    b->tail = (b->tail + 1) % b->slot_count;
+    b->stats.accepted_bytes += bytes;
+    b->stats.pending_bytes += bytes;
+    ++b->stats.occupied_slots;
+    if (b->stats.pending_bytes > b->stats.peak_pending_bytes)
+      b->stats.peak_pending_bytes = b->stats.pending_bytes;
+    if (b->stats.occupied_slots > b->stats.peak_occupied_slots)
+      b->stats.peak_occupied_slots = b->stats.occupied_slots;
+    input.beg = (const unsigned char*)input.beg + bytes;
+    platform_cond_broadcast(b->changed);
+  }
+  platform_mutex_unlock(b->mutex);
+  return (struct writer_result){ status, input };
+}
+
+static struct writer_result
+buffered_flush(struct writer* self)
+{
+  struct buffered_writer* b = (struct buffered_writer*)self;
+  platform_mutex_lock(b->mutex);
+  b->flush_requested = 1;
+  platform_cond_broadcast(b->changed);
+  while (!b->flushed)
+    platform_cond_wait(b->changed, b->mutex);
+  int failed = b->stats.failed;
+  platform_mutex_unlock(b->mutex);
+  return failed ? writer_error() : writer_ok();
+}
+
+static struct writer_result
+buffered_close(struct writer* self)
+{
+  struct buffered_writer* b = (struct buffered_writer*)self;
+  platform_mutex_lock(b->mutex);
+  if (b->flush_requested) {
+    b->close_requested = 1;
+    platform_cond_broadcast(b->changed);
+    while (!b->closed)
+      platform_cond_wait(b->changed, b->mutex);
+  }
+  int failed = b->stats.failed;
+  platform_mutex_unlock(b->mutex);
+  return failed ? writer_error() : writer_ok();
+}
+
+static void
+release(struct buffered_writer* b)
+{
+  platform_cond_free(b->changed);
+  platform_mutex_free(b->mutex);
+  free(b->slots);
+  free(b->data);
+  free(b);
+}
+
+struct buffered_writer*
+buffered_writer_create(struct writer* downstream,
+                       const struct buffered_writer_config* config)
+{
+  if (!downstream || !downstream->append || !downstream->flush || !config ||
+      !config->slot_bytes || !config->slot_count ||
+      config->slot_count > SIZE_MAX / config->slot_bytes ||
+      config->slot_count > SIZE_MAX / sizeof(struct buffered_slot))
+    return NULL;
+  struct buffered_writer* b = calloc(1, sizeof(*b));
+  if (!b)
+    return NULL;
+  b->writer =
+    (struct writer){ buffered_append, buffered_flush, buffered_close };
+  b->downstream = downstream;
+  b->slot_bytes = config->slot_bytes;
+  b->slot_count = config->slot_count;
+  b->data = malloc(b->slot_count * b->slot_bytes);
+  b->slots = calloc(b->slot_count, sizeof(*b->slots));
+  b->mutex = platform_mutex_new();
+  b->changed = platform_cond_new();
+  if (!b->data || !b->slots || !b->mutex || !b->changed)
+    goto fail;
+  b->worker = platform_thread_start(worker_main, b);
+  if (!b->worker)
+    goto fail;
+  return b;
+fail:
+  release(b);
+  return NULL;
+}
+
+struct writer*
+buffered_writer_as_writer(struct buffered_writer* b)
+{
+  return &b->writer;
+}
+
+struct buffered_writer_stats
+buffered_writer_get_stats(struct buffered_writer* b)
+{
+  platform_mutex_lock(b->mutex);
+  struct buffered_writer_stats stats = b->stats;
+  platform_mutex_unlock(b->mutex);
+  return stats;
+}
+
+int
+buffered_writer_destroy(struct buffered_writer* b)
+{
+  if (!b)
+    return 0;
+  int failed = writer_flush(&b->writer).error != 0;
+  failed |= writer_close(&b->writer).error != 0;
+  platform_mutex_lock(b->mutex);
+  b->stop = 1;
+  platform_cond_broadcast(b->changed);
+  platform_mutex_unlock(b->mutex);
+  failed |= platform_thread_join(b->worker) != 0;
+  release(b);
+  return failed;
+}

--- a/src/writer.buffered.h
+++ b/src/writer.buffered.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "writer.h"
+
+struct buffered_writer;
+
+struct buffered_writer_config
+{
+  size_t slot_bytes; // maximum bytes accepted by one append; nonzero
+  size_t slot_count; // includes the slot being forwarded; nonzero
+};
+
+struct buffered_writer_stats
+{
+  uint64_t accepted_bytes;
+  uint64_t forwarded_bytes; // consumed by downstream, not necessarily persisted
+  uint64_t abandoned_bytes; // accepted but not consumed after a terminal result
+  size_t pending_bytes;     // queued + currently forwarding
+  size_t peak_pending_bytes;
+  size_t occupied_slots; // includes the slot being forwarded
+  size_t peak_occupied_slots;
+  uint64_t completed_slots;
+  uint64_t backpressure_ns; // caller time waiting for a free slot
+  uint64_t queue_ns;        // sum: acceptance to start of downstream append
+  uint64_t max_queue_ns;
+  uint64_t downstream_ns; // sum: downstream append, including partial retries
+  uint64_t max_downstream_ns;
+  uint64_t max_completion_ns; // acceptance to downstream append return
+  int downstream_finished;
+  int failed; // sticky, including abandoned input and flush/close failures
+};
+
+// A bounded, copying adapter. Borrows downstream, which (along with its sink,
+// configuration and GPU context) must outlive the adapter. Only the worker
+// calls downstream; do not access it separately until destroying the adapter.
+// The downstream writer must permit serialized calls from a different thread
+// and release its reference to consumed input before append returns. CPU/GPU
+// tile-stream writers satisfy this contract.
+//
+// Externally serialize append/flush/close/destroy calls. get_stats may run
+// concurrently. Downstream callbacks must not reenter the adapter.
+//
+// Payload allocation is exactly slot_count * slot_bytes, plus fixed bookkeeping
+// per slot and one worker thread. No per-append allocation. slot_bytes and
+// input sizes must respect the downstream input granularity (e.g. whole
+// elements). Returns NULL on invalid config, allocation failure or thread-start
+// failure.
+struct buffered_writer*
+buffered_writer_create(struct writer* downstream,
+                       const struct buffered_writer_config* config);
+
+// append waits for one free slot, copies at most slot_bytes, and returns the
+// unaccepted suffix in rest. The accepted prefix can immediately be reused.
+// An empty rest can be {NULL,NULL}. Use writer_append_wait for larger inputs.
+// Acceptance is not downstream completion; inspect flush's result even when
+// every append succeeded. Backpressure blocks without a timeout or drops.
+//
+// A downstream failure stops forwarding and abandons the unconsumed accepted
+// suffix, counted in stats. Early downstream `finished` does the same: if any
+// accepted bytes remain, the adapter reports fail, otherwise finished. Future
+// appends accept nothing. No borrowed/copy-buffer pointer is returned in rest.
+// A downstream writer that makes no progress fails after writer_append_wait's
+// bounded retries.
+//
+// flush stops acceptance, drains the queue (unless downstream terminates), then
+// flushes downstream even after failure. close publishes downstream metadata
+// after flush; before flush it is a no-op, as with the tile-stream writers.
+// Both wait for completion, are idempotent, and report sticky failures.
+struct writer*
+buffered_writer_as_writer(struct buffered_writer* buffered);
+
+struct buffered_writer_stats
+buffered_writer_get_stats(struct buffered_writer* buffered);
+
+// Flush, close, join and release the adapter, never downstream. Returns nonzero
+// on any failure, including abandoned input. NULL is allowed and succeeds.
+int
+buffered_writer_destroy(struct buffered_writer* buffered);

--- a/src/writer.buffered.h
+++ b/src/writer.buffered.h
@@ -6,9 +6,8 @@ struct buffered_writer;
 
 struct buffered_writer_config
 {
-  size_t slot_bytes;      // maximum bytes accepted by one append; nonzero
-  size_t slot_count;      // maximum queued + active appends; nonzero
-  size_t max_drain_slots; // maximum slots per downstream batch; 0 = slot_count
+  size_t capacity_bytes;  // maximum queued + active bytes; nonzero
+  size_t max_drain_bytes; // bytes per drain; 0 = capacity_bytes
 };
 
 struct buffered_writer_stats
@@ -18,17 +17,11 @@ struct buffered_writer_stats
   uint64_t abandoned_bytes; // accepted but not consumed after a terminal result
   size_t pending_bytes;     // queued + currently forwarding
   size_t peak_pending_bytes;
-  size_t occupied_slots; // includes appends in the active downstream batch
-  size_t peak_occupied_slots;
-  uint64_t completed_slots;
   uint64_t completed_batches;
   size_t max_batch_bytes;
-  uint64_t backpressure_ns; // caller time waiting for a free slot
-  uint64_t queue_ns;        // sum per slot: acceptance to downstream start
-  uint64_t max_queue_ns;
-  uint64_t downstream_ns; // sum per batch, including partial retries
+  uint64_t backpressure_ns; // caller time waiting for free capacity
+  uint64_t downstream_ns;   // sum per batch, including partial retries
   uint64_t max_downstream_ns;
-  uint64_t max_completion_ns; // acceptance to downstream append return
   int downstream_finished;
   int failed; // sticky, including abandoned input and flush/close failures
 };
@@ -43,28 +36,28 @@ struct buffered_writer_stats
 // Externally serialize append/flush/close/destroy calls. get_stats may run
 // concurrently. Downstream callbacks must not reenter the adapter.
 //
-// Payload allocation is slot_count * slot_bytes in a shared ring, plus one
-// bookkeeping entry per slot and one worker thread. Active drains pin only
-// their slots; all other slots remain available to the producer. No per-append
-// allocation or packing copy. max_drain_slots must be <= slot_count. slot_bytes
-// and input sizes must respect downstream input granularity (e.g. elements).
+// Payload allocation is capacity_bytes in a shared ring, plus fixed bookkeeping
+// and one worker thread. Active drains pin only their bytes; all remaining
+// capacity is shared with the producer. No per-append allocation or packing
+// copy. max_drain_bytes must be <= capacity_bytes. Capacity, drain cap and
+// input sizes must respect downstream granularity (e.g. whole elements).
 // Returns NULL on invalid config, allocation failure or thread-start failure.
 struct buffered_writer*
 buffered_writer_create(struct writer* downstream,
                        const struct buffered_writer_config* config);
 
-// append waits for one free slot, copies at most slot_bytes (stopping at the
-// ring boundary), and returns the unaccepted suffix in rest. The accepted
-// prefix can immediately be reused.
-// An empty rest can be {NULL,NULL}. Use writer_append_wait for larger inputs.
-// Acceptance is not downstream completion; inspect flush's result even when
-// every append succeeded. Backpressure blocks without a timeout or drops.
-// The worker submits a contiguous backlog prefix of at most max_drain_slots
-// in one downstream append, retrying for partial acceptance or stalls. A drain
-// also stops at the ring boundary. On return its slots are reusable and the
-// next drain starts immediately if input remains; it never waits to fill a
-// batch. Short appends are packed without gaps; caller append boundaries are
-// not preserved downstream. A size cap does not bound downstream call time.
+// append waits for free capacity, copies as much input as fits up to the ring
+// boundary, and returns the unaccepted suffix in rest. The accepted prefix can
+// immediately be reused. An empty rest can be {NULL,NULL}. Use
+// writer_append_wait to retry unaccepted input. Acceptance is not downstream
+// completion; inspect flush's result even when every append succeeded.
+// Backpressure blocks without a timeout or drops. The worker submits a
+// contiguous backlog prefix of at most max_drain_bytes in one downstream
+// append, retrying for partial acceptance or stalls. A drain also stops at the
+// ring boundary. On return its bytes are reusable and the next drain starts
+// immediately if input remains; it never waits to fill a batch. Short appends
+// are packed without gaps; caller append boundaries are not preserved
+// downstream. A size cap does not bound downstream call time.
 //
 // A downstream failure stops forwarding and abandons the unconsumed accepted
 // suffix, counted in stats. Early downstream `finished` does the same: if any

--- a/src/writer.buffered.h
+++ b/src/writer.buffered.h
@@ -4,10 +4,12 @@
 
 struct buffered_writer;
 
+// Byte limits and append sizes must respect downstream input granularity.
+// Requires max_drain_bytes <= capacity_bytes.
 struct buffered_writer_config
 {
-  size_t capacity_bytes;  // maximum queued + active bytes; nonzero
-  size_t max_drain_bytes; // bytes per drain; 0 = capacity_bytes
+  size_t capacity_bytes;  // maximum pending bytes; nonzero
+  size_t max_drain_bytes; // maximum batch bytes; 0 = capacity_bytes
 };
 
 struct buffered_writer_stats
@@ -26,57 +28,35 @@ struct buffered_writer_stats
   int failed; // sticky, including abandoned input and flush/close failures
 };
 
-// A bounded, copying adapter. Borrows downstream, which (along with its sink,
-// configuration and GPU context) must outlive the adapter. Only the worker
-// calls downstream; do not access it separately until destroying the adapter.
-// The downstream writer must permit serialized calls from a different thread
-// and release its reference to consumed input before append returns. CPU/GPU
-// tile-stream writers satisfy this contract.
-//
-// Externally serialize append/flush/close/destroy calls. get_stats may run
-// concurrently. Downstream callbacks must not reenter the adapter.
-//
-// Payload allocation is capacity_bytes in a shared ring, plus fixed bookkeeping
-// and one worker thread. Active drains pin only their bytes; all remaining
-// capacity is shared with the producer. No per-append allocation or packing
-// copy. max_drain_bytes must be <= capacity_bytes. Capacity, drain cap and
-// input sizes must respect downstream granularity (e.g. whole elements).
-// Returns NULL on invalid config, allocation failure or thread-start failure.
+// Borrows downstream and its dependencies until destroy; do not call downstream
+// separately. It must provide append/flush, allow serialized calls from another
+// thread, and retain no pointers to consumed input after append returns.
+// Callbacks must not reenter the adapter. Serialize append, flush, close and
+// destroy. Returns NULL on invalid arguments or resource failure.
 struct buffered_writer*
 buffered_writer_create(struct writer* downstream,
                        const struct buffered_writer_config* config);
 
-// append waits for free capacity, copies as much input as fits up to the ring
-// boundary, and returns the unaccepted suffix in rest. The accepted prefix can
-// immediately be reused. An empty rest can be {NULL,NULL}. Use
-// writer_append_wait to retry unaccepted input. Acceptance is not downstream
-// completion; inspect flush's result even when every append succeeded.
-// Backpressure blocks without a timeout or drops. The worker submits a
-// contiguous backlog prefix of at most max_drain_bytes in one downstream
-// append, retrying for partial acceptance or stalls. A drain also stops at the
-// ring boundary. On return its bytes are reusable and the next drain starts
-// immediately if input remains; it never waits to fill a batch. Short appends
-// are packed without gaps; caller append boundaries are not preserved
-// downstream. A size cap does not bound downstream call time.
+// Returns an interface valid until destroy.
+// append copies an input prefix and returns the unaccepted suffix in rest.
+// Accepted input is immediately reusable. Append blocks when full, without
+// a timeout. Input order is preserved; append boundaries may change.
 //
-// A downstream failure stops forwarding and abandons the unconsumed accepted
-// suffix, counted in stats. Early downstream `finished` does the same: if any
-// accepted bytes remain, the adapter reports fail, otherwise finished. Future
-// appends accept nothing. No borrowed/copy-buffer pointer is returned in rest.
-// A downstream writer that makes no progress fails after writer_append_wait's
-// bounded retries.
+// Downstream failure or completion stops acceptance. Remaining accepted bytes
+// are abandoned and cause failure. Always check flush or destroy for errors.
 //
-// flush stops acceptance, drains the queue (unless downstream terminates), then
-// flushes downstream even after failure. close publishes downstream metadata
-// after flush; before flush it is a no-op, as with the tile-stream writers.
-// Both wait for completion, are idempotent, and report sticky failures.
+// flush stops acceptance, drains unless downstream has terminated, and flushes
+// downstream even after failure. close calls downstream close after flush and
+// is a no-op before flush. Both wait for completion, are idempotent, and report
+// sticky failures.
 struct writer*
 buffered_writer_as_writer(struct buffered_writer* buffered);
 
+// Thread-safe snapshot; stop concurrent readers before destroy.
 struct buffered_writer_stats
 buffered_writer_get_stats(struct buffered_writer* buffered);
 
-// Flush, close, join and release the adapter, never downstream. Returns nonzero
-// on any failure, including abandoned input. NULL is allowed and succeeds.
+// Flushes, closes and frees the adapter, leaving downstream alive.
+// Returns nonzero on failure. NULL succeeds.
 int
 buffered_writer_destroy(struct buffered_writer* buffered);

--- a/src/writer.buffered.h
+++ b/src/writer.buffered.h
@@ -6,8 +6,9 @@ struct buffered_writer;
 
 struct buffered_writer_config
 {
-  size_t slot_bytes; // maximum bytes accepted by one append; nonzero
-  size_t slot_count; // maximum queued + active appends; nonzero
+  size_t slot_bytes;      // maximum bytes accepted by one append; nonzero
+  size_t slot_count;      // maximum queued + active appends; nonzero
+  size_t max_drain_slots; // maximum slots per downstream batch; 0 = slot_count
 };
 
 struct buffered_writer_stats
@@ -42,26 +43,28 @@ struct buffered_writer_stats
 // Externally serialize append/flush/close/destroy calls. get_stats may run
 // concurrently. Downstream callbacks must not reenter the adapter.
 //
-// Payload allocation is slot_count * slot_bytes, split between two contiguous
-// buffers (the first gets the extra slot for odd counts). A full producer
-// buffer applies backpressure until the worker swaps buffers. With one slot,
-// refill waits for the active drain to finish. Fixed bookkeeping and one worker
-// thread; no per-append allocation or packing copy. slot_bytes and input sizes
-// must respect the downstream input granularity (e.g. whole elements). Returns
-// NULL on invalid config, allocation failure or thread-start failure.
+// Payload allocation is slot_count * slot_bytes in a shared ring, plus one
+// bookkeeping entry per slot and one worker thread. Active drains pin only
+// their slots; all other slots remain available to the producer. No per-append
+// allocation or packing copy. max_drain_slots must be <= slot_count. slot_bytes
+// and input sizes must respect downstream input granularity (e.g. elements).
+// Returns NULL on invalid config, allocation failure or thread-start failure.
 struct buffered_writer*
 buffered_writer_create(struct writer* downstream,
                        const struct buffered_writer_config* config);
 
-// append waits for one free slot, copies at most slot_bytes, and returns the
-// unaccepted suffix in rest. The accepted prefix can immediately be reused.
+// append waits for one free slot, copies at most slot_bytes (stopping at the
+// ring boundary), and returns the unaccepted suffix in rest. The accepted
+// prefix can immediately be reused.
 // An empty rest can be {NULL,NULL}. Use writer_append_wait for larger inputs.
 // Acceptance is not downstream completion; inspect flush's result even when
 // every append succeeded. Backpressure blocks without a timeout or drops.
-// The worker submits the entire queued backlog in one downstream append,
-// retrying only for partial acceptance or stalls. Appends accepted during that
-// call accumulate in the other buffer for the next drain. Short appends are
-// packed without gaps; caller append boundaries are not preserved downstream.
+// The worker submits a contiguous backlog prefix of at most max_drain_slots
+// in one downstream append, retrying for partial acceptance or stalls. A drain
+// also stops at the ring boundary. On return its slots are reusable and the
+// next drain starts immediately if input remains; it never waits to fill a
+// batch. Short appends are packed without gaps; caller append boundaries are
+// not preserved downstream. A size cap does not bound downstream call time.
 //
 // A downstream failure stops forwarding and abandons the unconsumed accepted
 // suffix, counted in stats. Early downstream `finished` does the same: if any

--- a/src/writer.buffered.h
+++ b/src/writer.buffered.h
@@ -7,7 +7,7 @@ struct buffered_writer;
 struct buffered_writer_config
 {
   size_t slot_bytes; // maximum bytes accepted by one append; nonzero
-  size_t slot_count; // includes the slot being forwarded; nonzero
+  size_t slot_count; // maximum queued + active appends; nonzero
 };
 
 struct buffered_writer_stats
@@ -17,13 +17,15 @@ struct buffered_writer_stats
   uint64_t abandoned_bytes; // accepted but not consumed after a terminal result
   size_t pending_bytes;     // queued + currently forwarding
   size_t peak_pending_bytes;
-  size_t occupied_slots; // includes the slot being forwarded
+  size_t occupied_slots; // includes appends in the active downstream batch
   size_t peak_occupied_slots;
   uint64_t completed_slots;
+  uint64_t completed_batches;
+  size_t max_batch_bytes;
   uint64_t backpressure_ns; // caller time waiting for a free slot
-  uint64_t queue_ns;        // sum: acceptance to start of downstream append
+  uint64_t queue_ns;        // sum per slot: acceptance to downstream start
   uint64_t max_queue_ns;
-  uint64_t downstream_ns; // sum: downstream append, including partial retries
+  uint64_t downstream_ns; // sum per batch, including partial retries
   uint64_t max_downstream_ns;
   uint64_t max_completion_ns; // acceptance to downstream append return
   int downstream_finished;
@@ -40,11 +42,13 @@ struct buffered_writer_stats
 // Externally serialize append/flush/close/destroy calls. get_stats may run
 // concurrently. Downstream callbacks must not reenter the adapter.
 //
-// Payload allocation is exactly slot_count * slot_bytes, plus fixed bookkeeping
-// per slot and one worker thread. No per-append allocation. slot_bytes and
-// input sizes must respect the downstream input granularity (e.g. whole
-// elements). Returns NULL on invalid config, allocation failure or thread-start
-// failure.
+// Payload allocation is slot_count * slot_bytes, split between two contiguous
+// buffers (the first gets the extra slot for odd counts). A full producer
+// buffer applies backpressure until the worker swaps buffers. With one slot,
+// refill waits for the active drain to finish. Fixed bookkeeping and one worker
+// thread; no per-append allocation or packing copy. slot_bytes and input sizes
+// must respect the downstream input granularity (e.g. whole elements). Returns
+// NULL on invalid config, allocation failure or thread-start failure.
 struct buffered_writer*
 buffered_writer_create(struct writer* downstream,
                        const struct buffered_writer_config* config);
@@ -54,6 +58,10 @@ buffered_writer_create(struct writer* downstream,
 // An empty rest can be {NULL,NULL}. Use writer_append_wait for larger inputs.
 // Acceptance is not downstream completion; inspect flush's result even when
 // every append succeeded. Backpressure blocks without a timeout or drops.
+// The worker submits the entire queued backlog in one downstream append,
+// retrying only for partial acceptance or stalls. Appends accepted during that
+// call accumulate in the other buffer for the next drain. Short appends are
+// packed without gaps; caller append boundaries are not preserved downstream.
 //
 // A downstream failure stops forwarding and abandons the unconsumed accepted
 // suffix, counted in stats. Early downstream `finished` does the same: if any

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,8 @@ target_link_libraries(
 
 # Threadpool unit tests
 add_test_exe(test_threadpool test_threadpool.c threadpool platform)
+add_test_exe(test_buffered_writer test_buffered_writer.c writer platform chucky_log)
+set_tests_properties(test-test_buffered_writer PROPERTIES TIMEOUT 30)
 
 # Index operations unit tests (pure CPU)
 add_test_exe(test_index_ops test_index_ops.c index_ops chucky_log)

--- a/tests/test_buffered_writer.c
+++ b/tests/test_buffered_writer.c
@@ -164,8 +164,8 @@ test_queue(int terminal, size_t limit)
     f.limit = limit;
     f.terminal = terminal;
   }
-  struct buffered_writer* b =
-    buffered_writer_create(&f.writer, &(struct buffered_writer_config){ 8, 2 });
+  struct buffered_writer* b = buffered_writer_create(
+    &f.writer, &(struct buffered_writer_config){ 8, 2, 0 });
   struct platform_thread* thread = NULL;
   CHECK(Fail, b);
   struct writer* w = buffered_writer_as_writer(b);
@@ -248,8 +248,8 @@ test_finalize(int flush_error, int close_error, int finish, int stall)
   f.stall = stall;
   if (finish)
     f.limit = 8;
-  struct buffered_writer* b =
-    buffered_writer_create(&f.writer, &(struct buffered_writer_config){ 8, 1 });
+  struct buffered_writer* b = buffered_writer_create(
+    &f.writer, &(struct buffered_writer_config){ 8, 1, 0 });
   CHECK(Fail, b);
   struct writer* w = buffered_writer_as_writer(b);
   CHECK(Fail, writer_close(w).error == 0 && f.closes == 0);
@@ -282,7 +282,7 @@ Fail:
 }
 
 // Hold each drain while the producer builds the next backlog. Vary append
-// sizes and alternate buffers repeatedly: every backlog must arrive as one
+// sizes and reuse descriptor slots: every contiguous backlog must arrive as one
 // packed append, including when a drain terminates inside the combined input.
 static int
 test_backlog(int terminal)
@@ -295,8 +295,8 @@ test_backlog(int terminal)
     f.limit = 10; // one byte, then a prefix of the first combined drain
     f.terminal = terminal;
   }
-  struct buffered_writer* b =
-    buffered_writer_create(&f.writer, &(struct buffered_writer_config){ 8, 6 });
+  struct buffered_writer* b = buffered_writer_create(
+    &f.writer, &(struct buffered_writer_config){ 8, 6, 0 });
   CHECK(Fail, b);
   struct writer* w = buffered_writer_as_writer(b);
   unsigned char input[64];
@@ -360,24 +360,165 @@ Fail:
 }
 
 static int
+test_capped_drain(void)
+{
+  struct fake_writer f;
+  if (fake_init(&f))
+    return 1;
+  f.hold_each = 1;
+  struct buffered_writer* b = buffered_writer_create(
+    &f.writer, &(struct buffered_writer_config){ 8, 7, 2 });
+  struct platform_thread* thread = NULL;
+  CHECK(Fail, b);
+  struct writer* w = buffered_writer_as_writer(b);
+  unsigned char input[80];
+  for (size_t i = 0; i < sizeof(input); ++i)
+    input[i] = (unsigned char)i;
+  CHECK(Fail, !writer_append_wait(w, (struct slice){ input, input + 8 }).error);
+  wait_call(&f, 1);
+  // One active slot leaves all six other slots available, not half the ring.
+  CHECK(Fail,
+        !writer_append_wait(w, (struct slice){ input + 8, input + 56 }).error);
+  memset(input, 0xFF, 56);
+  struct buffered_writer_stats stats = buffered_writer_get_stats(b);
+  CHECK(Fail, stats.occupied_slots == 7 && stats.pending_bytes == 56);
+
+  struct producer p = { .writer = w, .input = { input + 56, input + 64 } };
+  atomic_init(&p.started, 0);
+  atomic_init(&p.done, 0);
+  thread = platform_thread_start(produce, &p);
+  CHECK(Fail, thread);
+  while (!atomic_load(&p.started))
+    platform_sleep_ns(100000);
+  CHECK(Fail, !atomic_load(&p.done));
+  release_call(&f);
+  wait_call(&f, 2);
+  platform_thread_join(thread);
+  thread = NULL;
+  CHECK(Fail, !p.result.error && p.result.rest.beg == input + 64);
+  CHECK(Fail, f.append_bytes[1] == 16); // catch up by two slots in one call
+  memset(input + 56, 0xFF, 8);
+
+  p.input = (struct slice){ input + 64, input + 72 };
+  atomic_store(&p.started, 0);
+  atomic_store(&p.done, 0);
+  thread = platform_thread_start(produce, &p);
+  CHECK(Fail, thread);
+  while (!atomic_load(&p.started))
+    platform_sleep_ns(100000);
+  CHECK(Fail, !atomic_load(&p.done));
+  release_call(&f);
+  wait_call(&f, 3);
+  platform_thread_join(thread);
+  thread = NULL;
+  CHECK(Fail, !p.result.error && p.result.rest.beg == input + 72);
+  // A capped drain freed both slots while an older backlog still remains.
+  CHECK(Fail,
+        !writer_append_wait(w, (struct slice){ input + 72, input + 80 }).error);
+  memset(input, 0xFF, sizeof(input));
+  stats = buffered_writer_get_stats(b);
+  CHECK(Fail, stats.occupied_slots == 7 && stats.pending_bytes == 56);
+  CHECK(Fail, stats.forwarded_bytes == 24);
+  unhold(&f);
+  CHECK(Fail, !writer_flush(w).error);
+  stats = buffered_writer_get_stats(b);
+  CHECK(Fail, stats.max_batch_bytes == 16 && stats.completed_slots == 10);
+  CHECK(Fail, stats.completed_batches == 6 && f.appends == 6);
+  CHECK(Fail, stats.peak_occupied_slots == 7 && !stats.pending_bytes);
+  CHECK(Fail, stats.forwarded_bytes == 80 && !stats.abandoned_bytes);
+  for (int i = 0; i < f.entered; ++i)
+    CHECK(Fail, f.append_bytes[i] <= 16);
+  for (size_t i = 0; i < f.bytes; ++i)
+    CHECK(Fail, f.output[i] == i);
+  int error = buffered_writer_destroy(b);
+  b = NULL;
+  CHECK(Fail, !error);
+  fake_free(&f);
+  return 0;
+Fail:
+  unhold(&f);
+  if (thread)
+    platform_thread_join(thread);
+  buffered_writer_destroy(b);
+  fake_free(&f);
+  return 1;
+}
+
+// Uneven input crosses the payload boundary. The accepted prefix stops there;
+// retrying its suffix must preserve every byte and downstream granularity.
+static int
+test_ring_wrap(void)
+{
+  struct fake_writer f;
+  if (fake_init(&f))
+    return 1;
+  f.hold_each = 1;
+  struct buffered_writer* b = buffered_writer_create(
+    &f.writer, &(struct buffered_writer_config){ 8, 3, 2 });
+  CHECK(Fail, b);
+  struct writer* w = buffered_writer_as_writer(b);
+  unsigned char input[32];
+  for (size_t i = 0; i < sizeof(input); ++i)
+    input[i] = (unsigned char)i;
+  CHECK(Fail, !writer_append_wait(w, (struct slice){ input, input + 8 }).error);
+  wait_call(&f, 1);
+  CHECK(Fail, !writer_append(w, (struct slice){ input + 8, input + 15 }).error);
+  CHECK(Fail,
+        !writer_append(w, (struct slice){ input + 15, input + 22 }).error);
+  memset(input, 0xFF, 22);
+  release_call(&f);
+  wait_call(&f, 2);
+  CHECK(Fail, f.append_bytes[1] == 14);
+  struct writer_result r =
+    writer_append(w, (struct slice){ input + 22, input + 30 });
+  CHECK(Fail, !r.error && r.rest.beg == input + 24 && r.rest.end == input + 30);
+  memset(input + 22, 0xFF, 2);
+  release_call(&f);
+  wait_call(&f, 3);
+  CHECK(Fail, f.append_bytes[2] == 2);
+  CHECK(Fail, !writer_append_wait(w, r.rest).error);
+  memset(input + 24, 0xFF, 6);
+  unhold(&f);
+  CHECK(Fail, !writer_flush(w).error && f.bytes == 30 && f.appends == 4);
+  for (size_t i = 0; i < f.bytes; ++i)
+    CHECK(Fail, f.output[i] == i);
+  int error = buffered_writer_destroy(b);
+  b = NULL;
+  CHECK(Fail, !error);
+  fake_free(&f);
+  return 0;
+Fail:
+  unhold(&f);
+  buffered_writer_destroy(b);
+  fake_free(&f);
+  return 1;
+}
+
+static int
 test_destroy_and_config(void)
 {
   struct fake_writer f;
   if (fake_init(&f))
     return 1;
-  struct buffered_writer_config cfg = { 4, 2 };
+  struct buffered_writer_config cfg = { 4, 2, 0 };
   struct buffered_writer* b = NULL;
   CHECK(Fail, !buffered_writer_create(NULL, &cfg));
   CHECK(Fail, !buffered_writer_create(&f.writer, NULL));
   CHECK(Fail,
         !buffered_writer_create(&f.writer,
-                                &(struct buffered_writer_config){ 0, 2 }));
+                                &(struct buffered_writer_config){ 0, 2, 0 }));
   CHECK(Fail,
         !buffered_writer_create(&f.writer,
-                                &(struct buffered_writer_config){ 4, 0 }));
+                                &(struct buffered_writer_config){ 4, 0, 0 }));
   CHECK(Fail,
         !buffered_writer_create(
-          &f.writer, &(struct buffered_writer_config){ 2, SIZE_MAX }));
+          &f.writer, &(struct buffered_writer_config){ 2, SIZE_MAX, 0 }));
+  CHECK(Fail,
+        !buffered_writer_create(
+          &f.writer, &(struct buffered_writer_config){ 1, SIZE_MAX, 0 }));
+  CHECK(Fail,
+        !buffered_writer_create(&f.writer,
+                                &(struct buffered_writer_config){ 8, 2, 3 }));
   CHECK(Fail, buffered_writer_destroy(NULL) == 0);
   b = buffered_writer_create(&f.writer, &cfg);
   CHECK(Fail, b);
@@ -410,6 +551,8 @@ main(void)
   failed += test_backlog(0);
   failed += test_backlog(writer_error_fail);
   failed += test_backlog(writer_error_finished);
+  failed += test_capped_drain();
+  failed += test_ring_wrap();
   failed += test_finalize(0, 0, 0, 0);
   failed += test_finalize(1, 0, 0, 0);
   failed += test_finalize(0, 1, 0, 0);

--- a/tests/test_buffered_writer.c
+++ b/tests/test_buffered_writer.c
@@ -12,7 +12,9 @@ struct fake_writer
   struct platform_mutex* mutex;
   struct platform_cond* changed;
   int held;
+  int hold_each;
   int entered;
+  size_t append_bytes[128];
   size_t step;
   size_t limit;
   int terminal;
@@ -31,7 +33,12 @@ fake_append(struct writer* self, struct slice input)
 {
   struct fake_writer* f = (struct fake_writer*)self;
   platform_mutex_lock(f->mutex);
-  f->entered = 1;
+  if (f->hold_each)
+    f->held = 1;
+  if (f->entered < 128)
+    f->append_bytes[f->entered] =
+      (const unsigned char*)input.end - (const unsigned char*)input.beg;
+  ++f->entered;
   platform_cond_broadcast(f->changed);
   while (f->held)
     platform_cond_wait(f->changed, f->mutex);
@@ -69,6 +76,25 @@ fake_close(struct writer* self)
 
 static void
 unhold(struct fake_writer* f)
+{
+  platform_mutex_lock(f->mutex);
+  f->hold_each = 0;
+  f->held = 0;
+  platform_cond_broadcast(f->changed);
+  platform_mutex_unlock(f->mutex);
+}
+
+static void
+wait_call(struct fake_writer* f, int count)
+{
+  platform_mutex_lock(f->mutex);
+  while (f->entered < count)
+    platform_cond_wait(f->changed, f->mutex);
+  platform_mutex_unlock(f->mutex);
+}
+
+static void
+release_call(struct fake_writer* f)
 {
   platform_mutex_lock(f->mutex);
   f->held = 0;
@@ -255,6 +281,84 @@ Fail:
   return 1;
 }
 
+// Hold each drain while the producer builds the next backlog. Vary append
+// sizes and alternate buffers repeatedly: every backlog must arrive as one
+// packed append, including when a drain terminates inside the combined input.
+static int
+test_backlog(int terminal)
+{
+  struct fake_writer f;
+  if (fake_init(&f))
+    return 1;
+  f.hold_each = 1;
+  if (terminal) {
+    f.limit = 10; // one byte, then a prefix of the first combined drain
+    f.terminal = terminal;
+  }
+  struct buffered_writer* b =
+    buffered_writer_create(&f.writer, &(struct buffered_writer_config){ 8, 6 });
+  CHECK(Fail, b);
+  struct writer* w = buffered_writer_as_writer(b);
+  unsigned char input[64];
+  for (size_t i = 0; i < sizeof(input); ++i)
+    input[i] = (unsigned char)i;
+  CHECK(Fail, !writer_append(w, (struct slice){ input, input + 1 }).error);
+  wait_call(&f, 1);
+  const size_t sizes[][3] = { { 3, 8, 2 }, { 7, 1, 5 }, { 2, 4, 8 } };
+  size_t offset = 1;
+  for (int batch = 0; batch < (terminal ? 1 : 3); ++batch) {
+    size_t bytes = 0;
+    for (int slot = 0; slot < 3; ++slot) {
+      size_t n = sizes[batch][slot];
+      CHECK(
+        Fail,
+        !writer_append(w, (struct slice){ input + offset, input + offset + n })
+           .error);
+      memset(input + offset, 0xFF, n);
+      offset += n;
+      bytes += n;
+    }
+    release_call(&f);
+    wait_call(&f, batch + 2);
+    CHECK(Fail, f.append_bytes[batch + 1] == bytes);
+    struct buffered_writer_stats stats = buffered_writer_get_stats(b);
+    CHECK(Fail, stats.occupied_slots == 3 && stats.pending_bytes == bytes);
+  }
+  if (terminal) {
+    // Accepted during the combined downstream call: these must also be
+    // abandoned when it returns a terminal result, without another append.
+    CHECK(
+      Fail,
+      !writer_append(w, (struct slice){ input + offset, input + offset + 4 })
+         .error);
+    offset += 4;
+  }
+  memset(input, 0xFF, sizeof(input));
+  unhold(&f);
+  CHECK(Fail, writer_flush(w).error == (terminal != 0));
+  CHECK(Fail, f.appends == (terminal ? 2 : 4));
+  struct buffered_writer_stats stats = buffered_writer_get_stats(b);
+  CHECK(Fail, stats.completed_batches == (terminal ? 2u : 4u));
+  CHECK(Fail, stats.completed_slots == (terminal ? 4u : 10u));
+  CHECK(Fail, stats.max_batch_bytes == (terminal ? 13u : 14u));
+  CHECK(Fail, stats.forwarded_bytes == (terminal ? 10u : offset));
+  CHECK(Fail, stats.abandoned_bytes == (terminal ? offset - 10 : 0));
+  CHECK(Fail, !stats.occupied_slots && !stats.pending_bytes);
+  CHECK(Fail, stats.downstream_finished == (terminal == writer_error_finished));
+  for (size_t i = 0; i < f.bytes; ++i)
+    CHECK(Fail, f.output[i] == i);
+  int error = buffered_writer_destroy(b);
+  b = NULL;
+  CHECK(Fail, error == (terminal != 0));
+  fake_free(&f);
+  return 0;
+Fail:
+  unhold(&f);
+  buffered_writer_destroy(b);
+  fake_free(&f);
+  return 1;
+}
+
 static int
 test_destroy_and_config(void)
 {
@@ -303,6 +407,9 @@ main(void)
   failed += test_queue(writer_error_fail, 3);
   failed += test_queue(writer_error_finished, 3);
   failed += test_queue(writer_error_finished, 8);
+  failed += test_backlog(0);
+  failed += test_backlog(writer_error_fail);
+  failed += test_backlog(writer_error_finished);
   failed += test_finalize(0, 0, 0, 0);
   failed += test_finalize(1, 0, 0, 0);
   failed += test_finalize(0, 1, 0, 0);

--- a/tests/test_buffered_writer.c
+++ b/tests/test_buffered_writer.c
@@ -1,0 +1,312 @@
+#include "writer.buffered.h"
+
+#include "platform/platform.h"
+#include "util/prelude.h"
+
+#include <stdatomic.h>
+#include <string.h>
+
+struct fake_writer
+{
+  struct writer writer;
+  struct platform_mutex* mutex;
+  struct platform_cond* changed;
+  int held;
+  int entered;
+  size_t step;
+  size_t limit;
+  int terminal;
+  int stall;
+  int flush_error;
+  int close_error;
+  unsigned char output[128];
+  size_t bytes;
+  int appends;
+  int flushes;
+  int closes;
+};
+
+static struct writer_result
+fake_append(struct writer* self, struct slice input)
+{
+  struct fake_writer* f = (struct fake_writer*)self;
+  platform_mutex_lock(f->mutex);
+  f->entered = 1;
+  platform_cond_broadcast(f->changed);
+  while (f->held)
+    platform_cond_wait(f->changed, f->mutex);
+  platform_mutex_unlock(f->mutex);
+  ++f->appends;
+  if (f->stall)
+    return (struct writer_result){ 0, input };
+  size_t n = (const unsigned char*)input.end - (const unsigned char*)input.beg;
+  if (n > f->step)
+    n = f->step;
+  if (n > f->limit - f->bytes)
+    n = f->limit - f->bytes;
+  memcpy(f->output + f->bytes, input.beg, n);
+  f->bytes += n;
+  input.beg = (const unsigned char*)input.beg + n;
+  return (struct writer_result){ f->bytes == f->limit ? f->terminal : 0,
+                                 input };
+}
+
+static struct writer_result
+fake_flush(struct writer* self)
+{
+  struct fake_writer* f = (struct fake_writer*)self;
+  ++f->flushes;
+  return f->flush_error ? writer_error() : writer_ok();
+}
+
+static struct writer_result
+fake_close(struct writer* self)
+{
+  struct fake_writer* f = (struct fake_writer*)self;
+  ++f->closes;
+  return f->close_error ? writer_error() : writer_ok();
+}
+
+static void
+unhold(struct fake_writer* f)
+{
+  platform_mutex_lock(f->mutex);
+  f->held = 0;
+  platform_cond_broadcast(f->changed);
+  platform_mutex_unlock(f->mutex);
+}
+
+static void
+wait_entered(struct fake_writer* f)
+{
+  platform_mutex_lock(f->mutex);
+  while (!f->entered)
+    platform_cond_wait(f->changed, f->mutex);
+  platform_mutex_unlock(f->mutex);
+}
+
+static int
+fake_init(struct fake_writer* f)
+{
+  *f = (struct fake_writer){
+    .writer = { fake_append, fake_flush, fake_close },
+    .mutex = platform_mutex_new(),
+    .changed = platform_cond_new(),
+    .step = 128,
+    .limit = 128,
+    .terminal = writer_error_finished,
+  };
+  return !f->mutex || !f->changed;
+}
+
+static void
+fake_free(struct fake_writer* f)
+{
+  platform_cond_free(f->changed);
+  platform_mutex_free(f->mutex);
+}
+
+struct producer
+{
+  struct writer* writer;
+  struct slice input;
+  struct writer_result result;
+  atomic_int started;
+  atomic_int done;
+};
+
+static void
+produce(void* arg)
+{
+  struct producer* p = arg;
+  atomic_store(&p->started, 1);
+  p->result = writer_append(p->writer, p->input);
+  atomic_store(&p->done, 1);
+}
+
+// Hold the consumer before it reads: memory reuse, FIFO, slot ownership during
+// forwarding, partial acceptance, blocking at capacity, and failure wakeups.
+static int
+test_queue(int terminal, size_t limit)
+{
+  struct fake_writer f;
+  if (fake_init(&f))
+    return 1;
+  f.held = 1;
+  f.step = 3; // downstream partial progress
+  if (terminal) {
+    f.limit = limit;
+    f.terminal = terminal;
+  }
+  struct buffered_writer* b =
+    buffered_writer_create(&f.writer, &(struct buffered_writer_config){ 8, 2 });
+  struct platform_thread* thread = NULL;
+  CHECK(Fail, b);
+  struct writer* w = buffered_writer_as_writer(b);
+  unsigned char input[24];
+  for (size_t i = 0; i < sizeof(input); ++i)
+    input[i] = (unsigned char)i;
+  struct slice slice = { input, input + sizeof(input) };
+  struct writer_result r = writer_append(w, slice);
+  CHECK(Fail, !r.error && r.rest.beg == input + 8 && r.rest.end == slice.end);
+  memset(input, 0xFF, 8);
+  wait_entered(&f);
+  r = writer_append(w, r.rest);
+  CHECK(Fail, !r.error && r.rest.beg == input + 16);
+  memset(input + 8, 0xFF, 8);
+  struct buffered_writer_stats stats = buffered_writer_get_stats(b);
+  CHECK(Fail, stats.accepted_bytes == 16 && stats.forwarded_bytes == 0);
+  CHECK(Fail, stats.pending_bytes == 16 && stats.occupied_slots == 2);
+
+  struct producer p = { .writer = w, .input = r.rest };
+  atomic_init(&p.started, 0);
+  atomic_init(&p.done, 0);
+  thread = platform_thread_start(produce, &p);
+  CHECK(Fail, thread);
+  while (!atomic_load(&p.started))
+    platform_sleep_ns(100000);
+  CHECK(Fail, !atomic_load(&p.done)); // no slot can be reclaimed while held
+  unhold(&f);
+  platform_thread_join(thread);
+  thread = NULL;
+  if (terminal) {
+    CHECK(Fail, p.result.error == writer_error_fail);
+    CHECK(Fail,
+          p.result.rest.beg == input + 16 && p.result.rest.end == slice.end);
+  } else {
+    CHECK(Fail, !p.result.error && p.result.rest.beg == slice.end);
+  }
+  memset(input, 0xFF, sizeof(input));
+  CHECK(Fail, writer_flush(w).error == (terminal ? writer_error_fail : 0));
+  CHECK(Fail, writer_flush(w).error == (terminal ? writer_error_fail : 0));
+  CHECK(Fail, writer_close(w).error == (terminal ? writer_error_fail : 0));
+  CHECK(Fail, writer_close(w).error == (terminal ? writer_error_fail : 0));
+  CHECK(Fail, f.flushes == 1 && f.closes == 1);
+  stats = buffered_writer_get_stats(b);
+  CHECK(Fail, !stats.pending_bytes && !stats.occupied_slots);
+  CHECK(Fail, stats.peak_pending_bytes == 16 && stats.peak_occupied_slots == 2);
+  CHECK(Fail, stats.forwarded_bytes == (terminal ? limit : 24u));
+  CHECK(Fail, stats.abandoned_bytes == (terminal ? 16u - limit : 0u));
+  CHECK(Fail,
+        stats.accepted_bytes == stats.forwarded_bytes + stats.abandoned_bytes);
+  CHECK(Fail, stats.downstream_finished == (terminal == writer_error_finished));
+  CHECK(Fail, stats.failed == (terminal != 0));
+  for (size_t i = 0; i < f.bytes; ++i)
+    CHECK(Fail, f.output[i] == i);
+  r = writer_append(w, slice);
+  CHECK(Fail,
+        r.error == (terminal ? writer_error_fail : writer_error_finished));
+  CHECK(Fail, r.rest.beg == slice.beg && r.rest.end == slice.end);
+  int error = buffered_writer_destroy(b);
+  b = NULL;
+  CHECK(Fail, error == (terminal != 0));
+  fake_free(&f);
+  return 0;
+Fail:
+  unhold(&f);
+  if (thread)
+    platform_thread_join(thread);
+  buffered_writer_destroy(b);
+  fake_free(&f);
+  return 1;
+}
+
+static int
+test_finalize(int flush_error, int close_error, int finish, int stall)
+{
+  struct fake_writer f;
+  if (fake_init(&f))
+    return 1;
+  f.flush_error = flush_error;
+  f.close_error = close_error;
+  f.stall = stall;
+  if (finish)
+    f.limit = 8;
+  struct buffered_writer* b =
+    buffered_writer_create(&f.writer, &(struct buffered_writer_config){ 8, 1 });
+  CHECK(Fail, b);
+  struct writer* w = buffered_writer_as_writer(b);
+  CHECK(Fail, writer_close(w).error == 0 && f.closes == 0);
+  unsigned char input[8] = { 1, 2, 3 };
+  CHECK(Fail, writer_append(w, (struct slice){ NULL, NULL }).error == 0);
+  CHECK(Fail,
+        writer_append_wait(w, (struct slice){ input, input + 8 }).error == 0);
+  if (finish) {
+    struct writer_result r =
+      writer_append(w, (struct slice){ input, input + 8 });
+    CHECK(Fail, r.error == writer_error_finished && r.rest.beg == input);
+  }
+  CHECK(Fail, writer_flush(w).error == (flush_error || stall));
+  CHECK(Fail, writer_close(w).error == (flush_error || close_error || stall));
+  CHECK(Fail, writer_close(w).error == (flush_error || close_error || stall));
+  struct buffered_writer_stats stats = buffered_writer_get_stats(b);
+  CHECK(Fail, stats.abandoned_bytes == (stall ? 8u : 0u));
+  CHECK(Fail, f.flushes == 1 && f.closes == 1);
+  int error = buffered_writer_destroy(b);
+  b = NULL;
+  CHECK(Fail, error == (flush_error || close_error || stall));
+  // Borrowed downstream is still alive, and cleanup ran only once.
+  CHECK(Fail, f.flushes == 1 && f.closes == 1);
+  fake_free(&f);
+  return 0;
+Fail:
+  buffered_writer_destroy(b);
+  fake_free(&f);
+  return 1;
+}
+
+static int
+test_destroy_and_config(void)
+{
+  struct fake_writer f;
+  if (fake_init(&f))
+    return 1;
+  struct buffered_writer_config cfg = { 4, 2 };
+  struct buffered_writer* b = NULL;
+  CHECK(Fail, !buffered_writer_create(NULL, &cfg));
+  CHECK(Fail, !buffered_writer_create(&f.writer, NULL));
+  CHECK(Fail,
+        !buffered_writer_create(&f.writer,
+                                &(struct buffered_writer_config){ 0, 2 }));
+  CHECK(Fail,
+        !buffered_writer_create(&f.writer,
+                                &(struct buffered_writer_config){ 4, 0 }));
+  CHECK(Fail,
+        !buffered_writer_create(
+          &f.writer, &(struct buffered_writer_config){ 2, SIZE_MAX }));
+  CHECK(Fail, buffered_writer_destroy(NULL) == 0);
+  b = buffered_writer_create(&f.writer, &cfg);
+  CHECK(Fail, b);
+  unsigned char input[16] = { 1, 2, 3, 4 };
+  CHECK(Fail,
+        !writer_append_wait(buffered_writer_as_writer(b),
+                            (struct slice){ input, input + 16 })
+           .error);
+  memset(input, 0xFF, sizeof(input));
+  int error = buffered_writer_destroy(b);
+  b = NULL;
+  CHECK(Fail, !error && f.bytes == 16 && f.flushes == 1 && f.closes == 1);
+  CHECK(Fail, f.output[0] == 1 && f.output[3] == 4 && f.output[15] == 0);
+  fake_free(&f);
+  return 0;
+Fail:
+  buffered_writer_destroy(b);
+  fake_free(&f);
+  return 1;
+}
+
+int
+main(void)
+{
+  int failed = test_destroy_and_config();
+  failed += test_queue(0, 0);
+  failed += test_queue(writer_error_fail, 3);
+  failed += test_queue(writer_error_finished, 3);
+  failed += test_queue(writer_error_finished, 8);
+  failed += test_finalize(0, 0, 0, 0);
+  failed += test_finalize(1, 0, 0, 0);
+  failed += test_finalize(0, 1, 0, 0);
+  failed += test_finalize(0, 0, 1, 0);
+  failed += test_finalize(0, 0, 0, 1);
+  return failed != 0;
+}

--- a/tests/test_buffered_writer.c
+++ b/tests/test_buffered_writer.c
@@ -150,7 +150,7 @@ produce(void* arg)
   atomic_store(&p->done, 1);
 }
 
-// Hold the consumer before it reads: memory reuse, FIFO, slot ownership during
+// Hold the consumer before it reads: memory reuse, FIFO, byte ownership during
 // forwarding, partial acceptance, blocking at capacity, and failure wakeups.
 static int
 test_queue(int terminal, size_t limit)
@@ -165,7 +165,7 @@ test_queue(int terminal, size_t limit)
     f.terminal = terminal;
   }
   struct buffered_writer* b = buffered_writer_create(
-    &f.writer, &(struct buffered_writer_config){ 8, 2, 0 });
+    &f.writer, &(struct buffered_writer_config){ 16, 8 });
   struct platform_thread* thread = NULL;
   CHECK(Fail, b);
   struct writer* w = buffered_writer_as_writer(b);
@@ -173,16 +173,16 @@ test_queue(int terminal, size_t limit)
   for (size_t i = 0; i < sizeof(input); ++i)
     input[i] = (unsigned char)i;
   struct slice slice = { input, input + sizeof(input) };
-  struct writer_result r = writer_append(w, slice);
-  CHECK(Fail, !r.error && r.rest.beg == input + 8 && r.rest.end == slice.end);
+  struct writer_result r = writer_append(w, (struct slice){ input, input + 8 });
+  CHECK(Fail, !r.error && r.rest.beg == input + 8 && r.rest.end == input + 8);
   memset(input, 0xFF, 8);
   wait_entered(&f);
-  r = writer_append(w, r.rest);
+  r = writer_append(w, (struct slice){ input + 8, input + 24 });
   CHECK(Fail, !r.error && r.rest.beg == input + 16);
   memset(input + 8, 0xFF, 8);
   struct buffered_writer_stats stats = buffered_writer_get_stats(b);
   CHECK(Fail, stats.accepted_bytes == 16 && stats.forwarded_bytes == 0);
-  CHECK(Fail, stats.pending_bytes == 16 && stats.occupied_slots == 2);
+  CHECK(Fail, stats.pending_bytes == 16);
 
   struct producer p = { .writer = w, .input = r.rest };
   atomic_init(&p.started, 0);
@@ -191,7 +191,7 @@ test_queue(int terminal, size_t limit)
   CHECK(Fail, thread);
   while (!atomic_load(&p.started))
     platform_sleep_ns(100000);
-  CHECK(Fail, !atomic_load(&p.done)); // no slot can be reclaimed while held
+  CHECK(Fail, !atomic_load(&p.done)); // no bytes can be reclaimed while held
   unhold(&f);
   platform_thread_join(thread);
   thread = NULL;
@@ -209,8 +209,8 @@ test_queue(int terminal, size_t limit)
   CHECK(Fail, writer_close(w).error == (terminal ? writer_error_fail : 0));
   CHECK(Fail, f.flushes == 1 && f.closes == 1);
   stats = buffered_writer_get_stats(b);
-  CHECK(Fail, !stats.pending_bytes && !stats.occupied_slots);
-  CHECK(Fail, stats.peak_pending_bytes == 16 && stats.peak_occupied_slots == 2);
+  CHECK(Fail, !stats.pending_bytes);
+  CHECK(Fail, stats.peak_pending_bytes == 16);
   CHECK(Fail, stats.forwarded_bytes == (terminal ? limit : 24u));
   CHECK(Fail, stats.abandoned_bytes == (terminal ? 16u - limit : 0u));
   CHECK(Fail,
@@ -248,8 +248,8 @@ test_finalize(int flush_error, int close_error, int finish, int stall)
   f.stall = stall;
   if (finish)
     f.limit = 8;
-  struct buffered_writer* b = buffered_writer_create(
-    &f.writer, &(struct buffered_writer_config){ 8, 1, 0 });
+  struct buffered_writer* b =
+    buffered_writer_create(&f.writer, &(struct buffered_writer_config){ 8, 0 });
   CHECK(Fail, b);
   struct writer* w = buffered_writer_as_writer(b);
   CHECK(Fail, writer_close(w).error == 0 && f.closes == 0);
@@ -282,7 +282,7 @@ Fail:
 }
 
 // Hold each drain while the producer builds the next backlog. Vary append
-// sizes and reuse descriptor slots: every contiguous backlog must arrive as one
+// sizes: every contiguous backlog must arrive as one
 // packed append, including when a drain terminates inside the combined input.
 static int
 test_backlog(int terminal)
@@ -296,7 +296,7 @@ test_backlog(int terminal)
     f.terminal = terminal;
   }
   struct buffered_writer* b = buffered_writer_create(
-    &f.writer, &(struct buffered_writer_config){ 8, 6, 0 });
+    &f.writer, &(struct buffered_writer_config){ 48, 0 });
   CHECK(Fail, b);
   struct writer* w = buffered_writer_as_writer(b);
   unsigned char input[64];
@@ -308,8 +308,8 @@ test_backlog(int terminal)
   size_t offset = 1;
   for (int batch = 0; batch < (terminal ? 1 : 3); ++batch) {
     size_t bytes = 0;
-    for (int slot = 0; slot < 3; ++slot) {
-      size_t n = sizes[batch][slot];
+    for (int append = 0; append < 3; ++append) {
+      size_t n = sizes[batch][append];
       CHECK(
         Fail,
         !writer_append(w, (struct slice){ input + offset, input + offset + n })
@@ -322,7 +322,7 @@ test_backlog(int terminal)
     wait_call(&f, batch + 2);
     CHECK(Fail, f.append_bytes[batch + 1] == bytes);
     struct buffered_writer_stats stats = buffered_writer_get_stats(b);
-    CHECK(Fail, stats.occupied_slots == 3 && stats.pending_bytes == bytes);
+    CHECK(Fail, stats.pending_bytes == bytes);
   }
   if (terminal) {
     // Accepted during the combined downstream call: these must also be
@@ -339,11 +339,10 @@ test_backlog(int terminal)
   CHECK(Fail, f.appends == (terminal ? 2 : 4));
   struct buffered_writer_stats stats = buffered_writer_get_stats(b);
   CHECK(Fail, stats.completed_batches == (terminal ? 2u : 4u));
-  CHECK(Fail, stats.completed_slots == (terminal ? 4u : 10u));
   CHECK(Fail, stats.max_batch_bytes == (terminal ? 13u : 14u));
   CHECK(Fail, stats.forwarded_bytes == (terminal ? 10u : offset));
   CHECK(Fail, stats.abandoned_bytes == (terminal ? offset - 10 : 0));
-  CHECK(Fail, !stats.occupied_slots && !stats.pending_bytes);
+  CHECK(Fail, !stats.pending_bytes);
   CHECK(Fail, stats.downstream_finished == (terminal == writer_error_finished));
   for (size_t i = 0; i < f.bytes; ++i)
     CHECK(Fail, f.output[i] == i);
@@ -367,7 +366,7 @@ test_capped_drain(void)
     return 1;
   f.hold_each = 1;
   struct buffered_writer* b = buffered_writer_create(
-    &f.writer, &(struct buffered_writer_config){ 8, 7, 2 });
+    &f.writer, &(struct buffered_writer_config){ 56, 16 });
   struct platform_thread* thread = NULL;
   CHECK(Fail, b);
   struct writer* w = buffered_writer_as_writer(b);
@@ -376,12 +375,12 @@ test_capped_drain(void)
     input[i] = (unsigned char)i;
   CHECK(Fail, !writer_append_wait(w, (struct slice){ input, input + 8 }).error);
   wait_call(&f, 1);
-  // One active slot leaves all six other slots available, not half the ring.
+  // Eight active bytes leave the other 48 bytes available to the producer.
   CHECK(Fail,
         !writer_append_wait(w, (struct slice){ input + 8, input + 56 }).error);
   memset(input, 0xFF, 56);
   struct buffered_writer_stats stats = buffered_writer_get_stats(b);
-  CHECK(Fail, stats.occupied_slots == 7 && stats.pending_bytes == 56);
+  CHECK(Fail, stats.pending_bytes == 56);
 
   struct producer p = { .writer = w, .input = { input + 56, input + 64 } };
   atomic_init(&p.started, 0);
@@ -396,7 +395,7 @@ test_capped_drain(void)
   platform_thread_join(thread);
   thread = NULL;
   CHECK(Fail, !p.result.error && p.result.rest.beg == input + 64);
-  CHECK(Fail, f.append_bytes[1] == 16); // catch up by two slots in one call
+  CHECK(Fail, f.append_bytes[1] == 16); // catch up by 16 bytes in one call
   memset(input + 56, 0xFF, 8);
 
   p.input = (struct slice){ input + 64, input + 72 };
@@ -412,19 +411,19 @@ test_capped_drain(void)
   platform_thread_join(thread);
   thread = NULL;
   CHECK(Fail, !p.result.error && p.result.rest.beg == input + 72);
-  // A capped drain freed both slots while an older backlog still remains.
+  // A capped drain freed 16 bytes while an older backlog still remains.
   CHECK(Fail,
         !writer_append_wait(w, (struct slice){ input + 72, input + 80 }).error);
   memset(input, 0xFF, sizeof(input));
   stats = buffered_writer_get_stats(b);
-  CHECK(Fail, stats.occupied_slots == 7 && stats.pending_bytes == 56);
+  CHECK(Fail, stats.pending_bytes == 56);
   CHECK(Fail, stats.forwarded_bytes == 24);
   unhold(&f);
   CHECK(Fail, !writer_flush(w).error);
   stats = buffered_writer_get_stats(b);
-  CHECK(Fail, stats.max_batch_bytes == 16 && stats.completed_slots == 10);
+  CHECK(Fail, stats.max_batch_bytes == 16);
   CHECK(Fail, stats.completed_batches == 6 && f.appends == 6);
-  CHECK(Fail, stats.peak_occupied_slots == 7 && !stats.pending_bytes);
+  CHECK(Fail, stats.peak_pending_bytes == 56 && !stats.pending_bytes);
   CHECK(Fail, stats.forwarded_bytes == 80 && !stats.abandoned_bytes);
   for (int i = 0; i < f.entered; ++i)
     CHECK(Fail, f.append_bytes[i] <= 16);
@@ -454,7 +453,7 @@ test_ring_wrap(void)
     return 1;
   f.hold_each = 1;
   struct buffered_writer* b = buffered_writer_create(
-    &f.writer, &(struct buffered_writer_config){ 8, 3, 2 });
+    &f.writer, &(struct buffered_writer_config){ 24, 16 });
   CHECK(Fail, b);
   struct writer* w = buffered_writer_as_writer(b);
   unsigned char input[32];
@@ -495,30 +494,86 @@ Fail:
 }
 
 static int
+test_byte_cap(int terminal)
+{
+  struct fake_writer f;
+  if (fake_init(&f))
+    return 1;
+  f.hold_each = 1;
+  if (terminal) {
+    f.limit = 9; // terminate inside the third drain and the original append
+    f.terminal = terminal;
+  }
+  struct buffered_writer* b = buffered_writer_create(
+    &f.writer, &(struct buffered_writer_config){ 17, 5 });
+  CHECK(Fail, b);
+  struct writer* w = buffered_writer_as_writer(b);
+  unsigned char input[25];
+  for (size_t i = 0; i < sizeof(input); ++i)
+    input[i] = (unsigned char)i;
+  CHECK(Fail, !writer_append_wait(w, (struct slice){ input, input + 3 }).error);
+  wait_call(&f, 1);
+  // One append can exceed the drain cap. Short appends consume only their
+  // bytes.
+  struct writer_result r =
+    writer_append(w, (struct slice){ input + 3, input + 17 });
+  CHECK(Fail, !r.error && r.rest.beg == input + 17);
+  memset(input, 0xFF, 17);
+  CHECK(Fail, buffered_writer_get_stats(b).pending_bytes == 17);
+  release_call(&f);
+  wait_call(&f, 2);
+  CHECK(Fail, f.append_bytes[1] == 5); // split the 14-byte producer append
+  r = writer_append(w, (struct slice){ input + 17, input + 25 });
+  CHECK(Fail, !r.error && r.rest.beg == input + 20 && r.rest.end == input + 25);
+  memset(input + 17, 0xFF, 3);
+  release_call(&f);
+  wait_call(&f, 3);
+  CHECK(Fail, f.append_bytes[2] == 5);
+  r = writer_append(w, r.rest);
+  CHECK(Fail, !r.error && r.rest.beg == input + 25);
+  memset(input, 0xFF, sizeof(input));
+  CHECK(Fail, buffered_writer_get_stats(b).pending_bytes == 17);
+  unhold(&f);
+  CHECK(Fail, writer_flush(w).error == (terminal != 0));
+  CHECK(Fail, f.bytes == (terminal ? 9u : 25u));
+  const size_t expected[] = { 3, 5, 5, 4, 5, 3 };
+  CHECK(Fail, f.appends == (terminal ? 3 : 6));
+  for (int i = 0; i < f.appends; ++i)
+    CHECK(Fail, f.append_bytes[i] == expected[i]);
+  for (size_t i = 0; i < f.bytes; ++i)
+    CHECK(Fail, f.output[i] == i);
+  struct buffered_writer_stats stats = buffered_writer_get_stats(b);
+  CHECK(Fail, stats.max_batch_bytes == 5 && stats.peak_pending_bytes == 17);
+  CHECK(Fail,
+        !stats.pending_bytes && stats.abandoned_bytes == (terminal ? 16u : 0u));
+  int error = buffered_writer_destroy(b);
+  b = NULL;
+  CHECK(Fail, error == (terminal != 0));
+  fake_free(&f);
+  return 0;
+Fail:
+  unhold(&f);
+  buffered_writer_destroy(b);
+  fake_free(&f);
+  return 1;
+}
+
+static int
 test_destroy_and_config(void)
 {
   struct fake_writer f;
   if (fake_init(&f))
     return 1;
-  struct buffered_writer_config cfg = { 4, 2, 0 };
+  struct buffered_writer_config cfg = { 1, 0 };
   struct buffered_writer* b = NULL;
   CHECK(Fail, !buffered_writer_create(NULL, &cfg));
   CHECK(Fail, !buffered_writer_create(&f.writer, NULL));
   CHECK(Fail,
         !buffered_writer_create(&f.writer,
-                                &(struct buffered_writer_config){ 0, 2, 0 }));
+                                &(struct buffered_writer_config){ 0, 0 }));
   CHECK(Fail,
         !buffered_writer_create(&f.writer,
-                                &(struct buffered_writer_config){ 4, 0, 0 }));
-  CHECK(Fail,
-        !buffered_writer_create(
-          &f.writer, &(struct buffered_writer_config){ 2, SIZE_MAX, 0 }));
-  CHECK(Fail,
-        !buffered_writer_create(
-          &f.writer, &(struct buffered_writer_config){ 1, SIZE_MAX, 0 }));
-  CHECK(Fail,
-        !buffered_writer_create(&f.writer,
-                                &(struct buffered_writer_config){ 8, 2, 3 }));
+                                &(struct buffered_writer_config){ 8, 9 }));
   CHECK(Fail, buffered_writer_destroy(NULL) == 0);
   b = buffered_writer_create(&f.writer, &cfg);
   CHECK(Fail, b);
@@ -553,6 +608,9 @@ main(void)
   failed += test_backlog(writer_error_finished);
   failed += test_capped_drain();
   failed += test_ring_wrap();
+  failed += test_byte_cap(0);
+  failed += test_byte_cap(writer_error_fail);
+  failed += test_byte_cap(writer_error_finished);
   failed += test_finalize(0, 0, 0, 0);
   failed += test_finalize(1, 0, 0, 0);
   failed += test_finalize(0, 1, 0, 0);

--- a/tests/test_zarr_readback.c
+++ b/tests/test_zarr_readback.c
@@ -58,9 +58,9 @@ write_zarr(const char* store_path, struct codec_config codec, int buffered)
   if (buffered) {
     // Mode 2 accepts a whole extra frame before the bounded stream can
     // report finished, making the unconsumed accepted suffix deterministic.
-    struct buffered_writer_config buffering = { 2 * 17, 3, 2 };
+    struct buffered_writer_config buffering = { 2 * 17 * 3, 2 * 23 };
     if (buffered == 2)
-      buffering = (struct buffered_writer_config){ (size_t)total * 2, 1, 0 };
+      buffering = (struct buffered_writer_config){ (size_t)total * 2, 0 };
     adapter = buffered_writer_create(writer, &buffering);
     CHECK(Fail_stream, adapter);
     writer = buffered_writer_as_writer(adapter);

--- a/tests/test_zarr_readback.c
+++ b/tests/test_zarr_readback.c
@@ -58,9 +58,9 @@ write_zarr(const char* store_path, struct codec_config codec, int buffered)
   if (buffered) {
     // Mode 2 accepts a whole extra frame before the bounded stream can
     // report finished, making the unconsumed accepted suffix deterministic.
-    struct buffered_writer_config buffering = { 2 * 17, 3 };
+    struct buffered_writer_config buffering = { 2 * 17, 3, 2 };
     if (buffered == 2)
-      buffering = (struct buffered_writer_config){ (size_t)total * 2, 1 };
+      buffering = (struct buffered_writer_config){ (size_t)total * 2, 1, 0 };
     adapter = buffered_writer_create(writer, &buffering);
     CHECK(Fail_stream, adapter);
     writer = buffered_writer_as_writer(adapter);

--- a/tests/test_zarr_readback.c
+++ b/tests/test_zarr_readback.c
@@ -6,6 +6,7 @@
 #include "test_platform.h"
 #include "test_zarr_helpers.h"
 #include "util/prelude.h"
+#include "writer.buffered.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,19 +19,19 @@
 // --- write_zarr ---
 
 static int
-write_zarr(const char* store_path, struct codec_config codec)
+write_zarr(const char* store_path, struct codec_config codec, int buffered)
 {
   if (codec_is_blosc(codec.id) && compress_blosc_validate(codec))
     return 2;
 
-  const int total = NT * NY * NX;
+  const int total = (NT + (buffered == 2)) * NY * NX;
   uint16_t* src = (uint16_t*)malloc((size_t)total * sizeof(uint16_t));
   CHECK(Fail, src);
   for (int i = 0; i < total; ++i)
     src[i] = (uint16_t)(i & 0xFFFF);
 
   struct dimension dims[3];
-  dims_create(dims, "tyx", (uint64_t[]){ 0, NY, NX });
+  dims_create(dims, "tyx", (uint64_t[]){ buffered == 2 ? NT : 0, NY, NX });
   dims_set_chunk_sizes(dims, 3, (uint64_t[]){ 1, 4, 6 });
   dims[0].chunks_per_shard = NT; // unbounded dim needs explicit cps
   dims_set_shard_counts(dims, 3, (uint64_t[]){ 0, 1, 1 });
@@ -52,18 +53,40 @@ write_zarr(const char* store_path, struct codec_config codec)
     tile_stream_cpu_create(&config, test_zarr_sink_as_shard_sink(&zs));
   CHECK(Fail_sink, s);
 
+  struct buffered_writer* adapter = NULL;
+  struct writer* writer = tile_stream_cpu_writer(s);
+  if (buffered) {
+    // Mode 2 accepts a whole extra frame before the bounded stream can
+    // report finished, making the unconsumed accepted suffix deterministic.
+    struct buffered_writer_config buffering = { 2 * 17, 3 };
+    if (buffered == 2)
+      buffering = (struct buffered_writer_config){ (size_t)total * 2, 1 };
+    adapter = buffered_writer_create(writer, &buffering);
+    CHECK(Fail_stream, adapter);
+    writer = buffered_writer_as_writer(adapter);
+  }
   struct slice input = { .beg = src, .end = src + total };
-  struct writer_result r = writer_append(tile_stream_cpu_writer(s), input);
-  CHECK(Fail_stream, r.error == 0);
-  r = writer_flush(tile_stream_cpu_writer(s));
-  CHECK(Fail_stream, r.error == 0);
-
-  CHECK(Fail_stream, test_zarr_sink_flush(&zs) == 0);
+  CHECK(Fail_adapter, writer_append_wait(writer, input).error == 0);
+  memset(src, 0xFF, (size_t)total * sizeof(uint16_t));
+  CHECK(Fail_adapter, writer_flush(writer).error == (buffered == 2));
+  CHECK(Fail_adapter, writer_flush(writer).error == (buffered == 2));
+  CHECK(Fail_adapter, writer_close(writer).error == (buffered == 2));
+  CHECK(Fail_adapter, writer_close(writer).error == (buffered == 2));
+  CHECK(Fail_adapter, test_zarr_sink_flush(&zs) == 0);
+  if (buffered == 2) {
+    struct buffered_writer_stats stats = buffered_writer_get_stats(adapter);
+    CHECK(Fail_adapter, stats.downstream_finished && stats.failed);
+    CHECK(Fail_adapter, stats.forwarded_bytes == NT * NY * NX * 2);
+    CHECK(Fail_adapter, stats.abandoned_bytes == NY * NX * 2);
+  }
+  buffered_writer_destroy(adapter);
   tile_stream_cpu_destroy(s);
   test_zarr_sink_close(&zs);
   free(src);
   return 0;
 
+Fail_adapter:
+  buffered_writer_destroy(adapter);
 Fail_stream:
   tile_stream_cpu_destroy(s);
 Fail_sink:
@@ -107,21 +130,30 @@ main(void)
   int n_codecs = (int)(sizeof(codecs) / sizeof(codecs[0]));
 
   int err = 0;
-  for (int i = 0; i < n_codecs; ++i) {
-    char store[512];
-    snprintf(store, sizeof(store), "%s/%s", tmpdir, codecs[i].name);
-    CHECK(Cleanup, test_mkdir(store) == 0);
-    log_info("Writing %s ...", codecs[i].name);
-    int wrc = write_zarr(store, codecs[i].codec);
-    if (wrc == 2) { // blosc not available
-      log_info("  skipped: %s (codec not available)", codecs[i].name);
-      test_tmpdir_remove(store);
-      continue;
-    }
-    if (wrc) {
-      log_error("  write failed: %s", codecs[i].name);
-      err = 1;
-      goto Cleanup;
+  for (int buffered = 0; buffered <= 2; ++buffered) {
+    for (int i = 0; i < n_codecs; ++i) {
+      char store[512];
+      snprintf(store,
+               sizeof(store),
+               "%s/%s%s",
+               tmpdir,
+               codecs[i].name,
+               buffered == 2 ? "_buffered_limit"
+               : buffered    ? "_buffered"
+                             : "");
+      CHECK(Cleanup, test_mkdir(store) == 0);
+      log_info("Writing %s ...", codecs[i].name);
+      int wrc = write_zarr(store, codecs[i].codec, buffered);
+      if (wrc == 2) { // blosc not available
+        log_info("  skipped: %s (codec not available)", codecs[i].name);
+        test_tmpdir_remove(store);
+        continue;
+      }
+      if (wrc) {
+        log_error("  write failed: %s", codecs[i].name);
+        err = 1;
+        goto Cleanup;
+      }
     }
   }
 

--- a/tests/test_zarr_readback_gpu.c
+++ b/tests/test_zarr_readback_gpu.c
@@ -56,9 +56,9 @@ write_zarr(const char* store_path, struct codec_config codec, int buffered)
   if (buffered) {
     // Mode 2 accepts a whole extra frame before the bounded stream can
     // report finished, making the unconsumed accepted suffix deterministic.
-    struct buffered_writer_config buffering = { 2 * 1023, 3 };
+    struct buffered_writer_config buffering = { 2 * 1023, 3, 2 };
     if (buffered == 2)
-      buffering = (struct buffered_writer_config){ (size_t)total * 2, 1 };
+      buffering = (struct buffered_writer_config){ (size_t)total * 2, 1, 0 };
     adapter = buffered_writer_create(writer, &buffering);
     CHECK(FailStream, adapter);
     writer = buffered_writer_as_writer(adapter);

--- a/tests/test_zarr_readback_gpu.c
+++ b/tests/test_zarr_readback_gpu.c
@@ -5,6 +5,7 @@
 #include "test_platform.h"
 #include "test_zarr_helpers.h"
 #include "util/prelude.h"
+#include "writer.buffered.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,9 +16,9 @@
 #define NX 256
 
 static int
-write_zarr(const char* store_path, struct codec_config codec)
+write_zarr(const char* store_path, struct codec_config codec, int buffered)
 {
-  const int total = NT * NY * NX;
+  const int total = (NT + (buffered == 2)) * NY * NX;
   uint8_t* allocation = (uint8_t*)malloc((size_t)total * sizeof(uint16_t) + 1);
   CHECK(Fail, allocation);
   // Caller buffers need not be aligned.
@@ -28,7 +29,7 @@ write_zarr(const char* store_path, struct codec_config codec)
   }
 
   struct dimension dims[3];
-  dims_create(dims, "tyx", (uint64_t[]){ 0, NY, NX });
+  dims_create(dims, "tyx", (uint64_t[]){ buffered == 2 ? NT : 0, NY, NX });
   dims_set_chunk_sizes(dims, 3, (uint64_t[]){ 1, 128, 128 });
   dims[0].chunks_per_shard = NT;
   dims_set_shard_counts(dims, 3, (uint64_t[]){ 0, 1, 1 });
@@ -50,17 +51,41 @@ write_zarr(const char* store_path, struct codec_config codec)
   stream = tile_stream_gpu_create(&config, test_zarr_sink_as_shard_sink(&zs));
   CHECK(FailSink, stream);
 
+  struct buffered_writer* adapter = NULL;
+  struct writer* writer = tile_stream_gpu_writer(stream);
+  if (buffered) {
+    // Mode 2 accepts a whole extra frame before the bounded stream can
+    // report finished, making the unconsumed accepted suffix deterministic.
+    struct buffered_writer_config buffering = { 2 * 1023, 3 };
+    if (buffered == 2)
+      buffering = (struct buffered_writer_config){ (size_t)total * 2, 1 };
+    adapter = buffered_writer_create(writer, &buffering);
+    CHECK(FailStream, adapter);
+    writer = buffered_writer_as_writer(adapter);
+  }
   struct slice input = { .beg = src, .end = src + total * sizeof(uint16_t) };
-  CHECK(FailStream,
-        writer_append(tile_stream_gpu_writer(stream), input).error == 0);
-  CHECK(FailStream, writer_flush(tile_stream_gpu_writer(stream)).error == 0);
-  CHECK(FailStream, test_zarr_sink_flush(&zs) == 0);
+  CHECK(FailAdapter, writer_append_wait(writer, input).error == 0);
+  memset(src, 0xFF, (size_t)total * sizeof(uint16_t));
+  CHECK(FailAdapter, writer_flush(writer).error == (buffered == 2));
+  CHECK(FailAdapter, writer_flush(writer).error == (buffered == 2));
+  CHECK(FailAdapter, writer_close(writer).error == (buffered == 2));
+  CHECK(FailAdapter, writer_close(writer).error == (buffered == 2));
+  CHECK(FailAdapter, test_zarr_sink_flush(&zs) == 0);
+  if (buffered == 2) {
+    struct buffered_writer_stats stats = buffered_writer_get_stats(adapter);
+    CHECK(FailAdapter, stats.downstream_finished && stats.failed);
+    CHECK(FailAdapter, stats.forwarded_bytes == NT * NY * NX * 2);
+    CHECK(FailAdapter, stats.abandoned_bytes == NY * NX * 2);
+  }
+  buffered_writer_destroy(adapter);
 
   tile_stream_gpu_destroy(stream);
   test_zarr_sink_close(&zs);
   free(allocation);
   return 0;
 
+FailAdapter:
+  buffered_writer_destroy(adapter);
 FailStream:
   tile_stream_gpu_destroy(stream);
 FailSink:
@@ -91,6 +116,8 @@ main(void)
     const char* name;
     struct codec_config codec;
   } cases[] = {
+    { "none", { .id = CODEC_NONE } },
+    { "zstd", { .id = CODEC_ZSTD } },
     { "blosc_lz4_noshuffle",
       { .id = CODEC_BLOSC_LZ4,
         .level = 5,
@@ -134,17 +161,26 @@ main(void)
   };
 
   int error = 0;
-  for (size_t i = 0; i < countof(cases); ++i) {
-    char store[512];
-    snprintf(store, sizeof(store), "%s/%s", tmpdir, cases[i].name);
-    if (test_mkdir(store) != 0) {
-      error = 1;
-      goto Cleanup;
-    }
-    log_info("Writing GPU %s ...", cases[i].name);
-    if (write_zarr(store, cases[i].codec) != 0) {
-      error = 1;
-      goto Cleanup;
+  for (int buffered = 0; buffered <= 2; ++buffered) {
+    for (size_t i = 0; i < countof(cases); ++i) {
+      char store[512];
+      snprintf(store,
+               sizeof(store),
+               "%s/%s%s",
+               tmpdir,
+               cases[i].name,
+               buffered == 2 ? "_buffered_limit"
+               : buffered    ? "_buffered"
+                             : "");
+      if (test_mkdir(store) != 0) {
+        error = 1;
+        goto Cleanup;
+      }
+      log_info("Writing GPU %s ...", cases[i].name);
+      if (write_zarr(store, cases[i].codec, buffered) != 0) {
+        error = 1;
+        goto Cleanup;
+      }
     }
   }
 

--- a/tests/test_zarr_readback_gpu.c
+++ b/tests/test_zarr_readback_gpu.c
@@ -56,9 +56,9 @@ write_zarr(const char* store_path, struct codec_config codec, int buffered)
   if (buffered) {
     // Mode 2 accepts a whole extra frame before the bounded stream can
     // report finished, making the unconsumed accepted suffix deterministic.
-    struct buffered_writer_config buffering = { 2 * 1023, 3, 2 };
+    struct buffered_writer_config buffering = { 2 * 1023 * 3, 2 * 997 };
     if (buffered == 2)
-      buffering = (struct buffered_writer_config){ (size_t)total * 2, 1, 0 };
+      buffering = (struct buffered_writer_config){ (size_t)total * 2, 0 };
     adapter = buffered_writer_create(writer, &buffering);
     CHECK(FailStream, adapter);
     writer = buffered_writer_as_writer(adapter);


### PR DESCRIPTION
Add an optional bounded copying writer so paced producers can reuse accepted
input while CPU/GPU processing continues in a worker.

Drain a shared byte ring in capped batches, releasing capacity after each
batch and continuing immediately while input remains. Preserve input order,
backpressure, and sticky errors through flush and close.

Validated with CPU/GPU readback and sanitizers. The extra copy can reduce
sustained throughput, so buffering remains opt-in.
